### PR TITLE
Many Extensions: Disable health extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Build Quarkus main
         run: |
           git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly
+      - name: Build Quarkus Test Suite Parent
+        run: |
+          mvn -V -B -s .github/mvn-settings.xml install -DskipTests -DskipITs -pl .
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository

--- a/super-size/many-extensions/src/main/resources/application.properties
+++ b/super-size/many-extensions/src/main/resources/application.properties
@@ -8,3 +8,6 @@ quarkus.http.root-path=/api
 quarkus.artemis.url=foo
 quarkus.oidc.auth-server-url=https://localhost:8180/auth/realms/quarkus
 quarkus.oidc.client-id=quarkus-app
+
+# Disable health as OpenShift needs the Health to be UP, but we're not deploying the components like database and Artemis
+quarkus.health.extensions.enabled=false


### PR DESCRIPTION
The OpenShift deployment needs the healthcheck to be UP, but it was:

```
{"status":"DOWN","checks":[{"name":"Database connections health check","status":"UP"},{"name":"Artemis JMS health check","status":"DOWN"}]}
```

I think the purpose of this module is to cover as many extensions as possible, so I decided to exclude all the checks via property.

++ Building the Quarkus Test Suite parent separately:
This is a consequence that we're building only the changed modules in the PR workflow.
Also, the test framework does not deal well when the parent is not in the parent folder of the current module.