### PR TITLE
Add AMQ Streams provided by Red Hat Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ oc adm policy add-role-to-user edit qe -n openshift-user-workload-monitoring
 
 These requirements are necessary to verify the `micrometer/prometheus` and `micrometer/prometheus-kafka` tests. 
 
+- the OpenShift user must have permission to create Operators:
+
+```
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: install-operators-role
+rules:
+- apiGroups: ["operators.coreos.com"]
+  resources: ["operatorgroups"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+```
+
+These requirements are necessary to verify the tests with tag `include-operator-scenarios`.
+
 ## Running against Red Hat build of Quarkus
 
 When running against released Red Hat build of Quarkus make sure https://maven.repository.redhat.com/ga/ repository is defined in settings.xml.
@@ -95,6 +110,18 @@ The following command will execute the whole test suite including serverless tes
 
 ```
 ./mvnw clean verify -Dinclude.serverless
+```
+
+### OpenShift Operators
+
+The test suite contains a Maven profile activated using the `include.operator-scenarios` property or `operator-scenarios` profile name.
+This profile includes additional modules with serverless test coverage into the execution of the testsuite.
+Serverless test coverage supports both JVM and Native mode.
+
+The following command will execute the whole test suite including serverless tests:
+
+```
+./mvnw clean verify -Dinclude.operator-scenarios
 ```
 
 ## Existing tests

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OpenShiftOperatorAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OpenShiftOperatorAmqStreamsKafkaStreamIT.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.openshift.messaging.kafka;
+
+import org.junit.jupiter.api.Tag;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
+import io.quarkus.test.services.Operator;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.operator.KafkaInstance;
+
+@Tag("operator-scenarios")
+@OpenShiftScenario
+@EnabledIfOpenShiftScenarioPropertyIsTrue
+public class OpenShiftOperatorAmqStreamsKafkaStreamIT extends BaseKafkaStreamIT {
+    @Operator(name = "amq-streams", source = "redhat-operators")
+    static KafkaInstance kafka = new KafkaInstance();
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl);
+
+    @Override
+    public RestService getApp() {
+        return app;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,10 @@
         <quarkiverse.apicurio.registry.client.version>0.0.2</quarkiverse.apicurio.registry.client.version>
         <checkstyle.version>8.42</checkstyle.version>
         <jjwt.version>0.11.2</jjwt.version>
+
+        <tests.with.serverless>serverless</tests.with.serverless>
+        <tests.with.operator-scenarios>operator-scenarios</tests.with.operator-scenarios>
+        <exclusion.tests.with.tags>${tests.with.serverless},${tests.with.operator-scenarios}</exclusion.tests.with.tags>
     </properties>
 
     <modules>
@@ -308,7 +312,11 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
-                            <excludedGroups>serverless</excludedGroups>
+                            <excludedGroups>serverless,operator-scenarios</excludedGroups>
+                            <excludedGroups>
+                                ${tests.with.serverless},
+                                ${tests.with.operator-scenarios}
+                            </excludedGroups>
                             <systemPropertyVariables>
                                 <ts.openshift.scenario.enabled>true</ts.openshift.scenario.enabled>
                             </systemPropertyVariables>
@@ -348,20 +356,23 @@
                     <name>include.serverless</name>
                 </property>
             </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <groups>serverless</groups>
-                            <systemPropertyVariables>
-                                <ts.openshift.scenario.enabled>true</ts.openshift.scenario.enabled>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
+            <properties>
+                <!-- So tests are not excluded -->
+                <tests.with.serverless>yes</tests.with.serverless>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>operator-scenarios</id>
+            <activation>
+                <property>
+                    <name>include.operator-scenarios</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- So tests are not excluded -->
+                <tests.with.operator-scenarios>yes</tests.with.operator-scenarios>
+            </properties>
         </profile>
 
     </profiles>


### PR DESCRIPTION
The provided AMQ Streams solution uses the official Red Hat Operator, so in order to cover it we need to install the operator within the same test namespace and use it.

In order to run this scenario, we need to use:

```
mvn clean verify -Dinclude.operator-scenarios
```

Verified in OCP 4.7