### PR TITLE
Add coverage for `rest-client-jaxb` and `rest-client-jsonb`

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ It also verifies multiple deployment strategies like:
 ### `http-advanced`
 Verifies Server/Client http_2/1.1, Grpc and http redirections.
 
-
 ### `http-static`
 Verifies access to static pages and big static files over http.
 
@@ -146,6 +145,13 @@ This module covers basic scenarios about HTTP servlets under `quarkus-undertow` 
 
 ### `jaxrs`
 Simple bootstrap project created by *quarkus-maven-plugin*  
+
+### `http/rest-client`
+Verifies Rest Client configuration using `quarkus-rest-client-jaxb` (XML support) and `quarkus-rest-client-jsonb` (JSON support).
+This module will setup a very minimal configuration (only `quarkus-resteasy`) and have four endpoints:
+- Two endpoints to get a book in JSON and XML formats.
+- Two endpoints to get the value of the previous endpoints using the rest client interface. 
+
 #### Additions
 * *@Deprecated* annotation has been added for test regression purposes to ensure `java.lang` annotations are allowed for resources
 * Resource with multipart body support, provided parts are text, image and binary data, charset checked with `us-ascii` and `utf-8`

--- a/http/rest-client/pom.xml
+++ b/http/rest-client/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>http-rest-client</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: HTTP: Rest Client</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jaxb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jsonb</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/http/rest-client/src/main/java/io/quarkus/ts/http/restclient/ClientBookResource.java
+++ b/http/rest-client/src/main/java/io/quarkus/ts/http/restclient/ClientBookResource.java
@@ -1,0 +1,33 @@
+package io.quarkus.ts.http.restclient;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.quarkus.ts.http.restclient.xml.Book;
+
+@Path("/client/book")
+public class ClientBookResource {
+
+    @Inject
+    @RestClient
+    RestInterface restInterface;
+
+    @GET
+    @Path("/xml")
+    @Produces(MediaType.APPLICATION_XML)
+    public Book getAsXml() {
+        return restInterface.getAsXml();
+    }
+
+    @GET
+    @Path("/json")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Book getAsJson() {
+        return restInterface.getAsJson();
+    }
+}

--- a/http/rest-client/src/main/java/io/quarkus/ts/http/restclient/RestInterface.java
+++ b/http/rest-client/src/main/java/io/quarkus/ts/http/restclient/RestInterface.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.http.restclient;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.ts.http.restclient.xml.Book;
+
+@RegisterRestClient
+@Path("/book")
+@RegisterClientHeaders
+public interface RestInterface {
+
+    @GET
+    @Path("/xml")
+    @Produces(MediaType.APPLICATION_XML)
+    Book getAsXml();
+
+    @GET
+    @Path("/json")
+    @Produces(MediaType.APPLICATION_JSON)
+    Book getAsJson();
+}

--- a/http/rest-client/src/main/java/io/quarkus/ts/http/restclient/xml/Book.java
+++ b/http/rest-client/src/main/java/io/quarkus/ts/http/restclient/xml/Book.java
@@ -1,0 +1,24 @@
+package io.quarkus.ts.http.restclient.xml;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class Book {
+
+    private String title;
+
+    public Book() {
+    }
+
+    public Book(String title) {
+        this.title = title;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+}

--- a/http/rest-client/src/main/java/io/quarkus/ts/http/restclient/xml/BookAsJsonResource.java
+++ b/http/rest-client/src/main/java/io/quarkus/ts/http/restclient/xml/BookAsJsonResource.java
@@ -1,0 +1,16 @@
+package io.quarkus.ts.http.restclient.xml;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/book/json")
+public class BookAsJsonResource {
+
+    @GET
+    public String get() {
+        return "{\"title\":\"Title in Json\"}";
+    }
+}

--- a/http/rest-client/src/main/java/io/quarkus/ts/http/restclient/xml/BookAsXmlResource.java
+++ b/http/rest-client/src/main/java/io/quarkus/ts/http/restclient/xml/BookAsXmlResource.java
@@ -1,0 +1,16 @@
+package io.quarkus.ts.http.restclient.xml;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_XML)
+@Path("/book/xml")
+public class BookAsXmlResource {
+
+    @GET
+    public String hello() {
+        return "<book><title>Title in Xml</title></book>";
+    }
+}

--- a/http/rest-client/src/main/resources/application.properties
+++ b/http/rest-client/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+io.quarkus.ts.http.restclient.RestInterface/mp-rest/url=http://localhost:${quarkus.http.port}

--- a/http/rest-client/src/test/java/io/quarkus/ts/http/restclient/ClientBookResourceIT.java
+++ b/http/rest-client/src/test/java/io/quarkus/ts/http/restclient/ClientBookResourceIT.java
@@ -1,0 +1,26 @@
+package io.quarkus.ts.http.restclient;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+
+@QuarkusScenario
+public class ClientBookResourceIT {
+
+    @Test
+    public void shouldGetBookFromRestClientXml() {
+        given().get("/client/book/xml").then().statusCode(HttpStatus.SC_OK)
+                .body(is(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><book><title>Title in Xml</title></book>"));
+    }
+
+    @Test
+    public void shouldGetBookFromRestClientJson() {
+        given().get("/client/book/json").then().statusCode(HttpStatus.SC_OK)
+                .body(is("{\"title\":\"Title in Json\"}"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <module>http/http-static</module>
         <module>http/jaxrs</module>
         <module>http/reactive-routes</module>
+        <module>http/rest-client</module>
         <module>http/servlet-undertow</module>
         <module>http/vertx-web-client</module>
         <module>javaee-like-getting-started</module>


### PR DESCRIPTION
Verifies Rest Client configuration using `quarkus-rest-client-jaxb` (XML support) and `quarkus-rest-client-jsonb` (JSON support).
This module will setup a very minimal configuration (only `quarkus-resteasy`) and have four endpoints:
- Two endpoints to get a book in JSON and XML formats.
- Two endpoints to get the value of the previous endpoints using the rest client interface.

Fix https://github.com/quarkus-qe/quarkus-test-suite/issues/170