### PR TITLE
[2.2] Upgrade Quarkus Test Framework to 0.0.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.2.2.Final</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
-        <quarkus.qe.framework.version>0.0.10</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>0.0.11</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.27.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.2.2.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>


### PR DESCRIPTION
Backport of https://github.com/quarkus-qe/quarkus-test-suite/pull/282