### PR TITLE
Split Native job to run selected modules

### DIFF
--- a/.github/quarkus-ecosystem-test
+++ b/.github/quarkus-ecosystem-test
@@ -2,7 +2,7 @@
 set -e
 
 # run the tests on JVM
-mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify
+mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P $MAVEN_PROFILES
 
 # run the tests on Native
-mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=5g
+mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P $MAVEN_PROFILES -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=5g

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,8 @@ jobs:
 
           MODULES_ARG="${CHANGED// /,}"
           if [[ -n ${MODULES_ARG} ]]; then
-            mvn -fae -V -B -s .github/mvn-settings.xml -fae -pl $MODULES_ARG clean verify -Dnative \
+            echo "Running modules: ${MODULES_ARG}"
+            mvn -fae -V -B -s .github/mvn-settings.xml -fae -Dall-modules -pl $MODULES_ARG clean verify -Dnative \
                         -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
           fi
       - name: Zip Artifacts

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -76,7 +76,7 @@ jobs:
           chmod +x ./quarkus-dev-cli
       - name: Test in JVM mode
         run: |
-          mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
+          mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -Dall-modules -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -94,7 +94,12 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        image: [ "ubi-quarkus-native-image:21.0-java11", "ubi-quarkus-mandrel:21.0-java11" ]
+        image: [ "ubi-quarkus-native-image:21.2-java11", "ubi-quarkus-mandrel:21.2-java11" ]
+        profiles: [ "!http-modules,!security-modules,!sql-db-modules,!messaging-modules",
+                   "http-modules",
+                   "security-modules",
+                   "sql-db-modules",
+                   "messaging-modules"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1
@@ -129,10 +134,7 @@ jobs:
           chmod +x ./quarkus-dev-cli
       - name: Test in Native mode
         run: |
-          # Skip module due to high time execution on Native
-          MODULES="-pl '!sql-db/sql-app'"
-
-          mvn -fae -V -B -s .github/mvn-settings.xml $MODULES -fae clean verify -Dnative \
+          mvn -fae -V -B -s .github/mvn-settings.xml -P ${{ matrix.profiles }} -fae clean verify -Dnative \
             -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }} \
             -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
@@ -235,7 +237,7 @@ jobs:
         shell: bash
         run: |
           # Running only http/http-minimum as after some time, it gives disk full in Windows when running on Native.
-          mvn -fae -s .github/mvn-settings.xml clean verify -Dnative -Dquarkus.native.container-build=false -pl http/http-minimum
+          mvn -fae -s .github/mvn-settings.xml clean verify -Dall-modules -Dnative -Dquarkus.native.container-build=false -pl http/http-minimum
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -22,6 +22,13 @@ jobs:
     name: "Build against latest Quarkus snapshot"
     runs-on: ubuntu-latest
     if: github.actor == 'quarkusbot' || github.actor == 'Sgitario' || github.actor == 'rsvoboda'
+    strategy:
+      matrix:
+        profiles: [ "!http-modules,!security-modules,!sql-db-modules,!messaging-modules",
+                    "http-modules",
+                    "security-modules",
+                    "sql-db-modules",
+                    "messaging-modules"]
 
     steps:
       - name: Install yq
@@ -47,3 +54,4 @@ jobs:
         run: ./ecosystem-ci/setup-and-test
         env:
           ECOSYSTEM_CI_TOKEN: ${{ secrets.ECOSYSTEM_CI_TOKEN }}
+          MAVEN_PROFILES: ${{ matrix.profiles }}

--- a/.github/workflows/quarkus-test-framework-snapshot.yaml
+++ b/.github/workflows/quarkus-test-framework-snapshot.yaml
@@ -95,7 +95,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        image: [ "ubi-quarkus-native-image:21.0-java11", "ubi-quarkus-mandrel:21.0-java11" ]
+        image: [ "ubi-quarkus-native-image:21.2-java11", "ubi-quarkus-mandrel:21.2-java11" ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Running the tests amounts to standard `mvn clean verify`.
 This will use a specific Quarkus version, which can be modified by setting the `quarkus.platform.version` property.
 Alternatively, you can use `-Dquarkus-core-only` to run the test suite against Quarkus `999-SNAPSHOT`.
 In that case, make sure you have built Quarkus locally prior to running the tests.
+Moreover, all the modules are grouped by types: `http`, `security`, `messaging`... Hence we can run a concrete set of scenarios 
+just by selecting the right profile: `-P http-modules` or `-P security-modules`. Take into account that if you are selecting 
+another profile as OpenShift (`mvn clean verify -Dopenshift`), you need to explicitly to add `-Dall-modules` to include all 
+the modules in all the profiles.
 
 Since this is standard Quarkus configuration, it's possible to override using a system property.
 Therefore, if you want to run the tests with a different Java S2I image, run `mvn clean verify -Dquarkus.s2i.base-jvm-image=...`.
@@ -108,7 +112,7 @@ Serverless test coverage supports both JVM and Native mode.
 The following command will execute the whole test suite including serverless tests:
 
 ```
-./mvnw clean verify -Dinclude.serverless
+./mvnw clean verify -Dall-modules -Dinclude.serverless
 ```
 
 ### OpenShift Operators
@@ -120,7 +124,7 @@ Serverless test coverage supports both JVM and Native mode.
 The following command will execute the whole test suite including serverless tests:
 
 ```
-./mvnw clean verify -Dinclude.operator-scenarios
+./mvnw clean verify -Dall-modules -Dinclude.operator-scenarios
 ```
 
 ## Existing tests
@@ -541,7 +545,7 @@ We cover the following two scenarios:
 
 Verifies all the Quarkus CLI features: https://quarkus.io/version/main/guides/cli-tooling
 
-In order to enable this module, the test suite must be executed with `-Dinclude.quarkus-cli-tests`. The Quarkus CLI is expected to be called `quarkus`. We can configure the test suite to use another Quarkus CLI binary name using `-Dts.quarkus.cli.cmd=/path/to/quarkus-dev-cli`.
+In order to enable this module, the test suite must be executed with `-DallModules -Dinclude.quarkus-cli-tests`. The Quarkus CLI is expected to be called `quarkus`. We can configure the test suite to use another Quarkus CLI binary name using `-Dts.quarkus.cli.cmd=/path/to/quarkus-dev-cli`.
 
 ### `Kamelet`
 

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftQuickstartUsingS2iIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftQuickstartUsingS2iIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-@DisabledOnNative
+@DisabledOnNative(reason = "S2i is not supported on Native yet: https://github.com/quarkus-qe/quarkus-test-framework/issues/206")
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario
 public class OpenShiftQuickstartUsingS2iIT {

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftTodoDemoIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftTodoDemoIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-@DisabledOnNative
+@DisabledOnNative(reason = "S2i is not supported on Native yet: https://github.com/quarkus-qe/quarkus-test-framework/issues/206")
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario
 public class OpenShiftTodoDemoIT {

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
@@ -20,7 +20,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 import io.restassured.http.ContentType;
 
-@DisabledOnNative
+@DisabledOnNative(reason = "S2i is not supported on Native yet: https://github.com/quarkus-qe/quarkus-test-framework/issues/206")
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopVillainsIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopVillainsIT.java
@@ -21,7 +21,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 import io.restassured.http.ContentType;
 
-@DisabledOnNative
+@DisabledOnNative(reason = "S2i is not supported on Native yet: https://github.com/quarkus-qe/quarkus-test-framework/issues/206")
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeGrpcIntegrationIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeGrpcIntegrationIT.java
@@ -32,7 +32,6 @@ import io.quarkus.example.HelloRequest;
 import io.quarkus.test.bootstrap.GrpcService;
 import io.quarkus.test.logging.Log;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.restassured.response.Response;
 
@@ -43,7 +42,6 @@ import okhttp3.WebSocket;
 @Tag("QUARKUS-1026")
 @Tag("QUARKUS-1094")
 @QuarkusScenario
-@DisabledOnNative
 public class DevModeGrpcIntegrationIT {
 
     static final String NAME = "QE";

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/DevModeHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/DevModeHttpMinimumIT.java
@@ -12,14 +12,12 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.AwaitilityUtils;
 
 @Tag("QUARKUS-1026")
 @QuarkusScenario
-@DisabledOnNative
 @DisabledOnQuarkusVersion(version = "1\\..*", reason = "Continuous Testing was entered in 2.x")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class DevModeHttpMinimumIT {

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/DevModeKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/DevModeKafkaStreamIT.java
@@ -4,12 +4,10 @@ import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @Tag("QUARKUS-1026")
 @QuarkusScenario
-@DisabledOnNative
 public class DevModeKafkaStreamIT extends BaseKafkaStreamTest {
 
     /**

--- a/micrometer/prometheus/src/main/java/io/quarkus/ts/micrometer/prometheus/PrimeNumberResource.java
+++ b/micrometer/prometheus/src/main/java/io/quarkus/ts/micrometer/prometheus/PrimeNumberResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.micrometer.prometheus;
 
+import java.util.UUID;
 import java.util.concurrent.atomic.LongAccumulator;
 import java.util.function.Supplier;
 
@@ -9,8 +10,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.apache.commons.lang3.RandomStringUtils;
-
 import io.micrometer.core.instrument.MeterRegistry;
 
 @Path("/")
@@ -18,7 +17,7 @@ public class PrimeNumberResource {
     private static final int THREE = 3;
     private final LongAccumulator highestPrime = new LongAccumulator(Long::max, 0);
     private final MeterRegistry registry;
-    private final String uniqueId = RandomStringUtils.randomAlphabetic(5);
+    private final String uniqueId = UUID.randomUUID().toString().substring(0, 5);
 
     PrimeNumberResource(MeterRegistry registry) {
         this.registry = registry;

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <exclude.serverless.openshift.tests>**/Serverless*OpenShift*IT.java</exclude.serverless.openshift.tests>
         <exclude.operator.openshift.tests>**/Operator*OpenShift*IT.java</exclude.operator.openshift.tests>
         <exclude.quarkus.cli.tests>**/QuarkusCli*IT.java</exclude.quarkus.cli.tests>
+        <exclude.quarkus.devmode.tests>no</exclude.quarkus.devmode.tests>
     </properties>
     <modules>
         <module>config</module>
@@ -257,6 +258,7 @@
                                 <exclude>${exclude.serverless.openshift.tests}</exclude>
                                 <exclude>${exclude.operator.openshift.tests}</exclude>
                                 <exclude>${exclude.quarkus.cli.tests}</exclude>
+                                <exclude>${exclude.quarkus.devmode.tests}</exclude>
                             </excludes>
                             <systemPropertyVariables>
                                 <profile.id>${profile.id}</profile.id>
@@ -421,6 +423,7 @@
                 <quarkus.native.container-build>true</quarkus.native.container-build>
                 <quarkus.native.native-image-xmx>4g</quarkus.native.native-image-xmx>
                 <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.0-java11</quarkus.native.builder-image>
+                <exclude.quarkus.devmode.tests>**/*DevMode*IT.java</exclude.quarkus.devmode.tests>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -45,59 +45,6 @@
         <exclude.quarkus.cli.tests>**/QuarkusCli*IT.java</exclude.quarkus.cli.tests>
         <exclude.quarkus.devmode.tests>no</exclude.quarkus.devmode.tests>
     </properties>
-    <modules>
-        <module>config</module>
-        <module>properties</module>
-        <module>http/http-minimum</module>
-        <module>http/http-advanced</module>
-        <module>http/http-static</module>
-        <module>http/jaxrs</module>
-        <module>http/reactive-routes</module>
-        <module>http/rest-client</module>
-        <module>http/servlet-undertow</module>
-        <module>http/vertx-web-client</module>
-        <module>javaee-like-getting-started</module>
-        <module>scaling</module>
-        <module>micrometer/prometheus</module>
-        <module>micrometer/prometheus-kafka</module>
-        <module>micrometer/oidc</module>
-        <module>messaging/artemis</module>
-        <module>messaging/artemis-jta</module>
-        <module>messaging/amqp-reactive</module>
-        <module>messaging/qpid</module>
-        <module>messaging/kafka-streams-reactive-messaging</module>
-        <module>messaging/kafka-avro-reactive-messaging</module>
-        <module>microprofile</module>
-        <module>security/basic</module>
-        <module>security/https</module>
-        <module>security/jwt</module>
-        <module>security/keycloak</module>
-        <module>security/keycloak-authz</module>
-        <module>security/keycloak-jwt</module>
-        <module>security/keycloak-webapp</module>
-        <module>security/keycloak-oauth2</module>
-        <module>security/keycloak-multitenant</module>
-        <module>security/keycloak-oidc-client-basic</module>
-        <module>security/keycloak-oidc-client-extended</module>
-        <module>security/vertx-jwt</module>
-        <module>sql-db/sql-app</module>
-        <module>sql-db/multiple-pus</module>
-        <module>sql-db/panache-flyway</module>
-        <module>sql-db/vertx-sql</module>
-        <module>lifecycle-application</module>
-        <module>external-applications</module>
-        <module>scheduling/quartz</module>
-        <module>infinispan-client</module>
-        <module>super-size/many-extensions</module>
-        <module>quarkus-cli</module>
-        <module>kamelet</module>
-        <module>spring/spring-data</module>
-        <module>spring/spring-web</module>
-        <module>spring/spring-properties</module>
-        <module>logging/jboss</module>
-        <module>cache/caffeine</module>
-        <module>cache/spring</module>
-    </modules>
     <dependencyManagement>
         <dependencies>
             <!-- TODO: com.squareup.retrofit2:retrofit:2.9.0 should be removed on Quarkus 2.0.0.Alphas-->
@@ -391,6 +338,134 @@
     </repositories>
     <profiles>
         <profile>
+            <id>root-modules</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>all-modules</name>
+                </property>
+            </activation>
+            <modules>
+                <module>config</module>
+                <module>properties</module>
+                <module>javaee-like-getting-started</module>
+                <module>scaling</module>
+                <module>microprofile</module>
+                <module>lifecycle-application</module>
+                <module>external-applications</module>
+                <module>scheduling/quartz</module>
+                <module>infinispan-client</module>
+                <module>super-size/many-extensions</module>
+                <module>quarkus-cli</module>
+                <module>kamelet</module>
+                <module>logging/jboss</module>
+                <module>cache/caffeine</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>http-modules</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>all-modules</name>
+                </property>
+            </activation>
+            <modules>
+                <module>http/http-minimum</module>
+                <module>http/http-advanced</module>
+                <module>http/http-static</module>
+                <module>http/jaxrs</module>
+                <module>http/reactive-routes</module>
+                <module>http/rest-client</module>
+                <module>http/servlet-undertow</module>
+                <module>http/vertx-web-client</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>security-modules</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>all-modules</name>
+                </property>
+            </activation>
+            <modules>
+                <module>security/basic</module>
+                <module>security/https</module>
+                <module>security/jwt</module>
+                <module>security/keycloak</module>
+                <module>security/keycloak-authz</module>
+                <module>security/keycloak-jwt</module>
+                <module>security/keycloak-webapp</module>
+                <module>security/keycloak-oauth2</module>
+                <module>security/keycloak-multitenant</module>
+                <module>security/keycloak-oidc-client-basic</module>
+                <module>security/keycloak-oidc-client-extended</module>
+                <module>security/vertx-jwt</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>messaging-modules</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>all-modules</name>
+                </property>
+            </activation>
+            <modules>
+                <module>messaging/artemis</module>
+                <module>messaging/artemis-jta</module>
+                <module>messaging/amqp-reactive</module>
+                <module>messaging/qpid</module>
+                <module>messaging/kafka-streams-reactive-messaging</module>
+                <module>messaging/kafka-avro-reactive-messaging</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>micrometer-modules</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>all-modules</name>
+                </property>
+            </activation>
+            <modules>
+                <module>micrometer/prometheus</module>
+                <module>micrometer/prometheus-kafka</module>
+                <module>micrometer/oidc</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>sql-db-modules</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>all-modules</name>
+                </property>
+            </activation>
+            <modules>
+                <module>sql-db/sql-app</module>
+                <module>sql-db/multiple-pus</module>
+                <module>sql-db/panache-flyway</module>
+                <module>sql-db/vertx-sql</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>spring-modules</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>all-modules</name>
+                </property>
+            </activation>
+            <modules>
+                <module>spring/spring-data</module>
+                <module>spring/spring-web</module>
+                <module>spring/spring-properties</module>
+                <module>cache/spring</module>
+            </modules>
+        </profile>
+        <profile>
             <id>native</id>
             <activation>
                 <property>
@@ -422,7 +497,7 @@
                 <quarkus.package.type>native</quarkus.package.type>
                 <quarkus.native.container-build>true</quarkus.native.container-build>
                 <quarkus.native.native-image-xmx>4g</quarkus.native.native-image-xmx>
-                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.0-java11</quarkus.native.builder-image>
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.2-java11</quarkus.native.builder-image>
                 <exclude.quarkus.devmode.tests>**/*DevMode*IT.java</exclude.quarkus.devmode.tests>
             </properties>
         </profile>

--- a/properties/src/test/java/io/quarkus/qe/properties/toggle/ToggleablePropertiesOnDevModeIT.java
+++ b/properties/src/test/java/io/quarkus/qe/properties/toggle/ToggleablePropertiesOnDevModeIT.java
@@ -2,12 +2,10 @@ package io.quarkus.qe.properties.toggle;
 
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
 @QuarkusScenario
-@DisabledOnNative
 public class ToggleablePropertiesOnDevModeIT extends BaseToggleablePropertiesIT {
 
     private static final String APPLICATION_PROPERTIES = "src/main/resources/application.properties";

--- a/scheduling/quartz/src/test/java/io/quarkus/qe/scheduling/quartz/AnnotationScheduledJobsMySqlQuartzIT.java
+++ b/scheduling/quartz/src/test/java/io/quarkus/qe/scheduling/quartz/AnnotationScheduledJobsMySqlQuartzIT.java
@@ -8,35 +8,32 @@ import org.apache.http.HttpStatus;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.qe.scheduling.quartz.failover.AnnotationScheduledJob;
 import io.quarkus.qe.scheduling.quartz.failover.ExecutionEntity;
-import io.quarkus.qe.scheduling.quartz.failover.ExecutionService;
-import io.quarkus.qe.scheduling.quartz.failover.ExecutionsResource;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-@DisabledOnNative(reason = "Due to high native build execution time for the three Quarkus services")
 public class AnnotationScheduledJobsMySqlQuartzIT extends BaseMySqlQuartzIT {
 
     static final String NODE_ONE_NAME = "node-one";
     static final String NODE_TWO_NAME = "node-two";
 
-    @QuarkusApplication(classes = { AnnotationScheduledJob.class, ExecutionEntity.class, ExecutionService.class })
+    @QuarkusApplication
     static RestService one = new RestService().withProperties(MYSQL_PROPERTIES)
             .withProperty("owner.name", NODE_ONE_NAME)
             .withProperty("quarkus.datasource.jdbc.url", BaseMySqlQuartzIT::mysqlJdbcUrl);
 
-    @QuarkusApplication(classes = { AnnotationScheduledJob.class, ExecutionEntity.class, ExecutionService.class })
+    @QuarkusApplication
     static RestService two = new RestService().withProperties(MYSQL_PROPERTIES)
             .withProperty("owner.name", NODE_TWO_NAME)
             .withProperty("quarkus.datasource.jdbc.url", BaseMySqlQuartzIT::mysqlJdbcUrl);
 
-    @QuarkusApplication(classes = { ExecutionsResource.class, ExecutionEntity.class })
+    @QuarkusApplication
     static RestService app = new RestService().withProperties(MYSQL_PROPERTIES)
-            .withProperty("quarkus.datasource.jdbc.url", BaseMySqlQuartzIT::mysqlJdbcUrl);
+            .withProperty("quarkus.datasource.jdbc.url", BaseMySqlQuartzIT::mysqlJdbcUrl)
+            // Disable scheduler, so this app behaves as viewer of the two nodes.
+            .withProperty("quarkus.scheduler.enabled", "false");
 
     @Test
     public void testClusteringEnvironmentWithUniqueJobs() {

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/DevModeOidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/DevModeOidcSecurityIT.java
@@ -8,12 +8,10 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @Tag("QUARKUS-1026")
 @QuarkusScenario
-@DisabledOnNative
 public class DevModeOidcSecurityIT {
 
     @DevModeQuarkusApplication

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlIT.java
@@ -4,12 +4,10 @@ import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @Tag("QUARKUS-1026")
 @QuarkusScenario
-@DisabledOnNative
 public class DevModePostgresqlIT extends AbstractSqlDatabaseIT {
 
     @DevModeQuarkusApplication

--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/DevModeManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/DevModeManyExtensionsIT.java
@@ -2,11 +2,9 @@ package io.quarkus.ts.many.extensions;
 
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @QuarkusScenario
-@DisabledOnNative
 public class DevModeManyExtensionsIT extends ManyExtensionsIT {
 
     @DevModeQuarkusApplication


### PR DESCRIPTION
The idea would be to run the modules that take the most of the time in individual jobs, so the jobs do not exceed the timeout.

++ Update Mandrel image to use 21.2
++ Update reason of @DisabledOnNative for S2i deployments. Caused by: https://github.com/quarkus-qe/quarkus-test-framework/issues/206
++ Exclude DevMode tests on Native by Maven configuration
++ Refactor scheduling/quartz module to run tests on Native without build
++ Avoid to use RandomStringUtils in micrometer/prometheus, fails on Native

Fix https://github.com/quarkus-qe/quarkus-test-suite/issues/154