### PR TITLE
Add scenarios for Quarkus CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,18 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
+      - name: Build Quarkus CLI
+        run: |
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
+      - name: Install Quarkus CLI
+        run: |
+          cat <<EOF > ./quarkus-dev-cli
+          #!/bin/bash
+          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+          EOF
+          chmod +x ./quarkus-dev-cli
       - name: Build with Maven
-        run: mvn -fae -V -B -s .github/mvn-settings.xml clean verify
+        run: mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -106,9 +116,19 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
+      - name: Build Quarkus CLI
+        run: |
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
+      - name: Install Quarkus CLI
+        run: |
+          cat <<EOF > ./quarkus-dev-cli
+          #!/bin/bash
+          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+          EOF
+          chmod +x ./quarkus-dev-cli
       - name: Build with Maven
         run: |
-          mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=4g
+          mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=4g -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
         if: failure()
         run: |

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -66,9 +66,19 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
+      - name: Build Quarkus CLI
+        run: |
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
+      - name: Install Quarkus CLI
+        run: |
+          cat <<EOF > ./quarkus-dev-cli
+          #!/bin/bash
+          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+          EOF
+          chmod +x ./quarkus-dev-cli
       - name: Test in JVM mode
         run: |
-          mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify
+          mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -109,11 +119,22 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
+      - name: Build Quarkus CLI
+        run: |
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
+      - name: Install Quarkus CLI
+        run: |
+          cat <<EOF > ./quarkus-dev-cli
+          #!/bin/bash
+          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+          EOF
+          chmod +x ./quarkus-dev-cli
       - name: Test in Native mode
         run: |
           mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -Dnative \
             -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=4g \
-            -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }}
+            -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }} \
+            -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
         if: failure()
         run: |

--- a/README.md
+++ b/README.md
@@ -336,3 +336,9 @@ Test checks that the value gets updated.
 An OpenShift test verifying that an OpenShift deployment with a Quarkus application scales up and down.
 
 This test could be extended with some metric gathering.
+
+### `quarkus-cli`
+
+Verifies all the Quarkus CLI features: https://quarkus.io/version/main/guides/cli-tooling
+
+In order to enable this module, the test suite must be executed with `-Dinclude.quarkus-cli-tests`. The Quarkus CLI is expected to be called `quarkus`. We can configure the test suite to use another Quarkus CLI binary name using `-Dts.quarkus.cli.cmd=/path/to/quarkus-dev-cli`.

--- a/pom.xml
+++ b/pom.xml
@@ -35,12 +35,14 @@
         <quarkiverse.apicurio.registry.client.version>0.0.2</quarkiverse.apicurio.registry.client.version>
         <checkstyle.version>8.43</checkstyle.version>
         <jjwt.version>0.11.2</jjwt.version>
+        <profile.id>jvm</profile.id>
 
         <!-- Failsafe inclusions/exclusions rules -->
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>
         <exclude.serverless.openshift.tests>**/Serverless*OpenShift*IT.java</exclude.serverless.openshift.tests>
         <exclude.operator.openshift.tests>**/Operator*OpenShift*IT.java</exclude.operator.openshift.tests>
+        <exclude.quarkus.cli.tests>**/QuarkusCli*IT.java</exclude.quarkus.cli.tests>
     </properties>
 
     <modules>
@@ -70,6 +72,7 @@
         <module>security/keycloak-oidc-client</module>
         <module>sql-db/sql-app</module>
         <module>sql-db/multiple-pus</module>
+        <module>quarkus-cli</module>
     </modules>
 
     <dependencyManagement>
@@ -211,6 +214,9 @@
                                 <exclude>${exclude.serverless.openshift.tests}</exclude>
                                 <exclude>${exclude.operator.openshift.tests}</exclude>
                             </excludes>
+                            <systemProperties>
+                                <profile.id>${profile.id}</profile.id>
+                            </systemProperties>
                         </configuration>
                     </execution>
                 </executions>
@@ -292,6 +298,7 @@
                 </plugins>
             </build>
             <properties>
+                <profile.id>native</profile.id>
                 <quarkus.package.type>native</quarkus.package.type>
                 <quarkus.native.container-build>true</quarkus.native.container-build>
                 <quarkus.native.native-image-xmx>4g</quarkus.native.native-image-xmx>
@@ -358,6 +365,18 @@
             </activation>
             <properties>
                 <exclude.operator.openshift.tests>no</exclude.operator.openshift.tests>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>quarkus-cli-tests</id>
+            <activation>
+                <property>
+                    <name>include.quarkus-cli-tests</name>
+                </property>
+            </activation>
+            <properties>
+                <exclude.quarkus.cli.tests>no</exclude.quarkus.cli.tests>
             </properties>
         </profile>
 

--- a/quarkus-cli/pom.xml
+++ b/quarkus-cli/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>quarkus-cli</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Quarkus QE TS: Quarkus CLI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-cli</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <!-- Disable native build on this module -->
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.package.type>fast-jar</quarkus.package.type>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCompletionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCompletionIT.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.quarkus.cli;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
+
+@Tag("quarkus-cli")
+@QuarkusScenario
+@DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus CLI has been reworked in 2.x")
+public class QuarkusCliCompletionIT {
+
+    static final String EXPECTED_COMPLETION_OUTPUT = "Generates completions for the options and subcommands";
+
+    @Inject
+    static QuarkusCliClient cliClient;
+
+    @Test
+    public void shouldConfigureCompletion() {
+        QuarkusCliClient.Result result = cliClient.run("completion");
+
+        assertTrue(result.isSuccessful(), "Completion command failed: " + result.getOutput());
+        assertTrue(result.getOutput().contains(EXPECTED_COMPLETION_OUTPUT), "Unexpected output: " + result.getOutput());
+    }
+}

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateApplicationIT.java
@@ -1,0 +1,109 @@
+package io.quarkus.ts.quarkus.cli;
+
+import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
+
+@Tag("quarkus-cli")
+@QuarkusScenario
+@DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus CLI has been reworked in 2.x")
+public class QuarkusCliCreateApplicationIT {
+
+    static final String RESTEASY_EXTENSION = "quarkus-resteasy";
+    static final String SMALLRYE_HEALTH_EXTENSION = "quarkus-smallrye-health";
+    static final String RESTEASY_SPRING_WEB_EXTENSION = "quarkus-spring-web";
+
+    @Inject
+    static QuarkusCliClient cliClient;
+
+    @Test
+    public void shouldCreateApplicationOnJvm() {
+        // Create application
+        QuarkusCliRestService app = cliClient.createApplication("app");
+
+        // Should build on Jvm
+        QuarkusCliClient.Result result = app.buildOnJvm();
+        assertTrue(result.isSuccessful(), "The application didn't build on JVM. Output: " + result.getOutput());
+
+        // Start using DEV mode
+        app.start();
+        app.given().get().then().statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void shouldCreateApplicationWithCodeStarter() {
+        // Create application with Resteasy Jackson
+        QuarkusCliRestService app = cliClient.createApplication("app", RESTEASY_SPRING_WEB_EXTENSION);
+
+        // Verify By default, it installs only "quarkus-resteasy"
+        assertInstalledExtensions(app, RESTEASY_SPRING_WEB_EXTENSION);
+
+        // Start using DEV mode
+        app.start();
+        untilAsserted(() -> app.given().get("/greeting").then().statusCode(HttpStatus.SC_OK).and().body(is("Hello Spring")));
+    }
+
+    @Test
+    public void shouldAddAndRemoveExtensions() {
+        // Create application
+        QuarkusCliRestService app = cliClient.createApplication("app");
+
+        // By default, it installs only "quarkus-resteasy"
+        assertInstalledExtensions(app, RESTEASY_EXTENSION);
+
+        // Let's install Quarkus Smallrye Health
+        QuarkusCliClient.Result result = app.installExtension(SMALLRYE_HEALTH_EXTENSION);
+        assertTrue(result.isSuccessful(), SMALLRYE_HEALTH_EXTENSION + " was not installed. Output: " + result.getOutput());
+
+        // Verify both extensions now
+        assertInstalledExtensions(app, RESTEASY_EXTENSION, SMALLRYE_HEALTH_EXTENSION);
+
+        // The health endpoint should be now available
+        app.start();
+        untilAsserted(() -> app.given().get("/q/health").then().statusCode(HttpStatus.SC_OK));
+        app.stop();
+
+        // Let's now remove the Smallrye Health extension
+        result = app.removeExtension(SMALLRYE_HEALTH_EXTENSION);
+        assertTrue(result.isSuccessful(), SMALLRYE_HEALTH_EXTENSION + " was not uninstalled. Output: " + result.getOutput());
+
+        // The health endpoint should be now gone
+        app.start();
+        untilAsserted(() -> app.given().get("/q/health").then().statusCode(HttpStatus.SC_NOT_FOUND));
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "profile.id", matches = "native")
+    public void shouldBuildApplicationOnNative() {
+        // Create application
+        QuarkusCliRestService app = cliClient.createApplication("app");
+
+        // Should build on Native
+        QuarkusCliClient.Result result = app.buildOnNative();
+        assertTrue(result.isSuccessful(), "The application didn't build on Native. Output: " + result.getOutput());
+    }
+
+    private void assertInstalledExtensions(QuarkusCliRestService app, String... expectedExtensions) {
+        List<String> extensions = app.getInstalledExtensions();
+        assertEquals(expectedExtensions.length, extensions.size(),
+                "More than " + expectedExtensions.length + " extension(s) has been installed");
+        Stream.of(expectedExtensions).forEach(expectedExtension -> assertTrue(extensions.contains(expectedExtension),
+                expectedExtension + " not found in " + extensions));
+    }
+}

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -1,0 +1,140 @@
+package io.quarkus.ts.quarkus.cli;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.builder.Version;
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
+
+/**
+ * Note that the extensions list enhancements have been already reported as part
+ * of https://github.com/quarkusio/quarkus/issues/18062 and https://github.com/quarkusio/quarkus/issues/18064.
+ */
+@Tag("quarkus-cli")
+@QuarkusScenario
+@DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus CLI has been reworked in 2.x")
+public class QuarkusCliExtensionsIT {
+
+    static final String AGROAL_EXTENSION_NAME = "Agroal - Database connection pool";
+    static final String AGROAL_EXTENSION_ARTIFACT = "quarkus-agroal";
+    static final String AGROAL_EXTENSION_GUIDE = "https://quarkus.io/guides/datasource";
+    static final List<String> EXPECTED_PLATFORM_VERSIONS = Arrays.asList("1.13.4.Final", "1.13.7.Final");
+
+    @Inject
+    static QuarkusCliClient cliClient;
+
+    private QuarkusCliClient.Result result;
+
+    @Test
+    public void shouldListExtensionsUsingDefaults() {
+        // Current default option behaves as `--origins` which seems wrong to me.
+        // Reported by https://github.com/quarkusio/quarkus/issues/18062.
+        whenGetListExtensions();
+        assertListOriginsOptionOutput();
+    }
+
+    @Test
+    public void shouldListExtensionsUsingName() {
+        whenGetListExtensions("--name");
+        assertListNameOptionOutput();
+    }
+
+    @Test
+    public void shouldListExtensionsUsingOrigins() {
+        whenGetListExtensions("--origins");
+        assertListOriginsOptionOutput();
+    }
+
+    @Test
+    public void shouldListExtensionsUsingConcise() {
+        whenGetListExtensions("--concise");
+        assertListConciseOptionOutput();
+    }
+
+    @Test
+    public void shouldListExtensionsUsingFull() {
+        whenGetListExtensions("--full");
+        assertListFullOptionOutput();
+    }
+
+    @Test
+    public void shouldListExtensionsUsingOtherPlatformVersions() {
+        for (String expectedVersion : EXPECTED_PLATFORM_VERSIONS) {
+            whenGetListExtensions("--origins", "--platform-bom=io.quarkus:quarkus-bom:" + expectedVersion);
+            assertListOriginsOptionOutput(expectedVersion);
+        }
+    }
+
+    @Disabled("Pending for clarification around the --stream option: https://github.com/quarkusio/quarkus/issues/18064")
+    @Test
+    public void shouldListExtensionsUsingStream() {
+        // TODO
+    }
+
+    @Disabled("Pending for clarification around the --installable option: https://github.com/quarkusio/quarkus/issues/18064")
+    @Test
+    public void shouldListExtensionsUsingInstallable() {
+        // TODO
+    }
+
+    private void whenGetListExtensions(String... extraArgs) {
+        List<String> args = new ArrayList<>();
+        args.add("extension");
+        args.add("list");
+        args.addAll(Arrays.asList(extraArgs));
+
+        result = cliClient.run(args.toArray(new String[args.size()]));
+        assertResultIsSuccessful();
+    }
+
+    private void assertListOriginsOptionOutput() {
+        assertListOriginsOptionOutput(Version.getVersion());
+    }
+
+    private void assertListOriginsOptionOutput(String expectedVersion) {
+        // Origins only shows extension name ++ version. Reported by https://github.com/quarkusio/quarkus/issues/18062.
+        assertTrue(result.getOutput().contains(AGROAL_EXTENSION_NAME)
+                        && result.getOutput().contains(expectedVersion)
+                        && !result.getOutput().contains(AGROAL_EXTENSION_ARTIFACT)
+                        && !result.getOutput().contains(AGROAL_EXTENSION_GUIDE),
+                "--origins option output is unexpected. Version: " + expectedVersion + ". Output: " + result.getOutput());
+    }
+
+    private void assertListNameOptionOutput() {
+        // Concise shows only the artifact id
+        assertTrue(result.getOutput().contains(AGROAL_EXTENSION_ARTIFACT)
+                        && !result.getOutput().contains(AGROAL_EXTENSION_NAME),
+                "--name option output is unexpected. Output: " + result.getOutput());
+    }
+
+    private void assertListConciseOptionOutput() {
+        // Concise shows extension name ++ artifact id
+        assertTrue(result.getOutput().contains(AGROAL_EXTENSION_NAME)
+                        && result.getOutput().contains(AGROAL_EXTENSION_ARTIFACT)
+                        && !result.getOutput().contains(AGROAL_EXTENSION_GUIDE),
+                "--concise option output is unexpected. Output: " + result.getOutput());
+    }
+
+    private void assertListFullOptionOutput() {
+        // Full should show also the origins. Reported by https://github.com/quarkusio/quarkus/issues/18062.
+        assertTrue(result.getOutput().contains(AGROAL_EXTENSION_NAME)
+                        && result.getOutput().contains(AGROAL_EXTENSION_ARTIFACT)
+                        && result.getOutput().contains(AGROAL_EXTENSION_GUIDE),
+                "--full option output is unexpected. Output: " + result.getOutput());
+    }
+
+    private void assertResultIsSuccessful() {
+        assertTrue(result.isSuccessful(), "Extensions list command didn't work. Output: " + result.getOutput());
+    }
+}

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliHelpIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliHelpIT.java
@@ -1,0 +1,60 @@
+package io.quarkus.ts.quarkus.cli;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
+
+@Tag("quarkus-cli")
+@QuarkusScenario
+@DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus CLI has been reworked in 2.x")
+public class QuarkusCliHelpIT {
+
+    static final String HELP_COMMAND = "--help";
+
+    @Inject
+    static QuarkusCliClient cliClient;
+
+    @Test
+    public void shouldCommandsHaveHelpOption() {
+        for (CommandWithHelp command : CommandWithHelp.values()) {
+            QuarkusCliClient.Result result = cliClient.run(command.getCommand(), HELP_COMMAND);
+            assertTrue(result.isSuccessful(), "Help command for '" + command.getCommand() + "' didn't work");
+            assertTrue(result.getOutput().contains(command.getExpectedHelp()),
+                    "Unexpected help output for Command '" + command.getCommand() + "': " + result.getOutput());
+        }
+    }
+
+    enum CommandWithHelp {
+        CREATE("create", "Create a new project."),
+        CREATE_CLI("create cli", "Create a Quarkus command-line project."),
+        CREATE_APP("create app", "Create a Quarkus application project."),
+        BUILD("build", "Build the current project."),
+        DEV("dev", "Run the current project in dev (live coding) mode."),
+        EXTENSION("extension", "List, add, and remove extensions of an existing project."),
+        COMPLETION("completion", "bash/zsh completion:  source <(quarkus completion)"),
+        VERSION("version", "Display version information");
+
+        private final String command;
+        private final String expectedHelp;
+
+        CommandWithHelp(String command, String expectedHelp) {
+            this.command = command;
+            this.expectedHelp = expectedHelp;
+        }
+
+        public String getCommand() {
+            return command;
+        }
+
+        public String getExpectedHelp() {
+            return expectedHelp;
+        }
+    }
+}

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
@@ -1,0 +1,146 @@
+package io.quarkus.ts.quarkus.cli;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
+import io.quarkus.test.utils.FileUtils;
+
+@Tag("quarkus-cli")
+@QuarkusScenario
+@DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus CLI has been reworked in 2.x")
+public class QuarkusCliSpecialCharsIT {
+
+    static final String FOLDER_WITH_SPACES = "s p a c e s";
+    static final String FOLDER_WITH_SPECIAL_CHARS = ",;~!@#$%^&()";
+    static final String FOLDER_WITH_DIACRITICS = "ěščřžýáíéůú";
+    static final String FOLDER_WITH_JAPANESE = "元気かい";
+    static final String FOLDER_WITH_INTERNATIONALIZATION = "Îñţérñåţîöñåļîžåţîờñ";
+
+    static final String ARTIFACT_ID = "app";
+    static final String EXPECTED_BUILD_OUTPUT = "BUILD SUCCESS";
+    static final String PROFILE_ID = "profile.id";
+    static final String NATIVE = "native";
+    static final Path TARGET = Path.of("target");
+
+    @Inject
+    static QuarkusCliClient cliClient;
+
+    private QuarkusCliClient.Result result;
+
+    @Test
+    public void shouldCreateApplicationOnJvmWithSpaces() {
+        assertCreateJavaApplicationAtFolder(FOLDER_WITH_SPACES);
+    }
+
+    @Test
+    public void shouldCreateApplicationOnJvmWithSpecialChars() {
+        assertCreateJavaApplicationAtFolder(FOLDER_WITH_SPECIAL_CHARS);
+    }
+
+    @Test
+    public void shouldCreateApplicationOnJvmWithDiacritics() {
+        assertCreateJavaApplicationAtFolder(FOLDER_WITH_DIACRITICS);
+    }
+
+    @Test
+    public void shouldCreateApplicationOnJvmWithJapanese() {
+        assertCreateJavaApplicationAtFolder(FOLDER_WITH_JAPANESE);
+    }
+
+    @Test
+    public void shouldCreateApplicationOnJvmWithInternationalization() {
+        assertCreateJavaApplicationAtFolder(FOLDER_WITH_INTERNATIONALIZATION);
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = PROFILE_ID, matches = NATIVE)
+    public void shouldCreateApplicationOnNativeWithSpaces() {
+        assertCreateNativeApplicationAtFolder(FOLDER_WITH_SPACES);
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = PROFILE_ID, matches = NATIVE)
+    public void shouldCreateApplicationOnNativeWithSpecialChars() {
+        assertCreateNativeApplicationAtFolder(FOLDER_WITH_SPECIAL_CHARS);
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = PROFILE_ID, matches = NATIVE)
+    public void shouldCreateApplicationOnNativeWithDiacritics() {
+        assertCreateNativeApplicationAtFolder(FOLDER_WITH_DIACRITICS);
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = PROFILE_ID, matches = NATIVE)
+    public void shouldCreateApplicationOnNativeWithJapanese() {
+        assertCreateNativeApplicationAtFolder(FOLDER_WITH_JAPANESE);
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = PROFILE_ID, matches = NATIVE)
+    public void shouldCreateApplicationOnNativeWithInternationalization() {
+        assertCreateNativeApplicationAtFolder(FOLDER_WITH_INTERNATIONALIZATION);
+    }
+
+    private void assertCreateNativeApplicationAtFolder(String folder) {
+        // Should create app in a folder
+        whenCreateAppAt(folder);
+        thenResultIsSuccessful();
+
+        // Should be able to build the app
+        whenBuildOnNativeAppAt(folder);
+        thenBuildOutputIsSuccessful();
+
+        // Clean Up
+        deleteFolder(folder);
+    }
+
+    private void assertCreateJavaApplicationAtFolder(String folder) {
+        // Should create app in a folder
+        whenCreateAppAt(folder);
+        thenResultIsSuccessful();
+
+        // Should be able to build the app
+        whenBuildOnJvmAppAt(folder);
+        thenBuildOutputIsSuccessful();
+
+        // Clean Up
+        deleteFolder(folder);
+    }
+
+    private void whenBuildOnNativeAppAt(String folder) {
+        result = cliClient.run(TARGET.resolve(folder + "/" + ARTIFACT_ID), "build", "--native");
+    }
+
+    private void whenBuildOnJvmAppAt(String folder) {
+        result = cliClient.run(TARGET.resolve(folder + "/" + ARTIFACT_ID), "build");
+    }
+
+    private void whenCreateAppAt(String folder) {
+        result = cliClient.run("create", "app", "--artifact-id=" + ARTIFACT_ID, "--output-directory=" + folder);
+    }
+
+    private void thenResultIsSuccessful() {
+        assertTrue(result.isSuccessful(), "Something failed, output: " + result.getOutput());
+    }
+
+    private void thenBuildOutputIsSuccessful() {
+        thenResultIsSuccessful();
+        assertTrue(result.getOutput().contains(EXPECTED_BUILD_OUTPUT), "Unexpected output content: " + result.getOutput());
+    }
+
+    private void deleteFolder(String folder) {
+        FileUtils.deletePath(TARGET.resolve(folder));
+    }
+
+}

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliVersionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliVersionIT.java
@@ -1,0 +1,119 @@
+package io.quarkus.ts.quarkus.cli;
+
+import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import io.quarkus.builder.Version;
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
+
+@Tag("quarkus-cli")
+@QuarkusScenario
+@DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus CLI has been reworked in 2.x")
+public class QuarkusCliVersionIT {
+
+    static final String RESTEASY_EXTENSION = "quarkus-resteasy";
+    static final String SMALLRYE_HEALTH_EXTENSION = "quarkus-smallrye-health";
+    static final String RESTEASY_SPRING_WEB_EXTENSION = "quarkus-spring-web";
+
+    @Inject
+    static QuarkusCliClient cliClient;
+
+    @Test
+    public void shouldVersionMatchQuarkusVersion() {
+        // Using option
+        assertEquals("Client Version " + Version.getVersion(), cliClient.run("version").getOutput());
+
+        // Using shortcut
+        assertEquals("Client Version " + Version.getVersion(), cliClient.run("-v").getOutput());
+    }
+
+    @Test
+    public void shouldCreateApplicationOnJvm() {
+        // Create application
+        QuarkusCliRestService app = cliClient.createApplication("app");
+
+        // Should build on Jvm
+        QuarkusCliClient.Result result = app.buildOnJvm();
+        assertTrue(result.isSuccessful(), "The application didn't build on JVM. Output: " + result.getOutput());
+
+        // Start using DEV mode
+        app.start();
+        app.given().get().then().statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void shouldCreateApplicationWithCodeStarter() {
+        // Create application with Resteasy Jackson
+        QuarkusCliRestService app = cliClient.createApplication("app", RESTEASY_SPRING_WEB_EXTENSION);
+
+        // Verify By default, it installs only "quarkus-resteasy"
+        assertInstalledExtensions(app, RESTEASY_SPRING_WEB_EXTENSION);
+
+        // Start using DEV mode
+        app.start();
+        untilAsserted(() -> app.given().get("/greeting").then().statusCode(HttpStatus.SC_OK).and().body(is("Hello Spring")));
+    }
+
+    @Test
+    public void shouldAddAndRemoveExtensions() {
+        // Create application
+        QuarkusCliRestService app = cliClient.createApplication("app");
+
+        // By default, it installs only "quarkus-resteasy"
+        assertInstalledExtensions(app, RESTEASY_EXTENSION);
+
+        // Let's install Quarkus Smallrye Health
+        QuarkusCliClient.Result result = app.installExtension(SMALLRYE_HEALTH_EXTENSION);
+        assertTrue(result.isSuccessful(), SMALLRYE_HEALTH_EXTENSION + " was not installed. Output: " + result.getOutput());
+
+        // Verify both extensions now
+        assertInstalledExtensions(app, RESTEASY_EXTENSION, SMALLRYE_HEALTH_EXTENSION);
+
+        // The health endpoint should be now available
+        app.start();
+        untilAsserted(() -> app.given().get("/q/health").then().statusCode(HttpStatus.SC_OK));
+        app.stop();
+
+        // Let's now remove the Smallrye Health extension
+        result = app.removeExtension(SMALLRYE_HEALTH_EXTENSION);
+        assertTrue(result.isSuccessful(), SMALLRYE_HEALTH_EXTENSION + " was not uninstalled. Output: " + result.getOutput());
+
+        // The health endpoint should be now gone
+        app.start();
+        untilAsserted(() -> app.given().get("/q/health").then().statusCode(HttpStatus.SC_NOT_FOUND));
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "profile.id", matches = "native")
+    public void shouldBuildApplicationOnNative() {
+        // Create application
+        QuarkusCliRestService app = cliClient.createApplication("app");
+
+        // Should build on Native
+        QuarkusCliClient.Result result = app.buildOnNative();
+        assertTrue(result.isSuccessful(), "The application didn't build on Native. Output: " + result.getOutput());
+    }
+
+    private void assertInstalledExtensions(QuarkusCliRestService app, String... expectedExtensions) {
+        List<String> extensions = app.getInstalledExtensions();
+        assertEquals(expectedExtensions.length, extensions.size(),
+                "More than " + expectedExtensions.length + " extension(s) has been installed");
+        Stream.of(expectedExtensions).forEach(expectedExtension -> assertTrue(extensions.contains(expectedExtension),
+                expectedExtension + " not found in " + extensions));
+    }
+}

--- a/quarkus-cli/src/test/resources/test.properties
+++ b/quarkus-cli/src/test/resources/test.properties
@@ -1,0 +1,1 @@
+ts.global.generated-service.enabled=false


### PR DESCRIPTION
The first set of scenarios include:
- Check Quarkus CLI version
- Create / Build applications with/out extensions. On JVM and Native
- Run applications on DEV mode
- Check completion installation
- Check Help option for some commands
- Check with special characters
- Check list of extensions when not in a current Quarkus project