### PR TITLE
Quarkus and Maven profiles coverage

### DIFF
--- a/BEEFY_TS_MIGRATION_STATUS.md
+++ b/BEEFY_TS_MIGRATION_STATUS.md
@@ -4,6 +4,7 @@
 | 001-quarkus-getting-started-with-jaxrs | http/jaxrs |
 | 006-quartz-manually-scheduled-job | scheduling/quartz |
 | 003-quarkus-many-extensions | super-size/many-extensions |
+| 005-quarkus-and-maven-profiles | lifecycle-application |
 | 012-quarkus-kafka-streams | messaging/kafka-streams-reactive-messaging |
 | 013-quarkus-oidc-restclient | security/keycloak-oidc-client-extended |
 | 017-quartz-cluster | scheduling/quartz |

--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ Tests:
 Checks that the application can read configuration from a ConfigMap and a Secret.
 The ConfigMap/Secret is exposed by mounting it into the container file system or the Kubernetes API server.
 
+### `lifecycle-application`
+Verifies lifecycle application features like `@QuarkusMain` and `@CommandLineArguments`.
+Also ensures maven profile activation with properties and additional repository definition propagation into Quarkus maven plugin.
+
 ### `properties`
 
 Module that covers the runtime configuration to ensure the changes take effect. The configuration that is covered is:

--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -10,6 +10,11 @@
     <artifactId>lifecycle-application</artifactId>
     <packaging>jar</packaging>
     <name>Quarkus QE TS: Lifecycle Application</name>
+    <properties>
+        <!-- Using invalid Quarkus version to make sure the one defined in profile gets picked -->
+        <!-- Quarkus maven plugin had troubles to use stuff defined in profile -->
+        <quarkus.platform.version>9999999-SNAPSHOT</quarkus.platform.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -19,5 +24,29 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-openshift</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-spring-di</artifactId>
+            <version>1.3.2.Final-redhat-00001</version>
+        </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>my-profile</id>
+            <activation>
+                <property>
+                    <name>!no-profile</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+            </properties>
+            <repositories>
+                <repository>
+                    <id>red-hat-enterprise-maven-repository</id>
+                    <url>https://maven.repository.redhat.com/ga/</url>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Quarkus and Maven profiles coverage

Enhancing `lifecycle-application` module to save execution time.

Fixes https://github.com/quarkus-qe/quarkus-test-suite/issues/78 / migrates https://github.com/quarkus-qe/beefy-scenarios/tree/main/005-quarkus-and-maven-profiles