### PR TITLE
Add module to covers `quarkus-logging-json` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ Module that covers the runtime configuration to ensure the changes take effect. 
 - Properties from YAML and external files
 - Properties from Consul
 
+### `logging/jboss`
+
+Module that covers the logging functionality using JBoss Logging Manager. The following scenarios are covered:
+- Usage of `quarkus-logging-json` extension
+- Inject the `Logger` instance in beans
+- Inject a `Logger` instance using a custom category
+- Setting up the log level property for logger instances 
+
 ### `sql-db/sql-app`
 
 Verifies that the application can connect to a SQL database and persist data using Hibernate ORM with Panache.

--- a/logging/jboss/pom.xml
+++ b/logging/jboss/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>logging-jboss</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: Logging: JBoss</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-logging-json</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/logging/jboss/src/main/java/io/quarkus/ts/logging/jboss/LogResource.java
+++ b/logging/jboss/src/main/java/io/quarkus/ts/logging/jboss/LogResource.java
@@ -1,0 +1,48 @@
+package io.quarkus.ts.logging.jboss;
+
+import javax.inject.Inject;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.log.LoggerName;
+
+@Path("/log")
+public class LogResource {
+
+    public static final String CUSTOM_CATEGORY = "foo";
+
+    private static final Logger LOG = Logger.getLogger(LogResource.class);
+
+    @Inject
+    Logger log;
+
+    @LoggerName(CUSTOM_CATEGORY)
+    Logger customCategoryLog;
+
+    @POST
+    @Path("/static/{level}")
+    public void addLogMessageInStaticLogger(@PathParam("level") String level, @QueryParam("message") String message) {
+        addLogMessage(LOG, level, message);
+    }
+
+    @POST
+    @Path("/field/{level}")
+    public void addLogMessageInFieldLogger(@PathParam("level") String level, @QueryParam("message") String message) {
+        addLogMessage(log, level, message);
+    }
+
+    @POST
+    @Path("/field-with-custom-category/{level}")
+    public void addLogMessageInFieldWithCustomCategoryLogger(@PathParam("level") String level,
+            @QueryParam("message") String message) {
+        addLogMessage(customCategoryLog, level, message);
+    }
+
+    private void addLogMessage(Logger logger, String level, String message) {
+        logger.log(Logger.Level.valueOf(level), message);
+    }
+}

--- a/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/LogResourceIT.java
+++ b/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/LogResourceIT.java
@@ -1,0 +1,127 @@
+package io.quarkus.ts.logging.jboss;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class LogResourceIT {
+
+    private static final String EXPECTED_JSON_MESSAGE = "\"level\":\"INFO\",\"message\":\"Profile prod activated. \"";
+    private static final String MESSAGE = "messageLog";
+
+    @QuarkusApplication
+    static RestService app = new RestService();
+
+    @BeforeEach
+    public void setup() {
+        // Reset level to INFO
+        setLogLevelTo(Logger.Level.INFO);
+    }
+
+    @Test
+    public void shouldBeInJsonFormatByDefault() {
+        // By default, the format should be in JSON format
+        app.logs().assertContains(EXPECTED_JSON_MESSAGE);
+
+        disableJsonFormatLogging();
+        assertDoesNotContain(EXPECTED_JSON_MESSAGE);
+    }
+
+    @Test
+    public void shouldLogInStaticLogger() {
+        verifyLoggingRules(this::addMessageInStaticLog);
+    }
+
+    @Test
+    public void shouldLogInFieldLogger() {
+        verifyLoggingRules(this::addMessageInFieldLog);
+    }
+
+    @Test
+    public void shouldLogInFieldWithCustomCategoryLogger() {
+        verifyLoggingRules(this::addMessageInFieldWithCustomCategoryLog);
+    }
+
+    @Test
+    public void shouldCategoryBeWorkingOnlyForAffectedLoggers() {
+        // Write messages to several loggers
+        addMessageInFieldLog(Logger.Level.DEBUG, MESSAGE + "field1");
+        addMessageInFieldWithCustomCategoryLog(Logger.Level.DEBUG, MESSAGE + "category1");
+
+        // As it's DEBUG level, none should be shown
+        assertDoesNotContain(MESSAGE + "field1");
+        assertDoesNotContain(MESSAGE + "category1");
+
+        // Let's configure only the log with custom category to show DEBUG messages
+        setPropertyTo("quarkus.log.category.\"" + LogResource.CUSTOM_CATEGORY + "\".level", Logger.Level.DEBUG.name());
+
+        // Let's write messages again
+        addMessageInFieldLog(Logger.Level.DEBUG, MESSAGE + "field2");
+        addMessageInFieldWithCustomCategoryLog(Logger.Level.DEBUG, MESSAGE + "category2");
+
+        // Now, the message should be shown only in the logger of the custom category
+        assertDoesNotContain(MESSAGE + "field2");
+        app.logs().assertContains(MESSAGE + "category2");
+    }
+
+    private void verifyLoggingRules(BiConsumer<Logger.Level, String> writer) {
+        // Added INFO log
+        writer.accept(Logger.Level.INFO, MESSAGE + "1");
+        app.logs().assertContains(MESSAGE + "1");
+
+        // By default, DEBUG messages should not be shown
+        writer.accept(Logger.Level.DEBUG, MESSAGE + "2");
+        assertDoesNotContain(MESSAGE + "2");
+
+        // Set level to DEBUG
+        setLogLevelTo(Logger.Level.DEBUG);
+
+        // Now, DEBUG messages should be shown
+        writer.accept(Logger.Level.DEBUG, MESSAGE + "3");
+        app.logs().assertContains(MESSAGE + "3");
+    }
+
+    private void addMessageInStaticLog(Logger.Level level, String expectedMessage) {
+        app.given().post("/log/static/" + level.name() + "?message=" + expectedMessage);
+    }
+
+    private void addMessageInFieldLog(Logger.Level level, String expectedMessage) {
+        app.given().post("/log/field/" + level.name() + "?message=" + expectedMessage);
+    }
+
+    private void addMessageInFieldWithCustomCategoryLog(Logger.Level level, String expectedMessage) {
+        app.given().post("/log/field-with-custom-category/" + level.name() + "?message=" + expectedMessage);
+    }
+
+    private void disableJsonFormatLogging() {
+        setPropertyTo("quarkus.log.console.json", Boolean.FALSE.toString());
+    }
+
+    private void setLogLevelTo(Logger.Level info) {
+        setPropertyTo("quarkus.log.level", info.toString());
+    }
+
+    private void setPropertyTo(String property, String value) {
+        app.stop();
+        app.withProperty(property, value);
+        app.start();
+    }
+
+    /**
+     * TODO: This method will be included in the Test Framework API in 0.0.7.
+     */
+    private void assertDoesNotContain(String unexpectedLog) {
+        List<String> actualLogs = app.getLogs();
+        Assertions.assertTrue(actualLogs.stream().noneMatch(line -> line.contains(unexpectedLog)),
+                "Log does contain " + unexpectedLog + ". Full logs: " + actualLogs);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <module>quarkus-cli</module>
         <module>kamelet</module>
         <module>spring/spring-data</module>
+        <module>logging/jboss</module>
     </modules>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Module that covers the logging functionality using JBoss Logging Manager. The following scenarios are covered:
- Usage of `quarkus-logging-json` extension
- Inject the `Logger` instance in beans
- Inject a `Logger` instance using a custom category
- Setting up the log level property for logger instances

Fix https://github.com/quarkus-qe/quarkus-test-suite/issues/168