### PR TITLE
[2.2] Use Quarkus version 2.2.1.Final

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,41 +2,9 @@ name: "Pull Request CI"
 on:
   - pull_request
 jobs:
-  build-dependencies:
-    name: Build Dependencies
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ 11 ]
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Reclaim Disk Space
-        run: .github/ci-prerequisites.sh
-      - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
-        with:
-          java-version: ${{ matrix.java }}
-      - name: Build Quarkus main
-        run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly
-      - name: Tar Maven Repo
-        shell: bash
-        run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
-      - name: Persist Maven Repo
-        uses: actions/upload-artifact@v1
-        with:
-          name: maven-repo
-          path: maven-repo.tgz
   linux-validate-format:
     name: Linux - Validate format
     runs-on: ubuntu-latest
-    needs: build-dependencies
     strategy:
       matrix:
         java: [ 11 ]
@@ -52,21 +20,13 @@ jobs:
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: ${{ matrix.java }}
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v1
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Build with Maven
         run: |
           mvn -V -B -s .github/mvn-settings.xml verify -Dall-modules -Dvalidate-format -DskipTests -DskipITs
-  linux-build-jvm-latest:
-    name: PR - Linux - JVM build - Latest Version
+  linux-build-jvm-released:
+    name: PR - Linux - JVM build - Released Version
     runs-on: ubuntu-latest
-    needs: [ build-dependencies, linux-validate-format ]
+    needs: linux-validate-format
     strategy:
       matrix:
         java: [ 11 ]
@@ -85,22 +45,19 @@ jobs:
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: openjdk${{ matrix.java }}
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v1
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Build Quarkus CLI
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
+          git clone https://github.com/quarkusio/quarkus.git
+          cd quarkus
+          git checkout 2.2
+          mvn versions:set -DnewVersion=2.2.1.Final -DgenerateBackupPoms=false -pl .,build-parent,devtools/cli
+          cd devtools/cli
+          mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
       - name: Install Quarkus CLI
         run: |
           cat <<EOF > ./quarkus-dev-cli
           #!/bin/bash
-          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-2.2.1.Final-runner.jar "\$@"
           EOF
           chmod +x ./quarkus-dev-cli
       - name: Build with Maven
@@ -108,16 +65,16 @@ jobs:
       - name: Zip Artifacts
         if: failure()
         run: |
-          zip -R artifacts-latest-linux-jvm${{ matrix.java }}.zip '*-reports/*'
+          zip -R artifacts-released-linux-jvm${{ matrix.java }}.zip '*-reports/*'
       - uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: ci-artifacts
-          path: artifacts-latest-linux-jvm${{ matrix.java }}.zip
-  linux-build-native-latest:
-    name: PR - Linux - Native build - Latest Version
+          path: artifacts-released-linux-jvm${{ matrix.java }}.zip
+  linux-build-native-released:
+    name: PR - Linux - Native build - Released Version
     runs-on: ubuntu-latest
-    needs: [ build-dependencies, linux-validate-format ]
+    needs: linux-validate-format
     strategy:
       matrix:
         java: [ 11 ]
@@ -136,22 +93,19 @@ jobs:
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: openjdk${{ matrix.java }}
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v1
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Build Quarkus CLI
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
+          git clone https://github.com/quarkusio/quarkus.git
+          cd quarkus
+          git checkout 2.2
+          mvn versions:set -DnewVersion=2.2.1.Final -DgenerateBackupPoms=false -pl .,build-parent,devtools/cli
+          cd devtools/cli
+          mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
       - name: Install Quarkus CLI
         run: |
           cat <<EOF > ./quarkus-dev-cli
           #!/bin/bash
-          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-2.2.1.Final-runner.jar "\$@"
           EOF
           chmod +x ./quarkus-dev-cli
       - id: files
@@ -179,16 +133,16 @@ jobs:
       - name: Zip Artifacts
         if: failure()
         run: |
-          zip -R artifacts-latest-linux-native${{ matrix.java }}.zip '*-reports/*'
+          zip -R artifacts-released-linux-native${{ matrix.java }}.zip '*-reports/*'
       - uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: ci-artifacts
-          path: artifacts-latest-linux-native${{ matrix.java }}.zip
-  windows-build-jvm-latest:
-    name: PR - Windows - JVM build - Latest Version
+          path: artifacts-released-linux-native${{ matrix.java }}.zip
+  windows-build-jvm-released:
+    name: PR - Windows - JVM build - Released Version
     runs-on: windows-latest
-    needs: [ build-dependencies, linux-validate-format ]
+    needs: linux-validate-format
     strategy:
       matrix:
         java: [ 11 ]
@@ -204,14 +158,6 @@ jobs:
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: ${{ matrix.java }}
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v1
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Build in JVM mode
         shell: bash
         run: |
@@ -221,10 +167,10 @@ jobs:
         if: failure()
         run: |
           # Disambiguate windows find from cygwin find
-          /usr/bin/find . -name '*-reports/*' -type d | tar -czf artifacts-latest-windows-jvm${{ matrix.java }}.tar -T -
+          /usr/bin/find . -name '*-reports/*' -type d | tar -czf artifacts-released-windows-jvm${{ matrix.java }}.tar -T -
       - name: Archive artifacts
         if: failure()
         uses: actions/upload-artifact@v1
         with:
           name: ci-artifacts
-          path: artifacts-latest-windows-jvm${{ matrix.java }}.tar
+          path: artifacts-released-windows-jvm${{ matrix.java }}.tar

--- a/http/jaxrs-reactive/src/test/java/io/quarkus/ts/jaxrs/reactive/HttpCachingResourceIT.java
+++ b/http/jaxrs-reactive/src/test/java/io/quarkus/ts/jaxrs/reactive/HttpCachingResourceIT.java
@@ -12,6 +12,7 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.restassured.response.ValidatableResponse;
 
 @QuarkusScenario
@@ -38,6 +39,7 @@ public class HttpCachingResourceIT {
                                 containsString("private"))));
     }
 
+    @DisabledOnQuarkusVersion(version = "2.2.1.*", reason = "https://github.com/quarkusio/quarkus/issues/19822")
     @Test
     public void shouldGetNoCacheUnqualified() {
         whenGet("/nocache-unqualified").header(HttpHeaders.CACHE_CONTROL, is("no-cache"));

--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -39,7 +39,7 @@
                 </property>
             </activation>
             <properties>
-                <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+                <quarkus.platform.version>2.2.1.Final</quarkus.platform.version>
             </properties>
             <repositories>
                 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <failsafe-plugin.version>2.22.2</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.2.1.Final</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
         <quarkus.qe.framework.version>0.0.7</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.27.0</quarkus-qpid-jms.version>

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import io.quarkus.builder.Version;
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 
 /**
@@ -84,13 +86,12 @@ public class QuarkusCliExtensionsIT {
         assertListOriginsOptionOutput();
     }
 
+    @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not pushed into the platform site")
     @Test
     public void shouldListExtensionsUsingStream() {
-        whenGetListExtensions("--stream", "2.0");
-        assertTrue(result.getOutput().contains("io.quarkus:quarkus-universe-bom::pom:2.0"));
-
-        whenGetListExtensions("--stream", "2.1");
-        assertTrue(result.getOutput().contains("io.quarkus.platform:quarkus-bom::pom:2.1"));
+        String streamVersion = getCurrentStreamVersion();
+        whenGetListExtensions("--stream", streamVersion);
+        assertTrue(result.getOutput().contains("io.quarkus.platform:quarkus-bom::pom:" + streamVersion));
     }
 
     @Test
@@ -142,5 +143,10 @@ public class QuarkusCliExtensionsIT {
 
     private void assertResultIsSuccessful() {
         assertTrue(result.isSuccessful(), "Extensions list command didn't work. Output: " + result.getOutput());
+    }
+
+    private String getCurrentStreamVersion() {
+        String[] version = Version.getVersion().split(Pattern.quote("."));
+        return String.format("%s.%s", version[0], version[1]);
     }
 }


### PR DESCRIPTION
RHBQ will be based on 2.2.1.Final.

Daily action for branches are not being triggered, so we don't need to update it.

++ Backport of https://github.com/quarkus-qe/quarkus-test-suite/pull/207