### PR TITLE
Add module for `spring/spring-cloud-config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,10 @@ Covers two areas related to Spring Web:
   - CRUD endpoints.
   - Custom error handlers.
   - Cooperation with Qute templating engine.
+  
+### `spring/spring-cloud-config`
+
+Verifies that we can use an external Spring Cloud Server to inject configuration in our Quarkus applications.
 
 ### `spring/spring-properties`
 Exploratory testing for the `quarkus-spring-boot-properties` Quarkus extension. The application consists of a REST endpoint

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,7 @@
                                 <redis.image>quay.io/bitnami/redis:6.0</redis.image>
                                 <wiremock.image>quay.io/ocpmetal/wiremock</wiremock.image>
                                 <consul.image>quay.io/bitnami/consul:1.9.3</consul.image>
+                                <spring.cloud.server.image>hyness/spring-cloud-config-server</spring.cloud.server.image>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>
@@ -462,6 +463,7 @@
                 <module>spring/spring-data</module>
                 <module>spring/spring-web</module>
                 <module>spring/spring-properties</module>
+                <module>spring/spring-cloud-config</module>
                 <module>cache/spring</module>
             </modules>
         </profile>

--- a/spring/spring-cloud-config/README.md
+++ b/spring/spring-cloud-config/README.md
@@ -1,0 +1,45 @@
+# Quarkus Spring Cloud Config
+
+1. Start Spring Cloud Server from Docker
+
+We'll start a Spring Cloud Server instance using a property file placed at `src/test/resources`:
+
+```
+docker run -v /src/test/resources:/config -e SPRING_PROFILES_ACTIVE=native -p 8888:8888 hyness/spring-cloud-config-server
+```
+
+Note that the property file must be named as `{quarkus.application.name}-{quarkus.profile}.properties` (YAML is also allowed).
+
+To verify the Spring Cloud Server is up and running: `curl http://localhost:8888/{quarkus.application.name}/{quarkus.profile}` 
+(If you're using the file `application-SpringCloudConfigIT.properties`, then `curl http://localhost:8888/application/SpringCloudConfigIT`). 
+And you should get:
+
+```
+{
+    "name": "application",
+    "profiles": [
+        "SpringCloudConfigIT"
+    ],
+    "label": null,
+    "version": null,
+    "state": null,
+    "propertySources": [
+        {
+            "name": "file:config/application-SpringCloudConfigIT.properties",
+            "source": {
+                "custom.message": "Hello from Spring Cloud Server"
+            }
+        }
+    ]
+}
+``` 
+
+2. Start the Quarkus application
+
+```
+mvn -Dquarkus.profile=SpringCloudConfigIT quarkus:dev
+```
+
+Note that I used the profile `SpringCloudConfigIT` to use the property file called `application-SpringCloudConfigIT.properties`.
+
+Now, go to `http://localhost:8080/jaxrs/hello` and you should get `Hello from Spring Cloud Server`.

--- a/spring/spring-cloud-config/pom.xml
+++ b/spring/spring-cloud-config/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>spring-cloud-config</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: Spring: Spring Cloud Config</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-spring-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-spring-cloud-config-client</artifactId>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
+        <profile>
+            <id>skip-tests-on-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/spring/spring-cloud-config/src/main/java/io/quarkus/ts/spring/cloud/config/ConfigMappingGreetingResource.java
+++ b/spring/spring-cloud-config/src/main/java/io/quarkus/ts/spring/cloud/config/ConfigMappingGreetingResource.java
@@ -1,0 +1,17 @@
+package io.quarkus.ts.spring.cloud.config;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/custom-mapping/hello")
+public class ConfigMappingGreetingResource {
+
+    // TODO Disabled because https://github.com/quarkusio/quarkus/issues/19448
+    // @Inject
+    CustomMessageConfig config;
+
+    @GET
+    public String hello() {
+        return config.message();
+    }
+}

--- a/spring/spring-cloud-config/src/main/java/io/quarkus/ts/spring/cloud/config/CustomMessageConfig.java
+++ b/spring/spring-cloud-config/src/main/java/io/quarkus/ts/spring/cloud/config/CustomMessageConfig.java
@@ -1,0 +1,8 @@
+package io.quarkus.ts.spring.cloud.config;
+
+// TODO Disabled because https://github.com/quarkusio/quarkus/issues/19448
+// @ConfigMapping(prefix = "custom")
+public interface CustomMessageConfig {
+
+    String message();
+}

--- a/spring/spring-cloud-config/src/main/java/io/quarkus/ts/spring/cloud/config/JaxRsGreetingResource.java
+++ b/spring/spring-cloud-config/src/main/java/io/quarkus/ts/spring/cloud/config/JaxRsGreetingResource.java
@@ -1,0 +1,18 @@
+package io.quarkus.ts.spring.cloud.config;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/jaxrs/hello")
+public class JaxRsGreetingResource {
+
+    @ConfigProperty(name = "custom.message")
+    String message;
+
+    @GET
+    public String hello() {
+        return message;
+    }
+}

--- a/spring/spring-cloud-config/src/main/java/io/quarkus/ts/spring/cloud/config/SpringWebGreetingResource.java
+++ b/spring/spring-cloud-config/src/main/java/io/quarkus/ts/spring/cloud/config/SpringWebGreetingResource.java
@@ -1,0 +1,19 @@
+package io.quarkus.ts.spring.cloud.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/spring/hello")
+public class SpringWebGreetingResource {
+
+    @Value("${custom.message}")
+    String message;
+
+    @GetMapping
+    public String hello() {
+        return message;
+    }
+}

--- a/spring/spring-cloud-config/src/main/resources/application.properties
+++ b/spring/spring-cloud-config/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+# use the same name as the application name that was configured when standing up the Config Server
+quarkus.application.name=application
+# enable retrieval of configuration from the Config Server - this is off by default
+quarkus.spring-cloud-config.enabled=true
+quarkus.spring-cloud-config.fail-fast=true

--- a/spring/spring-cloud-config/src/test/java/io/quarkus/ts/spring/cloud/config/SpringCloudConfigIT.java
+++ b/spring/spring-cloud-config/src/test/java/io/quarkus/ts/spring/cloud/config/SpringCloudConfigIT.java
@@ -1,0 +1,34 @@
+package io.quarkus.ts.spring.cloud.config;
+
+import static org.hamcrest.Matchers.is;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class SpringCloudConfigIT {
+
+    @Container(image = "${spring.cloud.server.image}", port = 8888, expectedLog = "Started ConfigServer")
+    static RestService spring = new RestService()
+            .withProperty("SPRING_PROPERTY_FILE", "resource::/config/application-SpringCloudConfigIT.properties")
+            .withProperty("SPRING_PROFILES_ACTIVE", "native");
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.profile", "SpringCloudConfigIT")
+            .withProperty("quarkus.spring-cloud-config.url", () -> spring.getHost() + ":" + spring.getPort());
+
+    @ParameterizedTest
+    @ValueSource(strings = { "/jaxrs", "/spring" }) // TODO Disabled because https://github.com/quarkusio/quarkus/issues/19448: "/custom-mapping" })
+    public void shouldGetExpectedHelloMessage(String rootPath) {
+        app.given().get(rootPath + "/hello").then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is("Hello from Spring Cloud Server"));
+    }
+}

--- a/spring/spring-cloud-config/src/test/resources/config/application-SpringCloudConfigIT.properties
+++ b/spring/spring-cloud-config/src/test/resources/config/application-SpringCloudConfigIT.properties
@@ -1,0 +1,1 @@
+custom.message=Hello from Spring Cloud Server


### PR DESCRIPTION
Verifies that we can use an external Spring Cloud Server to inject configuration in our Quarkus applications.
Fix https://github.com/quarkus-qe/quarkus-test-suite/issues/184