### PR TITLE
Added lifecycle module ++ coverage of quarkus openshift arguments

### DIFF
--- a/OPENSHIFT_TS_MIGRATION_STATUS.md
+++ b/OPENSHIFT_TS_MIGRATION_STATUS.md
@@ -37,3 +37,4 @@
 | sql-db/multiple-pus | sql-db/multiple-pus |
 | deployment-strategies/quarkus | http/http-minimum with tag 'use-quarkus-openshift-extension' |
 | deployment-strategies/quarkus-serverless | http/http-minimum with tag 'use-quarkus-openshift-extension' |
+| lifecycle-application | lifecycle-application |

--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>lifecycle-application</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Quarkus QE TS: Lifecycle Application</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/lifecycle-application/src/main/java/io/quarkus/ts/lifecycle/ArgsResource.java
+++ b/lifecycle-application/src/main/java/io/quarkus/ts/lifecycle/ArgsResource.java
@@ -1,0 +1,25 @@
+package io.quarkus.ts.lifecycle;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.runtime.annotations.CommandLineArguments;
+
+@Path("/args")
+public class ArgsResource {
+    @Inject
+    @CommandLineArguments
+    String[] args;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String get() {
+        return Stream.of(args).collect(Collectors.joining(","));
+    }
+}

--- a/lifecycle-application/src/main/java/io/quarkus/ts/lifecycle/Main.java
+++ b/lifecycle-application/src/main/java/io/quarkus/ts/lifecycle/Main.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.lifecycle;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+@QuarkusMain
+public final class Main {
+    private static final Logger LOG = Logger.getLogger(Main.class);
+    private static final String ARGUMENTS_FROM_MAIN = "Received arguments: ";
+
+    private Main() {
+
+    }
+
+    public static void main(String... args) {
+        LOG.info(ARGUMENTS_FROM_MAIN + String.join(",", args));
+        Quarkus.run(args);
+    }
+}

--- a/lifecycle-application/src/main/resources/application.properties
+++ b/lifecycle-application/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.openshift.arguments=ARG1,ARG2

--- a/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/LifecycleApplicationIT.java
+++ b/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/LifecycleApplicationIT.java
@@ -1,0 +1,38 @@
+package io.quarkus.ts.lifecycle;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class LifecycleApplicationIT {
+
+    static final String LOGGING_PROPERTY = "-Djava.util.logging.manager=org.jboss.logmanager.LogManager";
+
+    @QuarkusApplication
+    static RestService app = new RestService();
+
+    @Test
+    public void shouldArgumentsNotContainLoggingProperty() {
+        String actualArguments = app.given().get("/args")
+                .then().statusCode(HttpStatus.SC_OK).extract().asString();
+
+        assertFalse(StringUtils.contains(actualArguments, LOGGING_PROPERTY),
+                "Actual arguments contain unexpected properties: " + actualArguments);
+    }
+
+    @Test
+    public void shouldPrintMessagesFromQuarkusMain() {
+        String argumentsLine = app.getLogs().stream().collect(Collectors.joining());
+        assertFalse(argumentsLine.contains(LOGGING_PROPERTY),
+                "Pod log contain unexpected properties. Actual content: " + argumentsLine);
+    }
+}

--- a/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/OpenShiftLifecycleApplicationIT.java
+++ b/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/OpenShiftLifecycleApplicationIT.java
@@ -1,0 +1,34 @@
+package io.quarkus.ts.lifecycle;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
+public class OpenShiftLifecycleApplicationIT extends LifecycleApplicationIT {
+
+    private static final List<String> EXPECTED_ARGUMENTS = Arrays.asList("ARG1", "ARG2");
+
+    @Test
+    public void shouldReturnCustomArguments() {
+        String actualArguments = app.given().get("/args")
+                .then().statusCode(HttpStatus.SC_OK).extract().asString();
+        // From endpoint
+        assertExpectedArguments(actualArguments);
+        // From logs
+        assertExpectedArguments(app.getLogs().stream().collect(Collectors.joining()));
+    }
+
+    private void assertExpectedArguments(String actualArguments) {
+        EXPECTED_ARGUMENTS.forEach(arg -> assertTrue(actualArguments.contains(arg),
+                "Expected argument " + arg + " was not found in actual arguments: " + actualArguments));
+    }
+}


### PR DESCRIPTION
The quarkus openshift arguments was fixed as part of https://github.com/quarkusio/quarkus/pull/17889

Fix https://github.com/quarkus-qe/quarkus-test-suite/issues/70

NOTE that I verify this module to be working locally and in OpenShift, but the test suite needs to be using the quarkus test framework 0.0.3 (it depends on https://github.com/quarkus-qe/quarkus-test-framework/pull/140).