### PR TITLE
Improve Native time on Daily action

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -231,7 +231,8 @@ jobs:
       - name: Build in Native mode
         shell: bash
         run: |
-          mvn -fae -s .github/mvn-settings.xml clean verify -Dnative -Dquarkus.native.container-build=false
+          # Running only http/http-minimum as after some time, it gives disk full in Windows when running on Native.
+          mvn -fae -s .github/mvn-settings.xml clean verify -Dnative -Dquarkus.native.container-build=false -pl http/http-minimum
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/quarkus-cli/pom.xml
+++ b/quarkus-cli/pom.xml
@@ -27,6 +27,7 @@
                 </property>
             </activation>
             <properties>
+                <!-- To not build the module on Native -->
                 <quarkus.package.type>fast-jar</quarkus.package.type>
             </properties>
         </profile>

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCompletionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCompletionIT.java
@@ -6,6 +6,7 @@ import javax.inject.Inject;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -15,6 +16,7 @@ import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 @Tag("quarkus-cli")
 @QuarkusScenario
 @DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus CLI has been reworked in 2.x")
+@DisabledIfSystemProperty(named = "profile.id", matches = "native", disabledReason = "Only for JVM verification")
 public class QuarkusCliCompletionIT {
 
     static final String EXPECTED_COMPLETION_OUTPUT = "Generates completions for the options and subcommands";

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -12,7 +12,7 @@ import javax.inject.Inject;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
@@ -23,7 +23,8 @@ import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 @Tag("quarkus-cli")
 @QuarkusScenario
 @DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus CLI has been reworked in 2.x")
-public class QuarkusCliCreateApplicationIT {
+@DisabledIfSystemProperty(named = "profile.id", matches = "native", disabledReason = "Only for JVM verification")
+public class QuarkusCliCreateJvmApplicationIT {
 
     static final String RESTEASY_EXTENSION = "quarkus-resteasy";
     static final String SMALLRYE_HEALTH_EXTENSION = "quarkus-smallrye-health";
@@ -109,19 +110,6 @@ public class QuarkusCliCreateApplicationIT {
         // The health endpoint should be now gone
         app.start();
         untilAsserted(() -> app.given().get("/q/health").then().statusCode(HttpStatus.SC_NOT_FOUND));
-    }
-
-    @Tag("QUARKUS-1071")
-    @Tag("QUARKUS-1072")
-    @Test
-    @EnabledIfSystemProperty(named = "profile.id", matches = "native")
-    public void shouldBuildApplicationOnNative() {
-        // Create application
-        QuarkusCliRestService app = cliClient.createApplication("app");
-
-        // Should build on Native
-        QuarkusCliClient.Result result = app.buildOnNative();
-        assertTrue(result.isSuccessful(), "The application didn't build on Native. Output: " + result.getOutput());
     }
 
     private void assertInstalledExtensions(QuarkusCliRestService app, String... expectedExtensions) {

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateNativeApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateNativeApplicationIT.java
@@ -1,0 +1,37 @@
+package io.quarkus.ts.quarkus.cli;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
+
+@Tag("QUARKUS-960")
+@Tag("quarkus-cli")
+@QuarkusScenario
+@DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus CLI has been reworked in 2.x")
+@EnabledIfSystemProperty(named = "profile.id", matches = "native", disabledReason = "Only for Native verification")
+public class QuarkusCliCreateNativeApplicationIT {
+
+    @Inject
+    static QuarkusCliClient cliClient;
+
+    @Tag("QUARKUS-1071")
+    @Tag("QUARKUS-1072")
+    @Test
+    public void shouldBuildApplicationOnNative() {
+        // Create application
+        QuarkusCliRestService app = cliClient.createApplication("app");
+
+        // Should build on Native
+        QuarkusCliClient.Result result = app.buildOnNative();
+        assertTrue(result.isSuccessful(), "The application didn't build on Native. Output: " + result.getOutput());
+    }
+}

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -10,6 +10,7 @@ import javax.inject.Inject;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.builder.Version;
 import io.quarkus.test.bootstrap.QuarkusCliClient;
@@ -24,6 +25,7 @@ import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 @Tag("quarkus-cli")
 @QuarkusScenario
 @DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus CLI has been reworked in 2.x")
+@DisabledIfSystemProperty(named = "profile.id", matches = "native", disabledReason = "Only for JVM verification")
 public class QuarkusCliExtensionsIT {
 
     static final String AGROAL_EXTENSION_NAME = "Agroal - Database connection pool";

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliHelpIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliHelpIT.java
@@ -6,6 +6,7 @@ import javax.inject.Inject;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -15,6 +16,7 @@ import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 @Tag("quarkus-cli")
 @QuarkusScenario
 @DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus CLI has been reworked in 2.x")
+@DisabledIfSystemProperty(named = "profile.id", matches = "native", disabledReason = "Only for JVM verification")
 public class QuarkusCliHelpIT {
 
     static final String HELP_COMMAND = "--help";

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient;
@@ -19,6 +20,7 @@ import io.quarkus.test.utils.FileUtils;
 @Tag("quarkus-cli")
 @QuarkusScenario
 @DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus CLI has been reworked in 2.x")
+@DisabledIfSystemProperty(named = "profile.id", matches = "native", disabledReason = "Only for JVM verification")
 public class QuarkusCliSpecialCharsIT {
 
     static final String FOLDER_WITH_SPACES = "s p a c e s";

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliVersionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliVersionIT.java
@@ -1,23 +1,15 @@
 package io.quarkus.ts.quarkus.cli;
 
-import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.List;
-import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
-import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.builder.Version;
 import io.quarkus.test.bootstrap.QuarkusCliClient;
-import io.quarkus.test.bootstrap.QuarkusCliRestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 
@@ -25,11 +17,8 @@ import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 @Tag("quarkus-cli")
 @QuarkusScenario
 @DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus CLI has been reworked in 2.x")
+@DisabledIfSystemProperty(named = "profile.id", matches = "native", disabledReason = "Only for JVM verification")
 public class QuarkusCliVersionIT {
-
-    static final String RESTEASY_EXTENSION = "quarkus-resteasy";
-    static final String SMALLRYE_HEALTH_EXTENSION = "quarkus-smallrye-health";
-    static final String RESTEASY_SPRING_WEB_EXTENSION = "quarkus-spring-web";
 
     @Inject
     static QuarkusCliClient cliClient;
@@ -41,78 +30,5 @@ public class QuarkusCliVersionIT {
 
         // Using shortcut
         assertEquals("Client Version " + Version.getVersion(), cliClient.run("-v").getOutput());
-    }
-
-    @Test
-    public void shouldCreateApplicationOnJvm() {
-        // Create application
-        QuarkusCliRestService app = cliClient.createApplication("app");
-
-        // Should build on Jvm
-        QuarkusCliClient.Result result = app.buildOnJvm();
-        assertTrue(result.isSuccessful(), "The application didn't build on JVM. Output: " + result.getOutput());
-
-        // Start using DEV mode
-        app.start();
-        app.given().get().then().statusCode(HttpStatus.SC_OK);
-    }
-
-    @Test
-    public void shouldCreateApplicationWithCodeStarter() {
-        // Create application with Resteasy Jackson
-        QuarkusCliRestService app = cliClient.createApplication("app", RESTEASY_SPRING_WEB_EXTENSION);
-
-        // Verify By default, it installs only "quarkus-resteasy"
-        assertInstalledExtensions(app, RESTEASY_SPRING_WEB_EXTENSION);
-
-        // Start using DEV mode
-        app.start();
-        untilAsserted(() -> app.given().get("/greeting").then().statusCode(HttpStatus.SC_OK).and().body(is("Hello Spring")));
-    }
-
-    @Test
-    public void shouldAddAndRemoveExtensions() {
-        // Create application
-        QuarkusCliRestService app = cliClient.createApplication("app");
-
-        // By default, it installs only "quarkus-resteasy"
-        assertInstalledExtensions(app, RESTEASY_EXTENSION);
-
-        // Let's install Quarkus Smallrye Health
-        QuarkusCliClient.Result result = app.installExtension(SMALLRYE_HEALTH_EXTENSION);
-        assertTrue(result.isSuccessful(), SMALLRYE_HEALTH_EXTENSION + " was not installed. Output: " + result.getOutput());
-
-        // Verify both extensions now
-        assertInstalledExtensions(app, RESTEASY_EXTENSION, SMALLRYE_HEALTH_EXTENSION);
-
-        // The health endpoint should be now available
-        app.start();
-        untilAsserted(() -> app.given().get("/q/health").then().statusCode(HttpStatus.SC_OK));
-        app.stop();
-
-        // Let's now remove the Smallrye Health extension
-        result = app.removeExtension(SMALLRYE_HEALTH_EXTENSION);
-        assertTrue(result.isSuccessful(), SMALLRYE_HEALTH_EXTENSION + " was not uninstalled. Output: " + result.getOutput());
-
-        // The health endpoint should be now gone
-        app.start();
-        untilAsserted(() -> app.given().get("/q/health").then().statusCode(HttpStatus.SC_NOT_FOUND));
-    }
-
-    @Test
-    @EnabledIfSystemProperty(named = "profile.id", matches = "native")
-    public void shouldBuildApplicationOnNative() {
-        // Create application
-        QuarkusCliRestService app = cliClient.createApplication("app");
-
-        // Should build on Native
-        QuarkusCliClient.Result result = app.buildOnNative();
-        assertTrue(result.isSuccessful(), "The application didn't build on Native. Output: " + result.getOutput());
-    }
-
-    private void assertInstalledExtensions(QuarkusCliRestService app, String... expectedExtensions) {
-        List<String> extensions = app.getInstalledExtensions();
-        Stream.of(expectedExtensions).forEach(expectedExtension -> assertTrue(extensions.contains(expectedExtension),
-                expectedExtension + " not found in " + extensions));
     }
 }

--- a/scheduling/quartz/src/test/java/io/quarkus/qe/scheduling/quartz/AnnotationScheduledJobsMySqlQuartzIT.java
+++ b/scheduling/quartz/src/test/java/io/quarkus/qe/scheduling/quartz/AnnotationScheduledJobsMySqlQuartzIT.java
@@ -14,9 +14,11 @@ import io.quarkus.qe.scheduling.quartz.failover.ExecutionService;
 import io.quarkus.qe.scheduling.quartz.failover.ExecutionsResource;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
+@DisabledOnNative(reason = "Due to high native build execution time for the three Quarkus services")
 public class AnnotationScheduledJobsMySqlQuartzIT extends BaseMySqlQuartzIT {
 
     static final String NODE_ONE_NAME = "node-one";


### PR DESCRIPTION
++ Run only http/http-minimum in Windows native only
++ Disable AnnotationScheduledJobsMySqlQuartzIT on Native as it takes around 30 min to finish
++ There were some duplicated test cases in QuarkusCliVersionIT and QuarkusCliCreateJvmApplicationIT