### PR TITLE
[2.2] Maintain Quarkus Ide Config independently

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
                     <dependency>
                         <artifactId>quarkus-ide-config</artifactId>
                         <groupId>io.quarkus</groupId>
-                        <version>${quarkus.platform.version}</version>
+                        <version>${quarkus-ide-config.version}</version>
                     </dependency>
                 </dependencies>
                 <configuration>


### PR DESCRIPTION
As this dependency is not part of RHBQ, we need to use the upstream version always.
Dependabot will maintain it.

Back port of https://github.com/quarkus-qe/quarkus-test-suite/pull/232