### PR TITLE
Migrate 015-quarkus-micrometer into micrometer/prometheus from Beefy

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,16 @@ There is a PrimeNumberResource that checks whether an integer is prime or not. T
 
 Where `{uniqueId}` is an unique identifier that is calculated at startup time to uniquely identify the metrics of the application.
 
+This module also covers the usage of `MeterRegistry` and `MicroProfile API`: 
+                                     
+- The `MeterRegistry` approach includes three scenarios: 
+`simple`: single call will increment the counter.
+`forloop`: will increment the counter a number of times.
+`forloop parallel`: will increment the counter a number of times using a parallel flow.
+- The `MicroProfile API` approach will include only the `simple` scenario.
+
+Moreover, we also cover the `HTTP Server` metrics in order to verify the `count`, `sum` and `count` metrics work as expected.
+
 In order to run this module, the OpenShift user must have permission to create ServiceMonitor CRDs and access to the `openshift-user-workload-monitoring` namespace. See [Other Prerequisites](#other-prerequisites) section.
 
 ### `micrometer/prometheus-kafka`

--- a/micrometer/prometheus-kafka/src/test/resources/service-monitor.yaml
+++ b/micrometer/prometheus-kafka/src/test/resources/service-monitor.yaml
@@ -8,6 +8,7 @@ spec:
   endpoints:
     - interval: 30s
       targetPort: 8080
+      path: /q/metrics
       scheme: http
   selector:
     matchLabels:

--- a/micrometer/prometheus/pom.xml
+++ b/micrometer/prometheus/pom.xml
@@ -31,5 +31,9 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/micrometer/prometheus/src/main/java/io/quarkus/ts/micrometer/prometheus/UsingMicroProfilePingPongResource.java
+++ b/micrometer/prometheus/src/main/java/io/quarkus/ts/micrometer/prometheus/UsingMicroProfilePingPongResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.micrometer.prometheus;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.metrics.annotation.Counted;
+
+@Path("/using-microprofile-pingpong")
+public class UsingMicroProfilePingPongResource {
+
+    private static final String PING_PONG = "ping pong";
+
+    @GET
+    @Counted(name = "simple_mp", absolute = true)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String simpleScenario() {
+        return PING_PONG;
+    }
+}

--- a/micrometer/prometheus/src/main/java/io/quarkus/ts/micrometer/prometheus/UsingRegistryPingPongResource.java
+++ b/micrometer/prometheus/src/main/java/io/quarkus/ts/micrometer/prometheus/UsingRegistryPingPongResource.java
@@ -1,0 +1,52 @@
+package io.quarkus.ts.micrometer.prometheus;
+
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Path("/using-registry-pingpong")
+public class UsingRegistryPingPongResource {
+
+    private static final String PING_PONG = "ping pong";
+
+    @Inject
+    MeterRegistry registry;
+
+    @GET
+    @Path("/simple_registry")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String simpleScenario() {
+        incrementCounter("simple_registry");
+
+        return PING_PONG;
+    }
+
+    @GET
+    @Path("/forloop")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String iterativeScenario(@QueryParam("count") int count) {
+        IntStream.range(0, count).forEach(i -> incrementCounter("forloop"));
+
+        return PING_PONG;
+    }
+
+    @GET
+    @Path("/forloopparallel")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String iterativeParallelScenario(@QueryParam("count") int count) {
+        IntStream.range(0, count).parallel().forEach(i -> incrementCounter("forloopparallel"));
+
+        return PING_PONG;
+    }
+
+    private void incrementCounter(String name) {
+        registry.counter(name).increment();
+    }
+}

--- a/micrometer/prometheus/src/main/java/io/quarkus/ts/micrometer/prometheus/WithoutCustomMetricsPingPongResource.java
+++ b/micrometer/prometheus/src/main/java/io/quarkus/ts/micrometer/prometheus/WithoutCustomMetricsPingPongResource.java
@@ -1,0 +1,18 @@
+package io.quarkus.ts.micrometer.prometheus;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/without-metrics-pingpong")
+public class WithoutCustomMetricsPingPongResource {
+
+    private static final String PING_PONG = "ping pong";
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String simpleScenario() {
+        return PING_PONG;
+    }
+}

--- a/micrometer/prometheus/src/main/resources/application.properties
+++ b/micrometer/prometheus/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 quarkus.openshift.labels.app-with-metrics=quarkus-app
+
+# MP Integration
+quarkus.micrometer.binder.mp-metrics.enabled=true

--- a/micrometer/prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/HttpServerMetricsIT.java
+++ b/micrometer/prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/HttpServerMetricsIT.java
@@ -1,0 +1,59 @@
+package io.quarkus.ts.micrometer.prometheus;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+
+@QuarkusScenario
+public class HttpServerMetricsIT {
+
+    private static final List<String> HTTP_SERVER_REQUESTS_METRICS_SUFFIX = Arrays.asList("count", "sum", "max");
+
+    private static final String HTTP_SERVER_REQUESTS_METRICS_FORMAT = "http_server_requests_seconds_%s{method=\"GET\",outcome=\"SUCCESS\",status=\"200\",uri=\"%s\",}";
+    private static final String PING_PONG_ENDPOINT = "/without-metrics-pingpong";
+
+    @Test
+    public void testHttpServerRequestsCountShouldBeRegistered() {
+        thenHttpServerRequestsMetricsAreNotPresent();
+
+        whenCallPingPong();
+        thenHttpServerRequestsMetricsArePresent();
+    }
+
+    private void whenCallPingPong() {
+        given()
+                .when().get(PING_PONG_ENDPOINT)
+                .then().statusCode(HttpStatus.SC_OK)
+                .body(is("ping pong"));
+    }
+
+    private void thenHttpServerRequestsMetricsAreNotPresent() {
+        String metrics = when().get("/q/metrics").then()
+                .statusCode(HttpStatus.SC_OK).extract().asString();
+
+        for (String metricSuffix : HTTP_SERVER_REQUESTS_METRICS_SUFFIX) {
+            String metric = String.format(HTTP_SERVER_REQUESTS_METRICS_FORMAT, metricSuffix, PING_PONG_ENDPOINT);
+            assertFalse(metrics.contains(metric), "Unexpected metric found: " + metric + ". Metrics: " + metrics);
+        }
+    }
+
+    private void thenHttpServerRequestsMetricsArePresent() {
+        String metrics = when().get("/q/metrics").then()
+                .statusCode(HttpStatus.SC_OK).extract().asString();
+
+        for (String metricSuffix : HTTP_SERVER_REQUESTS_METRICS_SUFFIX) {
+            String metric = String.format(HTTP_SERVER_REQUESTS_METRICS_FORMAT, metricSuffix, PING_PONG_ENDPOINT);
+            assertTrue(metrics.contains(metric), "Expected metric not found: " + metric + ". Metrics: " + metrics);
+        }
+    }
+}

--- a/micrometer/prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/UsingMicroProfilePingPongResourceIT.java
+++ b/micrometer/prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/UsingMicroProfilePingPongResourceIT.java
@@ -1,0 +1,37 @@
+package io.quarkus.ts.micrometer.prometheus;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsString;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+
+@QuarkusScenario
+public class UsingMicroProfilePingPongResourceIT {
+
+    private static final String PING_PONG_ENDPOINT = "/using-microprofile-pingpong";
+    private static final String COUNTER_FORMAT = "simple_mp_total{scope=\"application\",} %s.0";
+
+    @Test
+    public void testShouldReturnCountOne() {
+        whenCallPingPong();
+        thenCounterIs(1);
+    }
+
+    private void whenCallPingPong() {
+        given()
+                .when().get(PING_PONG_ENDPOINT)
+                .then().statusCode(HttpStatus.SC_OK)
+                .body(is("ping pong"));
+    }
+
+    private void thenCounterIs(int expectedCounter) {
+        when().get("/q/metrics").then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString(String.format(COUNTER_FORMAT, expectedCounter)));
+    }
+}

--- a/micrometer/prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/UsingRegistryPingPongResourceIT.java
+++ b/micrometer/prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/UsingRegistryPingPongResourceIT.java
@@ -1,0 +1,69 @@
+package io.quarkus.ts.micrometer.prometheus;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsString;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+
+@QuarkusScenario
+public class UsingRegistryPingPongResourceIT {
+
+    private static final String PING_PONG_ENDPOINT = "/using-registry-pingpong/";
+    private static final String SIMPLE_SCENARIO = "simple_registry";
+    private static final String FORLOOP_SCENARIO = "forloop";
+    private static final String FORLOOP_PARALLEL_SCENARIO = "forloopparallel";
+    private static final String COUNTER_FORMAT = "%s_total %s.0";
+    private static final String NO_QUERY_PARAMS = null;
+
+    private String currentScenario;
+
+    @Test
+    public void testSimpleScenarioShouldReturnCountOne() {
+        whenCallPingPongScenario(SIMPLE_SCENARIO);
+        thenCounterIs(1);
+    }
+
+    @Test
+    public void testIterativeScenarioShouldReturnCountOne() {
+        whenCallPingPongScenario(FORLOOP_SCENARIO, countQuery(50));
+        thenCounterIs(50);
+    }
+
+    @Test
+    public void testIterativeParallelScenarioShouldReturnCountOne() {
+        whenCallPingPongScenario(FORLOOP_PARALLEL_SCENARIO, countQuery(500));
+        thenCounterIs(500);
+    }
+
+    private void whenCallPingPongScenario(String scenario) {
+        whenCallPingPongScenario(scenario, NO_QUERY_PARAMS);
+    }
+
+    private void whenCallPingPongScenario(String scenario, String queryParams) {
+        currentScenario = scenario;
+        String path = PING_PONG_ENDPOINT + scenario;
+        if (queryParams != null) {
+            path += "?" + queryParams;
+        }
+
+        given()
+                .when().get(path)
+                .then().statusCode(HttpStatus.SC_OK)
+                .body(is("ping pong"));
+    }
+
+    private void thenCounterIs(int expectedCounter) {
+        when().get("/q/metrics").then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString(String.format(COUNTER_FORMAT, currentScenario, expectedCounter)));
+    }
+
+    private static final String countQuery(int count) {
+        return "count=" + count;
+    }
+}

--- a/micrometer/prometheus/src/test/resources/service-monitor.yaml
+++ b/micrometer/prometheus/src/test/resources/service-monitor.yaml
@@ -8,6 +8,7 @@ spec:
   endpoints:
   - interval: 30s
     targetPort: 8080
+    path: /q/metrics
     scheme: http
   selector:
     matchLabels:


### PR DESCRIPTION
We have copied the coverage from 015 into the existing micrometer/prometheus module.
Note that I don't think this coverage is relevant to be run on OpenShift.

Fix https://github.com/quarkus-qe/quarkus-test-suite/issues/85