### PR TITLE
Update Extensions Help command in Quarkus CLI

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliHelpIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliHelpIT.java
@@ -40,7 +40,7 @@ public class QuarkusCliHelpIT {
         CREATE_APP("create app", "Create a Quarkus application project."),
         BUILD("build", "Build the current project."),
         DEV("dev", "Run the current project in dev (live coding) mode."),
-        EXTENSION("extension", "List, add, and remove extensions of an existing project."),
+        EXTENSION("extension", "Configure extensions of an existing project."),
         COMPLETION("completion", "bash/zsh completion:  source <(quarkus completion)"),
         VERSION("version", "Display version information");
 


### PR DESCRIPTION
The help message changed in Upstream from "List, add, and remove extensions of an existing project." to "Configure extensions of an existing project."