### PR TITLE
Fix test: PostgresPoolIT.checkDbPoolTurnover

### DIFF
--- a/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/Application.java
+++ b/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/Application.java
@@ -50,9 +50,9 @@ public class Application {
     @IfBuildProfile("mysql")
     MySQLPool mysql;
 
-    @IfBuildProfile("db2")
     @Inject
     @Named("db2")
+    @IfBuildProfile("db2")
     DB2Pool db2;
 
     void onStart(@Observes StartupEvent ev) {

--- a/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/PoolApplication.java
+++ b/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/PoolApplication.java
@@ -29,7 +29,7 @@ public class PoolApplication {
                 .transform(iterator -> iterator.hasNext() ? iterator.next().getLong("active_con") : null);
     }
 
-    @Route(methods = Route.HttpMethod.PUT, path = "/connect")
+    @Route(methods = Route.HttpMethod.GET, path = "/connect")
     public Uni<Long> newConnection() {
         // Make just one extra query and Hold "Idle + 1 sec" in order to release inactive connections.
         return postgresql.preparedQuery("SELECT CURRENT_TIMESTAMP").execute()


### PR DESCRIPTION
The problem was caused by calling the Reactive Route using RESTAssured instead of using the WebClient instance. 
Calling using RestAssured was not waiting for the call to be ended and hence sometimes the response was empty (the number of active connections).
The rest of the changes are cosmetic, so this test looks more similar to what we have in Beefy.
I did check that now it's working on Native and JVM.

Fix https://github.com/quarkus-qe/quarkus-test-suite/issues/175