### PR TITLE
[2.2] Run only OpenShift tests when using the OpenShift Maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -520,6 +520,7 @@
                 </property>
             </activation>
             <properties>
+                <include.tests>**/*OpenShift*IT.java</include.tests>
                 <exclude.openshift.tests>no</exclude.openshift.tests>
             </properties>
         </profile>


### PR DESCRIPTION
Backport of https://github.com/quarkus-qe/quarkus-test-suite/pull/289