### PR TITLE
Dependabot: Ignore io.quarkus:quarkus-maven-plugin updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # For Quarkus Maven Plugin, updates are managed by Quarkus Bom dependency
+      - dependency-name: io.quarkus:quarkus-maven-plugin


### PR DESCRIPTION
For Quarkus Maven Plugin, updates are managed by Quarkus Bom dependency