### PR TITLE
Add undertow http server scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,14 @@ It also verifies multiple deployment strategies like:
 ### `http-advanced`
 Verifies Server/Client http_2/1.1, Grpc and http redirections.
 
+
 ### `http-static`
 Verifies access to static pages and big static files over http.
+
+### `servlet-undertow`
+This module covers basic scenarios about HTTP servlets under `quarkus-undertow` server more in details:
+- Http session eviction
+- Undertow web.xml configuration
 
 ### `jaxrs`
 Simple bootstrap project created by *quarkus-maven-plugin*  

--- a/http/servlet-undertow/pom.xml
+++ b/http/servlet-undertow/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>servlet-undertow</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: HTTP: servlet-undertow</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-undertow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/http/servlet-undertow/src/main/java/io/quarkus/ts/filters/CustomRequestFilter.java
+++ b/http/servlet-undertow/src/main/java/io/quarkus/ts/filters/CustomRequestFilter.java
@@ -1,0 +1,25 @@
+package io.quarkus.ts.filters;
+
+import java.io.IOException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class CustomRequestFilter implements Filter {
+
+    private static final Logger LOG = Logger.getLogger(CustomRequestFilter.class);
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+        LOG.info("LoggerFilter invoked.");
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+}

--- a/http/servlet-undertow/src/main/java/io/quarkus/ts/listener/SessionListener.java
+++ b/http/servlet-undertow/src/main/java/io/quarkus/ts/listener/SessionListener.java
@@ -1,0 +1,41 @@
+package io.quarkus.ts.listener;
+
+import java.util.LinkedList;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+
+@ApplicationScoped
+public final class SessionListener implements HttpSessionListener {
+
+    public static final String GAUGE_ACTIVE_SESSION = "io_quarkus_ts_active_sessions_amount";
+    private LinkedList<String> sessionsBucket = new LinkedList<>();
+
+    SessionListener(MeterRegistry registry) {
+        registry.gaugeCollectionSize(GAUGE_ACTIVE_SESSION, Tags.empty(), sessionsBucket);
+        new JvmMemoryMetrics().bindTo(registry);
+        new JvmGcMetrics().bindTo(registry);
+        new ProcessorMetrics().bindTo(registry);
+        new JvmThreadMetrics().bindTo(registry);
+        new ClassLoaderMetrics().bindTo(registry);
+    }
+
+    public void sessionCreated(HttpSessionEvent event) {
+        HttpSession session = event.getSession();
+        sessionsBucket.add(session.getId());
+    }
+
+    public void sessionDestroyed(HttpSessionEvent event) {
+        sessionsBucket.remove(event.getSession().getId());
+    }
+}

--- a/http/servlet-undertow/src/main/java/io/quarkus/ts/servlets/HelloWorld.java
+++ b/http/servlet-undertow/src/main/java/io/quarkus/ts/servlets/HelloWorld.java
@@ -1,0 +1,29 @@
+package io.quarkus.ts.servlets;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class HelloWorld extends HttpServlet {
+
+    private static final Logger LOG = Logger.getLogger(HelloWorld.class);
+
+    private static final String MESSAGE = "Hello World";
+
+    @Override
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        LOG.info(req.getSession().getId());
+        PrintWriter writer = resp.getWriter();
+        writer.write(MESSAGE);
+        writer.close();
+    }
+
+}

--- a/http/servlet-undertow/src/main/resources/META-INF/web.xml
+++ b/http/servlet-undertow/src/main/resources/META-INF/web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app>
+    <listener>
+        <listener-class>io.quarkus.ts.listener.SessionListener</listener-class>
+    </listener>
+    <filter>
+        <filter-name>CustomRequestFilter</filter-name>
+        <filter-class>io.quarkus.ts.filters.CustomRequestFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>CustomRequestFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <servlet>
+        <servlet-name>HelloWorld</servlet-name>
+        <servlet-class>io.quarkus.ts.servlets.HelloWorld</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>HelloWorld</servlet-name>
+        <url-pattern>hello</url-pattern>
+    </servlet-mapping>
+    <!-- session-timeout unit: minutes -->
+    <session-config>
+        <session-timeout>1</session-timeout>
+    </session-config>
+</web-app>

--- a/http/servlet-undertow/src/main/resources/application.properties
+++ b/http/servlet-undertow/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+quarkus.http.root-path=/app
+quarkus.servlet.context-path=/servlet
+
+quarkus.micrometer.export.json.enabled=true

--- a/http/servlet-undertow/src/test/java/io/quarkus/ts/servlets/HttpServletWithSessionListenerIT.java
+++ b/http/servlet-undertow/src/test/java/io/quarkus/ts/servlets/HttpServletWithSessionListenerIT.java
@@ -1,0 +1,57 @@
+package io.quarkus.ts.servlets;
+
+import static io.quarkus.ts.listener.SessionListener.GAUGE_ACTIVE_SESSION;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.util.Asserts;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.restassured.RestAssured;
+
+@QuarkusScenario
+public class HttpServletWithSessionListenerIT {
+
+    static final Duration ACTIVE_SESSION_TIMEOUT = Duration.ofMinutes(2);
+    static final Duration REST_ASSURANCE_POLL_INTERVAL = Duration.ofSeconds(1);
+
+    @Test
+    public void sessionEviction() {
+        int activeSessions = 20;
+        thenMakeHelloWorldQuery(activeSessions);
+        thenCheckActiveSessionsEqualTo(activeSessions);
+        thenWaitToEvictSessionsAndCheckActiveSessionsEqualTo(0);
+    }
+
+    private double getActiveSessions() {
+        return (Double) RestAssured.given().when()
+                .get("/app/q/metrics")
+                .then()
+                .statusCode(HttpStatus.SC_OK).extract().as(Map.class).get(GAUGE_ACTIVE_SESSION);
+    }
+
+    private void thenMakeHelloWorldQuery(int requestAmount) {
+        IntStream.range(0, requestAmount).forEach(i -> RestAssured.given().when()
+                .get("/app/servlet/hello")
+                .then()
+                .statusCode(HttpStatus.SC_OK));
+    }
+
+    private void thenCheckActiveSessionsEqualTo(int threshold) {
+        Asserts.check(getActiveSessions() == threshold, "Unexpected active sessions amount");
+    }
+
+    private void thenWaitToEvictSessionsAndCheckActiveSessionsEqualTo(int value) {
+        await()
+                .atLeast(Duration.ofSeconds(50))
+                .atMost(ACTIVE_SESSION_TIMEOUT)
+                .with()
+                .pollInterval(REST_ASSURANCE_POLL_INTERVAL)
+                .until(() -> getActiveSessions() == value);
+    }
+}

--- a/http/servlet-undertow/src/test/resources/test.properties
+++ b/http/servlet-undertow/src/test/resources/test.properties
@@ -1,0 +1,1 @@
+ts.app.log.enable=true

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <module>http/http-static</module>
         <module>http/jaxrs</module>
         <module>http/reactive-routes</module>
+        <module>http/servlet-undertow</module>
         <module>scaling</module>
         <module>micrometer/prometheus</module>
         <module>micrometer/prometheus-kafka</module>


### PR DESCRIPTION
Servlet’s are supported using a modified version of Undertow that runs on top of Vert.x, and RESTEasy is used to provide JAX-RS support. This PR cover basic use cases of undertow  HTTP server

This PR covers basic scenarios about HTTP servlets under `quarkus-undertow` server more in details:
- Http session eviction
- Undertow web.xml configuration


Fix #132 