### PR TITLE
Upgrade Kafka to use 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
           done
 
           MODULES_ARG="${CHANGED// /,}"
-          if [[ -n ${MODULES} ]]; then
+          if [[ -n ${MODULES_ARG} ]]; then
             mvn -fae -V -B -s .github/mvn-settings.xml -fae -pl $MODULES_ARG clean verify -Dnative \
                         -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=4g \
                         -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"

--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@
                                         <quarkus.native.native-image-xmx>${quarkus.native.native-image-xmx}</quarkus.native.native-image-xmx>
                                         <quarkus.native.builder-image>${quarkus.native.builder-image}</quarkus.native.builder-image>
                                         <!-- Product Supported -->
-                                        <amq-streams.image>registry.redhat.io/amq7/amq-streams-kafka-24-rhel7</amq-streams.image>
+                                        <amq-streams.image>registry.redhat.io/amq7/amq-streams-kafka-27-rhel7</amq-streams.image>
                                         <amq-streams.version>1.7.0</amq-streams.version>
                                     </systemProperties>
                                 </configuration>


### PR DESCRIPTION
This was done in OpenShift Test Suite as part of https://github.com/quarkus-qe/quarkus-openshift-test-suite/commit/5d9eadd0dbf72b5cbf531bb08f26d6bbbb7c9c74.

For Strimzi in local, we're already using the version 2.7, but an old version, I will update it in the test framework as a low priority task.

Fix https://github.com/quarkus-qe/quarkus-test-suite/issues/67