### PR TITLE
Add blocking Kafka producer scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,12 @@ There is an EventsProducer that generate stock prices events every 1s. The event
 A Kafka consumer will read these events serialized by AVRO and change an `status` property to `COMPLETED`. 
 The streams of completed events will be exposed through an SSE endpoint. 
 
+### `messaging/kafka-producer`
+
+This scenario is focus on issues related only to Kafka producer. 
+Verifies that Kafka producer doesn't block the main thread  and also doesn't takes more time than `mp.messaging.outgoing.<CHANNEL>.max.block.ms`, and also
+doesn't retry more times than `mp.messaging.outgoing.<CHANNEL>.retries`
+
 ### `messaging/qpid`
 
 Verifies that JMS server is up and running and Quarkus can communicate with this service.

--- a/messaging/kafka-producer/pom.xml
+++ b/messaging/kafka-producer/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>kafka-producer</artifactId>
+    <name>Quarkus QE TS: Messaging: Kafka producer</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-containers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
+        <profile>
+            <id>skip-tests-on-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/messaging/kafka-producer/src/main/java/io/quarkus/ts/messaging/kafka/Application.java
+++ b/messaging/kafka-producer/src/main/java/io/quarkus/ts/messaging/kafka/Application.java
@@ -1,0 +1,61 @@
+package io.quarkus.ts.messaging.kafka;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.Route;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.ext.web.handler.CorsHandler;
+import io.vertx.ext.web.handler.LoggerHandler;
+
+@ApplicationScoped
+public class Application {
+
+    private static final Logger LOG = Logger.getLogger(Application.class);
+
+    @ConfigProperty(name = "app.name")
+    public String serviceName;
+
+    @Inject
+    FailureHandler failureHandler;
+
+    @Inject
+    KafkaBlockingProducer producer;
+
+    Router router;
+
+    void init(@Observes Router router) {
+        this.router = router;
+    }
+
+    void onStart(@Observes StartupEvent ev) {
+        LOG.info(String.format("Application %s starting...", serviceName));
+        addRoute(HttpMethod.POST, "/event/:topic", rc -> producer.pushEventToTopic(rc));
+        addRoute(HttpMethod.POST, "/event", rc -> producer.pushEvent(rc));
+    }
+
+    void onStop(@Observes ShutdownEvent ev) {
+        LOG.info(String.format("Application %s stopping...", serviceName));
+    }
+
+    private void addRoute(HttpMethod method, String path, Handler<RoutingContext> handler) {
+        Route route = this.router.route(method, path)
+                .handler(CorsHandler.create("*"))
+                .handler(LoggerHandler.create());
+
+        if (method.equals(HttpMethod.POST) || method.equals(HttpMethod.PUT))
+            route.handler(BodyHandler.create());
+
+        route.handler(handler).failureHandler(rc -> failureHandler.handler(rc));
+    }
+}

--- a/messaging/kafka-producer/src/main/java/io/quarkus/ts/messaging/kafka/FailureHandler.java
+++ b/messaging/kafka-producer/src/main/java/io/quarkus/ts/messaging/kafka/FailureHandler.java
@@ -1,0 +1,36 @@
+package io.quarkus.ts.messaging.kafka;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.HttpException;
+
+@ApplicationScoped
+public class FailureHandler {
+
+    public void handler(final RoutingContext ctx) {
+        JsonObject error = defaultError(ctx.normalizedPath());
+
+        if (ctx.failure() instanceof HttpException) {
+            HttpException httpExp = (HttpException) ctx.failure();
+            error.put("status", httpExp.getStatusCode());
+        }
+
+        if (ctx.failure().getMessage() != null) {
+            error.put("message", ctx.failure().getMessage());
+        }
+
+        ctx.response().setStatusCode(error.getInteger("status"));
+        ctx.response().end(error.encode());
+    }
+
+    private JsonObject defaultError(String path) {
+        return new JsonObject()
+                .put("timestamp", System.currentTimeMillis())
+                .put("status", HttpResponseStatus.INTERNAL_SERVER_ERROR.code())
+                .put("error", HttpResponseStatus.valueOf(HttpResponseStatus.INTERNAL_SERVER_ERROR.code()).reasonPhrase())
+                .put("path", path);
+    }
+}

--- a/messaging/kafka-producer/src/main/java/io/quarkus/ts/messaging/kafka/KafkaBlockingProducer.java
+++ b/messaging/kafka-producer/src/main/java/io/quarkus/ts/messaging/kafka/KafkaBlockingProducer.java
@@ -1,0 +1,90 @@
+package io.quarkus.ts.messaging.kafka;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.jboss.logging.Logger;
+
+import io.smallrye.reactive.messaging.MutinyEmitter;
+import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class KafkaBlockingProducer {
+
+    private static final Logger LOG = Logger.getLogger(KafkaBlockingProducer.class);
+
+    @Inject
+    @Channel("test")
+    MutinyEmitter<String> emitter;
+
+    public void pushEvent(final RoutingContext context) {
+        Long startMs = System.currentTimeMillis();
+        emitter.send("ping")
+                .onFailure().invoke(exception -> {
+                    long endMs = System.currentTimeMillis() - startMs;
+                    context.response()
+                            .setStatusCode(408)
+                            .putHeader("x-ms", String.valueOf(endMs))
+                            .putHeader("Content-Type", "application/json")
+                            .end(exception.getMessage());
+                })
+                .subscribe().with(resp -> {
+                    long endMs = System.currentTimeMillis() - startMs;
+                    context.response()
+                            .putHeader("x-ms", String.valueOf(endMs))
+                            .putHeader("Content-Type", "application/json")
+                            .end("success");
+                });
+
+    }
+
+    public void pushEventToTopic(final RoutingContext context) {
+        Long startMs = System.currentTimeMillis();
+        String topic = context.request().getParam("topic");
+        OutgoingKafkaRecordMetadata<?> metadata = OutgoingKafkaRecordMetadata.builder()
+                .withTopic(topic)
+                .withKey(UUID.randomUUID().toString())
+                .build();
+
+        Message<String> msg = Message.of("ping")
+                .withAck(handlerSuccess(context, startMs))
+                .withNack(handlerError(context, startMs))
+                .addMetadata(metadata);
+
+        emitter.send(msg);
+    }
+
+    private Function<Throwable, CompletionStage<Void>> handlerError(RoutingContext context, Long startMs) {
+        return exception -> {
+            long endMs = System.currentTimeMillis() - startMs;
+            context.response()
+                    .setStatusCode(408)
+                    .putHeader("x-ms", "" + endMs)
+                    .putHeader("Content-Type", "application/json")
+                    .end(exception.getMessage());
+
+            return CompletableFuture.completedFuture(null);
+        };
+    }
+
+    private Supplier<CompletionStage<Void>> handlerSuccess(RoutingContext context, Long startMs) {
+        return () -> {
+            long endMs = System.currentTimeMillis() - startMs;
+            context.response()
+                    .putHeader("x-ms", "" + endMs)
+                    .putHeader("Content-Type", "application/json")
+                    .end("success");
+
+            return CompletableFuture.completedFuture(null);
+        };
+    }
+}

--- a/messaging/kafka-producer/src/main/resources/application.properties
+++ b/messaging/kafka-producer/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+app.name=blockingProducer
+
+kafka.bootstrap.servers=localhost:9092
+mp.messaging.outgoing.test.connector=smallrye-kafka
+mp.messaging.outgoing.test.key.serializer=org.apache.kafka.common.serialization.StringSerializer
+mp.messaging.outgoing.test.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+mp.messaging.outgoing.test.max.block.ms=100
+mp.messaging.outgoing.test.retries=0

--- a/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/BlockingProducerIT.java
+++ b/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/BlockingProducerIT.java
@@ -1,0 +1,86 @@
+package io.quarkus.ts.messaging.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+
+@Tag("QUARKUS-1090")
+@QuarkusScenario
+public class BlockingProducerIT {
+    private static final int TIMEOUT_SEC = 5;
+    private static final int EVENTS = 100;
+    static final long KAFKA_MAX_BLOCK_MS = 100;
+    static final long DEVIATION_ERROR_MS = 80;
+    static final long KAFKA_MAX_BLOCK_TIME_MS = KAFKA_MAX_BLOCK_MS + DEVIATION_ERROR_MS;
+
+    static CustomStrimziKafkaContainer kafkaContainer;
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .onPreStart(app -> {
+                Map<String, String> kafkaProp = Map.of("auto.create.topics.enable", "false");
+                kafkaContainer = new CustomStrimziKafkaContainer("0.24.0-kafka-2.7.0", kafkaProp);
+                kafkaContainer.start();
+            })
+            .withProperty("kafka.bootstrap.servers", () -> kafkaContainer.getBootstrapServers());
+
+    // TODO https://github.com/quarkus-qe/quarkus-test-framework/issues/248
+    // Remove after all once this ticket is resolved
+    @AfterAll
+    public static void afterAll() {
+        kafkaContainer.stop();
+    }
+
+    @Test
+    public void kafkaProducerBlocksIfTopicsNotExistWithMetadata() {
+        UniAssertSubscriber<Integer> subscriber = makeHttpReqAsJson("/event/tooLongToExist")
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        int reqTime = subscriber.awaitItem(Duration.ofSeconds(TIMEOUT_SEC)).getItem();
+        assertTrue(reqTime < KAFKA_MAX_BLOCK_TIME_MS, getErrorMsg(reqTime));
+    }
+
+    @Test
+    public void kafkaProducerBlocksIfTopicsNotExistEmitterWithoutMetadata() {
+        UniAssertSubscriber<Integer> subscriber = makeHttpReqAsJson("/event")
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        int reqTime = subscriber.awaitItem(Duration.ofSeconds(TIMEOUT_SEC)).getItem();
+        assertTrue(reqTime < KAFKA_MAX_BLOCK_TIME_MS, getErrorMsg(reqTime));
+    }
+
+    @Test
+    public void severalEventsProducedKeepResponseTimes() {
+        for (int i = 0; i < EVENTS; i++) {
+            UniAssertSubscriber<Integer> subscriber = makeHttpReqAsJson("/event")
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            int reqTime = subscriber.awaitItem(Duration.ofSeconds(TIMEOUT_SEC)).getItem();
+            assertTrue(reqTime < KAFKA_MAX_BLOCK_TIME_MS, getErrorMsg(reqTime));
+        }
+    }
+
+    private Uni<Integer> makeHttpReqAsJson(String path) {
+        return app.mutiny().postAbs(getAppEndpoint() + path).send()
+                .map(resp -> Integer.parseInt(resp.getHeader("x-ms")));
+    }
+
+    private String getAppEndpoint() {
+        return String.format("http://localhost:%d/", app.getPort());
+    }
+
+    private String getErrorMsg(long reqTime) {
+        return String.format("reqTime %d greater than KafkaMaxBlockMs %d", reqTime, KAFKA_MAX_BLOCK_TIME_MS);
+    }
+}

--- a/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/CustomStrimziKafkaContainer.java
+++ b/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/CustomStrimziKafkaContainer.java
@@ -1,0 +1,79 @@
+package io.quarkus.ts.messaging.kafka;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Map;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.images.builder.Transferable;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.ContainerNetwork;
+
+public class CustomStrimziKafkaContainer extends GenericContainer<CustomStrimziKafkaContainer> {
+
+    protected static final String LATEST_KAFKA_VERSION = "2.7.0";
+    protected static final String STARTER_SCRIPT = "/testcontainers_start.sh";
+    protected static final int KAFKA_PORT = 9092;
+    protected static final int ZOOKEEPER_PORT = 2181;
+
+    private int kafkaExposedPort;
+    Map<String, String> kafkaServerProp;
+
+    public CustomStrimziKafkaContainer(final String version, final Map<String, String> kafkaServerProp) {
+        super("quay.io/strimzi/kafka:" + version);
+        super.withNetwork(Network.SHARED);
+        this.kafkaServerProp = kafkaServerProp;
+        // exposing kafka port from the container
+        withExposedPorts(KAFKA_PORT);
+
+        withEnv("LOG_DIR", "/tmp");
+    }
+
+    @Override
+    public void doStart() {
+        withCommand("sh", "-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
+        super.doStart();
+    }
+
+    public CustomStrimziKafkaContainer(final Map<String, String> kafkaServerProp) {
+        this("latest-kafka-" + LATEST_KAFKA_VERSION, kafkaServerProp);
+    }
+
+    @Override
+    protected void containerIsStarting(InspectContainerResponse containerInfo, boolean reused) {
+        super.containerIsStarting(containerInfo, reused);
+
+        kafkaExposedPort = getMappedPort(KAFKA_PORT);
+
+        StringBuilder advertisedListeners = new StringBuilder(getBootstrapServers());
+
+        Collection<ContainerNetwork> cns = containerInfo.getNetworkSettings().getNetworks().values();
+
+        for (ContainerNetwork cn : cns) {
+            advertisedListeners.append("," + "BROKER://").append(cn.getIpAddress()).append(":9093");
+        }
+
+        String command = "#!/bin/bash \n";
+        command += "bin/zookeeper-server-start.sh config/zookeeper.properties &\n";
+        command += "bin/kafka-server-start.sh config/server.properties --override listeners=PLAINTEXT://0.0.0.0:9092,BROKER://0.0.0.0:9093"
+                +
+                " --override advertised.listeners=" + advertisedListeners +
+                " --override zookeeper.connect=localhost:" + ZOOKEEPER_PORT +
+                " --override listener.security.protocol.map=PLAINTEXT:PLAINTEXT,BROKER:PLAINTEXT" +
+                " --override inter.broker.listener.name=BROKER";
+
+        for (Map.Entry<String, String> entry : kafkaServerProp.entrySet()) {
+            command += " --override " + entry.getKey() + "=" + entry.getValue() + "\n";
+        }
+
+        copyFileToContainer(
+                Transferable.of(command.getBytes(StandardCharsets.UTF_8), 700),
+                STARTER_SCRIPT);
+    }
+
+    public String getBootstrapServers() {
+        return String.format("PLAINTEXT://%s:%s", getContainerIpAddress(), kafkaExposedPort);
+    }
+}

--- a/messaging/kafka-producer/src/test/resources/test.properties
+++ b/messaging/kafka-producer/src/test/resources/test.properties
@@ -1,0 +1,1 @@
+ts.app.log.enable=true

--- a/pom.xml
+++ b/pom.xml
@@ -421,6 +421,7 @@
                 <module>messaging/qpid</module>
                 <module>messaging/kafka-streams-reactive-messaging</module>
                 <module>messaging/kafka-avro-reactive-messaging</module>
+                <module>messaging/kafka-producer</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
When a topic doesn't exist then Kafka producer blocks 60sec (default time). 

This scenario verified that the main thread is not blocked and also that the total amount of time needed to complete a request doesn't exceed `ProducerConfig.MAX_BLOCK_MS_CONFIG`. 

