### PR TITLE
Maintain Quarkus Ide Config independently

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
         <quarkus.qe.framework.version>0.0.8</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.27.0</quarkus-qpid-jms.version>
+        <quarkus-ide-config.version>2.2.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>
         <apicurio.registry.utils.serde.version>1.3.2.Final</apicurio.registry.utils.serde.version>
         <quarkiverse.apicurio.registry.client.version>0.0.2</quarkiverse.apicurio.registry.client.version>
@@ -245,7 +246,7 @@
                     <dependency>
                         <artifactId>quarkus-ide-config</artifactId>
                         <groupId>io.quarkus</groupId>
-                        <version>${quarkus.platform.version}</version>
+                        <version>${quarkus-ide-config.version}</version>
                     </dependency>
                 </dependencies>
                 <configuration>


### PR DESCRIPTION
As this dependency is not part of RHBQ, we need to use the upstream version always.
Dependabot will maintain it.