### PR TITLE
Move on to new Quarkus apicurio registry library

### DIFF
--- a/messaging/kafka-avro-reactive-messaging/pom.xml
+++ b/messaging/kafka-avro-reactive-messaging/pom.xml
@@ -20,8 +20,15 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-apicurio-registry-avro</artifactId>
+        </dependency>
+        <!-- Quarkus extension for generating Java code from Avro schemas -->
+        <!-- with this, you don't have to use avro-maven-plugin -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-avro</artifactId>
         </dependency>
+        <!-- Confluent AVRO libraries -->
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
@@ -29,21 +36,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-scheduler</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.apicurio</groupId>
-            <artifactId>apicurio-registry-utils-serde</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.interceptor</groupId>
-                    <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- quarkiverse-apicurio-registry-client: native mode dependency -->
-        <dependency>
-            <groupId>io.quarkiverse.apicurio</groupId>
-            <artifactId>quarkiverse-apicurio-registry-client</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/messaging/kafka-avro-reactive-messaging/src/main/resources/application.properties
+++ b/messaging/kafka-avro-reactive-messaging/src/main/resources/application.properties
@@ -2,17 +2,17 @@
 %dev.kafka.bootstrap.servers=localhost:9092
 #TODO: Disable health check because of https://github.com/quarkusio/quarkus/issues/15464
 %dev.quarkus.reactive-messaging.health.enabled=false
-%dev.mp.messaging.connector.smallrye-kafka.apicurio.registry.url=http://localhost:8081/api
+%dev.mp.messaging.connector.smallrye-kafka.apicurio.registry.url=http://localhost:8081/apis/registry/v2
 %dev.mp.messaging.outgoing.source-stock-price.connector=smallrye-kafka
 %dev.mp.messaging.outgoing.source-stock-price.topic=stock-price
-%dev.mp.messaging.outgoing.source-stock-price.value.serializer=io.apicurio.registry.utils.serde.AvroKafkaSerializer
-%dev.mp.messaging.outgoing.source-stock-price.apicurio.registry.artifact-id=io.apicurio.registry.utils.serde.strategy.SimpleTopicIdStrategy
-%dev.mp.messaging.outgoing.source-stock-price.apicurio.registry.global-id=io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy
-%dev.mp.messaging.outgoing.source-stock-price.apicurio.registry.avro-datum-provider=io.apicurio.registry.utils.serde.avro.ReflectAvroDatumProvider
+%dev.mp.messaging.outgoing.source-stock-price.value.serializer=io.apicurio.registry.serde.avro.AvroKafkaSerializer
+%dev.mp.messaging.outgoing.source-stock-price.apicurio.registry.avro-datum-provider=io.apicurio.registry.serde.avro.ReflectAvroDatumProvider
+%dev.mp.messaging.outgoing.source-stock-price.apicurio.registry.auto-register=true
+
 %dev.mp.messaging.incoming.channel-stock-price.connector=smallrye-kafka
 %dev.mp.messaging.incoming.channel-stock-price.topic=stock-price
 %dev.mp.messaging.incoming.channel-stock-price.specific.avro.reader=true
-%dev.mp.messaging.incoming.channel-stock-price.value.deserializer=io.apicurio.registry.utils.serde.AvroKafkaDeserializer
+%dev.mp.messaging.incoming.channel-stock-price.value.deserializer=io.apicurio.registry.serde.avro.AvroKafkaDeserializer
 %dev.mp.messaging.incoming.channel-stock-price.auto.offset.reset=earliest
 %dev.mp.messaging.incoming.channel-stock-price.enable.auto.commit=true
-%dev.mp.messaging.incoming.channel-stock-price.apicurio.registry.avro-datum-provider=io.apicurio.registry.utils.serde.avro.ReflectAvroDatumProvider
+%dev.mp.messaging.incoming.channel-stock-price.apicurio.registry.avro-datum-provider=io.apicurio.registry.serde.avro.ReflectAvroDatumProvider

--- a/messaging/kafka-avro-reactive-messaging/src/main/resources/docker-compose-strimzi.yaml
+++ b/messaging/kafka-avro-reactive-messaging/src/main/resources/docker-compose-strimzi.yaml
@@ -32,7 +32,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
   schema-registry:
-    image: apicurio/apicurio-registry-mem:1.3.1.Final
+    image: apicurio/apicurio-registry-mem:2.0.1.Final
     ports:
       - 8081:8080
     depends_on:

--- a/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/OpenShiftAmqStreamsKafkaAvroIT.java
+++ b/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/OpenShiftAmqStreamsKafkaAvroIT.java
@@ -13,11 +13,12 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsKafkaAvroIT extends BaseKafkaAvroIT {
 
-    @KafkaContainer(vendor = KafkaVendor.STRIMZI, image = "${amq-streams.image}", version = "${amq-streams.version}", withRegistry = true)
+    @KafkaContainer(vendor = KafkaVendor.STRIMZI, image = "${amq-streams.image}", version = "${amq-streams.version}", withRegistry = true, registryPath = "/apis/registry/v2")
     static KafkaService kafka = new KafkaService();
 
     @QuarkusApplication
     static RestService app = new RestService()
+            .withProperties("strimzi-application.properties")
             .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
             .withProperty("kafka.registry.url", kafka::getRegistryUrl);
 

--- a/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/StrimziKafkaAvroIT.java
+++ b/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/StrimziKafkaAvroIT.java
@@ -10,7 +10,7 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 @QuarkusScenario
 public class StrimziKafkaAvroIT extends BaseKafkaAvroIT {
 
-    @KafkaContainer(vendor = KafkaVendor.STRIMZI, withRegistry = true)
+    @KafkaContainer(vendor = KafkaVendor.STRIMZI, withRegistry = true, registryPath = "/apis/registry/v2")
     static KafkaService kafka = new KafkaService();
 
     @QuarkusApplication

--- a/messaging/kafka-avro-reactive-messaging/src/test/resources/strimzi-application.properties
+++ b/messaging/kafka-avro-reactive-messaging/src/test/resources/strimzi-application.properties
@@ -1,19 +1,21 @@
 # Configuration file - Quarkus profile: Strimzi
 kafka.bootstrap.servers=kafka-broker-1:9092
+mp.messaging.outgoing.source-stock-price.connector=smallrye-kafka
 # TODO: Disable health check because of https://github.com/quarkusio/quarkus/issues/15464
 quarkus.reactive-messaging.health.enabled=false
+
 mp.messaging.connector.smallrye-kafka.apicurio.registry.url=${kafka.registry.url}
-mp.messaging.outgoing.source-stock-price.connector=smallrye-kafka
+
+mp.messaging.outgoing.source-stock-price.value.serializer=io.apicurio.registry.serde.avro.AvroKafkaSerializer
+mp.messaging.outgoing.source-stock-price.apicurio.registry.avro-datum-provider=io.apicurio.registry.serde.avro.ReflectAvroDatumProvider
+mp.messaging.outgoing.source-stock-price.apicurio.registry.auto-register=true
 mp.messaging.outgoing.source-stock-price.topic=stock-price
-mp.messaging.outgoing.source-stock-price.value.serializer=io.apicurio.registry.utils.serde.AvroKafkaSerializer
-mp.messaging.outgoing.source-stock-price.apicurio.registry.artifact-id=io.apicurio.registry.utils.serde.strategy.SimpleTopicIdStrategy
-mp.messaging.outgoing.source-stock-price.apicurio.registry.global-id=io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy
-mp.messaging.outgoing.source-stock-price.apicurio.registry.avro-datum-provider=io.apicurio.registry.utils.serde.avro.ReflectAvroDatumProvider
+
 mp.messaging.incoming.channel-stock-price.connector=smallrye-kafka
 mp.messaging.incoming.channel-stock-price.topic=stock-price
-mp.messaging.incoming.channel-stock-price.specific.avro.reader=true
-mp.messaging.incoming.channel-stock-price.value.deserializer=io.apicurio.registry.utils.serde.AvroKafkaDeserializer
 mp.messaging.incoming.channel-stock-price.auto.offset.reset=earliest
 mp.messaging.incoming.channel-stock-price.enable.auto.commit=true
-mp.messaging.incoming.channel-stock-price.apicurio.registry.avro-datum-provider=io.apicurio.registry.utils.serde.avro.ReflectAvroDatumProvider
+mp.messaging.incoming.channel-stock-price.value.deserializer=io.apicurio.registry.serde.avro.AvroKafkaDeserializer
+mp.messaging.incoming.channel-stock-price.apicurio.registry.avro-datum-provider=io.apicurio.registry.serde.avro.ReflectAvroDatumProvider
+
 quarkus.openshift.expose=true

--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,9 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
-        <quarkus.qe.framework.version>0.0.7</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>0.0.9</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.27.0</quarkus-qpid-jms.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>
-        <apicurio.registry.utils.serde.version>1.3.2.Final</apicurio.registry.utils.serde.version>
-        <quarkiverse.apicurio.registry.client.version>0.0.2</quarkiverse.apicurio.registry.client.version>
         <confluent.kafka-avro-serializer.version>6.2.0</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.16.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.6.2</impsort-maven-plugin.version>
@@ -47,12 +45,6 @@
     </properties>
     <dependencyManagement>
         <dependencies>
-            <!-- TODO: com.squareup.retrofit2:retrofit:2.9.0 should be removed on Quarkus 2.0.0.Alphas-->
-            <dependency>
-                <groupId>com.squareup.retrofit2</groupId>
-                <artifactId>retrofit</artifactId>
-                <version>2.9.0</version>
-            </dependency>
             <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
@@ -73,16 +65,6 @@
                 <version>${camel-quarkus-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.apicurio</groupId>
-                <artifactId>apicurio-registry-utils-serde</artifactId>
-                <version>${apicurio.registry.utils.serde.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkiverse.apicurio</groupId>
-                <artifactId>quarkiverse-apicurio-registry-client</artifactId>
-                <version>${quarkiverse.apicurio.registry.client.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>


### PR DESCRIPTION
depends on: https://github.com/quarkus-qe/quarkus-test-framework/pull/230

New Quarkus Apicurio registry library was released in order to produce/consumer Kafka AVRO messages. 
If you are using Kafka Strimzi the only dependency that is required are:

`io.quarkus:quarkus-avro` // Quarkus extension for generating Java code from Avro schemas
`io.quarkus:quarkus-apicurio-registry-avro`// in order to integrate Apirurio AVRO registry into Quarkus app

Doc Ref: https://quarkus.io/guides/kafka-schema-registry-avro 