### PR TITLE
Fix annoying error message on MultiplePersistenceIT tearUp test

### DIFF
--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/openshift/sqldb/multiplepus/MultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/openshift/sqldb/multiplepus/MultiplePersistenceIT.java
@@ -65,18 +65,12 @@ public class MultiplePersistenceIT {
     @BeforeEach
     public void cleanUp() {
         if (latestFruitId != null) {
-            app.given()
-                    .delete("/fruit/" + latestFruitId)
-                    .then()
-                    .statusCode(HttpStatus.SC_NO_CONTENT);
+            app.given().delete("/fruit/" + latestFruitId);
             latestFruitId = null;
         }
 
         if (latestVegetableId != null) {
-            app.given()
-                    .delete("/vegetable/" + latestVegetableId)
-                    .then()
-                    .statusCode(HttpStatus.SC_NO_CONTENT);
+            app.given().delete("/vegetable/" + latestVegetableId);
             latestVegetableId = null;
         }
     }


### PR DESCRIPTION
 When I run the test on my local environment I saw some "errors" on the log

```
Expected status code <204> but was <404>.

        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
        at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:72)
        at org.codehaus.groovy.reflection.CachedConstructor.doConstructorInvoke(CachedConstructor.java:59)
        at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrap.callConstructor(ConstructorSite.java:84)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:277)
        at io.restassured.internal.ResponseSpecificationImpl$HamcrestAssertionClosure.validate(ResponseSpecificationImpl.groovy:493)
        at io.restassured.internal.ResponseSpecificationImpl$HamcrestAssertionClosure$validate$1.call(Unknown Source)
        at io.restassured.internal.ResponseSpecificationImpl.validateResponseIfRequired(ResponseSpecificationImpl.groovy:674)
        at jdk.internal.reflect.GeneratedMethodAccessor52.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.codehaus.groovy.runtime.callsite.PlainObjectMetaMethodSite.doInvoke(PlainObjectMetaMethodSite.java:43)
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:193)

```

In the end, wasn't an error, is just that in the test TearUp we are verifying that a specific HTTP request returns an HTTP code that is not always true. So, I decided to remove this check. 