### PR TITLE
Migrate 602-spring-data-rest from BeefyTS

### DIFF
--- a/BEEFY_TS_MIGRATION_STATUS.md
+++ b/BEEFY_TS_MIGRATION_STATUS.md
@@ -14,3 +14,4 @@
 | 302-quarkus-vertx-jwt | security/vertx-jwt|
 | 304-quarkus-vertx-routes | http/reactive-routes |
 | 601-spring-data-primitive-types | spring/spring-data-primitive-types |
+| 602-spring-data-rest | spring/spring-data-rest |

--- a/README.md
+++ b/README.md
@@ -520,3 +520,11 @@ need it to be deployed into ocp or some other platform.
 ### `spring/spring-data-primitive-types`
 - Spring Data JPA: CRUD repository operation (default and custom), mapped superclass, query over embedded camelCase field, HTTP response filter.
 - Spring DI: presence of Spring-defined beans in CDI context, injected transitive dependencies, multiple ways of retrieving the beans.
+
+
+### `spring/spring-data-rest`
+Verifies functionality of Spring Data REST extension in following areas:
+- Automatic export of CRUD operations, manually restrict export of repo operations.
+- Usage together with Hibernate Validator constraints.
+- Pagination and sorting.
+- 1:m entity relationship.

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <module>quarkus-cli</module>
         <module>kamelet</module>
         <module>spring/spring-data-primitive-types</module>
+        <module>spring/spring-data-rest</module>
     </modules>
     <dependencyManagement>
         <dependencies>

--- a/spring/spring-data-rest/README.md
+++ b/spring/spring-data-rest/README.md
@@ -1,0 +1,42 @@
+# Quarkus - Spring Data REST
+
+## Scope of the testing
+
+Used addition features and functionality:
+
+- Hibernate Validator
+- One-to-Many and Many-to-One relationship
+- DevServices
+
+Used quarkus-spring-data-rest repositories:
+
+- CrudRepository
+- PagingAndSortingRepository
+
+Test for the CrudRepository:
+
+- Verify all the CRUD methods are available for end user
+
+Test for the PagingAndSortingRepository:
+
+- Redefine default path via *path* attribute
+- Define collection's root name via *collectionResourceRel* attribute
+- Export only certain CRUD methods and restrict the use of others for the end-user
+- Verify pagination and sorting are working correct
+
+## Requirements
+
+To compile and run this demo you will need:
+
+- JDK 1.8+
+- GraalVM
+
+In addition, you will need either a PostgreSQL database, or Docker to run one. Database for tests handled automatically using
+Testcontainers and enriched via `import.sql` file.
+
+To run PostgreSQL database in Docker run:
+> docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:11.5
+
+Connection properties for the Agroal datasource are defined in the standard Quarkus configuration file,
+`src/main/resources/application.properties`.
+

--- a/spring/spring-data-rest/pom.xml
+++ b/spring/spring-data-rest/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>spring-data-rest</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: spring-data-rest</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-spring-data-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
+        <profile>
+            <id>skip-tests-on-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/spring/spring-data-rest/src/main/java/io/quarkus/ts/spring/data/rest/Book.java
+++ b/spring/spring-data-rest/src/main/java/io/quarkus/ts/spring/data/rest/Book.java
@@ -1,0 +1,75 @@
+package io.quarkus.ts.spring.data.rest;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotBlank;
+
+import org.hibernate.validator.constraints.Length;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
+@Entity
+public class Book {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Length(min = 2, max = 50, message = "length must be between {min} and {max}")
+    @NotBlank(message = "Name may not be blank")
+    private String name;
+
+    @Length(min = 2, max = 50, message = "length must be between {min} and {max}")
+    @NotBlank(message = "Author may not be blank")
+    private String author;
+
+    @JsonBackReference
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "library_id")
+    private Library library;
+
+    public Book() {
+    }
+
+    public Book(String name, String author) {
+        this.name = name;
+        this.author = author;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public Library getLibrary() {
+        return library;
+    }
+
+    public void setLibrary(Library library) {
+        this.library = library;
+    }
+}

--- a/spring/spring-data-rest/src/main/java/io/quarkus/ts/spring/data/rest/BookRepository.java
+++ b/spring/spring-data-rest/src/main/java/io/quarkus/ts/spring/data/rest/BookRepository.java
@@ -1,0 +1,29 @@
+package io.quarkus.ts.spring.data.rest;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.rest.core.annotation.RestResource;
+
+@RepositoryRestResource(exported = false, path = "books", collectionResourceRel = "books")
+public interface BookRepository extends PagingAndSortingRepository<Book, Long> {
+
+    @Override
+    @RestResource(exported = true)
+    Page<Book> findAll(Pageable pageable);
+
+    @RestResource(exported = true)
+    List<Book> findByOrderByNameDesc();
+
+    @Override
+    @RestResource(path = "id")
+    Optional<Book> findById(Long id);
+
+    @Override
+    @RestResource()
+    Book save(Book book);
+}

--- a/spring/spring-data-rest/src/main/java/io/quarkus/ts/spring/data/rest/Library.java
+++ b/spring/spring-data-rest/src/main/java/io/quarkus/ts/spring/data/rest/Library.java
@@ -1,0 +1,60 @@
+package io.quarkus.ts.spring.data.rest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.validation.constraints.NotBlank;
+
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
+@Entity
+public class Library {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank(message = "Name may not be blank")
+    private String name;
+
+    @JsonManagedReference
+    @OneToMany(mappedBy = "library", cascade = CascadeType.ALL)
+    private List<Book> books = new ArrayList<>();
+
+    public Library() {
+    }
+
+    public Library(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<Book> getBooks() {
+        return books;
+    }
+
+    public void setBooks(List<Book> books) {
+        this.books = books;
+    }
+}

--- a/spring/spring-data-rest/src/main/java/io/quarkus/ts/spring/data/rest/LibraryRepository.java
+++ b/spring/spring-data-rest/src/main/java/io/quarkus/ts/spring/data/rest/LibraryRepository.java
@@ -1,0 +1,12 @@
+package io.quarkus.ts.spring.data.rest;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RestResource;
+
+public interface LibraryRepository extends CrudRepository<Library, Long> {
+    @Override
+    @RestResource(path = "id")
+    Optional<Library> findById(Long id);
+}

--- a/spring/spring-data-rest/src/main/resources/application.properties
+++ b/spring/spring-data-rest/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+# Using devServices
+quarkus.datasource.db-kind=postgresql
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.sql-load-script=import.sql

--- a/spring/spring-data-rest/src/main/resources/import.sql
+++ b/spring/spring-data-rest/src/main/resources/import.sql
@@ -1,0 +1,6 @@
+INSERT INTO library(name) VALUES('Library1');
+
+INSERT INTO book(name, author, library_id) VALUES ('Aeneid','Virgil', 1);
+INSERT INTO book(name, author, library_id) VALUES ('Beach House','James Patterson',1);
+INSERT INTO book(name, author) VALUES ('Cadillac Desert','Marc Reisner');
+INSERT INTO book(name, author) VALUES ('Dagon and Other Macabre Tales','H.P. Lovecraft ');

--- a/spring/spring-data-rest/src/test/java/io/quarkus/ts/spring/data/rest/AbstractDbIT.java
+++ b/spring/spring-data-rest/src/test/java/io/quarkus/ts/spring/data/rest/AbstractDbIT.java
@@ -1,0 +1,28 @@
+package io.quarkus.ts.spring.data.rest;
+
+import io.quarkus.test.bootstrap.DefaultService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+public class AbstractDbIT {
+    static final String POSTGRESQL_USER = "user";
+    static final String POSTGRESQL_PASSWORD = "user";
+    static final String POSTGRESQL_DATABASE = "mydb";
+    static final int POSTGRESQL_PORT = 5432;
+
+    @Container(image = "registry.access.redhat.com/rhscl/postgresql-10-rhel7", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    static final DefaultService database = new DefaultService()
+            .withProperty("POSTGRESQL_USER", POSTGRESQL_USER)
+            .withProperty("POSTGRESQL_PASSWORD", POSTGRESQL_PASSWORD)
+            .withProperty("POSTGRESQL_DATABASE", POSTGRESQL_DATABASE);
+
+    @QuarkusApplication
+    static final RestService app = new RestService()
+            .withProperty("quarkus.datasource.username", POSTGRESQL_USER)
+            .withProperty("quarkus.datasource.password", POSTGRESQL_PASSWORD)
+            .withProperty("quarkus.datasource.jdbc.url",
+                    () -> database.getHost().replace("http", "jdbc:postgresql") + ":" + database.getPort() + "/"
+                            + POSTGRESQL_DATABASE);
+
+}

--- a/spring/spring-data-rest/src/test/java/io/quarkus/ts/spring/data/rest/BookRepositoryIT.java
+++ b/spring/spring-data-rest/src/test/java/io/quarkus/ts/spring/data/rest/BookRepositoryIT.java
@@ -1,0 +1,115 @@
+package io.quarkus.ts.spring.data.rest;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.restassured.response.Response;
+
+@QuarkusScenario
+class BookRepositoryIT extends AbstractDbIT {
+
+    @Test
+    void testAllRepositoryMethods() throws InterruptedException {
+        //GET - List all books (should have all 4 books the database has initially)
+        app.given()
+                .accept("application/json")
+                .when().get("/books")
+                .then()
+                .statusCode(200)
+                .body(
+                        containsString("Aeneid"),
+                        containsString("Beach House"),
+                        containsString("Cadillac Desert"),
+                        containsString("Dagon and Other Macabre Tales"));
+
+        //POST - Create a new Book
+        app.given()
+                .contentType("application/json")
+                .accept("application/json")
+                .body("{\"name\": \"Early Asimov\", \"author\": \"Isaac Asimov\"}")
+                .when().post("/books")
+                .then()
+                .statusCode(201)
+                .body(containsString("Early Asimov"))
+                .body("id", notNullValue())
+                .extract().body().jsonPath().getString("id");
+
+        //PUT - Update a new Book
+        app.given()
+                .contentType("application/json")
+                .accept("application/json")
+                .body("{\"name\": \"Early Asimov 2nd Edition\", \"author\": \"Isaac Asimov\"}")
+                .when().put("/books/5")
+                .then()
+                .statusCode(204);
+
+        //GET{id} - Find new book by id
+        app.given()
+                .when().get("/books/id/5")
+                .then()
+                .statusCode(200)
+                .body(
+                        containsString("Early Asimov 2nd Edition"));
+
+        //DELETE - Try to delete a book via HTTP (method not allowed)
+        app.given()
+                .when().delete("/books/5")
+                .then()
+                .statusCode(405);
+
+        //Test repository pagination
+        app.given()
+                .accept("application/json")
+                .queryParam("size", "2")
+                .queryParam("page", "0")
+                .when().get("/books")
+                .then()
+                .statusCode(200)
+                .body(
+                        containsString("Aeneid"),
+                        containsString("Beach House"),
+                        not(containsString("Cadillac Desert")),
+                        not(containsString("Dagon and Other Macabre Tales")),
+                        not(containsString("Early Asimov 2nd Edition")));
+
+        //Test repository sorting
+        List<String> bookNamesSortedDesc = new ArrayList<>(Arrays.asList(
+                "Early Asimov 2nd Edition",
+                "Dagon and Other Macabre Tales",
+                "Cadillac Desert",
+                "Beach House",
+                "Aeneid"));
+        Response response = app.given()
+                .accept("application/json")
+                .queryParam("sort", "-name")
+                .when().get("/books")
+                .then()
+                .statusCode(200).extract().response();
+        List<String> bookNamesRepositorySortedDesc = response.jsonPath().getList("name");
+
+        assertEquals(bookNamesSortedDesc, bookNamesRepositorySortedDesc);
+
+    }
+
+    @Test
+    void testRepositoryValidator() throws InterruptedException {
+        //Try to add a book with invalid constraints
+        app.given()
+                .contentType("application/json")
+                .body("{\"name\": \"Q\", \"author\": \"Li\"}")
+                .when().post("/books")
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(containsString("length must be between 2 and 50"));
+    }
+}

--- a/spring/spring-data-rest/src/test/java/io/quarkus/ts/spring/data/rest/LibraryRepositoryIT.java
+++ b/spring/spring-data-rest/src/test/java/io/quarkus/ts/spring/data/rest/LibraryRepositoryIT.java
@@ -1,0 +1,80 @@
+package io.quarkus.ts.spring.data.rest;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+
+@QuarkusScenario
+public class LibraryRepositoryIT extends AbstractDbIT {
+    @Test
+    void testAllRepositoryMethods() throws InterruptedException {
+
+        //GET - List all libraries
+        app.given()
+                .accept("application/json")
+                .when().get("/library")
+                .then()
+                .statusCode(200)
+                .body(
+                        containsString("Library1"));
+
+        //POST - Create a new Library
+        app.given()
+                .contentType("application/json")
+                .accept("application/json")
+                .body("{\"name\": \"Library2\"}")
+                .when().post("/library")
+                .then()
+                .statusCode(201)
+                .body(containsString("Library2"))
+                .body("id", notNullValue())
+                .extract().body().jsonPath().getString("id");
+
+        //GET{id} - Find new library by id
+        app.given()
+                .when().get("/library/id/2")
+                .then()
+                .statusCode(200)
+                .body(
+                        containsString("Library2"));
+
+        //PUT - Update library entry
+        app.given()
+                .contentType("application/json")
+                .accept("application/json")
+                .body("{\"name\": \"Library Two\"}")
+                .when().put("/library/2")
+                .then()
+                .statusCode(204);
+
+        //GET{id} - Verify update
+        app.given()
+                .when().get("/library/id/2")
+                .then()
+                .statusCode(200)
+                .body(
+                        containsString("Library Two"));
+
+        //DELETE - Delete a library
+        app.given()
+                .when().delete("/library/2")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    void testRepositoryValidator() throws InterruptedException {
+        //Try to add a library with invalid constraints
+        app.given()
+                .contentType("application/json")
+                .body("{\"name\": \"\"}")
+                .when().post("/library")
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(containsString("Name may not be blank"));
+    }
+}

--- a/spring/spring-data-rest/src/test/java/io/quarkus/ts/spring/data/rest/OpenShiftBookRepositoryIT.java
+++ b/spring/spring-data-rest/src/test/java/io/quarkus/ts/spring/data/rest/OpenShiftBookRepositoryIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.spring.data.rest;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftBookRepositoryIT extends BookRepositoryIT {
+}

--- a/spring/spring-data-rest/src/test/java/io/quarkus/ts/spring/data/rest/OpenShiftLibraryRepositoryIT.java
+++ b/spring/spring-data-rest/src/test/java/io/quarkus/ts/spring/data/rest/OpenShiftLibraryRepositoryIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.spring.data.rest;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftLibraryRepositoryIT extends LibraryRepositoryIT {
+}

--- a/spring/spring-data-rest/src/test/resources/test.properties
+++ b/spring/spring-data-rest/src/test/resources/test.properties
@@ -1,0 +1,3 @@
+ts.app.log.enable=true
+ts.database.log.enable=true
+ts.database.openshift.use-internal-service-as-url=true


### PR DESCRIPTION
Migration of the module `602-spring-data-rest` from BeefyTS into `spring/spring-data-rest`.
Other modules expected in the `spring` group (see https://github.com/quarkus-qe/quarkus-test-suite/issues/98).

This module is a candidate for a merger with `spring/spring-data-primitivetypes` (see https://github.com/quarkus-qe/quarkus-test-suite/pull/134 and related issue).