### PR TITLE
[2.2] Tag DB2 Handler IT as incompatible with FIPS

### DIFF
--- a/sql-db/vertx-sql/src/main/resources/application.properties
+++ b/sql-db/vertx-sql/src/main/resources/application.properties
@@ -45,7 +45,7 @@ quarkus.datasource.db2.reactive=true
 quarkus.datasource.db2.db-kind=db2
 quarkus.datasource.db2.username=test
 quarkus.datasource.db2.password=test
-quarkus.datasource.db2.reactive.url=vertx-reactive:db2://localhost:50000/amadeus
+quarkus.datasource.db2.reactive.url=db2://localhost:50000/amadeus
 
 # Flyway
 quarkus.flyway.db2.schemas=amadeus
@@ -59,7 +59,7 @@ quarkus.datasource.mssql.reactive=true
 quarkus.datasource.mssql.db-kind=mssql
 quarkus.datasource.mssql.username=sa
 quarkus.datasource.mssql.password=QuArKuS_tEsT
-quarkus.datasource.mssql.reactive.url=vertx-reactive:sqlserver://localhost:1433/msdb
+quarkus.datasource.mssql.reactive.url=sqlserver://localhost:1433/msdb
 
 # Flyway
 quarkus.flyway.mssql.schemas=msdb

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/Db2HandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/Db2HandlerIT.java
@@ -1,11 +1,15 @@
 package io.quarkus.qe.vertx.sql.handlers;
 
+import org.junit.jupiter.api.Tag;
+
 import io.quarkus.test.bootstrap.Db2Service;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
+// Reported in https://github.com/IBM/Db2/issues/43
+@Tag("fips-incompatible")
 @QuarkusScenario
 public class Db2HandlerIT extends CommonTestCases {
     private static final String DATABASE = "amadeus";
@@ -15,12 +19,10 @@ public class Db2HandlerIT extends CommonTestCases {
 
     @QuarkusApplication
     static final RestService app = new RestService()
-            .withProperty("quarkus.datasource.db2.jdbc.url",
-                    () -> db2.getHost().replace("http", "jdbc:db2") + ":" +
-                            db2.getPort() + "/" + DATABASE)
-            .withProperty("quarkus.datasource.db2.reactive.url",
-                    () -> db2.getHost().replace("http", "db2") + ":" +
-                            db2.getPort() + "/" + DATABASE)
+            .withProperty("quarkus.datasource.db2.username", db2.getUser())
+            .withProperty("quarkus.datasource.db2.password", db2.getPassword())
+            .withProperty("quarkus.datasource.db2.jdbc.url", db2::getJdbcUrl)
+            .withProperty("quarkus.datasource.db2.reactive.url", db2::getReactiveUrl)
             .withProperty("app.selected.db", "db2")
             // Enable Flyway for DB2
             .withProperty("quarkus.flyway.db2.migrate-at-start", "true");

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/MysqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/MysqlHandlerIT.java
@@ -16,6 +16,8 @@ public class MysqlHandlerIT extends CommonTestCases {
 
     @QuarkusApplication
     static final RestService app = new RestService()
+            .withProperty("quarkus.datasource.mysql.username", mysql.getUser())
+            .withProperty("quarkus.datasource.mysql.password", mysql.getPassword())
             .withProperty("quarkus.datasource.mysql.jdbc.url", mysql::getJdbcUrl)
             .withProperty("quarkus.datasource.mysql.reactive.url", mysql::getReactiveUrl)
             .withProperty("app.selected.db", "mysql")

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/PostgresqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/PostgresqlHandlerIT.java
@@ -16,6 +16,8 @@ public class PostgresqlHandlerIT extends CommonTestCases {
 
     @QuarkusApplication
     static final RestService app = new RestService()
+            .withProperty("quarkus.datasource.username", postgres.getUser())
+            .withProperty("quarkus.datasource.password", postgres.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", postgres::getJdbcUrl)
             .withProperty("quarkus.datasource.reactive.url", postgres::getReactiveUrl)
             .withProperty("app.selected.db", "postgresql")


### PR DESCRIPTION
Reported in https://github.com/IBM/Db2/issues/43

Backport of https://github.com/quarkus-qe/quarkus-test-suite/pull/290