### PR TITLE
Cover quarkus.log.min-level scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Module that covers the logging functionality using JBoss Logging Manager. The fo
 - Inject the `Logger` instance in beans
 - Inject a `Logger` instance using a custom category
 - Setting up the log level property for logger instances 
+- Check default `quarkus.log.min-level` value
 
 ### `sql-db/hibernate`
 

--- a/logging/jboss/src/main/java/io/quarkus/ts/logging/jboss/LogResource.java
+++ b/logging/jboss/src/main/java/io/quarkus/ts/logging/jboss/LogResource.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.logging.jboss;
 
 import javax.inject.Inject;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -40,6 +41,16 @@ public class LogResource {
     public void addLogMessageInFieldWithCustomCategoryLogger(@PathParam("level") String level,
             @QueryParam("message") String message) {
         addLogMessage(customCategoryLog, level, message);
+    }
+
+    @GET
+    public void logExample() {
+        LOG.fatal("Fatal log example");
+        LOG.error("Error log example");
+        LOG.warn("Warn log example");
+        LOG.info("Info log example");
+        LOG.debug("Debug log example");
+        LOG.trace("Trace log example");
     }
 
     private void addLogMessage(Logger logger, String level, String message) {

--- a/logging/jboss/src/main/resources/application.properties
+++ b/logging/jboss/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+#When you set the logging level below the minimum logging level, you must adjust the minimum logging level as well.
+#Otherwise, the value of minimum logging level overrides the logging level.
+# DOC:
+# https://access.redhat.com/documentation/en-us/red_hat_build_of_quarkus/1.11/html-single/configuring_logging_with_quarkus/index#ref-example-logging-configuration_quarkus-configuring-logging
+# https://quarkus.io/guides/logging
+# https://quarkus.io/guides/all-config#quarkus-core_quarkus.log.min-level
+
+# By default min-level is set to DEBUG
+#quarkus.log.min-level=DEBUG
+quarkus.log.level=TRACE

--- a/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/LogResourceIT.java
+++ b/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/LogResourceIT.java
@@ -4,6 +4,7 @@ import java.util.function.BiConsumer;
 
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -69,6 +70,23 @@ public class LogResourceIT {
         // Now, the message should be shown only in the logger of the custom category
         app.logs().assertDoesNotContain(MESSAGE + "field2");
         app.logs().assertContains(MESSAGE + "category2");
+    }
+
+    @Test
+    // TODO
+    // https://github.com/quarkusio/quarkus/issues/20066
+    @Disabled
+    public void checkDefaultLogMinLevel() {
+        app.given().when().get("/log").then().statusCode(204);
+
+        app.logs().assertContains("Fatal log example");
+        app.logs().assertContains("Error log example");
+        app.logs().assertContains("Warn log example");
+        app.logs().assertContains("Info log example");
+        app.logs().assertContains("Debug log example");
+
+        // the value of minimum logging level overrides the logging level
+        app.logs().assertDoesNotContain("Trace log example");
     }
 
     private void verifyLoggingRules(BiConsumer<Logger.Level, String> writer) {


### PR DESCRIPTION
This PR covers the default behavior of  `quarkus.log.min-level` over JBoss Logger. 

related issue: 
https://github.com/quarkusio/quarkus/issues/20066
https://github.com/quarkusio/quarkus/pull/13376