### PR TITLE
Add coverage of `quarkus-cache`

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,3 +578,12 @@ For the Quarkus application, pod killing is used the same approach as in configm
 By default, when the Infinispan server is down and the application can't open a connection, it tries to connect again, up to 10 times (max_retries) and gives up after 60s (connect_timeout).
 Because of that we are using the `hotrod-client.properties` file where are the max_retries and connect_timeout reduced. Without this the application will be still trying to connect to the Infinispan server next 10 minutes and the incremented number can appear later.
 The last three tests are for testing of the multiple client access to the cache. We simulate the second client by deploying the second deployment config, Service, and Route for these tests. These are copied from the `openshift.yml` file. 
+
+### `cache/caffeine`
+
+Verifies the `quarkus-cache` extension using `@CacheResult`, `@CacheInvalidate`, `@CacheInvalidateAll` and `@CacheKey`.
+It covers different usages: 
+1. from an application scoped service
+2. from a request scoped service
+3. from a blocking endpoint
+4. from a reactive endpoint 

--- a/cache/caffeine/pom.xml
+++ b/cache/caffeine/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>cache-caffeine</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: Cache: Caffeine</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/ApplicationScopeService.java
+++ b/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/ApplicationScopeService.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.cache.caffeine;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ApplicationScopeService extends BaseServiceWithCache {
+}

--- a/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/BaseServiceWithCache.java
+++ b/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/BaseServiceWithCache.java
@@ -1,0 +1,38 @@
+package io.quarkus.ts.cache.caffeine;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.CacheKey;
+import io.quarkus.cache.CacheResult;
+
+public abstract class BaseServiceWithCache {
+
+    private static final String CACHE_NAME = "service-cache";
+
+    private static int counter = 0;
+
+    @CacheResult(cacheName = CACHE_NAME)
+    public String getValue() {
+        return "Value: " + counter++;
+    }
+
+    @CacheInvalidate(cacheName = CACHE_NAME)
+    public void invalidate() {
+        // do nothing
+    }
+
+    @CacheResult(cacheName = CACHE_NAME)
+    public String getValueWithPrefix(@CacheKey String prefix) {
+        return prefix + ": " + counter++;
+    }
+
+    @CacheInvalidate(cacheName = CACHE_NAME)
+    public void invalidateWithPrefix(@CacheKey String prefix) {
+        // do nothing
+    }
+
+    @CacheInvalidateAll(cacheName = CACHE_NAME)
+    public void invalidateAll() {
+        // do nothing
+    }
+}

--- a/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/BlockingWithCacheResource.java
+++ b/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/BlockingWithCacheResource.java
@@ -1,0 +1,55 @@
+package io.quarkus.ts.cache.caffeine;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.CacheKey;
+import io.quarkus.cache.CacheResult;
+import io.smallrye.common.annotation.Blocking;
+
+@Blocking
+@Path("/api/blocking")
+public class BlockingWithCacheResource {
+
+    private static final String CACHE_NAME = "api-blocking-cache";
+
+    private static int counter = 0;
+
+    @GET
+    @CacheResult(cacheName = CACHE_NAME)
+    public String getValue() {
+        return "Value: " + counter++;
+    }
+
+    @POST
+    @Path("/invalidate-cache")
+    @CacheInvalidate(cacheName = CACHE_NAME)
+    public void invalidate() {
+        // do nothing
+    }
+
+    @GET
+    @Path("/using-prefix/{prefix}")
+    @CacheResult(cacheName = CACHE_NAME)
+    public String getValueWithPrefix(@PathParam("prefix") @CacheKey String prefix) {
+        return prefix + ": " + counter++;
+    }
+
+    @POST
+    @Path("/using-prefix/{prefix}/invalidate-cache")
+    @CacheInvalidate(cacheName = CACHE_NAME)
+    public void invalidateWithPrefix(@PathParam("prefix") @CacheKey String prefix) {
+        // do nothing
+    }
+
+    @POST
+    @Path("/invalidate-cache-all")
+    @CacheInvalidateAll(cacheName = CACHE_NAME)
+    public void invalidateAll() {
+        // do nothing
+    }
+}

--- a/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/ReactiveWithCacheResource.java
+++ b/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/ReactiveWithCacheResource.java
@@ -1,0 +1,56 @@
+package io.quarkus.ts.cache.caffeine;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.CacheKey;
+import io.quarkus.cache.CacheResult;
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.mutiny.Uni;
+
+@NonBlocking
+@Path("/api/reactive")
+public class ReactiveWithCacheResource {
+
+    private static final String CACHE_NAME = "api-reactive-cache";
+
+    private static int counter = 0;
+
+    @GET
+    @CacheResult(cacheName = CACHE_NAME)
+    public Uni<String> getValue() {
+        return Uni.createFrom().item("Value: " + counter++);
+    }
+
+    @POST
+    @Path("/invalidate-cache")
+    @CacheInvalidate(cacheName = CACHE_NAME)
+    public void invalidate() {
+        // do nothing
+    }
+
+    @GET
+    @Path("/using-prefix/{prefix}")
+    @CacheResult(cacheName = CACHE_NAME)
+    public Uni<String> getValueWithPrefix(@PathParam("prefix") @CacheKey String prefix) {
+        return Uni.createFrom().item(prefix + ": " + counter++);
+    }
+
+    @POST
+    @Path("/using-prefix/{prefix}/invalidate-cache")
+    @CacheInvalidate(cacheName = CACHE_NAME)
+    public void invalidateWithPrefix(@PathParam("prefix") @CacheKey String prefix) {
+        // do nothing
+    }
+
+    @POST
+    @Path("/invalidate-cache-all")
+    @CacheInvalidateAll(cacheName = CACHE_NAME)
+    public void invalidateAll() {
+        // do nothing
+    }
+}

--- a/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/RequestScopeService.java
+++ b/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/RequestScopeService.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.cache.caffeine;
+
+import javax.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class RequestScopeService extends BaseServiceWithCache {
+}

--- a/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/ServiceWithCacheResource.java
+++ b/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/ServiceWithCacheResource.java
@@ -1,0 +1,65 @@
+package io.quarkus.ts.cache.caffeine;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/services")
+public class ServiceWithCacheResource {
+
+    public static final String APPLICATION_SCOPE_SERVICE_PATH = "application-scope";
+    public static final String REQUEST_SCOPE_SERVICE_PATH = "request-scope";
+
+    @Inject
+    ApplicationScopeService applicationScopeService;
+
+    @Inject
+    RequestScopeService requestScopeService;
+
+    @GET
+    @Path("/{service}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getValueFromService(@PathParam("service") String service) {
+        return lookupServiceByPathParam(service).getValue();
+    }
+
+    @POST
+    @Path("/{service}/invalidate-cache")
+    public void invalidateCacheFromService(@PathParam("service") String service) {
+        lookupServiceByPathParam(service).invalidate();
+    }
+
+    @POST
+    @Path("/{service}/invalidate-cache-all")
+    public void invalidateCacheAllFromService(@PathParam("service") String service) {
+        lookupServiceByPathParam(service).invalidateAll();
+    }
+
+    @GET
+    @Path("/{service}/using-prefix/{prefix}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getValueUsingPrefixFromService(@PathParam("service") String service, @PathParam("prefix") String prefix) {
+        return lookupServiceByPathParam(service).getValueWithPrefix(prefix);
+    }
+
+    @POST
+    @Path("/{service}/using-prefix/{prefix}/invalidate-cache")
+    public void invalidateCacheUsingPrefixFromService(@PathParam("service") String service,
+            @PathParam("prefix") String prefix) {
+        lookupServiceByPathParam(service).invalidateWithPrefix(prefix);
+    }
+
+    private BaseServiceWithCache lookupServiceByPathParam(String service) {
+        if (APPLICATION_SCOPE_SERVICE_PATH.equals(service)) {
+            return applicationScopeService;
+        } else if (REQUEST_SCOPE_SERVICE_PATH.equals(service)) {
+            return requestScopeService;
+        }
+
+        throw new IllegalArgumentException("Service " + service + " is not recognised");
+    }
+}

--- a/cache/caffeine/src/test/java/io/quarkus/ts/cache/caffeine/cache/caffeine/OpenShiftServiceWithCacheResourceIT.java
+++ b/cache/caffeine/src/test/java/io/quarkus/ts/cache/caffeine/cache/caffeine/OpenShiftServiceWithCacheResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.cache.caffeine.cache.caffeine;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftServiceWithCacheResourceIT extends ServiceWithCacheResourceIT {
+}

--- a/cache/caffeine/src/test/java/io/quarkus/ts/cache/caffeine/cache/caffeine/ServiceWithCacheResourceIT.java
+++ b/cache/caffeine/src/test/java/io/quarkus/ts/cache/caffeine/cache/caffeine/ServiceWithCacheResourceIT.java
@@ -1,0 +1,164 @@
+package io.quarkus.ts.cache.caffeine.cache.caffeine;
+
+import static io.quarkus.ts.cache.caffeine.ServiceWithCacheResource.APPLICATION_SCOPE_SERVICE_PATH;
+import static io.quarkus.ts.cache.caffeine.ServiceWithCacheResource.REQUEST_SCOPE_SERVICE_PATH;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+
+@QuarkusScenario
+public class ServiceWithCacheResourceIT {
+
+    private static final String SERVICE_APPLICATION_SCOPE_PATH = "/services/" + APPLICATION_SCOPE_SERVICE_PATH;
+    private static final String SERVICE_REQUEST_SCOPE_PATH = "/services/" + REQUEST_SCOPE_SERVICE_PATH;
+    private static final String RESOURCE_BLOCKING_API_PATH = "/api/blocking";
+    private static final String RESOURCE_REACTIVE_API_PATH = "/api/reactive";
+
+    /**
+     * Check whether the `@CacheResult` annotation works when used in a service.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { SERVICE_APPLICATION_SCOPE_PATH, SERVICE_REQUEST_SCOPE_PATH, RESOURCE_BLOCKING_API_PATH,
+            RESOURCE_REACTIVE_API_PATH })
+    public void shouldGetTheSameValueAlwaysWhenGettingValueFromPath(String path) {
+        // We call the service endpoint
+        String value = getFromPath(path);
+
+        // At this point, the cache is populated and we should get the same value from the cache
+        assertEquals(value, getFromPath(path), "Value was different which means cache is not working");
+    }
+
+    /**
+     * Check whether the `@CacheInvalidate` annotation invalidates the cache when used in a service.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { SERVICE_APPLICATION_SCOPE_PATH, SERVICE_REQUEST_SCOPE_PATH, RESOURCE_BLOCKING_API_PATH,
+            RESOURCE_REACTIVE_API_PATH })
+    public void shouldGetDifferentValueWhenInvalidateCacheFromPath(String path) {
+        // We call the service endpoint
+        String value = getFromPath(path);
+
+        // invalidate the cache
+        invalidateCacheFromPath(path);
+
+        // Then the value should be different as we have invalidated the cache.
+        assertNotEquals(value, getFromPath(path), "Value was equal which means cache invalidate didn't work");
+    }
+
+    /**
+     * Check whether the `@CacheResult` annotation works when used in a service.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { SERVICE_APPLICATION_SCOPE_PATH, SERVICE_REQUEST_SCOPE_PATH, RESOURCE_BLOCKING_API_PATH,
+            RESOURCE_REACTIVE_API_PATH })
+    public void shouldGetTheSameValueForSamePrefixesWhenGettingValueFromPath(String path) {
+        // We call the service endpoint
+        String value = getValueFromPathUsingPrefix(path, "prefix1");
+
+        // At this point, the cache is populated and we should get the same value from the cache
+        assertEquals(value, getValueFromPathUsingPrefix(path, "prefix1"),
+                "Value was different which means cache is not working");
+        // But different value using another prefix
+        assertNotEquals(value, getValueFromPathUsingPrefix(path, "prefix2"),
+                "Value was equal which means @CacheKey didn't work");
+    }
+
+    /**
+     * Check whether the `@CacheInvalidate` annotation does not invalidate all the caches
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { SERVICE_APPLICATION_SCOPE_PATH, SERVICE_REQUEST_SCOPE_PATH, RESOURCE_BLOCKING_API_PATH,
+            RESOURCE_REACTIVE_API_PATH })
+    public void shouldGetTheSameValuesEvenAfterCallingToCacheInvalidateFromPath(String path) {
+        // We call the service endpoints
+        String valueOfPrefix1 = getValueFromPathUsingPrefix(path, "prefix1");
+        String valueOfPrefix2 = getValueFromPathUsingPrefix(path, "prefix2");
+
+        // invalidate the cache: this should not invalidate all the keys
+        invalidateCacheFromPath(path);
+
+        // At this point, the cache is populated and we should get the same value from the cache
+        assertEquals(valueOfPrefix1, getValueFromPathUsingPrefix(path, "prefix1"));
+        // But different value using another prefix
+        assertEquals(valueOfPrefix2, getValueFromPathUsingPrefix(path, "prefix2"));
+    }
+
+    /**
+     * Check whether the `@CacheInvalidate` and `@CacheKey` annotations work as expected.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { SERVICE_APPLICATION_SCOPE_PATH, SERVICE_REQUEST_SCOPE_PATH, RESOURCE_BLOCKING_API_PATH,
+            RESOURCE_REACTIVE_API_PATH })
+    public void shouldGetDifferentValueWhenInvalidateCacheOnlyForOnePrefixFromPath(String path) {
+        // We call the service endpoints
+        String valueOfPrefix1 = getValueFromPathUsingPrefix(path, "prefix1");
+        String valueOfPrefix2 = getValueFromPathUsingPrefix(path, "prefix2");
+
+        // invalidate the cache: this should not invalidate all the keys
+        invalidateCacheWithPrefixFromPath(path, "prefix1");
+
+        // The cache was invalidated only for prefix1, so the value should be different
+        assertNotEquals(valueOfPrefix1, getValueFromPathUsingPrefix(path, "prefix1"));
+        // The cache was not invalidated for prefix2, so the value should be the same
+        assertEquals(valueOfPrefix2, getValueFromPathUsingPrefix(path, "prefix2"));
+    }
+
+    /**
+     * Check whether the `@CacheInvalidateAll` annotation works as expected.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { SERVICE_APPLICATION_SCOPE_PATH, SERVICE_REQUEST_SCOPE_PATH, RESOURCE_BLOCKING_API_PATH,
+            RESOURCE_REACTIVE_API_PATH })
+    public void shouldGetDifferentValueWhenInvalidateAllTheCacheFromPath(String path) {
+        // We call the service endpoints
+        String value = getFromPath(path);
+        String valueOfPrefix1 = getValueFromPathUsingPrefix(path, "prefix1");
+        String valueOfPrefix2 = getValueFromPathUsingPrefix(path, "prefix2");
+
+        // invalidate all the cache
+        invalidateCacheAllFromPath(path);
+
+        // Then, all the values should be different:
+        assertNotEquals(value, getFromPath(path));
+        assertNotEquals(valueOfPrefix1, getValueFromPathUsingPrefix(path, "prefix1"));
+        assertNotEquals(valueOfPrefix2, getValueFromPathUsingPrefix(path, "prefix2"));
+    }
+
+    private void invalidateCacheAllFromPath(String path) {
+        postFromPath(path + "/invalidate-cache-all");
+    }
+
+    private void invalidateCacheWithPrefixFromPath(String path, String prefix) {
+        postFromPath(path + "/using-prefix/" + prefix + "/invalidate-cache");
+    }
+
+    private void invalidateCacheFromPath(String path) {
+        postFromPath(path + "/invalidate-cache");
+    }
+
+    private String getValueFromPathUsingPrefix(String path, String prefix) {
+        return getFromPath(path + "/using-prefix/" + prefix);
+    }
+
+    private String getFromPath(String path) {
+        return given()
+                .when().get(path)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().asString();
+    }
+
+    private void postFromPath(String path) {
+        given()
+                .when().post(path)
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <module>kamelet</module>
         <module>spring/spring-data</module>
         <module>logging/jboss</module>
+        <module>cache/caffeine</module>
     </modules>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Verifies the `quarkus-cache` extension using the `@CacheResult`, `@CacheInvalidate` and `@CacheKey` annotations.
It covers different usages: 
1. from an application scoped service
2. from a request scoped service
3. from a blocking endpoint
4. from a reactive endpoint

Fix https://github.com/quarkus-qe/quarkus-test-suite/issues/165