### PR TITLE
Update GraalVM version to 21.2 for Windows Native

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -197,7 +197,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: [ "21.0.0.java11"]
+        graalvm-version: [ "21.2.0.java11"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1

--- a/.github/workflows/quarkus-test-framework-snapshot.yaml
+++ b/.github/workflows/quarkus-test-framework-snapshot.yaml
@@ -194,7 +194,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: [ "21.0.0.java11"]
+        graalvm-version: [ "21.2.0.java11"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1


### PR DESCRIPTION
Due to this change: https://github.com/quarkusio/quarkus/pull/19534, when using the 20.0 GraalVM version, it was failing with:

```
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Running Quarkus native-image plugin on GraalVM Version 21.0.0 (Java Version 11.0.10+8-jvmci-21.0-b06)
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] C:\hostedtoolcache\windows\GraalVM\21.0.0-java11-amd64\x64\bin\native-image.cmd -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory -J-Dvertx.disableDnsResolver=true -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=3 -J-Duser.language=en -J-Duser.country=US -J-Dfile.encoding=UTF-8 -H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy\$BySpaceAndTime -H:+JNI -H:+AllowFoldMethods -jar http-minimum-1.0.0-SNAPSHOT-runner.jar -H:FallbackThreshold=0 -H:+ReportExceptionStackTraces -J-Xmx4g -H:-AddAllCharsets -H:EnableURLProtocols=http -H:-UseServiceLoaderFeature -H:+StackTrace http-minimum-1.0.0-SNAPSHOT-runner
[http-minimum-1.0.0-SNAPSHOT-runner:3420]    classlist:   6,865.95 ms,  0.96 GB
[http-minimum-1.0.0-SNAPSHOT-runner:3420]        setup:     730.13 ms,  0.96 GB
Fatal error:java.lang.TypeNotPresentException: Type com.oracle.svm.core.jdk.JDK16OrEarlier not present
	at java.base/sun.reflect.annotation.TypeNotPresentExceptionProxy.generateException(TypeNotPresentExceptionProxy.java:46)
	at java.base/sun.reflect.annotation.AnnotationInvocationHandler.invoke(AnnotationInvocationHandler.java:86)
	at com.sun.proxy.$Proxy64.onlyWith(Unknown Source)
```

This class was added in 21.1.0 and according to Quarkus Upstream documentation https://quarkus.io/guides/building-native-image#prerequisites-for-oracle-graalvm-ceee, we should use this version 21.1.0 as minimal to be compatible, so we need to upgrade the graalvm version.