### PR TITLE
Dependabot to ignore io.quarkus:quarkus-spring-di

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     ignore:
       # For Quarkus Maven Plugin, updates are managed by Quarkus Bom dependency
       - dependency-name: io.quarkus:quarkus-maven-plugin
+      # This dependency is used in `lifecycle-application` to verify Maven errors, we need to ignore it
+      - dependency-name: io.quarkus:quarkus-spring-di


### PR DESCRIPTION
The dependency io.quarkus:quarkus-spring-di is using a concrete version in the module `lifecycle-application` to verify some Maven configuration error. Therefore, we need Dependabot to ignore version bumps for this dependency.