### PR TITLE
Migrate external applications modules from Quarkus OpenShift TS

### DIFF
--- a/OPENSHIFT_TS_MIGRATION_STATUS.md
+++ b/OPENSHIFT_TS_MIGRATION_STATUS.md
@@ -38,3 +38,6 @@
 | deployment-strategies/quarkus | http/http-minimum with tag 'use-quarkus-openshift-extension' |
 | deployment-strategies/quarkus-serverless | http/http-minimum with tag 'use-quarkus-openshift-extension' |
 | lifecycle-application | lifecycle-application |
+| external-applications | external-applications/todo-demo-app |
+| external-applications | external-applications/quarkus-workshop-super-heroes |
+| external-applications | external-applications/quickstart-using-s2i |

--- a/README.md
+++ b/README.md
@@ -335,6 +335,30 @@ An OpenShift test verifying that an OpenShift deployment with a Quarkus applicat
 
 This test could be extended with some metric gathering.
 
+### `external-applications`
+
+It contains three applications:
+
+#### `todo-demo-app`
+
+This test produces an S2I source deployment config for OpenShift with [todo-demo-app](https://github.com/quarkusio/todo-demo-app) 
+serving a simple todo checklist. The code for this application lives outside of the test suite's codebase.
+
+The test verifies that the application with a sample of libraries is buildable and deployable via supported means.
+
+#### `quarkus-workshop-super-heroes`
+
+This test produces an S2I source deployment config for OpenShift with 
+[Quarkus Super heroes workshop](https://github.com/quarkusio/quarkus-workshops) application.
+The code for this application lives outside of the test suite's codebase.
+
+The test verifies that the application is buildable and deployable. It also verifies that the REST and MicroProfile APIs
+function properly on OpenShift, as well as the database integrations.
+
+#### `quickstart-using-s2i`
+
+This test mimics the quickstart tutorial provided in OpenShift.
+
 ### `quarkus-cli`
 
 Verifies all the Quarkus CLI features: https://quarkus.io/version/main/guides/cli-tooling

--- a/external-applications/pom.xml
+++ b/external-applications/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>external-applications</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: External Applications</name>
+    <build>
+        <plugins>
+            <!-- Skip Quarkus Maven plugin build on JVM and Native since we're going to deploy external apps -->
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftQuickstartUsingS2iIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftQuickstartUsingS2iIT.java
@@ -1,0 +1,26 @@
+package io.quarkus.ts.external.applications;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
+import io.quarkus.test.services.GitRepositoryQuarkusApplication;
+
+@DisabledOnNative
+@DisabledOnQuarkusVersion(version = "9\\..*", reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
+@OpenShiftScenario
+public class OpenShiftQuickstartUsingS2iIT {
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
+    static final RestService app = new RestService();
+
+    @Test
+    public void verify() {
+        app.given()
+                .get("/hello")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+}

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftTodoDemoIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftTodoDemoIT.java
@@ -1,0 +1,26 @@
+package io.quarkus.ts.external.applications;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
+import io.quarkus.test.services.GitRepositoryQuarkusApplication;
+
+@DisabledOnNative
+@DisabledOnQuarkusVersion(version = "9\\..*", reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
+@OpenShiftScenario
+public class OpenShiftTodoDemoIT {
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/todo-demo-app.git", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests=true")
+    static final RestService app = new RestService();
+
+    @Test
+    public void verify() {
+        app.given()
+                .get()
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+}

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
@@ -1,0 +1,201 @@
+package io.quarkus.ts.external.applications;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.DefaultService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.GitRepositoryQuarkusApplication;
+import io.restassured.http.ContentType;
+
+@DisabledOnNative
+@DisabledOnQuarkusVersion(version = "9\\..*", reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
+@OpenShiftScenario
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class OpenShiftWorkshopHeroesIT {
+    private static String heroId;
+
+    private static final String DEFAULT_NAME = "Test Hero";
+    private static final String UPDATED_NAME = "Updated Test Hero";
+    private static final String DEFAULT_OTHER_NAME = "Other Test Hero Name";
+    private static final String UPDATED_OTHER_NAME = "Updated Other Test Hero Name";
+    private static final String DEFAULT_PICTURE = "harold.png";
+    private static final String UPDATED_PICTURE = "hackerman.png";
+    private static final String DEFAULT_POWERS = "Partakes in this test";
+    private static final String UPDATED_POWERS = "Partakes in update test";
+    private static final int DEFAULT_LEVEL = 42;
+    private static final int UPDATED_LEVEL = 43;
+
+    private static final String POSTGRESQL_USER = "superman";
+    private static final String POSTGRESQL_PASSWORD = "superman";
+    private static final String POSTGRESQL_DATABASE = "heroes-database";
+    private static final int POSTGRESQL_PORT = 5432;
+
+    @Container(image = "registry.redhat.io/rhscl/postgresql-12-rhel7", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    static DefaultService database = new DefaultService()
+            .withProperty("POSTGRESQL_USER", POSTGRESQL_USER)
+            .withProperty("POSTGRESQL_PASSWORD", POSTGRESQL_PASSWORD)
+            .withProperty("POSTGRESQL_DATABASE", POSTGRESQL_DATABASE);
+
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-workshops.git", contextDir = "quarkus-workshop-super-heroes/super-heroes/rest-hero", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests")
+    static final RestService app = new RestService()
+            .withProperty("quarkus.http.port", "8080")
+            .withProperty("quarkus.datasource.username", POSTGRESQL_USER)
+            .withProperty("quarkus.datasource.password", POSTGRESQL_PASSWORD)
+            .withProperty("quarkus.datasource.jdbc.url",
+                    () -> database.getHost().replace("http", "jdbc:postgresql") + ":" + database.getPort() + "/"
+                            + POSTGRESQL_DATABASE);
+
+    @Test
+    public void testHello() {
+        app.given()
+                .get("/api/heroes/hello")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is("hello"));
+    }
+
+    @Test
+    public void testOpenApi() {
+        app.given()
+                .accept(ContentType.JSON)
+                .when().get("/q/openapi")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testLiveness() {
+        app.given()
+                .accept(ContentType.JSON)
+                .when().get("/q/health/live")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testReadiness() {
+        app.given()
+                .accept(ContentType.JSON)
+                .when().get("/q/health/ready")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testMetrics() {
+        app.given()
+                .accept(ContentType.JSON)
+                .when().get("/q/metrics/application")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    @Order(1)
+    public void testCreateHero() {
+        Hero hero = new Hero();
+        hero.name = DEFAULT_NAME;
+        hero.otherName = DEFAULT_OTHER_NAME;
+        hero.level = DEFAULT_LEVEL;
+        hero.picture = DEFAULT_PICTURE;
+        hero.powers = DEFAULT_POWERS;
+
+        String location = app.given()
+                .body(hero)
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .when()
+                .post("/api/heroes")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .extract().header("Location");
+        assertTrue(location.contains("/api/heroes"));
+
+        String[] segments = location.split("/");
+        heroId = segments[segments.length - 1];
+        assertNotNull(heroId);
+
+        app.given()
+                .pathParam("id", heroId)
+                .when().get("/api/heroes/{id}")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .contentType(ContentType.JSON)
+                .body("name", is(DEFAULT_NAME))
+                .body("otherName", is(DEFAULT_OTHER_NAME))
+                .body("level", is(DEFAULT_LEVEL * 3))
+                .body("picture", is(DEFAULT_PICTURE))
+                .body("powers", is(DEFAULT_POWERS));
+    }
+
+    @Test
+    @Order(2)
+    public void testUpdateHero() {
+        Hero hero = new Hero();
+        hero.id = Long.valueOf(heroId);
+        hero.name = UPDATED_NAME;
+        hero.otherName = UPDATED_OTHER_NAME;
+        hero.level = UPDATED_LEVEL;
+        hero.picture = UPDATED_PICTURE;
+        hero.powers = UPDATED_POWERS;
+
+        app.given()
+                .body(hero)
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .when()
+                .put("/api/heroes")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .contentType(ContentType.JSON)
+                .body("name", is(UPDATED_NAME))
+                .body("otherName", is(UPDATED_OTHER_NAME))
+                .body("level", is(UPDATED_LEVEL))
+                .body("picture", is(UPDATED_PICTURE))
+                .body("powers", is(UPDATED_POWERS));
+    }
+
+    @Test
+    @Order(3)
+    public void testDeleteHero() {
+        app.given()
+                .pathParam("id", heroId)
+                .when().delete("/api/heroes/{id}")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    @Test
+    @Order(4)
+    public void testCalledOperationMetrics() {
+        app.given()
+                .accept(ContentType.JSON)
+                .when().get("/q/metrics/application")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("'io.quarkus.workshop.superheroes.hero.HeroResource.countCreateHero'", is(1))
+                .body("'io.quarkus.workshop.superheroes.hero.HeroResource.countUpdateHero'", is(1))
+                .body("'io.quarkus.workshop.superheroes.hero.HeroResource.countDeleteHero'", is(1));
+    }
+
+    static class Hero {
+        public Long id;
+        public String name;
+        public String otherName;
+        public int level;
+        public String picture;
+        public String powers;
+    }
+}

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopVillainsIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopVillainsIT.java
@@ -1,0 +1,202 @@
+package io.quarkus.ts.external.applications;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.http.HttpStatus;
+import org.hamcrest.core.Is;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.DefaultService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.GitRepositoryQuarkusApplication;
+import io.restassured.http.ContentType;
+
+@DisabledOnNative
+@DisabledOnQuarkusVersion(version = "9\\..*", reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
+@OpenShiftScenario
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class OpenShiftWorkshopVillainsIT {
+    private static String villainId;
+
+    private static final String DEFAULT_NAME = "Test Villain";
+    private static final String UPDATED_NAME = "Updated Test Villain";
+    private static final String DEFAULT_OTHER_NAME = "Other Test Villain Name";
+    private static final String UPDATED_OTHER_NAME = "Updated Other Test Villain Name";
+    private static final String DEFAULT_PICTURE = "harold.png";
+    private static final String UPDATED_PICTURE = "hackerman.png";
+    private static final String DEFAULT_POWERS = "Partakes in this test";
+    private static final String UPDATED_POWERS = "Partakes in update test";
+    private static final int DEFAULT_LEVEL = 42;
+    private static final int UPDATED_LEVEL = 43;
+
+    private static final String POSTGRESQL_USER = "superbad";
+    private static final String POSTGRESQL_PASSWORD = "superbad";
+    private static final String POSTGRESQL_DATABASE = "villains-database";
+    private static final int POSTGRESQL_PORT = 5432;
+
+    @Container(image = "registry.redhat.io/rhscl/postgresql-12-rhel7", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    static DefaultService database = new DefaultService()
+            .withProperty("POSTGRESQL_USER", POSTGRESQL_USER)
+            .withProperty("POSTGRESQL_PASSWORD", POSTGRESQL_PASSWORD)
+            .withProperty("POSTGRESQL_DATABASE", POSTGRESQL_DATABASE);
+
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-workshops.git", contextDir = "quarkus-workshop-super-heroes/super-heroes/rest-villain", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests")
+    static final RestService app = new RestService()
+            .withProperty("quarkus.http.port", "8080")
+            .withProperty("quarkus.datasource.username", POSTGRESQL_USER)
+            .withProperty("quarkus.datasource.password", POSTGRESQL_PASSWORD)
+            .withProperty("quarkus.datasource.jdbc.url",
+                    () -> database.getHost().replace("http", "jdbc:postgresql") + ":" + database.getPort() + "/"
+                            + POSTGRESQL_DATABASE);
+
+    @Test
+    public void testHello() {
+        app.given()
+                .get("/api/villains/hello")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is("hello"));
+    }
+
+    @Test
+    public void testOpenApi() {
+        app.given()
+                .accept(ContentType.JSON)
+                .when().get("/q/openapi")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testLiveness() {
+        app.given()
+                .accept(ContentType.JSON)
+                .when().get("/q/health/live")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testReadiness() {
+        app.given()
+                .accept(ContentType.JSON)
+                .when().get("/q/health/ready")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testMetrics() {
+        app.given()
+                .accept(ContentType.JSON)
+                .when().get("/q/metrics/application")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    @Order(1)
+    public void testCreateVillain() {
+        Villain villain = new Villain();
+        villain.name = DEFAULT_NAME;
+        villain.otherName = DEFAULT_OTHER_NAME;
+        villain.level = DEFAULT_LEVEL;
+        villain.picture = DEFAULT_PICTURE;
+        villain.powers = DEFAULT_POWERS;
+
+        String location = app.given()
+                .body(villain)
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .when()
+                .post("/api/villains")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .extract().header("Location");
+        assertTrue(location.contains("/api/villains"));
+
+        String[] segments = location.split("/");
+        villainId = segments[segments.length - 1];
+        assertNotNull(villainId);
+
+        app.given()
+                .pathParam("id", villainId)
+                .when().get("/api/villains/{id}")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .contentType(ContentType.JSON)
+                .body("name", is(DEFAULT_NAME))
+                .body("otherName", is(DEFAULT_OTHER_NAME))
+                .body("level", is(DEFAULT_LEVEL * 2))
+                .body("picture", is(DEFAULT_PICTURE))
+                .body("powers", is(DEFAULT_POWERS));
+    }
+
+    @Test
+    @Order(2)
+    public void testUpdateVillain() {
+        Villain villain = new Villain();
+        villain.id = Long.valueOf(villainId);
+        villain.name = UPDATED_NAME;
+        villain.otherName = UPDATED_OTHER_NAME;
+        villain.level = UPDATED_LEVEL;
+        villain.picture = UPDATED_PICTURE;
+        villain.powers = UPDATED_POWERS;
+
+        app.given()
+                .body(villain)
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .when()
+                .put("/api/villains")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .contentType(ContentType.JSON)
+                .body("name", Is.is(UPDATED_NAME))
+                .body("otherName", Is.is(UPDATED_OTHER_NAME))
+                .body("level", Is.is(UPDATED_LEVEL))
+                .body("picture", Is.is(UPDATED_PICTURE))
+                .body("powers", Is.is(UPDATED_POWERS));
+    }
+
+    @Test
+    @Order(3)
+    public void testDeleteVillain() {
+        app.given()
+                .pathParam("id", villainId)
+                .when().delete("/api/villains/{id}")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    @Test
+    @Order(4)
+    public void testCalledOperationMetrics() {
+        app.given()
+                .accept(ContentType.JSON)
+                .when().get("/q/metrics/application")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("'io.quarkus.workshop.superheroes.villain.VillainResource.countCreateVillain'", is(1))
+                .body("'io.quarkus.workshop.superheroes.villain.VillainResource.countUpdateVillain'", is(1))
+                .body("'io.quarkus.workshop.superheroes.villain.VillainResource.countDeleteVillain'", is(1));
+    }
+
+    static class Villain {
+        public Long id;
+        public String name;
+        public String otherName;
+        public int level;
+        public String picture;
+        public String powers;
+    }
+}

--- a/external-applications/src/test/resources/test.properties
+++ b/external-applications/src/test/resources/test.properties
@@ -1,0 +1,3 @@
+# Building external apps in OpenShift can be quite slow when downloading Maven dependencies
+ts.global.startup.timeout=20m
+ts.database.openshift.use-internal-service-as-url=true

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,8 @@
         <module>security/keycloak-oidc-client</module>
         <module>sql-db/sql-app</module>
         <module>sql-db/multiple-pus</module>
+        <module>lifecycle-application</module>
+        <module>external-applications</module>
         <module>quarkus-cli</module>
     </modules>
     <dependencyManagement>
@@ -175,6 +177,7 @@
                 <version>${quarkus-plugin.version}</version>
                 <executions>
                     <execution>
+                        <id>build</id>
                         <goals>
                             <goal>build</goal>
                             <goal>generate-code</goal>


### PR DESCRIPTION
### `external-applications`

It contains three applications:

#### `todo-demo-app`

This test produces an S2I source deployment config for OpenShift with [todo-demo-app](https://github.com/quarkusio/todo-demo-app) 
serving a simple todo checklist. The code for this application lives outside of the test suite's codebase.

The test verifies that the application with a sample of libraries is buildable and deployable via supported means.

#### `quarkus-workshop-super-heroes`

This test produces an S2I source deployment config for OpenShift with 
[Quarkus Super heroes workshop](https://github.com/quarkusio/quarkus-workshops) application.
The code for this application lives outside of the test suite's codebase.

The test verifies that the application is buildable and deployable. It also verifies that the REST and MicroProfile APIs
function properly on OpenShift, as well as the database integrations.

#### `quickstart-using-s2i`

This test mimics the quickstart tutorial provided in OpenShift.

Fix https://github.com/quarkus-qe/quarkus-test-suite/issues/68