### PR TITLE
Define images as system properties and have community/product services

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -129,7 +129,10 @@ jobs:
           chmod +x ./quarkus-dev-cli
       - name: Test in Native mode
         run: |
-          mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -Dnative \
+          # Skip module due to high time execution on Native
+          MODULES="-pl '!sql-db/sql-app'"
+
+          mvn -fae -V -B -s .github/mvn-settings.xml $MODULES -fae clean verify -Dnative \
             -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }} \
             -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.RestService;
@@ -23,6 +24,7 @@ import io.restassured.http.ContentType;
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftWorkshopHeroesIT {
     private static String heroId;
 
@@ -42,7 +44,7 @@ public class OpenShiftWorkshopHeroesIT {
     private static final String POSTGRESQL_DATABASE = "heroes-database";
     private static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "registry.redhat.io/rhscl/postgresql-12-rhel7", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.12.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static DefaultService database = new DefaultService()
             .withProperty("POSTGRESQL_USER", POSTGRESQL_USER)
             .withProperty("POSTGRESQL_PASSWORD", POSTGRESQL_PASSWORD)

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopVillainsIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopVillainsIT.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.RestService;
@@ -24,6 +25,7 @@ import io.restassured.http.ContentType;
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftWorkshopVillainsIT {
     private static String villainId;
 
@@ -43,7 +45,7 @@ public class OpenShiftWorkshopVillainsIT {
     private static final String POSTGRESQL_DATABASE = "villains-database";
     private static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "registry.redhat.io/rhscl/postgresql-12-rhel7", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.12.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static DefaultService database = new DefaultService()
             .withProperty("POSTGRESQL_USER", POSTGRESQL_USER)
             .withProperty("POSTGRESQL_PASSWORD", POSTGRESQL_PASSWORD)

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
@@ -57,7 +57,7 @@ public class HttpAdvancedIT {
     private static final int KEYCLOAK_PORT = 8080;
     private static final int ASSERT_TIMEOUT_SECONDS = 10;
 
-    @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Admin console listening", port = KEYCLOAK_PORT)
+    @Container(image = "${keycloak.image}", expectedLog = "Admin console listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
 
     @QuarkusApplication(ssl = true)

--- a/http/vertx-web-client/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceIT.java
+++ b/http/vertx-web-client/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceIT.java
@@ -52,7 +52,7 @@ public class ChuckNorrisResourceIT {
     @JaegerContainer(image = "jaegertracing/all-in-one:latest", tracePort = TRACE_PORT, restPort = REST_PORT, expectedLog = "\"Health Check state change\",\"status\":\"ready\"")
     static final JaegerService jaeger = new JaegerService();
 
-    @Container(image = "rodolpheche/wiremock", port = 8080, expectedLog = "verbose")
+    @Container(image = "${wiremock.image}", port = 8080, expectedLog = "verbose")
     static DefaultService wiremock = new DefaultService();
 
     @QuarkusApplication

--- a/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/OpenShiftAmqStreamsKafkaAvroIT.java
+++ b/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/OpenShiftAmqStreamsKafkaAvroIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.messaging.kafka;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -8,6 +10,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsKafkaAvroIT extends BaseKafkaAvroIT {
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI, image = "${amq-streams.image}", version = "${amq-streams.version}", withRegistry = true)

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/OpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/OpenShiftAmqStreamsKafkaStreamIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.messaging.kafka;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -8,7 +10,9 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTest {
+
     @KafkaContainer(vendor = KafkaVendor.STRIMZI, image = "${amq-streams.image}", version = "${amq-streams.version}", withRegistry = true)
     static KafkaService kafka = new KafkaService();
 

--- a/micrometer/oidc/src/test/java/io/quarkus/ts/micrometer/oidc/BaseMicrometerOidcSecurityIT.java
+++ b/micrometer/oidc/src/test/java/io/quarkus/ts/micrometer/oidc/BaseMicrometerOidcSecurityIT.java
@@ -29,7 +29,7 @@ public abstract class BaseMicrometerOidcSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
 
     private AuthzClient authzClient;

--- a/micrometer/prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftAmqStreamsAlertEventsIT.java
+++ b/micrometer/prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftAmqStreamsAlertEventsIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.micrometer.prometheus.kafka;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -7,7 +9,9 @@ import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsAlertEventsIT extends BaseOpenShiftAlertEventsIT {
+
     @KafkaContainer(image = "${amq-streams.image}", version = "${amq-streams.version}")
     static KafkaService kafka = new KafkaService();
 

--- a/pom.xml
+++ b/pom.xml
@@ -229,9 +229,9 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <systemProperties>
+                    <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemProperties>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>
@@ -253,9 +253,21 @@
                                 <exclude>${exclude.operator.openshift.tests}</exclude>
                                 <exclude>${exclude.quarkus.cli.tests}</exclude>
                             </excludes>
-                            <systemProperties>
+                            <systemPropertyVariables>
                                 <profile.id>${profile.id}</profile.id>
-                            </systemProperties>
+                                <!-- Services used in test suite -->
+                                <keycloak.image>quay.io/keycloak/keycloak:14.0.0</keycloak.image>
+                                <rhsso.73.image>registry.access.redhat.com/redhat-sso-7/sso73-openshift</rhsso.73.image>
+                                <postgresql.10.image>registry.access.redhat.com/rhscl/postgresql-10-rhel7</postgresql.10.image>
+                                <mysql.57.image>quay.io/bitnami/mysql:5.7.32</mysql.57.image>
+                                <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7</mysql.80.image>
+                                <mariadb.102.image>registry.access.redhat.com/rhscl/mariadb-102-rhel7</mariadb.102.image>
+                                <mssql.image>mcr.microsoft.com/mssql/rhel/server</mssql.image>
+                                <db2.image>quay.io/pjgg/db2:11.5.5.0</db2.image>
+                                <redis.image>quay.io/bitnami/redis:6.0</redis.image>
+                                <wiremock.image>quay.io/ocpmetal/wiremock</wiremock.image>
+                                <consul.image>quay.io/bitnami/consul:1.9.3</consul.image>
+                            </systemPropertyVariables>
                         </configuration>
                     </execution>
                 </executions>
@@ -385,16 +397,13 @@
                         <executions>
                             <execution>
                                 <configuration>
-                                    <systemProperties>
+                                    <systemPropertyVariables>
                                         <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                                         <quarkus.package.type>${quarkus.package.type}</quarkus.package.type>
                                         <quarkus.native.container-build>${quarkus.native.container-build}</quarkus.native.container-build>
                                         <quarkus.native.native-image-xmx>${quarkus.native.native-image-xmx}</quarkus.native.native-image-xmx>
                                         <quarkus.native.builder-image>${quarkus.native.builder-image}</quarkus.native.builder-image>
-                                        <!-- Product Supported -->
-                                        <amq-streams.image>registry.redhat.io/amq7/amq-streams-kafka-27-rhel7</amq-streams.image>
-                                        <amq-streams.version>1.7.0</amq-streams.version>
-                                    </systemProperties>
+                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -437,6 +446,12 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
+                                <!-- Product Services -->
+                                <rhsso.74.image>registry.redhat.io/rh-sso-7/sso74-openshift-rhel8</rhsso.74.image>
+                                <postgresql.12.image>registry.redhat.io/rhscl/postgresql-12-rhel7</postgresql.12.image>
+                                <mariadb.103.image>registry.redhat.io/rhscl/mariadb-103-rhel7</mariadb.103.image>
+                                <amq-streams.image>registry.redhat.io/amq7/amq-streams-kafka-27-rhel7</amq-streams.image>
+                                <amq-streams.version>1.7.0</amq-streams.version>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/properties/src/test/java/io/quarkus/qe/properties/consul/ConsulConfigSourceIT.java
+++ b/properties/src/test/java/io/quarkus/qe/properties/consul/ConsulConfigSourceIT.java
@@ -27,7 +27,7 @@ public class ConsulConfigSourceIT {
     private static final String CONSUL_KEY = "config/app";
     private static final String CUSTOM_PROPERTY = "welcome.message";
 
-    @Container(image = "quay.io/bitnami/consul:1.9.3", expectedLog = "Synced node info", port = 8500)
+    @Container(image = "${consul.image}", expectedLog = "Synced node info", port = 8500)
     static ConsulService consul = new ConsulService().onPostStart(ConsulConfigSourceIT::onLoadConfigureConsul);
 
     @QuarkusApplication

--- a/scheduling/quartz/src/test/java/io/quarkus/qe/scheduling/quartz/BaseMySqlQuartzIT.java
+++ b/scheduling/quartz/src/test/java/io/quarkus/qe/scheduling/quartz/BaseMySqlQuartzIT.java
@@ -10,7 +10,7 @@ public abstract class BaseMySqlQuartzIT {
     static final String MYSQL_DATABASE = "mydb";
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "registry.access.redhat.com/rhscl/mysql-80-rhel7", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
     static DefaultService database = new DefaultService()
             .withProperty("MYSQL_USER", MYSQL_USER)
             .withProperty("MYSQL_PASSWORD", MYSQL_PASSWORD)

--- a/security/keycloak-authz/src/test/java/io/quarkus/ts/security/keycloak/authz/KeycloakAuthzSecurityIT.java
+++ b/security/keycloak-authz/src/test/java/io/quarkus/ts/security/keycloak/authz/KeycloakAuthzSecurityIT.java
@@ -11,7 +11,7 @@ public class KeycloakAuthzSecurityIT extends BaseAuthzSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
 
     @QuarkusApplication

--- a/security/keycloak-authz/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSso73AuthzSecurityIT.java
+++ b/security/keycloak-authz/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSso73AuthzSecurityIT.java
@@ -11,7 +11,7 @@ public class OpenShiftRhSso73AuthzSecurityIT extends BaseAuthzSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "registry.access.redhat.com/redhat-sso-7/sso73-openshift", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${rhsso.73.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
             .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
 

--- a/security/keycloak-authz/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSso74AuthzSecurityIT.java
+++ b/security/keycloak-authz/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSso74AuthzSecurityIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.security.keycloak.authz;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -7,11 +9,12 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSso74AuthzSecurityIT extends BaseAuthzSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "registry.redhat.io/rh-sso-7/sso74-openshift-rhel8", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${rhsso.74.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
             .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
 

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/KeycloakOidcJwtSecurityIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/KeycloakOidcJwtSecurityIT.java
@@ -10,7 +10,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakOidcJwtSecurityIT extends BaseOidcJwtSecurityIT {
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
 
     @QuarkusApplication

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/OpenShiftRhSso73OidcJwtSecurityIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/OpenShiftRhSso73OidcJwtSecurityIT.java
@@ -11,7 +11,7 @@ public class OpenShiftRhSso73OidcJwtSecurityIT extends BaseOidcJwtSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "registry.access.redhat.com/redhat-sso-7/sso73-openshift", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${rhsso.73.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
             .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
 

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/OpenShiftRhSso74OidcJwtSecurityIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/OpenShiftRhSso74OidcJwtSecurityIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.security.keycloak.jwt;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -7,11 +9,12 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSso74OidcJwtSecurityIT extends BaseOidcJwtSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "registry.redhat.io/rh-sso-7/sso74-openshift-rhel8", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${rhsso.74.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
             .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
 

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/KeycloakMultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/KeycloakMultiTenantSecurityIT.java
@@ -10,7 +10,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakMultiTenantSecurityIT extends BaseMultiTenantSecurityIT {
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
 
     @QuarkusApplication

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSso73MultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSso73MultiTenantSecurityIT.java
@@ -11,7 +11,7 @@ public class OpenShiftRhSso73MultiTenantSecurityIT extends BaseMultiTenantSecuri
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "registry.access.redhat.com/redhat-sso-7/sso73-openshift", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${rhsso.73.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
             .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
 

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSso74MultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSso74MultiTenantSecurityIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.security.keycloak.multitenant;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -7,11 +9,12 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSso74MultiTenantSecurityIT extends BaseMultiTenantSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "registry.redhat.io/rh-sso-7/sso74-openshift-rhel8", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${rhsso.74.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
             .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
 

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/KeycloakOauth2SecurityIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/KeycloakOauth2SecurityIT.java
@@ -11,7 +11,7 @@ public class KeycloakOauth2SecurityIT extends BaseOauth2SecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
 
     @QuarkusApplication

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/OpenShiftRhSso73Oauth2SecurityIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/OpenShiftRhSso73Oauth2SecurityIT.java
@@ -11,7 +11,7 @@ public class OpenShiftRhSso73Oauth2SecurityIT extends BaseOauth2SecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "registry.access.redhat.com/redhat-sso-7/sso73-openshift", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${rhsso.73.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
             .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
 

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/OpenShiftRhSso74Oauth2SecurityIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/OpenShiftRhSso74Oauth2SecurityIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.security;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -7,11 +9,12 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSso74Oauth2SecurityIT extends BaseOauth2SecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "registry.redhat.io/rh-sso-7/sso74-openshift-rhel8", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${rhsso.74.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
             .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
 

--- a/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/KeycloakOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/KeycloakOidcClientSecurityIT.java
@@ -10,7 +10,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakOidcClientSecurityIT extends BaseOidcClientSecurityIT {
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
 
     @QuarkusApplication

--- a/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/OpenShiftRhSso73OidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/OpenShiftRhSso73OidcClientSecurityIT.java
@@ -11,7 +11,7 @@ public class OpenShiftRhSso73OidcClientSecurityIT extends BaseOidcClientSecurity
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "registry.access.redhat.com/redhat-sso-7/sso73-openshift", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${rhsso.73.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
             .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
 

--- a/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/OpenShiftRhSso74OidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/OpenShiftRhSso74OidcClientSecurityIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.security.keycloak.oidcclient.basic;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -7,11 +9,12 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSso74OidcClientSecurityIT extends BaseOidcClientSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "registry.redhat.io/rh-sso-7/sso74-openshift-rhel8", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${rhsso.74.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
             .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
 

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseIT.java
@@ -16,7 +16,7 @@ public abstract class BaseIT {
     static final String CLIENT_ID_DEFAULT = "test-application-client";
     static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
 
-    @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
 
     @QuarkusApplication

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/KeycloakWebappSecurityIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/KeycloakWebappSecurityIT.java
@@ -10,7 +10,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakWebappSecurityIT extends BaseWebappSecurityIT {
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
 
     @QuarkusApplication

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/OpenShiftRhSso73WebappSecurityIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/OpenShiftRhSso73WebappSecurityIT.java
@@ -11,7 +11,7 @@ public class OpenShiftRhSso73WebappSecurityIT extends BaseWebappSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "registry.access.redhat.com/redhat-sso-7/sso73-openshift", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${rhsso.73.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
             .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
 

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/OpenShiftRhSso74WebappSecurityIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/OpenShiftRhSso74WebappSecurityIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.security.keycloak.webapp;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -7,11 +9,12 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSso74WebappSecurityIT extends BaseWebappSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "registry.redhat.io/rh-sso-7/sso74-openshift-rhel8", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${rhsso.74.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
             .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
 

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/KeycloakOidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/KeycloakOidcSecurityIT.java
@@ -11,7 +11,7 @@ public class KeycloakOidcSecurityIT extends BaseOidcSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
 
     @QuarkusApplication

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/OpenShiftRhSso73OidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/OpenShiftRhSso73OidcSecurityIT.java
@@ -11,7 +11,7 @@ public class OpenShiftRhSso73OidcSecurityIT extends BaseOidcSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "registry.access.redhat.com/redhat-sso-7/sso73-openshift", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${rhsso.73.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
             .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
 

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/OpenShiftRhSso74OidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/OpenShiftRhSso74OidcSecurityIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.security;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -7,11 +9,12 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSso74OidcSecurityIT extends BaseOidcSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "registry.redhat.io/rh-sso-7/sso74-openshift-rhel8", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    @Container(image = "${rhsso.74.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
     static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
             .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
 

--- a/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/AbstractCommonIT.java
+++ b/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/AbstractCommonIT.java
@@ -33,7 +33,7 @@ public abstract class AbstractCommonIT {
     Replicant replicant;
     Vertx vertx;
 
-    @Container(image = "quay.io/bitnami/redis:6.0", port = REDIS_PORT, expectedLog = "Ready to accept connections")
+    @Container(image = "${redis.image}", port = REDIS_PORT, expectedLog = "Ready to accept connections")
     static DefaultService redis = new DefaultService().withProperty("ALLOW_EMPTY_PASSWORD", "YES");
 
     @QuarkusApplication

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/AbstractDbIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/AbstractDbIT.java
@@ -11,7 +11,7 @@ public class AbstractDbIT {
     static final String POSTGRESQL_DATABASE = "mydb";
     static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "registry.access.redhat.com/rhscl/postgresql-10-rhel7", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.10.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static final DefaultService database = new DefaultService()
             .withProperty("POSTGRESQL_USER", POSTGRESQL_USER)
             .withProperty("POSTGRESQL_PASSWORD", POSTGRESQL_PASSWORD)

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiplePersistenceIT.java
@@ -34,13 +34,14 @@ public class MultiplePersistenceIT {
     static final int EXPECTED_VEGETABLES_SIZE = 7;
     static final long INVALID_ID = 999L;
 
-    @Container(image = "registry.access.redhat.com/rhscl/mariadb-102-rhel7", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.102.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static DefaultService mariadb = new DefaultService()
             .withProperty("MYSQL_USER", MARIADB_USER)
             .withProperty("MYSQL_PASSWORD", MARIADB_PASSWORD)
-            .withProperty("MYSQL_DATABASE", MARIADB_DATABASE);
+            .withProperty("MYSQL_DATABASE", MARIADB_DATABASE)
+            .withProperty("MARIADB_ROOT_PASSWORD", MARIADB_PASSWORD);
 
-    @Container(image = "registry.access.redhat.com/rhscl/postgresql-10-rhel7", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.10.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static DefaultService postgresql = new DefaultService()
             .withProperty("POSTGRESQL_USER", POSTGRESQL_USER)
             .withProperty("POSTGRESQL_PASSWORD", POSTGRESQL_PASSWORD)

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/BaseIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/BaseIT.java
@@ -11,7 +11,7 @@ public class BaseIT {
     static final String MYSQL_DATABASE = "test";
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "quay.io/bitnami/mysql:5.7.32", port = MYSQL_PORT, expectedLog = "ready for connections")
+    @Container(image = "${mysql.57.image}", port = MYSQL_PORT, expectedLog = "ready for connections")
     static DefaultService database = new DefaultService()
             .withProperty("MYSQL_USER", MYSQL_USER)
             .withProperty("MYSQL_PASSWORD", MYSQL_PASSWORD)

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MariaDB102DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MariaDB102DatabaseIT.java
@@ -14,11 +14,11 @@ public class MariaDB102DatabaseIT extends AbstractSqlDatabaseIT {
     static final String MARIADB_DATABASE = "mydb";
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "registry.access.redhat.com/rhscl/mariadb-102-rhel7", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.102.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static DefaultService database = new DefaultService()
             .withProperty("MYSQL_USER", MARIADB_USER)
-            .withProperty("MYSQL_PASSWORD", MARIADB_PASSWORD)
-            .withProperty("MYSQL_DATABASE", MARIADB_DATABASE);
+            .withProperty("MYSQL_DATABASE", MARIADB_DATABASE)
+            .withProperty("MYSQL_PASSWORD", MARIADB_PASSWORD);
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("mariadb_app.properties")

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MariaDB103DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MariaDB103DatabaseIT.java
@@ -17,7 +17,7 @@ public class MariaDB103DatabaseIT extends AbstractSqlDatabaseIT {
     static final String MYSQL_DATABASE = "mydb";
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "registry.redhat.io/rhscl/mariadb-103-rhel7", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.103.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
     static DefaultService database = new DefaultService()
             .withProperty("MYSQL_USER", MYSQL_USER)
             .withProperty("MYSQL_PASSWORD", MYSQL_PASSWORD)

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MySqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MySqlDatabaseIT.java
@@ -14,7 +14,7 @@ public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {
     static final String MYSQL_DATABASE = "mydb";
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "registry.access.redhat.com/rhscl/mysql-80-rhel7", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
     static DefaultService database = new DefaultService()
             .withProperty("MYSQL_USER", MYSQL_USER)
             .withProperty("MYSQL_PASSWORD", MYSQL_PASSWORD)

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMssqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMssqlDatabaseIT.java
@@ -11,7 +11,7 @@ public class OpenShiftMssqlDatabaseIT extends AbstractSqlDatabaseIT {
 
     static final int MSSQL_PORT = 1433;
 
-    @Container(image = "mcr.microsoft.com/mssql/rhel/server", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
+    @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
     static DefaultService mssql = new DefaultService();
 
     @QuarkusApplication

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/Postgresql10DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/Postgresql10DatabaseIT.java
@@ -14,7 +14,7 @@ public class Postgresql10DatabaseIT extends AbstractSqlDatabaseIT {
     static final String POSTGRESQL_DATABASE = "mydb";
     static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "registry.access.redhat.com/rhscl/postgresql-10-rhel7", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.10.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static DefaultService database = new DefaultService()
             .withProperty("POSTGRESQL_USER", POSTGRESQL_USER)
             .withProperty("POSTGRESQL_PASSWORD", POSTGRESQL_PASSWORD)

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/Postgresql12DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/Postgresql12DatabaseIT.java
@@ -17,7 +17,7 @@ public class Postgresql12DatabaseIT extends AbstractSqlDatabaseIT {
     static final String POSTGRESQL_DATABASE = "mydb";
     static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "registry.redhat.io/rhscl/postgresql-12-rhel7", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.12.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static DefaultService database = new DefaultService()
             .withProperty("POSTGRESQL_USER", POSTGRESQL_USER)
             .withProperty("POSTGRESQL_PASSWORD", POSTGRESQL_PASSWORD)

--- a/sql-db/vertx-sql/pom.xml
+++ b/sql-db/vertx-sql/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <artifactId>vertx-sql</artifactId>
     <packaging>jar</packaging>
-    <name>Quarkus QE TS: SQL Database: exploratory testing</name>
+    <name>Quarkus QE TS: SQL Database: Vert.x SQL</name>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/dbpool/PostgresPoolIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/dbpool/PostgresPoolIT.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.response.Response;
@@ -29,6 +30,8 @@ import io.vertx.mutiny.ext.web.client.HttpResponse;
 import io.vertx.mutiny.ext.web.client.WebClient;
 import io.vertx.mutiny.ext.web.client.predicate.ResponsePredicate;
 
+@DisabledOnNative(reason = "This test is randomly failing in Native. "
+        + "Reported by https://github.com/quarkus-qe/quarkus-test-suite/issues/175")
 @QuarkusScenario
 @TestMethodOrder(OrderAnnotation.class)
 public class PostgresPoolIT {
@@ -43,11 +46,11 @@ public class PostgresPoolIT {
      */
     private static final int DATASOURCE_MAX_SIZE = 5;
 
-    @Container(image = "quay.io/rhoar_qe/postgres", port = 5432, expectedLog = "database system is ready to accept connections")
+    @Container(image = "${postgresql.10.image}", port = 5432, expectedLog = "listening on IPv4 address")
     static DefaultService postgres = new DefaultService()
-            .withProperty("POSTGRES_USER", "test")
-            .withProperty("POSTGRES_PASSWORD", "test")
-            .withProperty("POSTGRES_DB", POSTGRESQL_DATABASE);
+            .withProperty("POSTGRESQL_USER", "test")
+            .withProperty("POSTGRESQL_PASSWORD", "test")
+            .withProperty("POSTGRESQL_DATABASE", POSTGRESQL_DATABASE);
 
     @QuarkusApplication
     static final RestService app = new RestService()

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/Db2HandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/Db2HandlerIT.java
@@ -10,7 +10,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class Db2HandlerIT extends CommonTestCases {
     private static final String DATABASE = "amadeus";
 
-    @Container(image = "quay.io/pjgg/db2:11.5.5.0", port = 50000, expectedLog = "Setup has completed")
+    @Container(image = "${db2.image}", port = 50000, expectedLog = "Setup has completed")
     static DefaultService db2 = new DefaultService()
             .withProperty("LICENSE", "accept")
             .withProperty("DB2INST1_PASSWORD", "test")

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/MysqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/MysqlHandlerIT.java
@@ -10,7 +10,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class MysqlHandlerIT extends CommonTestCases {
     private static final String DATABASE = "amadeus";
 
-    @Container(image = "quay.io/bitnami/mysql:5.7.32", port = 3306, expectedLog = "MySQL Community Server")
+    @Container(image = "${mysql.57.image}", port = 3306, expectedLog = "ready for connections")
     static DefaultService mysql = new DefaultService()
             .withProperty("MYSQL_ROOT_PASSWORD", "test")
             .withProperty("MYSQL_USER", "test")

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/PostgresqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/PostgresqlHandlerIT.java
@@ -10,11 +10,11 @@ import io.quarkus.test.services.QuarkusApplication;
 public class PostgresqlHandlerIT extends CommonTestCases {
     private static final String POSTGRESQL_DATABASE = "amadeus";
 
-    @Container(image = "quay.io/rhoar_qe/postgres", port = 5432, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.10.image}", port = 5432, expectedLog = "listening on IPv4 address")
     static DefaultService postgres = new DefaultService()
-            .withProperty("POSTGRES_USER", "test")
-            .withProperty("POSTGRES_PASSWORD", "test")
-            .withProperty("POSTGRES_DB", POSTGRESQL_DATABASE);
+            .withProperty("POSTGRESQL_USER", "test")
+            .withProperty("POSTGRESQL_PASSWORD", "test")
+            .withProperty("POSTGRESQL_DATABASE", POSTGRESQL_DATABASE);
 
     @QuarkusApplication
     static final RestService app = new RestService()


### PR DESCRIPTION
++ These changes will use the community services by default and the services from RedHat registry in the `redhat-registry`.
++ Disable sql-app in Daily run for Native builds