### PR TITLE
Upgrade AMQ Streams to 1.7.0

### DIFF
--- a/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OpenShiftAmqStreamsKafkaAvroIT.java
+++ b/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OpenShiftAmqStreamsKafkaAvroIT.java
@@ -13,8 +13,8 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 public class OpenShiftAmqStreamsKafkaAvroIT extends BaseKafkaAvroIT {
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI,
-            image = "registry.redhat.io/amq7/amq-streams-kafka-24-rhel7",
-            version = "1.5.0",
+            image = "${amq-streams.image}",
+            version = "${amq-streams.version}",
             withRegistry = true)
     static KafkaService kafka = new KafkaService();
 

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OpenShiftAmqStreamsKafkaStreamIT.java
@@ -12,8 +12,8 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 @EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamIT {
     @KafkaContainer(vendor = KafkaVendor.STRIMZI,
-            image = "registry.redhat.io/amq7/amq-streams-kafka-24-rhel7",
-            version = "1.5.0",
+            image = "${amq-streams.image}",
+            version = "${amq-streams.version}",
             withRegistry = true)
     static KafkaService kafka = new KafkaService();
 

--- a/micrometer/prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/AmqStreamsOpenShiftAlertEventsIT.java
+++ b/micrometer/prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/AmqStreamsOpenShiftAlertEventsIT.java
@@ -10,8 +10,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @OpenShiftScenario
 @EnabledIfOpenShiftScenarioPropertyIsTrue
 public class AmqStreamsOpenShiftAlertEventsIT extends BaseOpenShiftAlertEventsIT {
-    @KafkaContainer(image = "registry.redhat.io/amq7/amq-streams-kafka-24-rhel7",
-            version = "1.5.0")
+    @KafkaContainer(image = "${amq-streams.image}", version = "${amq-streams.version}")
     static KafkaService kafka = new KafkaService();
 
     @QuarkusApplication

--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,11 @@
                                         <quarkus.native.builder-image>
                                             ${quarkus.native.builder-image}
                                         </quarkus.native.builder-image>
+                                        <!-- Product Supported -->
+                                        <amq-streams.image>
+                                            registry.redhat.io/amq7/amq-streams-kafka-24-rhel7
+                                        </amq-streams.image>
+                                        <amq-streams.version>1.7.0</amq-streams.version>
                                     </systemProperties>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
This is related to the changes in https://github.com/quarkus-qe/quarkus-openshift-test-suite/pull/279. 
The Strimzi upgrade is done as part of the Test Framework: https://github.com/quarkus-qe/quarkus-test-framework/issues/15
This PR addresses the AMQ streams upgrade only.

Fix https://github.com/quarkus-qe/quarkus-test-suite/issues/31