### PR TITLE
Migrate 011 and 014 into sql-db

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,29 @@ Verifies that the application can connect to multiple SQL databases and persist 
 The application also uses RESTEasy to expose a RESTful API, Jackson for JSON serialization, and Hibernate Validator to validate inputs.
 The multiple persistence units are defined in `application.properties`.
 
+### `sql-db/panache-flyway`
+
+Module that test whether we can setup a REST API using ORM Panache with Flyway and a MySQL database. Moreover, it covers XA transactions.
+
+Topics covered here:
+- https://quarkus.io/guides/hibernate-orm-panache
+- https://quarkus.io/guides/rest-data-panache
+- https://quarkus.io/guides/flyway
+
+Base application:
+- Define multiple datasources (https://quarkus.io/guides/datasource#multiple-datasources): default (transactions enabled), `with-xa` (transactions xa).
+- Define Panache entity `ApplicationEntity` and its respective REST resource `ApplicationResource` (https://quarkus.io/guides/rest-data-panache).
+- Define a REST resource `DataSourceResource` that provides info about the datasources.
+
+Additional tests:
+- Rest Data with Panache test according to https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-976.md  
+Additional UserEntity is a simple JPA entity that was created with aim to avoid inheritance of PanacheEntity methods
+and instead test the additional combination of JPA entity + PanacheRepository + PanacheRepositoryResource, where
+PanacheRepository is a facade class. Facade class can override certain methods to change the default behaviour of the
+PanacheRepositoryResource methods.
+
+- AgroalPoolTest, will cover how the db pool is managed in terms of IDLE-timeout, max connections and concurrency. 
+
 ### `security/basic`
 
 Verifies the simplest way of doing authn/authz.

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <surefire-plugin.version>2.22.2</surefire-plugin.version>
         <failsafe-plugin.version>2.22.2</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
@@ -74,6 +75,7 @@
         <module>security/vertx-jwt</module>
         <module>sql-db/sql-app</module>
         <module>sql-db/multiple-pus</module>
+        <module>sql-db/panache-flyway</module>
         <module>lifecycle-application</module>
         <module>external-applications</module>
         <module>quarkus-cli</module>
@@ -178,6 +180,10 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire-plugin.version}</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${failsafe-plugin.version}</version>
@@ -203,6 +209,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    </systemProperties>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/sql-db/panache-flyway/pom.xml
+++ b/sql-db/panache-flyway/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>sqldb-panache-flyway</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: SQL Database: Panache + Flyway</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-rest-data-panache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-mysql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
+        <profile>
+            <id>skip-tests-on-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/ApplicationEntity.java
+++ b/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/ApplicationEntity.java
@@ -1,0 +1,58 @@
+package io.quarkus.qe.sqldb.panacheflyway;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Transient;
+import javax.validation.constraints.NotEmpty;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+import org.hibernate.annotations.SqlFragmentAlias;
+
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+
+@Entity(name = "application")
+@FilterDef(name = "useLikeByName", parameters = { @ParamDef(name = "name", type = "string") })
+@Filter(name = "useLikeByName", condition = "name like :name")
+@FilterDef(name = "useServiceByName", parameters = { @ParamDef(name = "name", type = "string") })
+public class ApplicationEntity extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
+    @NotEmpty(message = "name can't be null")
+    @Column(unique = true, nullable = false)
+    public String name;
+
+    @ManyToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "version_id", nullable = false)
+    public VersionEntity version;
+
+    @JsonManagedReference
+    @OneToMany(mappedBy = "application", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @Filter(name = "useServiceByName", condition = "{s}.name = :name", aliases = {
+            @SqlFragmentAlias(alias = "s", table = "service")
+    })
+    public List<ServiceEntity> services = new ArrayList<>();
+
+    @Transient
+    public Optional<ServiceEntity> getServiceByName(String serviceName) {
+        return services.stream().filter(s -> serviceName.equals(s.name)).findFirst();
+    }
+}

--- a/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/ApplicationQueryResource.java
+++ b/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/ApplicationQueryResource.java
@@ -1,0 +1,42 @@
+package io.quarkus.qe.sqldb.panacheflyway;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import javax.transaction.Transactional;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+
+@Path("/application/filterBy")
+@Transactional
+public class ApplicationQueryResource {
+
+    @GET
+    @Path("/{filterName}")
+    @Produces("application/json")
+    public List<ApplicationEntity> filterBy(@PathParam("filterName") String filterName, @Context UriInfo uriInfo) {
+        PanacheQuery<ApplicationEntity> query = ApplicationEntity.<ApplicationEntity> findAll()
+                .filter(filterName, asMap(uriInfo.getQueryParameters()));
+        return query.list();
+    }
+
+    private Map<String, Object> asMap(MultivaluedMap<String, String> map) {
+        if (map == null) {
+            return Collections.emptyMap();
+        }
+
+        return map.entrySet().stream()
+                .collect(Collectors.toMap(Entry::getKey,
+                        e -> e.getValue().stream().collect(Collectors.joining(","))));
+    }
+}

--- a/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/ApplicationResource.java
+++ b/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/ApplicationResource.java
@@ -1,0 +1,6 @@
+package io.quarkus.qe.sqldb.panacheflyway;
+
+import io.quarkus.hibernate.orm.rest.data.panache.PanacheEntityResource;
+
+public interface ApplicationResource extends PanacheEntityResource<ApplicationEntity, Long> {
+}

--- a/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/DataSourceResource.java
+++ b/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/DataSourceResource.java
@@ -1,0 +1,37 @@
+package io.quarkus.qe.sqldb.panacheflyway;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.agroal.DataSource;
+
+@ApplicationScoped
+@Path("/data-source")
+public class DataSourceResource {
+    @Inject
+    AgroalDataSource defaultDataSource;
+
+    @Inject
+    @DataSource("with-xa")
+    AgroalDataSource xaDataSource;
+
+    @GET
+    @Path("/default/connection-provider-class")
+    public String defaultConnectionProviderClass() {
+        return getConnectionProviderClass(defaultDataSource);
+    }
+
+    @GET
+    @Path("/with-xa/connection-provider-class")
+    public String withXaConnectionProviderClass() {
+        return getConnectionProviderClass(xaDataSource);
+    }
+
+    private String getConnectionProviderClass(AgroalDataSource dataSource) {
+        return dataSource.getConfiguration().connectionPoolConfiguration()
+                .connectionFactoryConfiguration().connectionProviderClass().getName();
+    }
+}

--- a/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/ServiceEntity.java
+++ b/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/ServiceEntity.java
@@ -1,0 +1,28 @@
+package io.quarkus.qe.sqldb.panacheflyway;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+
+@Entity(name = "service")
+public class ServiceEntity extends PanacheEntityBase {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
+    @Column(nullable = false)
+    public String name;
+
+    @ManyToOne
+    @JoinColumn(name = "application_id", nullable = false)
+    @JsonBackReference
+    public ApplicationEntity application;
+}

--- a/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/UserEntity.java
+++ b/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/UserEntity.java
@@ -1,0 +1,30 @@
+package io.quarkus.qe.sqldb.panacheflyway;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity(name = "user_entity")
+public class UserEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/UserRepository.java
+++ b/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/UserRepository.java
@@ -1,0 +1,15 @@
+package io.quarkus.qe.sqldb.panacheflyway;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+
+@ApplicationScoped
+public class UserRepository implements PanacheRepositoryBase<UserEntity, Long> {
+
+    @Override
+    public PanacheQuery<UserEntity> findAll() {
+        return find("select u from user_entity u order by u.name asc");
+    }
+}

--- a/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/UserResource.java
+++ b/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/UserResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.qe.sqldb.panacheflyway;
+
+import java.util.List;
+
+import io.quarkus.hibernate.orm.rest.data.panache.PanacheRepositoryResource;
+import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Sort;
+import io.quarkus.rest.data.panache.MethodProperties;
+import io.quarkus.rest.data.panache.ResourceProperties;
+
+@ResourceProperties(hal = true, halCollectionName = "user_list", path = "users")
+public interface UserResource extends PanacheRepositoryResource<UserRepository, UserEntity, Long> {
+
+    @Override
+    @MethodProperties(path = "all")
+    List<UserEntity> list(Page page, Sort sort);
+
+    @Override
+    @MethodProperties(exposed = false)
+    UserEntity update(Long id, UserEntity entity);
+}

--- a/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/VersionEntity.java
+++ b/sql-db/panache-flyway/src/main/java/io/quarkus/qe/sqldb/panacheflyway/VersionEntity.java
@@ -1,0 +1,12 @@
+package io.quarkus.qe.sqldb.panacheflyway;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+
+@Entity(name = "version")
+public class VersionEntity extends PanacheEntityBase {
+    @Id
+    public String id;
+}

--- a/sql-db/panache-flyway/src/main/resources/application.properties
+++ b/sql-db/panache-flyway/src/main/resources/application.properties
@@ -1,0 +1,35 @@
+
+# Database
+quarkus.datasource.db-kind=mysql
+quarkus.datasource.username=user
+quarkus.datasource.password=user
+quarkus.datasource.jdbc.url=jdbc:mysql://localhost:3306/db?currentSchema=test
+quarkus.hibernate-orm.database.generation=validate
+
+# XA
+quarkus.datasource.with-xa.db-kind=${quarkus.datasource.db-kind}
+quarkus.datasource.with-xa.username=${quarkus.datasource.username}
+quarkus.datasource.with-xa.password=${quarkus.datasource.password}
+quarkus.datasource.with-xa.jdbc.url=${quarkus.datasource.jdbc.url}
+quarkus.datasource.with-xa.jdbc.transactions=xa
+
+# Flyway
+quarkus.flyway.migrate-at-start=true
+quarkus.flyway.schemas=test
+
+# Performance test for AgroalPoolTest
+%agroal_pool_test.quarkus.datasource.db-kind=mysql
+%agroal_pool_test.quarkus.datasource.username=user
+%agroal_pool_test.quarkus.datasource.password=user
+%agroal_pool_test.quarkus.datasource.jdbc.url=jdbc:mysql://localhost:3306/db?currentSchema=test
+%agroal_pool_test.quarkus.datasource.jdbc.transactions=enabled
+%agroal_pool_test.quarkus.datasource.jdbc.max-size=3
+%agroal_pool_test.quarkus.datasource.jdbc.min-size=1
+%agroal_pool_test.quarkus.datasource.jdbc.background-validation-interval=1S
+%agroal_pool_test.quarkus.datasource.jdbc.idle-removal-interval=1S
+%agroal_pool_test.quarkus.datasource.jdbc.acquisition-timeout=60S
+%agroal_pool_test.quarkus.datasource.jdbc.validation-query-sql=SELECT CURRENT_TIMESTAMP
+%agroal_pool_test.quarkus.datasource.jdbc.new-connection-sql=SELECT CURRENT_TIMESTAMP
+
+quarkus.hibernate-orm.log.bind-parameters=true
+quarkus.hibernate-orm.log.sql=true

--- a/sql-db/panache-flyway/src/main/resources/db/migration/V1.0.0__init.sql
+++ b/sql-db/panache-flyway/src/main/resources/db/migration/V1.0.0__init.sql
@@ -1,0 +1,5 @@
+CREATE TABLE application
+(
+  id            BIGINT PRIMARY KEY AUTO_INCREMENT,
+  name          VARCHAR(100) NOT NULL UNIQUE
+);

--- a/sql-db/panache-flyway/src/main/resources/db/migration/V1.0.1__entity_with_id_varchar.sql
+++ b/sql-db/panache-flyway/src/main/resources/db/migration/V1.0.1__entity_with_id_varchar.sql
@@ -1,0 +1,6 @@
+CREATE TABLE version
+(
+  id          VARCHAR(100) PRIMARY KEY
+);
+
+ALTER TABLE application ADD COLUMN version_id VARCHAR(100) REFERENCES version(id);

--- a/sql-db/panache-flyway/src/main/resources/db/migration/V1.0.2__add_service.sql
+++ b/sql-db/panache-flyway/src/main/resources/db/migration/V1.0.2__add_service.sql
@@ -1,0 +1,6 @@
+CREATE TABLE service
+(
+  id              BIGINT PRIMARY KEY AUTO_INCREMENT,
+  name            VARCHAR(100) NOT NULL,
+  application_id  BIGINT NOT NULL REFERENCES application(id)
+);

--- a/sql-db/panache-flyway/src/main/resources/db/migration/V1.0.3__add_user.sql
+++ b/sql-db/panache-flyway/src/main/resources/db/migration/V1.0.3__add_user.sql
@@ -1,0 +1,8 @@
+CREATE TABLE user_entity
+(
+  id              BIGINT PRIMARY KEY AUTO_INCREMENT,
+  name            VARCHAR(100) NOT NULL
+);
+
+INSERT INTO user_entity(name) VALUES ('Balaba');
+INSERT INTO user_entity(name) VALUES ('Alaba');

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/ApplicationResourceIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/ApplicationResourceIT.java
@@ -1,0 +1,203 @@
+package io.quarkus.qe.sqldb.panacheflyway;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.ws.rs.core.MediaType;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+
+@QuarkusScenario
+public class ApplicationResourceIT extends BaseIT {
+
+    static final String APPLICATION_PATH = "/application";
+    static final String EXPECTED_VERSION = "1.2.0";
+
+    private ApplicationEntity actualEntity;
+    private ApplicationEntity[] actualList;
+
+    @AfterEach
+    public void tearDown() {
+        deleteEntityIfExists();
+    }
+
+    @Test
+    public void shouldCreateApplication() {
+        whenCreateApplication("my-app-name");
+        thenApplicationMatches("my-app-name");
+    }
+
+    @Test
+    public void shouldUpdateApplication() {
+        whenCreateApplication("my-app-name");
+        whenUpdateApplication("another-app-name");
+        thenApplicationMatches("another-app-name");
+    }
+
+    @Test
+    public void shouldListApplications() {
+        whenCreateApplication("my-app-name");
+        whenGetApplications();
+        thenApplicationsCountIs(1);
+        thenApplicationsContainWithName("my-app-name");
+    }
+
+    @Test
+    public void shouldDeleteApplication() {
+        whenCreateApplication("my-app-name");
+        whenDeleteApplication();
+        whenGetApplications();
+        thenApplicationsCountIs(0);
+    }
+
+    @Test
+    public void shouldReturnBadRequestIfApplicationNameIsNull() {
+        applicationPath().body(new ApplicationEntity()).post()
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(containsString("name can't be null"));
+    }
+
+    @Test
+    public void shouldFindApplicationWhenFilteringByName() {
+        whenCreateApplication("my-app-name");
+        whenFilterApplicationByName("useLikeByName", "name", "%-app-%");
+        thenApplicationsCountIs(1);
+    }
+
+    @Test
+    public void shouldNotFindApplicationWhenFilteringByName() {
+        whenCreateApplication("my-app-name");
+        whenFilterApplicationByName("useLikeByName", "name", "%not-exist%");
+        thenApplicationsCountIs(0);
+    }
+
+    @Test
+    public void shouldFindApplicationWhenFilteringByServiceName() {
+        givenApplicationWithServices("service-a", "service-b");
+        whenFilterApplicationByName("useServiceByName", "name", "service-a");
+        thenApplicationsContainService("service-a");
+        thenApplicationsDoNotContainService("service-b");
+    }
+
+    private void givenApplicationWithServices(String... services) {
+        whenCreateApplication("my-app-name");
+
+        for (String service : services) {
+            whenCreateService(service);
+            thenServiceIsFound(service);
+        }
+    }
+
+    private void whenCreateService(String serviceName) {
+        ServiceEntity service = new ServiceEntity();
+        service.name = serviceName;
+        actualEntity.services.add(service);
+        applicationPath().body(actualEntity).put("/" + actualEntity.id)
+                .then().statusCode(HttpStatus.SC_NO_CONTENT);
+        whenGetApplication();
+    }
+
+    private void whenFilterApplicationByName(String filterName, String paramName, String paramValue) {
+        String params = String.format("?%s=%s", paramName, paramValue);
+
+        actualList = applicationPath().get("filterBy/" + filterName + params).then()
+                .statusCode(HttpStatus.SC_OK).and().extract().as(ApplicationEntity[].class);
+    }
+
+    private void whenCreateApplication(String appName) {
+        ApplicationEntity request = new ApplicationEntity();
+        request.name = appName;
+        request.version = new VersionEntity();
+        request.version.id = EXPECTED_VERSION;
+
+        actualEntity = applicationPath().body(request).post()
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .and().extract().as(ApplicationEntity.class);
+    }
+
+    private void whenUpdateApplication(String appName) {
+        actualEntity.name = appName;
+        applicationPath().body(actualEntity).put("/" + actualEntity.id)
+                .then().statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    private void whenDeleteApplication() {
+        applicationPath().delete("/" + actualEntity.id)
+                .then().statusCode(HttpStatus.SC_NO_CONTENT);
+
+        actualEntity = null;
+    }
+
+    private void whenGetApplication() {
+        actualEntity = applicationPath().get("/" + actualEntity.id).then().statusCode(HttpStatus.SC_OK).and().extract()
+                .as(ApplicationEntity.class);
+    }
+
+    private void whenGetApplications() {
+        actualList = applicationPath().get().then().statusCode(HttpStatus.SC_OK).and().extract().as(ApplicationEntity[].class);
+    }
+
+    private void thenApplicationMatches(String expectedAppName) {
+        assertNotNull(actualEntity.id);
+        assertEquals(expectedAppName, actualEntity.name);
+        assertEquals(EXPECTED_VERSION, actualEntity.version.id);
+    }
+
+    private void thenApplicationsCountIs(int expectedCount) {
+        assertNotNull(actualList);
+        assertEquals(expectedCount, actualList.length);
+    }
+
+    private void thenApplicationsContainWithName(String expectedAppName) {
+        assertNotNull(actualList);
+        assertTrue(Stream.of(actualList).allMatch(item -> expectedAppName.equals(item.name)));
+    }
+
+    private void thenApplicationsContainService(String expectedServiceName) {
+        thenApplicationsMatchServicesCondition(actualServices -> actualServices.contains(expectedServiceName));
+    }
+
+    private void thenApplicationsDoNotContainService(String expectedServiceName) {
+        thenApplicationsMatchServicesCondition(actualServices -> !actualServices.contains(expectedServiceName));
+    }
+
+    private void thenApplicationsMatchServicesCondition(Predicate<List<String>> servicePredicate) {
+        for (ApplicationEntity actualApplication : actualList) {
+            List<String> actualServices = actualApplication.services.stream().map(s -> s.name).collect(Collectors.toList());
+            assertTrue(servicePredicate.test(actualServices), "Service not expected. Found: " + actualServices);
+        }
+    }
+
+    private void thenServiceIsFound(String expectedServiceName) {
+        assertNotNull(actualEntity.services);
+        assertFalse(actualEntity.services.isEmpty(), "No services found");
+        assertTrue(actualEntity.getServiceByName(expectedServiceName).isPresent());
+    }
+
+    private void deleteEntityIfExists() {
+        if (actualEntity != null) {
+            whenDeleteApplication();
+        }
+    }
+
+    private static final RequestSpecification applicationPath() {
+        return given().accept(MediaType.APPLICATION_JSON).contentType(ContentType.JSON).when().basePath(APPLICATION_PATH);
+    }
+}

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/BaseIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/BaseIT.java
@@ -1,0 +1,28 @@
+package io.quarkus.qe.sqldb.panacheflyway;
+
+import io.quarkus.test.bootstrap.DefaultService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+public class BaseIT {
+    static final String MYSQL_USER = "user";
+    static final String MYSQL_PASSWORD = "user";
+    static final String MYSQL_DATABASE = "test";
+    static final int MYSQL_PORT = 3306;
+
+    @Container(image = "quay.io/bitnami/mysql:5.7.32", port = MYSQL_PORT, expectedLog = "ready for connections")
+    static DefaultService database = new DefaultService()
+            .withProperty("MYSQL_USER", MYSQL_USER)
+            .withProperty("MYSQL_PASSWORD", MYSQL_PASSWORD)
+            .withProperty("MYSQL_ROOT_PASSWORD", MYSQL_PASSWORD)
+            .withProperty("MYSQL_DATABASE", MYSQL_DATABASE);
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.datasource.username", MYSQL_USER)
+            .withProperty("quarkus.datasource.password", MYSQL_PASSWORD)
+            .withProperty("quarkus.datasource.jdbc.url",
+                    () -> database.getHost().replace("http", "jdbc:mysql") + ":" + database.getPort() + "/"
+                            + MYSQL_DATABASE);
+}

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/DataSourceIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/DataSourceIT.java
@@ -1,0 +1,32 @@
+package io.quarkus.qe.sqldb.panacheflyway;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import javax.ws.rs.core.MediaType;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+
+@QuarkusScenario
+public class DataSourceIT extends BaseIT {
+
+    private static final String DATA_SOURCE_PATH = "/data-source";
+
+    @Test
+    public void shouldDataSourceBeProperlyConfigured() {
+        dataSourcePath().get("/default/connection-provider-class")
+                .then().statusCode(HttpStatus.SC_OK).and().body(is("com.mysql.cj.jdbc.Driver"));
+
+        dataSourcePath().get("/with-xa/connection-provider-class")
+                .then().statusCode(HttpStatus.SC_OK).and().body(is("com.mysql.cj.jdbc.MysqlXADataSource"));
+    }
+
+    private static final RequestSpecification dataSourcePath() {
+        return given().accept(MediaType.APPLICATION_JSON).contentType(ContentType.JSON).when().basePath(DATA_SOURCE_PATH);
+    }
+}

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/UserResourceIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/UserResourceIT.java
@@ -1,0 +1,99 @@
+package io.quarkus.qe.sqldb.panacheflyway;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+
+@QuarkusScenario
+class UserResourceIT extends BaseIT {
+
+    private final static String NEW_USER_ID = "3";
+
+    @Test
+    void testAllRepositoryMethods() {
+
+        //GET - List all users
+        //Assert that order matches. UserRepository override it to be ascend. Initial order defined by import.sql
+        String userList = given()
+                .accept("application/hal+json")
+                .when().get("/users/all")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().response().jsonPath().getString("_embedded.user_list.name");
+        assertEquals("[Alaba, Balaba]", userList);
+
+        //POST - Create a new User
+        given()
+                .contentType("application/json")
+                .accept("application/json")
+                .body("{\"name\": \"Culibaba\"}")
+                .when().post("/users")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body(containsString("Culibaba"))
+                .body("id", notNullValue());
+
+        //PUT - Update a new User (method not allowed)
+        given()
+                .contentType("application/json")
+                .accept("application/json")
+                .body("{\"name\": \"Donbaba\"}")
+                .when().put("/users/" + NEW_USER_ID)
+                .then()
+                .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
+
+        //GET{id} - Find new user by id
+        given()
+                .when().get("/users/" + NEW_USER_ID)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(
+                        containsString("Culibaba"));
+
+        //DELETE - Delete new user via HTTP
+        given()
+                .when().delete("/users/" + NEW_USER_ID)
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        //Test repository pagination
+        given()
+                .accept("application/json")
+                .queryParam("size", "1")
+                .queryParam("page", "0")
+                .when().get("/users/all")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(
+                        containsString("Alaba"),
+                        not(containsString("Balaba")));
+    }
+
+    @Test
+    void testSortAscRepositoryQuery() {
+        String userList = getUsersSorted("name");
+        assertEquals("[Alaba, Balaba]", userList);
+    }
+
+    @Test
+    void testSortDescRepositoryQuery() {
+        String userList = getUsersSorted("-name");
+        assertEquals("[Balaba, Alaba]", userList);
+    }
+
+    private String getUsersSorted(String sortFieldName) {
+        return given()
+                .accept("application/hal+json")
+                .when().get("/users/all?sort=" + sortFieldName)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().response().jsonPath().getString("_embedded.user_list.name");
+    }
+}

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/dbpool/AgroalPoolTest.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/dbpool/AgroalPoolTest.java
@@ -1,0 +1,183 @@
+package io.quarkus.qe.sqldb.panacheflyway.dbpool;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.apache.http.HttpStatus;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.qe.sqldb.panacheflyway.UserRepository;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.tuples.Tuple2;
+
+/**
+ * The aim of these tests is verified agroal and entityManager pool management
+ * Some of these tests required some extra load, in order to reproduce concurrency issues.
+ */
+@QuarkusTest
+@TestProfile(AgroalTestProfile.class)
+public class AgroalPoolTest {
+
+    private final int CONCURRENCY_LEVEL = 20;
+
+    @Inject
+    EntityManager em;
+
+    @Inject
+    UserRepository users;
+
+    @Inject
+    AgroalDataSource agroalDataSource;
+
+    @ConfigProperty(name = "quarkus.datasource.jdbc.idle-removal-interval")
+    String idleSec;
+
+    @ConfigProperty(name = "quarkus.datasource.jdbc.max-size")
+    int datasourceMaxSize;
+
+    @ConfigProperty(name = "quarkus.datasource.jdbc.min-size")
+    int datasourceMinSize;
+
+    @Test
+    @Disabled("Pending Zulip conversation about quarkus.datasource.jdbc.idle-removal-interval")
+    public void idleTimeoutTest() throws InterruptedException {
+        makeApplicationQuery();
+        Thread.sleep(Duration.ofMillis(getIdleMs() + 1).toMillis());
+        assertEquals(1, activeConnections(), "agroalCheckIdleTimeout: Expected " + datasourceMinSize + " active connections");
+    }
+
+    @Test
+    public void poolTurnoverTest() {
+        final int events = 500;
+        final AtomicInteger max = new AtomicInteger(0);
+
+        AssertSubscriber<Tuple2<Long, Long>> subscriber = Multi.createBy().combining()
+                .streams(makeApplicationQueryAsync(events), activeConnectionsAsync(events))
+                .asTuple().subscribe().withSubscriber(AssertSubscriber.create(events));
+
+        subscriber.awaitItems(events).getItems().forEach(t -> {
+            Long activeCon = t.getItem2();
+            if (max.intValue() < activeCon) {
+                max.set(activeCon.intValue());
+            }
+            assertTrue(datasourceMaxSize >= activeCon, "More SQL connections than pool max-size");
+            assertTrue(datasourceMinSize <= activeCon, "Less SQL connections than pool min-size");
+        });
+    }
+
+    @Test
+    public void borderConditionBetweenIdleAndGetConnectionTest() {
+        final int events = 500;
+        for (int k = 0; k < events; k++) {
+            AssertSubscriber<Integer> subscriber = Multi.createFrom().range(0, CONCURRENCY_LEVEL).flatMap(n -> Multi
+                    .createFrom().ticks()
+                    .every(Duration.ofMillis(getIdleMs() + 3))
+                    .onOverflow().drop()
+                    .onFailure().invoke(e -> Assertions.fail("Unexpected exception " + e.getMessage()))
+                    .onItem().transform(i -> makeApplicationQuery()))
+                    .subscribe()
+                    .withSubscriber(AssertSubscriber.create(CONCURRENCY_LEVEL));
+
+            subscriber
+                    .awaitItems(CONCURRENCY_LEVEL)
+                    .getItems()
+                    .forEach(statusCode -> assertEquals(statusCode, HttpStatus.SC_OK, "Unexpected Application response"));
+        }
+    }
+
+    @Test
+    public void concurrentLoadTest() {
+        final int events = 100;
+        for (int i = 0; i < events; i++) {
+            Multi.createFrom()
+                    .range(0, CONCURRENCY_LEVEL).subscribe()
+                    .with(n -> assertEquals(2, users.count(), "UnexpectedUser Amount"));
+        }
+    }
+
+    @Test
+    public void connectionConcurrencyTest() {
+        final int events = 500;
+        for (int k = 0; k < events; k++) {
+            AssertSubscriber<String> subscriber = Multi.createFrom().range(0, CONCURRENCY_LEVEL).flatMap(n -> Multi
+                    .createFrom().ticks()
+                    .every(Duration.ofMillis(getIdleMs() + 3))
+                    .onOverflow().drop()
+                    .onFailure().invoke(e -> Assertions.fail("Unexpected exception " + e.getMessage()))
+                    .onItem().transform(i -> makeAgroalRawQuery()))
+                    .subscribe()
+                    .withSubscriber(AssertSubscriber.create(CONCURRENCY_LEVEL));
+
+            subscriber
+                    .awaitItems(CONCURRENCY_LEVEL)
+                    .getItems()
+                    .forEach(currentTime -> assertFalse(currentTime.isEmpty(), "Unexpected Application response"));
+        }
+    }
+
+    private long getIdleMs() {
+        int idle = Integer.parseInt(idleSec.replaceAll("[A-Z]", ""));
+        return Duration.ofSeconds(idle).toMillis();
+    }
+
+    private Multi<Long> activeConnectionsAsync(int events) {
+        return Multi.createFrom().range(0, events).onItem().transform(i -> activeConnections());
+    }
+
+    private Multi<Long> makeApplicationQueryAsync(int events) {
+        return Multi.createFrom().range(0, events).onItem().transform(i -> {
+            makeApplicationQuery();
+            return 0L;
+        });
+    }
+
+    private Long activeConnections() {
+        Query query = em.createNativeQuery("select * from INFORMATION_SCHEMA.PROCESSLIST;");
+        return (long) query.getResultList().size();
+    }
+
+    private int makeApplicationQuery() {
+        return given()
+                .accept("application/hal+json")
+                .when().get("/users/all")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().response().statusCode();
+    }
+
+    private String makeAgroalRawQuery() {
+        String currentTime = "";
+        try {
+            Connection con = agroalDataSource.getConnection();
+            ResultSet rs = con.createStatement().executeQuery("SELECT CURRENT_TIMESTAMP");
+            rs.next();
+            currentTime = rs.getString(1);
+            rs.close();
+            con.close();
+        } catch (SQLException e) {
+            assertNull(e.getCause(), "makeAgroalRawQuery: Agroal datasource/poolImpl unexpected error");
+        }
+
+        return currentTime;
+    }
+}

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/dbpool/AgroalTestProfile.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/dbpool/AgroalTestProfile.java
@@ -1,0 +1,31 @@
+package io.quarkus.qe.sqldb.panacheflyway.dbpool;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class AgroalTestProfile implements QuarkusTestProfile {
+
+    public static final String PROFILE = "agroal_pool_test";
+
+    @Override
+    public String getConfigProfile() {
+        return PROFILE;
+    }
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return Collections.singletonList(new TestResourceEntry(MySqlDatabaseTestResource.class));
+    }
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> config = new HashMap<>();
+        config.put("quarkus.datasource.devservices", "false");
+        config.put("quarkus.datasource.with-xa.devservices", "false");
+        return config;
+    }
+}

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/dbpool/MySqlDatabaseTestResource.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/dbpool/MySqlDatabaseTestResource.java
@@ -1,0 +1,56 @@
+package io.quarkus.qe.sqldb.panacheflyway.dbpool;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class MySqlDatabaseTestResource implements QuarkusTestResourceLifecycleManager {
+
+    private static final String QUARKUS_DB_JDBC_URL = "quarkus.datasource%s.jdbc.url";
+    private static final String QUARKUS_DB_USER = "quarkus.datasource%s.username";
+    private static final String QUARKUS_DB_PASSWORD = "quarkus.datasource%s.password";
+    private static final String DEFAULT_SCHEMA = "test";
+    private static final String MYSQL = "mysql";
+    private static final String WITH_XA_PROFILE = ".with-xa";
+
+    private MySQLContainer<?> container;
+
+    @Override
+    public Map<String, String> start() {
+        container = new MySQLContainer<>(
+                DockerImageName.parse("quay.io/bitnami/mysql:5.7.32").asCompatibleSubstituteFor(MYSQL));
+        container.withUrlParam("currentSchema", DEFAULT_SCHEMA);
+        container.start();
+
+        Map<String, String> config = new HashMap<>();
+        config.put(defaultDataSource(QUARKUS_DB_JDBC_URL), container.getJdbcUrl());
+        config.put(defaultDataSource(QUARKUS_DB_USER), container.getUsername());
+        config.put(defaultDataSource(QUARKUS_DB_PASSWORD), container.getPassword());
+        config.put(withXaDataSource(QUARKUS_DB_JDBC_URL), container.getJdbcUrl());
+        config.put(withXaDataSource(QUARKUS_DB_USER), container.getUsername());
+        config.put(withXaDataSource(QUARKUS_DB_PASSWORD), container.getPassword());
+
+        return Collections.unmodifiableMap(config);
+    }
+
+    @Override
+    public void stop() {
+        Optional.ofNullable(container).ifPresent(GenericContainer::stop);
+    }
+
+    private String defaultDataSource(String key) {
+        return String.format(key, StringUtils.EMPTY);
+    }
+
+    private String withXaDataSource(String key) {
+        return String.format(key, WITH_XA_PROFILE);
+    }
+}


### PR DESCRIPTION
Migrate 011-quarkus-panache-rest-flyway and 014-quarkus-panache-with-transactions-xa into sql-db/panache-flyway.
Module that test whether we can setup a REST API using ORM Panache with Flyway and a MySQL database. Moreover, it covers XA transactions.

Topics covered here:
- https://quarkus.io/guides/hibernate-orm-panache
- https://quarkus.io/guides/rest-data-panache
- https://quarkus.io/guides/flyway

Base application:
- Define multiple datasources (https://quarkus.io/guides/datasource#multiple-datasources): default (transactions enabled), `with-xa` (transactions xa).
- Define Panache entity `ApplicationEntity` and its respective REST resource `ApplicationResource` (https://quarkus.io/guides/rest-data-panache).
- Define a REST resource `DataSourceResource` that provides info about the datasources.

Additional tests:
- Rest Data with Panache test according to https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-976.md  
Additional UserEntity is a simple JPA entity that was created with aim to avoid inheritance of PanacheEntity methods
and instead test the additional combination of JPA entity + PanacheRepository + PanacheRepositoryResource, where
PanacheRepository is a facade class. Facade class can override certain methods to change the default behaviour of the
PanacheRepositoryResource methods.

- AgroalPoolTest, will cover how the db pool is managed in terms of IDLE-timeout, max connections and concurrency.

Fix https://github.com/quarkus-qe/quarkus-test-suite/issues/82