### PR TITLE
Add module `scheduling/spring` to cover `quarkus-spring-scheduled` ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,10 @@ We cover the following two scenarios:
 - Scenario from guide: https://quarkus.io/guides/quartz
 - Failover scenario where will run two instances of the same scheduled job. Then, it simulates a failover of one of the instances and then verify that the second instance continue working as expected.
 
+### `scheduling/spring`
+
+We cover the following scenario from guide: https://quarkus.io/guides/spring-scheduled with some adjustments to use only Spring API.
+
 ### `quarkus-cli`
 
 Verifies all the Quarkus CLI features: https://quarkus.io/version/main/guides/cli-tooling

--- a/pom.xml
+++ b/pom.xml
@@ -463,6 +463,7 @@
                 <module>spring/spring-web</module>
                 <module>spring/spring-properties</module>
                 <module>cache/spring</module>
+                <module>scheduling/spring</module>
             </modules>
         </profile>
         <profile>

--- a/scheduling/spring/pom.xml
+++ b/scheduling/spring/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>scheduling-spring</artifactId>
+    <name>Quarkus QE TS: Scheduling: Spring</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-spring-scheduled</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-spring-web</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/scheduling/spring/src/main/java/io/quarkus/qe/scheduling/spring/AnnotationScheduledCounter.java
+++ b/scheduling/spring/src/main/java/io/quarkus/qe/scheduling/spring/AnnotationScheduledCounter.java
@@ -1,0 +1,35 @@
+package io.quarkus.qe.scheduling.spring;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import io.quarkus.qe.scheduling.spring.services.CounterService;
+
+@Component
+public class AnnotationScheduledCounter {
+
+    @Autowired
+    CounterService service;
+
+    @PostConstruct
+    void init() {
+        service.reset(caller());
+    }
+
+    public int get() {
+        return service.get(caller());
+    }
+
+    @Scheduled(cron = "0/1 * * * * ?")
+    void increment() {
+        service.invoke(caller());
+    }
+
+    private static final String caller() {
+        return AnnotationScheduledCounter.class.getName();
+    }
+
+}

--- a/scheduling/spring/src/main/java/io/quarkus/qe/scheduling/spring/CountResource.java
+++ b/scheduling/spring/src/main/java/io/quarkus/qe/scheduling/spring/CountResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.qe.scheduling.spring;
+
+import javax.ws.rs.core.MediaType;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/scheduler/count")
+public class CountResource {
+
+    @Autowired
+    AnnotationScheduledCounter annotationScheduledcounter;
+
+    @GetMapping(value = "annotation", produces = MediaType.TEXT_PLAIN)
+    public Integer getAnnotationCount() {
+        return annotationScheduledcounter.get();
+    }
+}

--- a/scheduling/spring/src/main/java/io/quarkus/qe/scheduling/spring/services/CounterService.java
+++ b/scheduling/spring/src/main/java/io/quarkus/qe/scheduling/spring/services/CounterService.java
@@ -1,0 +1,25 @@
+package io.quarkus.qe.scheduling.spring.services;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class CounterService {
+
+    private final Map<String, AtomicInteger> counters = new ConcurrentHashMap<>();
+
+    public void reset(String caller) {
+        counters.putIfAbsent(caller, new AtomicInteger());
+    }
+
+    public int get(String caller) {
+        return counters.get(caller).get();
+    }
+
+    public void invoke(String caller) {
+        counters.get(caller).incrementAndGet();
+    }
+}

--- a/scheduling/spring/src/test/java/io/quarkus/qe/scheduling/spring/OpenShiftSpringScheduledIT.java
+++ b/scheduling/spring/src/test/java/io/quarkus/qe/scheduling/spring/OpenShiftSpringScheduledIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.qe.scheduling.spring;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftSpringScheduledIT extends SpringScheduledIT {
+}

--- a/scheduling/spring/src/test/java/io/quarkus/qe/scheduling/spring/SpringScheduledIT.java
+++ b/scheduling/spring/src/test/java/io/quarkus/qe/scheduling/spring/SpringScheduledIT.java
@@ -1,0 +1,33 @@
+package io.quarkus.qe.scheduling.spring;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+
+@QuarkusScenario
+public class SpringScheduledIT {
+
+    @Test
+    public void testAnnotationScheduledCounter() throws InterruptedException {
+        Thread.sleep(1000);
+        assertCounter("/scheduler/count/annotation", 0);
+        Thread.sleep(1000);
+        assertCounter("/scheduler/count/annotation", 1);
+    }
+
+    private void assertCounter(String counterPath, int expectedCount) {
+        String body = given()
+                .when().get(counterPath)
+                .then().statusCode(HttpStatus.SC_OK)
+                .extract().asString();
+
+        int actualCounter = Integer.valueOf(body);
+
+        assertTrue(actualCounter > expectedCount,
+                "Actual counter '" + actualCounter + "' must be greater than the expected '" + expectedCount + "'");
+    }
+}


### PR DESCRIPTION
We cover the following scenario from guide: https://quarkus.io/guides/spring-scheduled with some adjustments to use only Spring API.

Fix https://github.com/quarkus-qe/quarkus-test-suite/issues/186