### PR TITLE
Use Quarkus 999-SNAPSHOT ++ Use naming convention to exclude tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,43 @@ name: "Pull Request CI"
 on:
   - pull_request
 jobs:
-  build-released:
-    name: JVM build - released Quarkus
+  build-dependencies:
+    name: Build Dependencies
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11 ]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Reclaim Disk Space
+        run: .github/ci-prerequisites.sh
+      - name: Install JDK {{ matrix.java }}
+        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Build Quarkus main
+        run: |
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly
+      - name: Build Quarkus QE Test Framework
+        run: git clone https://github.com/quarkus-qe/quarkus-test-framework && cd quarkus-test-framework && mvn -B -s .github/mvn-settings.xml clean install -Pframework
+      - name: Tar Maven Repo
+        shell: bash
+        run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
+      - name: Persist Maven Repo
+        uses: actions/upload-artifact@v1
+        with:
+          name: maven-repo
+          path: maven-repo.tgz
+  build-jvm:
+    name: JVM build - latest Quarkus
+    runs-on: ubuntu-latest
+    needs: build-dependencies
     strategy:
       matrix:
         java: [ 11 ]
@@ -23,22 +57,29 @@ jobs:
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: openjdk${{ matrix.java }}
-      - name: Build Quarkus QE Test Framework
-        run: git clone https://github.com/quarkus-qe/quarkus-test-framework && cd quarkus-test-framework && mvn -B -s .github/mvn-settings.xml clean install -Pframework
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
       - name: Build with Maven
         run: mvn -fae -V -B -s .github/mvn-settings.xml clean verify
       - name: Zip Artifacts
         if: failure()
         run: |
-          zip -R released-jvm${{ matrix.java }}.zip '*-reports/*'
+          zip -R artifacts-jvm${{ matrix.java }}.zip '*-reports/*'
       - uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: ci-artifacts
-          path: released-jvm${{ matrix.java }}.zip
+          path: artifacts-jvm${{ matrix.java }}.zip
   build-released-native:
     name: Native build - released Quarkus
     runs-on: ubuntu-latest
+    needs: build-dependencies
     strategy:
       matrix:
         java: [ 11 ]
@@ -57,17 +98,23 @@ jobs:
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: openjdk${{ matrix.java }}
-      - name: Build Quarkus QE Test Framework
-        run: git clone https://github.com/quarkus-qe/quarkus-test-framework && cd quarkus-test-framework && mvn -B -s .github/mvn-settings.xml clean install -Pframework
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
       - name: Build with Maven
         run: |
           mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dquarkus.profile=native -Dquarkus.native.container-runtime=docker
       - name: Zip Artifacts
         if: failure()
         run: |
-          zip -R released-native${{ matrix.java }}.zip '*-reports/*'
+          zip -R artifacts-native${{ matrix.java }}.zip '*-reports/*'
       - uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: ci-artifacts
-          path: released-native${{ matrix.java }}.zip
+          path: artifacts-native${{ matrix.java }}.zip

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -4,8 +4,8 @@ on:
   schedule:
     - cron: '0 23 * * *'
 jobs:
-  build-jvm:
-    name: Daily build - JVM
+  build-dependencies:
+    name: Build Dependencies
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,8 +24,48 @@ jobs:
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: ${{ matrix.java }}
+      - name: Build Quarkus main
+        run: |
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly
       - name: Build Quarkus QE Test Framework
         run: git clone https://github.com/quarkus-qe/quarkus-test-framework && cd quarkus-test-framework && mvn -B -s .github/mvn-settings.xml clean install -Pframework
+      - name: Tar Maven Repo
+        shell: bash
+        run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
+      - name: Persist Maven Repo
+        uses: actions/upload-artifact@v1
+        with:
+          name: maven-repo
+          path: maven-repo.tgz
+  build-jvm:
+    name: Daily build - JVM
+    runs-on: ubuntu-latest
+    needs: build-dependencies
+    strategy:
+      matrix:
+        java: [ 11 ]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Reclaim Disk Space
+        run: .github/ci-prerequisites.sh
+      - name: Install JDK {{ matrix.java }}
+        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
       - name: Test in JVM mode
         run: |
           mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify
@@ -42,6 +82,7 @@ jobs:
   build-native:
     name: Daily build - Native
     runs-on: ubuntu-latest
+    needs: build-dependencies
     strategy:
       matrix:
         java: [ 11 ]
@@ -60,8 +101,14 @@ jobs:
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: ${{ matrix.java }}
-      - name: Build Quarkus QE Test Framework
-        run: git clone https://github.com/quarkus-qe/quarkus-test-framework && cd quarkus-test-framework && mvn -B -s .github/mvn-settings.xml clean install -Pframework
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
       - name: Test in Native mode
         run: |
           mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -Dnative \

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftApiServerConfigMapConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftApiServerConfigMapConfigIT.java
@@ -3,11 +3,11 @@ package io.quarkus.ts.configmap.api.server;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.services.QuarkusApplication;
 
-public class ApiServerConfigSecretOpenShiftIT extends BaseConfigOpenShiftIT {
+public class OpenShiftApiServerConfigMapConfigIT extends OpenShiftBaseConfigIT {
 
     @QuarkusApplication
-    static RestService app = new RestService().withProperties("secret.api-server.properties")
-            .onPreStart(ApiServerConfigSecretOpenShiftIT::loadDefaultConfigSecret);
+    static RestService app = new RestService().withProperties("configmap.api-server.properties")
+            .onPreStart(OpenShiftApiServerConfigMapConfigIT::loadDefaultConfigMap);
 
     @Override
     protected RestService getApp() {
@@ -16,6 +16,6 @@ public class ApiServerConfigSecretOpenShiftIT extends BaseConfigOpenShiftIT {
 
     @Override
     protected String getConfigType() {
-        return SECRET;
+        return CONFIGMAP;
     }
 }

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftApiServerConfigSecretConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftApiServerConfigSecretConfigIT.java
@@ -3,11 +3,11 @@ package io.quarkus.ts.configmap.api.server;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.services.QuarkusApplication;
 
-public class FileSystemConfigMapOpenShiftIT extends BaseConfigOpenShiftIT {
+public class OpenShiftApiServerConfigSecretConfigIT extends OpenShiftBaseConfigIT {
 
     @QuarkusApplication
-    static RestService app = new RestService().withProperties("configmap.file-system.properties")
-            .onPreStart(FileSystemConfigMapOpenShiftIT::loadDefaultConfigMap);
+    static RestService app = new RestService().withProperties("secret.api-server.properties")
+            .onPreStart(OpenShiftApiServerConfigSecretConfigIT::loadDefaultConfigSecret);
 
     @Override
     protected RestService getApp() {
@@ -16,6 +16,6 @@ public class FileSystemConfigMapOpenShiftIT extends BaseConfigOpenShiftIT {
 
     @Override
     protected String getConfigType() {
-        return CONFIGMAP;
+        return SECRET;
     }
 }

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftBaseConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftBaseConfigIT.java
@@ -18,11 +18,9 @@ import io.quarkus.test.bootstrap.Service;
 import io.quarkus.test.bootstrap.inject.OpenShiftClient;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
-@EnabledIfOpenShiftScenarioPropertyIsTrue
-public abstract class BaseConfigOpenShiftIT {
+public abstract class OpenShiftBaseConfigIT {
 
     static final int ASSERT_TIMEOUT_MINUTES = 5;
     static final String CONFIGMAP = "configmap";

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftFileSystemConfigMapConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftFileSystemConfigMapConfigIT.java
@@ -3,11 +3,11 @@ package io.quarkus.ts.configmap.api.server;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.services.QuarkusApplication;
 
-public class ApiServerConfigMapOpenShiftIT extends BaseConfigOpenShiftIT {
+public class OpenShiftFileSystemConfigMapConfigIT extends OpenShiftBaseConfigIT {
 
     @QuarkusApplication
-    static RestService app = new RestService().withProperties("configmap.api-server.properties")
-            .onPreStart(ApiServerConfigMapOpenShiftIT::loadDefaultConfigMap);
+    static RestService app = new RestService().withProperties("configmap.file-system.properties")
+            .onPreStart(OpenShiftFileSystemConfigMapConfigIT::loadDefaultConfigMap);
 
     @Override
     protected RestService getApp() {

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftFileSystemConfigSecretConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftFileSystemConfigSecretConfigIT.java
@@ -3,11 +3,11 @@ package io.quarkus.ts.configmap.api.server;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.services.QuarkusApplication;
 
-public class FileSystemConfigSecretOpenShiftIT extends BaseConfigOpenShiftIT {
+public class OpenShiftFileSystemConfigSecretConfigIT extends OpenShiftBaseConfigIT {
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("secret.api-server.properties")
-            .onPreStart(FileSystemConfigSecretOpenShiftIT::loadDefaultConfigSecret);
+            .onPreStart(OpenShiftFileSystemConfigSecretConfigIT::loadDefaultConfigSecret);
 
     @Override
     protected RestService getApp() {

--- a/http/http-advanced/pom.xml
+++ b/http/http-advanced/pom.xml
@@ -94,18 +94,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
@@ -27,7 +27,7 @@ import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
+import io.quarkus.test.scenarios.annotations.EnabledOnQuarkusVersion;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.http.advanced.clients.HealthClientService;
@@ -126,7 +126,7 @@ public class HttpAdvancedIT {
 
     @Test
     @DisplayName("Non-application endpoint move to /q/")
-    @DisabledOnQuarkusVersion(version = "2\\..*", reason = "Redirection is no longer supported in 2.x")
+    @EnabledOnQuarkusVersion(version = "1\\..*", reason = "Redirection is no longer supported in 2.x")
     public void nonAppRedirections() {
         List<String> endpoints = Arrays.asList("/openapi", "/swagger-ui", "/metrics/base", "/metrics/application",
                 "/metrics/vendor", "/metrics", "/health/group", "/health/well", "/health/ready", "/health/live",
@@ -153,7 +153,7 @@ public class HttpAdvancedIT {
     }
 
     @Test
-    @DisabledOnQuarkusVersion(version = "2\\..*", reason = "Redirection is no longer supported in 2.x")
+    @EnabledOnQuarkusVersion(version = "1\\..*", reason = "Redirection is no longer supported in 2.x")
     public void vertxHttpClientRedirection() throws InterruptedException, URISyntaxException {
         CountDownLatch done = new CountDownLatch(1);
         Uni<Integer> statusCode = WebClient.create(Vertx.vertx(), defaultVertxHttpClientOptions())

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHttpAdvancedIT.java
@@ -2,9 +2,7 @@ package io.quarkus.ts.http.advanced;
 
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 @OpenShiftScenario
 public class OpenShiftHttpAdvancedIT extends HttpAdvancedIT {
     @Override

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/DevModeHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/DevModeHttpMinimumIT.java
@@ -33,7 +33,7 @@ public class DevModeHttpMinimumIT {
         // We wait for Quarkus to run the tests
         app.logs().assertContains("Running Tests for the first time");
         // But there are no tests yet
-        app.logs().assertContains("No tests to run");
+        app.logs().assertContains("No tests found");
         // We add a new test
         app.copyFile("src/test/resources/HelloResourceTest.java.template", "src/test/java/HelloResourceTest.java");
         // And now, Quarkus find it and run it

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftHttpMinimumIT.java
@@ -1,10 +1,8 @@
 package io.quarkus.ts.http.minimum;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftHttpMinimumIT extends HttpMinimumIT {
 
 }

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumIT.java
@@ -4,11 +4,9 @@ import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
-@EnabledIfOpenShiftScenarioPropertyIsTrue
-public class ExtensionDockerBuildStrategyOpenShiftHttpMinimumIT extends HttpMinimumIT {
+public class OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumIT extends HttpMinimumIT {
 
 }

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionHttpMinimumIT.java
@@ -4,11 +4,9 @@ import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
-@EnabledIfOpenShiftScenarioPropertyIsTrue
-public class ExtensionOpenShiftHttpMinimumIT extends HttpMinimumIT {
+public class OpenShiftUsingExtensionHttpMinimumIT extends HttpMinimumIT {
 
 }

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumIT.java
@@ -4,12 +4,10 @@ import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumIT extends HttpMinimumIT {
 
 }

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionOpenShiftHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionOpenShiftHttpMinimumIT.java
@@ -4,11 +4,9 @@ import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class ServerlessExtensionOpenShiftHttpMinimumIT extends HttpMinimumIT {
 }

--- a/messaging/amqp-reactive/src/test/java/io/quarkus/ts/messaging/amqpreactive/OpenShiftAmqpIT.java
+++ b/messaging/amqp-reactive/src/test/java/io/quarkus/ts/messaging/amqpreactive/OpenShiftAmqpIT.java
@@ -1,9 +1,7 @@
 package io.quarkus.ts.messaging.amqpreactive;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftAmqpIT extends AmqpIT {
 }

--- a/messaging/artemis-jta/src/test/java/io/quarkus/ts/messaging/artemisjta/OpenShiftArtemisJtaIT.java
+++ b/messaging/artemis-jta/src/test/java/io/quarkus/ts/messaging/artemisjta/OpenShiftArtemisJtaIT.java
@@ -1,9 +1,7 @@
 package io.quarkus.ts.messaging.artemisjta;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftArtemisJtaIT extends ArtemisJtaIT {
 }

--- a/messaging/artemis/src/test/java/io/quarkus/ts/messaging/artemis/OpenShiftArtemisIT.java
+++ b/messaging/artemis/src/test/java/io/quarkus/ts/messaging/artemis/OpenShiftArtemisIT.java
@@ -1,10 +1,8 @@
 package io.quarkus.ts.messaging.artemis;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftArtemisIT extends ArtemisIT {
 
 }

--- a/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OpenShiftAmqStreamsKafkaAvroIT.java
+++ b/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OpenShiftAmqStreamsKafkaAvroIT.java
@@ -3,13 +3,11 @@ package io.quarkus.ts.openshift.messaging.kafka;
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftAmqStreamsKafkaAvroIT extends BaseKafkaAvroIT {
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI,

--- a/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OpenShiftStrimziKafkaAvroIT.java
+++ b/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OpenShiftStrimziKafkaAvroIT.java
@@ -1,9 +1,7 @@
 package io.quarkus.ts.openshift.messaging.kafka;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftStrimziKafkaAvroIT extends StrimziKafkaAvroIT {
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OpenShiftAmqStreamsKafkaStreamIT.java
@@ -3,13 +3,11 @@ package io.quarkus.ts.openshift.messaging.kafka;
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamIT {
     @KafkaContainer(vendor = KafkaVendor.STRIMZI,
             image = "${amq-streams.image}",

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OpenShiftStrimziKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OpenShiftStrimziKafkaStreamIT.java
@@ -1,9 +1,7 @@
 package io.quarkus.ts.openshift.messaging.kafka;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftStrimziKafkaStreamIT extends StrimziKafkaStreamIT {
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/openshift/messaging/kafka/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
@@ -4,15 +4,13 @@ import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Operator;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.operator.KafkaInstance;
 
 @Tag("operator-scenarios")
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
-public class OpenShiftOperatorAmqStreamsKafkaStreamIT extends BaseKafkaStreamIT {
+public class OperatorOpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamIT {
     @Operator(name = "amq-streams", source = "redhat-operators")
     static KafkaInstance kafka = new KafkaInstance();
 

--- a/messaging/qpid/src/test/java/io/quarkus/ts/messaging/qpid/OpenShiftQpidIT.java
+++ b/messaging/qpid/src/test/java/io/quarkus/ts/messaging/qpid/OpenShiftQpidIT.java
@@ -1,9 +1,7 @@
 package io.quarkus.ts.messaging.qpid;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftQpidIT extends QpidIT {
 }

--- a/micrometer/prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftAmqStreamsAlertEventsIT.java
+++ b/micrometer/prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftAmqStreamsAlertEventsIT.java
@@ -3,20 +3,18 @@ package io.quarkus.ts.micrometer.prometheus.kafka;
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
-public class AmqStreamsOpenShiftAlertEventsIT extends BaseOpenShiftAlertEventsIT {
+public class OpenShiftAmqStreamsAlertEventsIT extends BaseOpenShiftAlertEventsIT {
     @KafkaContainer(image = "${amq-streams.image}", version = "${amq-streams.version}")
     static KafkaService kafka = new KafkaService();
 
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
-            .onPostStart(AmqStreamsOpenShiftAlertEventsIT::loadServiceMonitor);
+            .onPostStart(OpenShiftAmqStreamsAlertEventsIT::loadServiceMonitor);
 
     @Override
     protected RestService getApp() {

--- a/micrometer/prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftKafkaAlertEventsIT.java
+++ b/micrometer/prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftKafkaAlertEventsIT.java
@@ -3,13 +3,11 @@ package io.quarkus.ts.micrometer.prometheus.kafka;
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
-public class KafkaOpenShiftAlertEventsIT extends BaseOpenShiftAlertEventsIT {
+public class OpenShiftKafkaAlertEventsIT extends BaseOpenShiftAlertEventsIT {
 
     @KafkaContainer
     static KafkaService kafka = new KafkaService();
@@ -17,7 +15,7 @@ public class KafkaOpenShiftAlertEventsIT extends BaseOpenShiftAlertEventsIT {
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
-            .onPostStart(KafkaOpenShiftAlertEventsIT::loadServiceMonitor);
+            .onPostStart(OpenShiftKafkaAlertEventsIT::loadServiceMonitor);
 
     @Override
     protected RestService getApp() {

--- a/micrometer/prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/OpenShiftPrimeNumberResourceIT.java
+++ b/micrometer/prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/OpenShiftPrimeNumberResourceIT.java
@@ -18,7 +18,6 @@ import io.quarkus.test.bootstrap.Service;
 import io.quarkus.test.bootstrap.inject.OpenShiftClient;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.QuarkusApplication;
 
 /**
@@ -27,8 +26,7 @@ import io.quarkus.test.services.QuarkusApplication;
  * - `prime_number_test_{uniqueId}`: with information about the calculation of the prime number.
  */
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
-@EnabledIfOpenShiftScenarioPropertyIsTrue
-public class PrimeNumberResourceOpenShiftIT {
+public class OpenShiftPrimeNumberResourceIT {
 
     static final String PRIME_NUMBER_MAX = "prime_number_max_%s";
 
@@ -47,7 +45,7 @@ public class PrimeNumberResourceOpenShiftIT {
     static final Integer ANY_VALUE = null;
 
     @QuarkusApplication
-    static RestService app = new RestService().onPostStart(PrimeNumberResourceOpenShiftIT::loadServiceMonitor);
+    static RestService app = new RestService().onPostStart(OpenShiftPrimeNumberResourceIT::loadServiceMonitor);
 
     @Inject
     static OpenShiftClient client;

--- a/microprofile/pom.xml
+++ b/microprofile/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>microprofile</artifactId>
     <packaging>jar</packaging>
 
-    <name>Quarkus OpenShift TS: MicroProfile</name>
+    <name>Quarkus QE TS: MicroProfile</name>
 
     <dependencies>
         <dependency>

--- a/microprofile/src/test/java/io/quarkus/ts/openshift/microprofile/OpenShiftMicroProfileIT.java
+++ b/microprofile/src/test/java/io/quarkus/ts/openshift/microprofile/OpenShiftMicroProfileIT.java
@@ -12,10 +12,8 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 @DisabledOnQuarkusVersion(version = "1\\.3\\..*", reason = "https://github.com/quarkusio/quarkus/pull/7987")
 public class OpenShiftMicroProfileIT extends MicroProfileIT {
     private static final int EXPECTED_SPANS_SIZE = 3;

--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,11 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <surefire-plugin.version>2.22.2</surefire-plugin.version>
+        <failsafe-plugin.version>2.22.2</failsafe-plugin.version>
 
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.0.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
         <quarkus.qe.framework.version>0.0.2-SNAPSHOT</quarkus.qe.framework.version>
 
@@ -36,9 +36,11 @@
         <checkstyle.version>8.43</checkstyle.version>
         <jjwt.version>0.11.2</jjwt.version>
 
-        <tests.with.serverless>serverless</tests.with.serverless>
-        <tests.with.operator-scenarios>operator-scenarios</tests.with.operator-scenarios>
-        <exclusion.tests.with.tags>${tests.with.serverless},${tests.with.operator-scenarios}</exclusion.tests.with.tags>
+        <!-- Failsafe inclusions/exclusions rules -->
+        <include.tests>**/*IT.java</include.tests>
+        <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>
+        <exclude.serverless.openshift.tests>**/Serverless*OpenShift*IT.java</exclude.serverless.openshift.tests>
+        <exclude.operator.openshift.tests>**/Operator*OpenShift*IT.java</exclude.operator.openshift.tests>
     </properties>
 
     <modules>
@@ -162,6 +164,15 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${failsafe-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>io.quarkus</groupId>
@@ -183,21 +194,28 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <includes>
+                                <include>${include.tests}</include>
+                            </includes>
+                            <excludes>
+                                <exclude>${exclude.openshift.tests}</exclude>
+                                <exclude>${exclude.serverless.openshift.tests}</exclude>
+                                <exclude>${exclude.operator.openshift.tests}</exclude>
+                            </excludes>
+                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -233,21 +251,6 @@
 
     <profiles>
         <profile>
-            <id>quarkus-core-only</id>
-            <activation>
-                <property>
-                    <name>quarkus-core-only</name>
-                </property>
-            </activation>
-            <properties>
-                <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-                <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-                <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-                <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
-            </properties>
-        </profile>
-
-        <profile>
             <id>native</id>
             <activation>
                 <property>
@@ -258,7 +261,6 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${surefire-plugin.version}</version>
                         <executions>
                             <execution>
                                 <configuration>
@@ -306,24 +308,9 @@
                 </property>
             </activation>
 
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <excludedGroups>serverless,operator-scenarios</excludedGroups>
-                            <excludedGroups>
-                                ${tests.with.serverless},
-                                ${tests.with.operator-scenarios}
-                            </excludedGroups>
-                            <systemPropertyVariables>
-                                <ts.openshift.scenario.enabled>true</ts.openshift.scenario.enabled>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
+            <properties>
+                <exclude.openshift.tests>no</exclude.openshift.tests>
+            </properties>
         </profile>
 
         <profile>
@@ -357,8 +344,7 @@
                 </property>
             </activation>
             <properties>
-                <!-- So tests are not excluded -->
-                <tests.with.serverless>yes</tests.with.serverless>
+                <exclude.serverless.openshift.tests>no</exclude.serverless.openshift.tests>
             </properties>
         </profile>
 
@@ -370,8 +356,7 @@
                 </property>
             </activation>
             <properties>
-                <!-- So tests are not excluded -->
-                <tests.with.operator-scenarios>yes</tests.with.operator-scenarios>
+                <exclude.operator.openshift.tests>no</exclude.operator.openshift.tests>
             </properties>
         </profile>
 

--- a/scaling/pom.xml
+++ b/scaling/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>scaling</artifactId>
     <packaging>jar</packaging>
 
-    <name>Quarkus OpenShift TS: Scaling tests</name>
+    <name>Quarkus QE TS: Scaling tests</name>
 
     <dependencies>
         <dependency>

--- a/scaling/src/test/java/io/quarkus/ts/openshift/scaling/OpenShiftScalingIT.java
+++ b/scaling/src/test/java/io/quarkus/ts/openshift/scaling/OpenShiftScalingIT.java
@@ -1,21 +1,5 @@
 package io.quarkus.ts.openshift.scaling;
 
-import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.bootstrap.inject.OpenShiftClient;
-import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
-import io.quarkus.test.services.QuarkusApplication;
-import io.restassured.response.ValidatableResponse;
-import java.time.Duration;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import javax.inject.Inject;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
-
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,8 +8,25 @@ import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.bootstrap.inject.OpenShiftClient;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.response.ValidatableResponse;
+
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 @TestMethodOrder(OrderAnnotation.class)
 public class OpenShiftScalingIT {
 
@@ -63,7 +64,6 @@ public class OpenShiftScalingIT {
         whenMakeRequestTo("/scaling", replicas);
     }
 
-
     /**
      * Workflow:
      * * Scale to two replicas and verify that both of the replicas are responding.
@@ -84,7 +84,6 @@ public class OpenShiftScalingIT {
         thenCheckReplicasAmount(1);
         whenMakeRequestTo("/scaling", replicas);
     }
-
 
     /**
      * Workflow:

--- a/security/basic/src/test/java/io/quarkus/ts/openshift/security/basic/OpenShiftBasicSecurityIT.java
+++ b/security/basic/src/test/java/io/quarkus/ts/openshift/security/basic/OpenShiftBasicSecurityIT.java
@@ -1,9 +1,7 @@
 package io.quarkus.ts.openshift.security.basic;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftBasicSecurityIT extends BasicSecurityIT {
 }

--- a/security/jwt/src/test/java/io/quarkus/ts/security/jwt/OpenShiftCookieJwtSecurityIT.java
+++ b/security/jwt/src/test/java/io/quarkus/ts/security/jwt/OpenShiftCookieJwtSecurityIT.java
@@ -1,9 +1,7 @@
 package io.quarkus.ts.security.jwt;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftCookieJwtSecurityIT extends CookieJwtSecurityIT {
 }

--- a/security/jwt/src/test/java/io/quarkus/ts/security/jwt/OpenShiftOauth2JwtSecurityIT.java
+++ b/security/jwt/src/test/java/io/quarkus/ts/security/jwt/OpenShiftOauth2JwtSecurityIT.java
@@ -1,9 +1,7 @@
 package io.quarkus.ts.security.jwt;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftOauth2JwtSecurityIT extends Oauth2JwtSecurityIT {
 }

--- a/security/keycloak-authz/pom.xml
+++ b/security/keycloak-authz/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-keycloak</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/security/keycloak-authz/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSso73AuthzSecurityIT.java
+++ b/security/keycloak-authz/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSso73AuthzSecurityIT.java
@@ -3,12 +3,10 @@ package io.quarkus.ts.security.keycloak.authz;
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftRhSso73AuthzSecurityIT extends BaseAuthzSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;

--- a/security/keycloak-authz/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSso74AuthzSecurityIT.java
+++ b/security/keycloak-authz/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSso74AuthzSecurityIT.java
@@ -3,12 +3,10 @@ package io.quarkus.ts.security.keycloak.authz;
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftRhSso74AuthzSecurityIT extends BaseAuthzSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;

--- a/security/keycloak-jwt/pom.xml
+++ b/security/keycloak-jwt/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-keycloak</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/OpenShiftRhSso73OidcJwtSecurityIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/OpenShiftRhSso73OidcJwtSecurityIT.java
@@ -3,12 +3,10 @@ package io.quarkus.ts.security.keycloak.jwt;
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftRhSso73OidcJwtSecurityIT extends BaseOidcJwtSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/OpenShiftRhSso74OidcJwtSecurityIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/OpenShiftRhSso74OidcJwtSecurityIT.java
@@ -3,12 +3,10 @@ package io.quarkus.ts.security.keycloak.jwt;
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftRhSso74OidcJwtSecurityIT extends BaseOidcJwtSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;

--- a/security/keycloak-multitenant/pom.xml
+++ b/security/keycloak-multitenant/pom.xml
@@ -34,6 +34,7 @@
         <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-keycloak</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSso73MultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSso73MultiTenantSecurityIT.java
@@ -3,12 +3,10 @@ package io.quarkus.ts.security.keycloak.multitenant;
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftRhSso73MultiTenantSecurityIT extends BaseMultiTenantSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSso74MultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSso74MultiTenantSecurityIT.java
@@ -3,12 +3,10 @@ package io.quarkus.ts.security.keycloak.multitenant;
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftRhSso74MultiTenantSecurityIT extends BaseMultiTenantSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/OpenShiftRhSso73Oauth2SecurityIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/OpenShiftRhSso73Oauth2SecurityIT.java
@@ -3,12 +3,10 @@ package io.quarkus.ts.security;
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftRhSso73Oauth2SecurityIT extends BaseOauth2SecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/OpenShiftRhSso74Oauth2SecurityIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/OpenShiftRhSso74Oauth2SecurityIT.java
@@ -3,12 +3,10 @@ package io.quarkus.ts.security;
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftRhSso74Oauth2SecurityIT extends BaseOauth2SecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;

--- a/security/keycloak-oidc-client/pom.xml
+++ b/security/keycloak-oidc-client/pom.xml
@@ -36,6 +36,7 @@
         <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-keycloak</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/OpenShiftRhSso73OidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/OpenShiftRhSso73OidcClientSecurityIT.java
@@ -3,12 +3,10 @@ package io.quarkus.ts.security.keycloak.oidcclient;
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftRhSso73OidcClientSecurityIT extends BaseOidcClientSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;

--- a/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/OpenShiftRhSso74OidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/OpenShiftRhSso74OidcClientSecurityIT.java
@@ -3,12 +3,10 @@ package io.quarkus.ts.security.keycloak.oidcclient;
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftRhSso74OidcClientSecurityIT extends BaseOidcClientSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;

--- a/security/keycloak-webapp/pom.xml
+++ b/security/keycloak-webapp/pom.xml
@@ -34,6 +34,7 @@
         <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-keycloak</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/OpenShiftRhSso73WebappSecurityIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/OpenShiftRhSso73WebappSecurityIT.java
@@ -3,12 +3,10 @@ package io.quarkus.ts.security.keycloak.webapp;
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftRhSso73WebappSecurityIT extends BaseWebappSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/OpenShiftRhSso74WebappSecurityIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/OpenShiftRhSso74WebappSecurityIT.java
@@ -3,12 +3,10 @@ package io.quarkus.ts.security.keycloak.webapp;
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftRhSso74WebappSecurityIT extends BaseWebappSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/OpenShiftRhSso73OidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/OpenShiftRhSso73OidcSecurityIT.java
@@ -3,12 +3,10 @@ package io.quarkus.ts.security;
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftRhSso73OidcSecurityIT extends BaseOidcSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/OpenShiftRhSso74OidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/OpenShiftRhSso74OidcSecurityIT.java
@@ -3,12 +3,10 @@ package io.quarkus.ts.security;
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftRhSso74OidcSecurityIT extends BaseOidcSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/openshift/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/openshift/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
@@ -1,9 +1,7 @@
 package io.quarkus.ts.openshift.sqldb.multiplepus;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftMultiplePersistenceIT extends MultiplePersistenceIT {
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/openshift/sqldb/OpenShiftMariaDB102DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/openshift/sqldb/OpenShiftMariaDB102DatabaseIT.java
@@ -1,9 +1,7 @@
 package io.quarkus.ts.openshift.sqldb;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftMariaDB102DatabaseIT extends MariaDB102DatabaseIT {
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/openshift/sqldb/OpenShiftMariaDB103DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/openshift/sqldb/OpenShiftMariaDB103DatabaseIT.java
@@ -3,10 +3,8 @@ package io.quarkus.ts.openshift.sqldb;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftMariaDB103DatabaseIT extends MariaDB103DatabaseIT {
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/openshift/sqldb/OpenShiftMssqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/openshift/sqldb/OpenShiftMssqlDatabaseIT.java
@@ -3,12 +3,10 @@ package io.quarkus.ts.openshift.sqldb;
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftMssqlDatabaseIT extends AbstractSqlDatabaseIT {
 
     static final int MSSQL_PORT = 1433;

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/openshift/sqldb/OpenShiftMySqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/openshift/sqldb/OpenShiftMySqlDatabaseIT.java
@@ -1,9 +1,7 @@
 package io.quarkus.ts.openshift.sqldb;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftMySqlDatabaseIT extends MySqlDatabaseIT {
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/openshift/sqldb/OpenShiftPostgresql10DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/openshift/sqldb/OpenShiftPostgresql10DatabaseIT.java
@@ -1,9 +1,7 @@
 package io.quarkus.ts.openshift.sqldb;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 public class OpenShiftPostgresql10DatabaseIT extends Postgresql10DatabaseIT {
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/openshift/sqldb/OpenShiftPostgresql12DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/openshift/sqldb/OpenShiftPostgresql12DatabaseIT.java
@@ -3,10 +3,8 @@ package io.quarkus.ts.openshift.sqldb;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
 @OpenShiftScenario
-@EnabledIfOpenShiftScenarioPropertyIsTrue
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftPostgresql12DatabaseIT extends Postgresql12DatabaseIT {
 }


### PR DESCRIPTION
Let's use 999-SNAPSHOT by default.
Also, I've refactored the solution to exclude/include tests by naming convention. For example, if we enable the openshift Maven profile, the tests with names starting with "OpenShift" will be included.
This strategy scales well when adding more types of tests like Serverless or CLI.