### PR TITLE
[2.2] RemoteDev scenario to check DEV ui is not found

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/RemoteDevModeHttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/RemoteDevModeHttpAdvancedIT.java
@@ -1,0 +1,33 @@
+package io.quarkus.ts.http.advanced;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.RemoteDevModeQuarkusApplication;
+
+@QuarkusScenario
+public class RemoteDevModeHttpAdvancedIT {
+
+    @RemoteDevModeQuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.oidc.enabled", "false")
+            .withProperty("quarkus.keycloak.policy-enforcer.enable", "false")
+            .withProperty("quarkus.keycloak.devservices.enabled", "false");
+
+    @Test
+    public void serviceShouldBeUpAndRunning() {
+        given().get("/api/hello").then().statusCode(HttpStatus.SC_OK).body("content", is("Hello, World!"));
+    }
+
+    @Tag("QUARKUS-834")
+    @Test
+    public void devUiShouldBeNotFound() {
+        app.given().get("/q/dev").then().statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
This PR is to verify https://issues.redhat.com/browse/QUARKUS-834

Back port of https://github.com/quarkus-qe/quarkus-test-suite/pull/244