### PR TITLE
Drop quarkus-maven-plugin definition from http-advanced module

### DIFF
--- a/http/http-advanced/pom.xml
+++ b/http/http-advanced/pom.xml
@@ -71,23 +71,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
     <profiles>
         <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
         <profile>


### PR DESCRIPTION
Drop quarkus-maven-plugin definition from http-advanced module

quarkus-maven-plugin is defined in root pom