### PR TITLE
Upgrade Quarkus to 2.2.2.Final

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,14 @@ jobs:
           git clone https://github.com/quarkusio/quarkus.git
           cd quarkus
           git checkout 2.2
-          mvn versions:set -DnewVersion=2.2.1.Final -DgenerateBackupPoms=false -pl .,build-parent,devtools/cli
+          mvn versions:set -DnewVersion=2.2.2.Final -DgenerateBackupPoms=false -pl .,build-parent,devtools/cli
           cd devtools/cli
           mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
       - name: Install Quarkus CLI
         run: |
           cat <<EOF > ./quarkus-dev-cli
           #!/bin/bash
-          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-2.2.1.Final-runner.jar "\$@"
+          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-2.2.2.Final-runner.jar "\$@"
           EOF
           chmod +x ./quarkus-dev-cli
       - name: Build with Maven
@@ -98,14 +98,14 @@ jobs:
           git clone https://github.com/quarkusio/quarkus.git
           cd quarkus
           git checkout 2.2
-          mvn versions:set -DnewVersion=2.2.1.Final -DgenerateBackupPoms=false -pl .,build-parent,devtools/cli
+          mvn versions:set -DnewVersion=2.2.2.Final -DgenerateBackupPoms=false -pl .,build-parent,devtools/cli
           cd devtools/cli
           mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
       - name: Install Quarkus CLI
         run: |
           cat <<EOF > ./quarkus-dev-cli
           #!/bin/bash
-          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-2.2.1.Final-runner.jar "\$@"
+          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-2.2.2.Final-runner.jar "\$@"
           EOF
           chmod +x ./quarkus-dev-cli
       - id: files

--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -39,7 +39,7 @@
                 </property>
             </activation>
             <properties>
-                <quarkus.platform.version>2.2.1.Final</quarkus.platform.version>
+                <quarkus.platform.version>2.2.2.Final</quarkus.platform.version>
             </properties>
             <repositories>
                 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -18,11 +18,11 @@
         <failsafe-plugin.version>2.22.2</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.2.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.2.2.Final</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
         <quarkus.qe.framework.version>0.0.8</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.27.0</quarkus-qpid-jms.version>
-        <quarkus-ide-config.version>2.2.1.Final</quarkus-ide-config.version>
+        <quarkus-ide-config.version>2.2.2.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>
         <apicurio.registry.utils.serde.version>1.3.2.Final</apicurio.registry.utils.serde.version>
         <quarkiverse.apicurio.registry.client.version>0.0.2</quarkiverse.apicurio.registry.client.version>

--- a/spring/spring-cloud-config/src/main/java/io/quarkus/ts/spring/cloud/config/ConfigMappingGreetingResource.java
+++ b/spring/spring-cloud-config/src/main/java/io/quarkus/ts/spring/cloud/config/ConfigMappingGreetingResource.java
@@ -1,13 +1,13 @@
 package io.quarkus.ts.spring.cloud.config;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
 @Path("/custom-mapping/hello")
 public class ConfigMappingGreetingResource {
 
-    // TODO Disabled because https://github.com/quarkusio/quarkus/issues/19448
-    // @Inject
+    @Inject
     CustomMessageConfig config;
 
     @GET

--- a/spring/spring-cloud-config/src/main/java/io/quarkus/ts/spring/cloud/config/CustomMessageConfig.java
+++ b/spring/spring-cloud-config/src/main/java/io/quarkus/ts/spring/cloud/config/CustomMessageConfig.java
@@ -1,7 +1,8 @@
 package io.quarkus.ts.spring.cloud.config;
 
-// TODO Disabled because https://github.com/quarkusio/quarkus/issues/19448
-// @ConfigMapping(prefix = "custom")
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "custom")
 public interface CustomMessageConfig {
 
     String message();

--- a/spring/spring-cloud-config/src/test/java/io/quarkus/ts/spring/cloud/config/SpringCloudConfigIT.java
+++ b/spring/spring-cloud-config/src/test/java/io/quarkus/ts/spring/cloud/config/SpringCloudConfigIT.java
@@ -3,6 +3,7 @@ package io.quarkus.ts.spring.cloud.config;
 import static org.hamcrest.Matchers.is;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -24,8 +25,9 @@ public class SpringCloudConfigIT {
             .withProperty("quarkus.profile", "SpringCloudConfigIT")
             .withProperty("quarkus.spring-cloud-config.url", () -> spring.getHost() + ":" + spring.getPort());
 
+    @Tag("QUARKUS-1218")
     @ParameterizedTest
-    @ValueSource(strings = { "/jaxrs", "/spring" }) // TODO Disabled because https://github.com/quarkusio/quarkus/issues/19448: "/custom-mapping" })
+    @ValueSource(strings = { "/jaxrs", "/spring", "/custom-mapping" })
     public void shouldGetExpectedHelloMessage(String rootPath) {
         app.given().get(rootPath + "/hello").then()
                 .statusCode(HttpStatus.SC_OK)


### PR DESCRIPTION
++ Using 2.2.2.Final is mandatory to build the branch 2.2 in Quarkus upstream (needed to use Quarkus CLI)
++ Enable tests for QUARKUS-1218: Regression issue for @ConfigMapping
The issue https://github.com/quarkusio/quarkus/issues/19448 was fixed by https://github.com/quarkusio/quarkus/pull/19937