### PR TITLE
[2.2] Fix OpenShift Keycloak + Sql Server scenarios

### DIFF
--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/BaseOidcJwtSecurityIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/BaseOidcJwtSecurityIT.java
@@ -22,8 +22,10 @@ import io.quarkus.test.bootstrap.RestService;
 
 public abstract class BaseOidcJwtSecurityIT {
 
-    static final String REALM_DEFAULT = "test-realm";
-    static final String CLIENT_ID_DEFAULT = "test-application-client";
+    protected static final String REALM_DEFAULT = "test-realm";
+    protected static final String CLIENT_ID_DEFAULT = "test-application-client";
+
+    private static final String LOGIN_REALM_REGEXP = ".*(Sign|Log) in to " + REALM_DEFAULT + ".*";
 
     private WebClient webClient;
     private HtmlPage page;
@@ -89,7 +91,7 @@ public abstract class BaseOidcJwtSecurityIT {
     }
 
     private void thenRedirectToLoginPage() {
-        assertEquals("Sign in to " + REALM_DEFAULT, page.getTitleText(),
+        assertTrue(page.getTitleText().matches(LOGIN_REALM_REGEXP),
                 "Login page title should display application realm");
     }
 

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseMultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseMultiTenantSecurityIT.java
@@ -26,8 +26,10 @@ import io.quarkus.test.bootstrap.RestService;
 
 public abstract class BaseMultiTenantSecurityIT {
 
-    static final String USER = "test-user";
-    static final String REALM_DEFAULT = "test-realm";
+    protected static final String USER = "test-user";
+    protected static final String REALM_DEFAULT = "test-realm";
+
+    private static final String LOGIN_REALM_REGEXP = ".*(Sign|Log) in to " + REALM_DEFAULT + ".*";
 
     private WebClient webClient;
 
@@ -62,7 +64,7 @@ public abstract class BaseMultiTenantSecurityIT {
     @EnumSource(value = Tenant.class, names = { "WEBAPP", "JWT" })
     public void testAuthenticationForWebAppTenants(Tenant webAppTenant) throws Exception {
         HtmlPage loginPage = webClient.getPage(getEndpointByTenant(webAppTenant));
-        assertEquals("Sign in to " + REALM_DEFAULT, loginPage.getTitleText(),
+        assertTrue(loginPage.getTitleText().matches(LOGIN_REALM_REGEXP),
                 "Login page title should display application realm");
 
         TextPage resourcePage = whenLogin(loginPage, USER);

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/BaseWebappSecurityIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/BaseWebappSecurityIT.java
@@ -28,8 +28,10 @@ import io.quarkus.test.bootstrap.RestService;
 
 public abstract class BaseWebappSecurityIT {
 
-    static final String REALM_DEFAULT = "test-realm";
-    static final String CLIENT_ID_DEFAULT = "test-application-client";
+    protected static final String REALM_DEFAULT = "test-realm";
+    protected static final String CLIENT_ID_DEFAULT = "test-application-client";
+
+    private static final String LOGIN_REALM_REGEXP = ".*(Sign|Log) in to " + REALM_DEFAULT + ".*";
 
     private WebClient webClient;
     private Page page;
@@ -153,7 +155,7 @@ public abstract class BaseWebappSecurityIT {
 
     private void thenRedirectToLoginPage() {
         assertTrue(page instanceof HtmlPage, "Should be in the Login page");
-        assertEquals("Sign in to " + REALM_DEFAULT, ((HtmlPage) page).getTitleText(),
+        assertTrue(((HtmlPage) page).getTitleText().matches(LOGIN_REALM_REGEXP),
                 "Login page title should display application realm");
     }
 

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MssqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MssqlDatabaseIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
+import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.bootstrap.SqlServerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
@@ -9,16 +9,23 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class MssqlDatabaseIT extends AbstractSqlDatabaseIT {
 
-    static final int MSSQL_PORT = 1433;
+    private static final String MSSQL_PASSWORD = "QuArKuS_tEsT";
+    private static final String DATABASE = "msdb";
+
+    private static final int MSSQL_PORT = 1433;
 
     @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
-    static SqlServerService mssql = new SqlServerService()
-            .withProperty("ACCEPT_EULA", "Y");
+    //fixme Replace with SqlServerService when https://github.com/quarkus-qe/quarkus-test-framework/issues/251 will be solved
+    static DefaultService mssql = new DefaultService()
+            .withProperty("ACCEPT_EULA", "Y")
+            .withProperty("SA_PASSWORD", MSSQL_PASSWORD);
 
     @QuarkusApplication
-    static RestService app = new RestService()
+    static final RestService app = new RestService()
             .withProperties("mssql.properties")
-            .withProperty("quarkus.datasource.username", mssql.getUser())
-            .withProperty("quarkus.datasource.password", mssql.getPassword())
-            .withProperty("quarkus.datasource.jdbc.url", mssql::getJdbcUrl);
+            .withProperty("quarkus.datasource.username", "sa")
+            .withProperty("quarkus.datasource.password", MSSQL_PASSWORD)
+            .withProperty("quarkus.datasource.jdbc.url",
+                    () -> mssql.getHost().replace("http", "jdbc:sqlserver") + ":" +
+                            mssql.getPort() + ";databaseName=" + DATABASE);
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MssqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MssqlDatabaseIT.java
@@ -1,0 +1,24 @@
+package io.quarkus.ts.sqldb.sqlapp;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.bootstrap.SqlServerService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class MssqlDatabaseIT extends AbstractSqlDatabaseIT {
+
+    static final int MSSQL_PORT = 1433;
+
+    @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
+    static SqlServerService mssql = new SqlServerService()
+            .withProperty("ACCEPT_EULA", "Y");
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperties("mssql.properties")
+            .withProperty("quarkus.datasource.username", mssql.getUser())
+            .withProperty("quarkus.datasource.password", mssql.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", mssql::getJdbcUrl);
+}

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMssqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMssqlDatabaseIT.java
@@ -1,30 +1,8 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
-import io.quarkus.test.bootstrap.DefaultService;
-import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.Container;
-import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-public class OpenShiftMssqlDatabaseIT extends AbstractSqlDatabaseIT {
-    private static final String MSSQL_PASSWORD = "QuArKuS_tEsT";
-    private static final String DATABASE = "msdb";
+public class OpenShiftMssqlDatabaseIT extends MssqlDatabaseIT {
 
-    static final int MSSQL_PORT = 1433;
-
-    @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
-    //fixme Replace with SqlServerService when https://github.com/quarkus-qe/quarkus-test-framework/issues/251 will be solved
-    static DefaultService mssql = new DefaultService()
-            .withProperty("ACCEPT_EULA", "Y")
-            .withProperty("SA_PASSWORD", MSSQL_PASSWORD);
-
-    @QuarkusApplication
-    static final RestService app = new RestService()
-            .withProperties("mssql.properties")
-            .withProperty("quarkus.datasource.username", "sa")
-            .withProperty("quarkus.datasource.password", MSSQL_PASSWORD)
-            .withProperty("quarkus.datasource.jdbc.url",
-                    () -> mssql.getHost().replace("http", "jdbc:sqlserver") + ":" +
-                            mssql.getPort() + ";databaseName=" + DATABASE);
 }


### PR DESCRIPTION
The problem is that in RH SSO 7.3 is expected `Log in to test-realm` and in RH SSO 7.4 is `Sign in to test-realm`.

I fixed it by using a regular expression.

Backport of https://github.com/quarkus-qe/quarkus-test-suite/pull/260