### PR TITLE
Use Quarkus version 2.2.1.Final

### DIFF
--- a/.github/quarkus-ecosystem-test
+++ b/.github/quarkus-ecosystem-test
@@ -2,7 +2,7 @@
 set -e
 
 # run the tests on JVM
-mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P $MAVEN_PROFILES
+mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P $MAVEN_PROFILES -Dquarkus.platform.version=999-SNAPSHOT
 
 # run the tests on Native
-mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P $MAVEN_PROFILES -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=5g
+mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P $MAVEN_PROFILES -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=5g -Dquarkus.platform.version=999-SNAPSHOT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,41 +2,9 @@ name: "Pull Request CI"
 on:
   - pull_request
 jobs:
-  build-dependencies:
-    name: Build Dependencies
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ 11 ]
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Reclaim Disk Space
-        run: .github/ci-prerequisites.sh
-      - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
-        with:
-          java-version: ${{ matrix.java }}
-      - name: Build Quarkus main
-        run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly
-      - name: Tar Maven Repo
-        shell: bash
-        run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
-      - name: Persist Maven Repo
-        uses: actions/upload-artifact@v1
-        with:
-          name: maven-repo
-          path: maven-repo.tgz
   linux-validate-format:
     name: Linux - Validate format
     runs-on: ubuntu-latest
-    needs: build-dependencies
     strategy:
       matrix:
         java: [ 11 ]
@@ -52,21 +20,13 @@ jobs:
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: ${{ matrix.java }}
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v1
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Build with Maven
         run: |
           mvn -V -B -s .github/mvn-settings.xml verify -Dall-modules -Dvalidate-format -DskipTests -DskipITs
-  linux-build-jvm-latest:
-    name: PR - Linux - JVM build - Latest Version
+  linux-build-jvm-released:
+    name: PR - Linux - JVM build - Released Version
     runs-on: ubuntu-latest
-    needs: [ build-dependencies, linux-validate-format ]
+    needs: linux-validate-format
     strategy:
       matrix:
         java: [ 11 ]
@@ -85,22 +45,19 @@ jobs:
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: openjdk${{ matrix.java }}
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v1
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Build Quarkus CLI
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
+          git clone https://github.com/quarkusio/quarkus.git
+          cd quarkus
+          git checkout 2.2
+          mvn versions:set -DnewVersion=2.2.1.Final -DgenerateBackupPoms=false -pl .,build-parent,devtools/cli
+          cd devtools/cli
+          mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
       - name: Install Quarkus CLI
         run: |
           cat <<EOF > ./quarkus-dev-cli
           #!/bin/bash
-          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-2.2.1.Final-runner.jar "\$@"
           EOF
           chmod +x ./quarkus-dev-cli
       - name: Build with Maven
@@ -108,16 +65,16 @@ jobs:
       - name: Zip Artifacts
         if: failure()
         run: |
-          zip -R artifacts-latest-linux-jvm${{ matrix.java }}.zip '*-reports/*'
+          zip -R artifacts-released-linux-jvm${{ matrix.java }}.zip '*-reports/*'
       - uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: ci-artifacts
-          path: artifacts-latest-linux-jvm${{ matrix.java }}.zip
-  linux-build-native-latest:
-    name: PR - Linux - Native build - Latest Version
+          path: artifacts-released-linux-jvm${{ matrix.java }}.zip
+  linux-build-native-released:
+    name: PR - Linux - Native build - Released Version
     runs-on: ubuntu-latest
-    needs: [ build-dependencies, linux-validate-format ]
+    needs: linux-validate-format
     strategy:
       matrix:
         java: [ 11 ]
@@ -136,22 +93,19 @@ jobs:
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: openjdk${{ matrix.java }}
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v1
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Build Quarkus CLI
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
+          git clone https://github.com/quarkusio/quarkus.git
+          cd quarkus
+          git checkout 2.2
+          mvn versions:set -DnewVersion=2.2.1.Final -DgenerateBackupPoms=false -pl .,build-parent,devtools/cli
+          cd devtools/cli
+          mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
       - name: Install Quarkus CLI
         run: |
           cat <<EOF > ./quarkus-dev-cli
           #!/bin/bash
-          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-2.2.1.Final-runner.jar "\$@"
           EOF
           chmod +x ./quarkus-dev-cli
       - id: files
@@ -179,16 +133,16 @@ jobs:
       - name: Zip Artifacts
         if: failure()
         run: |
-          zip -R artifacts-latest-linux-native${{ matrix.java }}.zip '*-reports/*'
+          zip -R artifacts-released-linux-native${{ matrix.java }}.zip '*-reports/*'
       - uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: ci-artifacts
-          path: artifacts-latest-linux-native${{ matrix.java }}.zip
-  windows-build-jvm-latest:
-    name: PR - Windows - JVM build - Latest Version
+          path: artifacts-released-linux-native${{ matrix.java }}.zip
+  windows-build-jvm-released:
+    name: PR - Windows - JVM build - Released Version
     runs-on: windows-latest
-    needs: [ build-dependencies, linux-validate-format ]
+    needs: linux-validate-format
     strategy:
       matrix:
         java: [ 11 ]
@@ -204,14 +158,6 @@ jobs:
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: ${{ matrix.java }}
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v1
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Build in JVM mode
         shell: bash
         run: |
@@ -221,10 +167,10 @@ jobs:
         if: failure()
         run: |
           # Disambiguate windows find from cygwin find
-          /usr/bin/find . -name '*-reports/*' -type d | tar -czf artifacts-latest-windows-jvm${{ matrix.java }}.tar -T -
+          /usr/bin/find . -name '*-reports/*' -type d | tar -czf artifacts-released-windows-jvm${{ matrix.java }}.tar -T -
       - name: Archive artifacts
         if: failure()
         uses: actions/upload-artifact@v1
         with:
           name: ci-artifacts
-          path: artifacts-latest-windows-jvm${{ matrix.java }}.tar
+          path: artifacts-released-windows-jvm${{ matrix.java }}.tar

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -76,7 +76,7 @@ jobs:
           chmod +x ./quarkus-dev-cli
       - name: Test in JVM mode
         run: |
-          mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -Dall-modules -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
+          mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -Dall-modules -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version=999-SNAPSHOT
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -134,7 +134,7 @@ jobs:
           chmod +x ./quarkus-dev-cli
       - name: Test in Native mode
         run: |
-          mvn -fae -V -B -s .github/mvn-settings.xml -P ${{ matrix.profiles }} -fae clean verify -Dnative \
+          mvn -fae -V -B -s .github/mvn-settings.xml -P ${{ matrix.profiles }} -fae clean verify -Dquarkus.platform.version=999-SNAPSHOT -Dnative \
             -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }} \
             -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
@@ -177,7 +177,7 @@ jobs:
       - name: Build in JVM mode
         shell: bash
         run: |
-          mvn -fae -s .github/mvn-settings.xml clean verify
+          mvn -fae -s .github/mvn-settings.xml clean verify -Dquarkus.platform.version=999-SNAPSHOT
       - name: Zip Artifacts
         shell: bash
         if: failure()
@@ -237,7 +237,7 @@ jobs:
         shell: bash
         run: |
           # Running only http/http-minimum as after some time, it gives disk full in Windows when running on Native.
-          mvn -fae -s .github/mvn-settings.xml clean verify -Dall-modules -Dnative -Dquarkus.native.container-build=false -pl http/http-minimum
+          mvn -fae -s .github/mvn-settings.xml clean verify -Dall-modules -Dquarkus.platform.version=999-SNAPSHOT -Dnative -Dquarkus.native.container-build=false -pl http/http-minimum
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/http/jaxrs-reactive/src/test/java/io/quarkus/ts/jaxrs/reactive/HttpCachingResourceIT.java
+++ b/http/jaxrs-reactive/src/test/java/io/quarkus/ts/jaxrs/reactive/HttpCachingResourceIT.java
@@ -12,6 +12,7 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.restassured.response.ValidatableResponse;
 
 @QuarkusScenario
@@ -38,6 +39,7 @@ public class HttpCachingResourceIT {
                                 containsString("private"))));
     }
 
+    @DisabledOnQuarkusVersion(version = "2.2.1.*", reason = "https://github.com/quarkusio/quarkus/issues/19822")
     @Test
     public void shouldGetNoCacheUnqualified() {
         whenGet("/nocache-unqualified").header(HttpHeaders.CACHE_CONTROL, is("no-cache"));

--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -39,7 +39,7 @@
                 </property>
             </activation>
             <properties>
-                <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+                <quarkus.platform.version>2.2.1.Final</quarkus.platform.version>
             </properties>
             <repositories>
                 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <failsafe-plugin.version>2.22.2</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.2.1.Final</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
         <quarkus.qe.framework.version>0.0.8</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.27.0</quarkus-qpid-jms.version>


### PR DESCRIPTION
Due to this issue: https://github.com/quarkusio/quarkus/issues/19875, we can't use 999-SNAPSHOT until is fixed, therefore Main will be based on 2.2.1.Final.

++ Daily actions and Quarkus Ecosystem will still use 999-SNAPSHOT to check out the status with 999-SNAPSHOT
++ Disable HttpCachingResourceIT.shouldGetNoCacheUnqualified due to https://github.com/quarkusio/quarkus/issues/19822