### PR TITLE
[2.2] Many Extensions: Disable health extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
             MODULES_MAVEN_PARAM="-pl ${MODULES_ARG}"
           fi
 
+          mvn -V -B -s .github/mvn-settings.xml install -DskipTests -DskipITs -pl .
+
           mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dall-modules -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" $MODULES_MAVEN_PARAM
       - name: Zip Artifacts
         if: failure()
@@ -147,6 +149,8 @@ jobs:
         run: |
           if [[ -n ${MODULES_ARG} ]]; then
             echo "Running modules: ${MODULES_ARG}"
+            mvn -V -B -s .github/mvn-settings.xml install -DskipTests -DskipITs -pl .
+
             mvn -fae -V -B -s .github/mvn-settings.xml -fae -Dall-modules -pl $MODULES_ARG clean verify -Dnative \
                         -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
           fi
@@ -188,6 +192,8 @@ jobs:
             echo "Running modules: ${MODULES_ARG}"
             MODULES_MAVEN_PARAM="-pl ${MODULES_ARG}"
           fi
+
+          mvn -V -B -s .github/mvn-settings.xml install -DskipTests -DskipITs -pl .
 
           mvn -fae -s .github/mvn-settings.xml clean verify -Dall-modules $MODULES_MAVEN_PARAM
       - name: Zip Artifacts

--- a/super-size/many-extensions/src/main/resources/application.properties
+++ b/super-size/many-extensions/src/main/resources/application.properties
@@ -8,3 +8,6 @@ quarkus.http.root-path=/api
 quarkus.artemis.url=foo
 quarkus.oidc.auth-server-url=https://localhost:8180/auth/realms/quarkus
 quarkus.oidc.client-id=quarkus-app
+
+# Disable health as OpenShift needs the Health to be UP, but we're not deploying the components like database and Artemis
+quarkus.health.extensions.enabled=false


### PR DESCRIPTION
The OpenShift deployment needs the healthcheck to be UP, but it was:

```
{"status":"DOWN","checks":[{"name":"Database connections health check","status":"UP"},{"name":"Artemis JMS health check","status":"DOWN"}]}
```

I think the purpose of this module is to cover as many extensions as possible, so I decided to exclude all the checks via property.

++ Building the Quarkus Test Suite parent separately:
This is a consequence that we're building only the changed modules in the PR workflow.
Also, the test framework does not deal well when the parent is not in the parent folder of the current module.

Backport of https://github.com/quarkus-qe/quarkus-test-suite/pull/270