### PR TITLE
Use retrofit:2.9.0 to overwrite version from quarkus-universe-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,7 @@
 
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>
         <apicurio.registry.utils.serde.version>1.3.2.Final</apicurio.registry.utils.serde.version>
-        <!-- New Version 0.0.2 of Apicurio does not work on Native with 1.X Quarkus version  -->
-        <quarkiverse.apicurio.registry.client.version>0.0.1</quarkiverse.apicurio.registry.client.version>
+        <quarkiverse.apicurio.registry.client.version>0.0.2</quarkiverse.apicurio.registry.client.version>
         <apache.avro.version>1.10.2</apache.avro.version>
         <checkstyle.version>8.42</checkstyle.version>
         <jjwt.version>0.11.2</jjwt.version>
@@ -69,6 +68,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- TODO: com.squareup.retrofit2:retrofit:2.9.0 should be removed on Quarkus 2.0.0.Alphas-->
+            <dependency>
+                <groupId>com.squareup.retrofit2</groupId>
+                <artifactId>retrofit</artifactId>
+                <version>2.9.0</version>
+            </dependency>
+
             <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>


### PR DESCRIPTION
When using Quarkus Universe Bom, it brings a lot of dependencies. One of them is https://mvnrepository.com/artifact/org.apache.camel.quarkus/camel-quarkus-support-retrofit/1.8.1 which brings retrofit:2.5.0. 
The problem is that quarkiverse apicurio dependency needs retrofit:2.9.0 and makes the test fails on Native.

However, should we report this incompability issue? Wdyt @mjurc ?