### PR TITLE
[2.2] Add MongoDB scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,3 +686,15 @@ More information about this extension in https://quarkus.io/guides/spring-cache.
 ### `test-tooling/pact`
 
 Verifies, that quarkus works correctly with third-party tool called Pact-JVM
+
+### `nosql-db/mongodb`
+
+Test data operations on MongoDB: insert one document into a collection, list all documents in a collection, find documents from
+a collection using a filter and a projection. All tests are performed using:
+
+- MongoClient
+- MongoClient with BSON codec for all entities
+
+### `nosql-db/mongodb-reactive`
+
+Reactive equivalent of `nosql-db/mongodb`. Uses reactive ReactiveMongoClient (without codecs)

--- a/nosql-db/mongodb-reactive/pom.xml
+++ b/nosql-db/mongodb-reactive/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>nosqldb-mongodb-reactive</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: NoSQL Database: MongoDB Reactive</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mongodb-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-database</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
+        <profile>
+            <id>skip-tests-on-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/AbstractReactiveMongoDao.java
+++ b/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/AbstractReactiveMongoDao.java
@@ -1,0 +1,32 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.List;
+import java.util.function.Function;
+
+import javax.inject.Inject;
+
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import io.quarkus.mongodb.FindOptions;
+import io.quarkus.mongodb.reactive.ReactiveMongoClient;
+import io.quarkus.mongodb.reactive.ReactiveMongoCollection;
+import io.smallrye.mutiny.Uni;
+
+public class AbstractReactiveMongoDao<E> implements MongoDaoInterface {
+    @Inject
+    ReactiveMongoClient mongoClient;
+
+    protected Uni<List<E>> list(String collection, Bson filter, Bson projection, Function<Document, E> converter) {
+        return getCollection(collection).find(new FindOptions().filter(filter).projection(projection)).map(converter).collect()
+                .asList();
+    }
+
+    protected Uni<Void> add(String collection, Document document) {
+        return getCollection(collection).insertOne(document).onItem().ignore().andContinueWithNull();
+    }
+
+    private ReactiveMongoCollection<Document> getCollection(String collection) {
+        return mongoClient.getDatabase(FRUIT_DB_NAME).getCollection(collection);
+    }
+}

--- a/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/Fruit.java
+++ b/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/Fruit.java
@@ -1,0 +1,70 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.Objects;
+
+import org.bson.Document;
+
+public class Fruit {
+
+    private String name;
+    private String description;
+    private String id;
+
+    public Fruit() {
+    }
+
+    public Fruit(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Fruit)) {
+            return false;
+        }
+
+        Fruit other = (Fruit) obj;
+
+        return Objects.equals(other.name, this.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.name);
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public static Fruit fromDocument(Document document) {
+        return new Fruit(document.getString("name"), document.getString("description"));
+    }
+
+    public Document toDocument() {
+        return new Document()
+                .append("name", this.getName())
+                .append("description", this.getDescription());
+    }
+}

--- a/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/FruitBasket.java
+++ b/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/FruitBasket.java
@@ -1,0 +1,74 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.bson.Document;
+
+public class FruitBasket {
+    private String name;
+    private List<Fruit> items;
+    private String id;
+
+    public FruitBasket() {
+    }
+
+    public FruitBasket(String name, List<Fruit> items) {
+        this.name = name;
+        this.items = items;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<Fruit> getItems() {
+        return items;
+    }
+
+    public void setItems(List<Fruit> items) {
+        this.items = items;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        FruitBasket that = (FruitBasket) o;
+        return Objects.equals(name, that.name) && Objects.equals(items, that.items);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, items);
+    }
+
+    public static FruitBasket fromDocument(Document document) {
+        final List<Document> items = document.getList("items", Document.class);
+        final List<Fruit> fruits = items == null ? null : items.stream().map(Fruit::fromDocument).collect(Collectors.toList());
+        return new FruitBasket(document.getString("name"), fruits);
+    }
+
+    public Document toDocument() {
+        List<Document> items = this.getItems() == null ? null
+                : this.getItems().stream().map(Fruit::toDocument).collect(Collectors.toList());
+        return new Document()
+                .append("name", this.getName())
+                .append("items", items);
+    }
+}

--- a/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/MongoDaoInterface.java
+++ b/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/MongoDaoInterface.java
@@ -1,0 +1,5 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+public interface MongoDaoInterface {
+    String FRUIT_DB_NAME = "fruit";
+}

--- a/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/ReactiveFruitBasketResource.java
+++ b/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/ReactiveFruitBasketResource.java
@@ -1,0 +1,39 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/reactive_fruit_baskets")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ReactiveFruitBasketResource {
+
+    @Inject
+    ReactiveFruitBasketService fruitBasketService;
+
+    @GET
+    public Uni<List<FruitBasket>> getAllFruitBaskets() {
+        return fruitBasketService.listFruitBaskets();
+    }
+
+    @GET
+    @Path("/find-items/{fruitBasketName}")
+    public Uni<List<FruitBasket>> findFruitBasketAndGetItems(String fruitBasketName) {
+        return fruitBasketService.findFruitBasketsItemsOnly(fruitBasketName);
+    }
+
+    @POST
+    public Uni<List<FruitBasket>> addFruitBasket(FruitBasket fruitBasket) {
+        return fruitBasketService.addFruitBasket(fruitBasket)
+                .onItem().ignore().andSwitchTo(this::getAllFruitBaskets);
+    }
+}

--- a/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/ReactiveFruitBasketService.java
+++ b/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/ReactiveFruitBasketService.java
@@ -1,0 +1,29 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class ReactiveFruitBasketService extends AbstractReactiveMongoDao<FruitBasket> {
+
+    public static final String REACTIVE_FRUIT_BASKET_COLLECTION_NAME = "reactive_fruit_basket";
+
+    public Uni<List<FruitBasket>> listFruitBaskets() {
+        return list(REACTIVE_FRUIT_BASKET_COLLECTION_NAME, Filters.empty(), null, FruitBasket::fromDocument);
+    }
+
+    public Uni<Void> addFruitBasket(FruitBasket fruitBasket) {
+        return add(REACTIVE_FRUIT_BASKET_COLLECTION_NAME, fruitBasket.toDocument());
+    }
+
+    public Uni<List<FruitBasket>> findFruitBasketsItemsOnly(String fruitBasketName) {
+        return list(REACTIVE_FRUIT_BASKET_COLLECTION_NAME, Filters.eq("name", fruitBasketName), Projections.include("items"),
+                FruitBasket::fromDocument);
+    }
+}

--- a/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/ReactiveFruitResource.java
+++ b/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/ReactiveFruitResource.java
@@ -1,0 +1,33 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/reactive_fruits")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ReactiveFruitResource {
+
+    @Inject
+    ReactiveFruitService fruitService;
+
+    @GET
+    public Uni<List<Fruit>> getAllFruits() {
+        return fruitService.listFruits();
+    }
+
+    @POST
+    public Uni<List<Fruit>> addFruit(Fruit fruit) {
+        return fruitService.addFruit(fruit)
+                .onItem().ignore().andSwitchTo(this::getAllFruits);
+    }
+}

--- a/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/ReactiveFruitService.java
+++ b/nosql-db/mongodb-reactive/src/main/java/io/quarkus/ts/nosqldb/mongodb/ReactiveFruitService.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import com.mongodb.client.model.Filters;
+
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class ReactiveFruitService extends AbstractReactiveMongoDao<Fruit> {
+
+    public static final String REACTIVE_FRUIT_COLLECTION_NAME = "reactive_fruit";
+
+    public Uni<List<Fruit>> listFruits() {
+        return list(REACTIVE_FRUIT_COLLECTION_NAME, Filters.empty(), null, Fruit::fromDocument);
+    }
+
+    public Uni<Void> addFruit(Fruit fruit) {
+        return add(REACTIVE_FRUIT_COLLECTION_NAME, fruit.toDocument());
+    }
+}

--- a/nosql-db/mongodb-reactive/src/main/resources/application.properties
+++ b/nosql-db/mongodb-reactive/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.mongodb.connection-string=mongodb://localhost:27017

--- a/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/AbstractMongoDbIT.java
+++ b/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/AbstractMongoDbIT.java
@@ -1,0 +1,107 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.HttpRequest;
+import io.vertx.mutiny.ext.web.client.HttpResponse;
+
+public abstract class AbstractMongoDbIT {
+    @ParameterizedTest
+    @ValueSource(strings = { "/reactive_fruits" })
+    public void fruitsEndpoints(String path) {
+        final Fruit fruit1 = new Fruit("fruit1", "fruit description 1");
+        final Fruit fruit2 = new Fruit("fruit2", "fruit description 2");
+
+        List<Fruit> fruits1 = postEntity(path, fruit1, Fruit.class);
+        assertThat(fruits1).isNotNull();
+        assertThat(fruits1.size()).isEqualTo(1);
+        assertThat(fruits1).contains(fruit1);
+
+        fruits1 = postEntity(path, fruit2, Fruit.class);
+        assertThat(fruits1.size()).isEqualTo(2);
+        assertThat(fruits1).contains(fruit1, fruit2);
+
+        List<Fruit> fruits2 = getEntities(path, Fruit.class);
+        assertThat(fruits2).isEqualTo(fruits1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "/reactive_fruit_baskets" })
+    public void fruitBasketsEndpoints(String path) {
+        final Fruit fruit1 = new Fruit("fruit1", "fruit description 1");
+        final Fruit fruit2 = new Fruit("fruit2", "fruit description 2");
+        final FruitBasket fruitBasket1 = new FruitBasket("null", null);
+        final FruitBasket fruitBasket2 = new FruitBasket("empty", List.of());
+        final FruitBasket fruitBasket3 = new FruitBasket("full", List.of(fruit1, fruit2));
+
+        List<FruitBasket> fruitBaskets1 = postEntity(path, fruitBasket1, FruitBasket.class);
+        assertThat(fruitBaskets1).isNotNull();
+        assertThat(fruitBaskets1.size()).isEqualTo(1);
+        assertThat(fruitBaskets1).contains(fruitBasket1);
+        assertThat(fruitBaskets1.get(0).getItems()).isNull();
+
+        fruitBaskets1 = postEntity(path, fruitBasket2, FruitBasket.class);
+        assertThat(fruitBaskets1).isNotNull();
+        assertThat(fruitBaskets1.size()).isEqualTo(2);
+        assertThat(fruitBaskets1).contains(fruitBasket1, fruitBasket2);
+        assertThat(fruitBaskets1.get(1).getItems()).isEmpty();
+
+        fruitBaskets1 = postEntity(path, fruitBasket3, FruitBasket.class);
+        assertThat(fruitBaskets1).isNotNull();
+        assertThat(fruitBaskets1.size()).isEqualTo(3);
+        assertThat(fruitBaskets1).contains(fruitBasket1, fruitBasket2, fruitBasket3);
+        assertThat(fruitBaskets1.get(2).getItems()).contains(fruit1, fruit2);
+
+        List<FruitBasket> fruitBaskets2 = getEntities(path, FruitBasket.class);
+        assertThat(fruitBaskets2).isEqualTo(fruitBaskets1);
+
+        List<FruitBasket> fruitBaskets3 = getEntities(path + "/find-items/" + fruitBasket3.getName(), FruitBasket.class);
+        assertThat(fruitBaskets3).isNotNull();
+        assertThat(fruitBaskets3.size()).isEqualTo(1);
+        assertThat(fruitBaskets3.get(0).getName()).isNull();
+        assertThat(fruitBaskets3.get(0).getId()).isNull();
+        assertThat(fruitBaskets3.get(0).getItems()).isEqualTo(fruitBasket3.getItems());
+    }
+
+    private <T> List<T> postEntity(String path, T entity, Class<T> clazz) {
+        final HttpRequest<Buffer> request = createRequest(path, HttpMethod.POST);
+        final HttpResponse<Buffer> response = getResponse(request.sendJson(entity));
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_OK);
+        return parseJsonArrayResponse(response, clazz);
+    }
+
+    private <T> List<T> getEntities(String path, Class<T> clazz) {
+        final HttpRequest<Buffer> request = createRequest(path, HttpMethod.GET);
+        final HttpResponse<Buffer> response = getResponse(request.send());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_OK);
+        return parseJsonArrayResponse(response, clazz);
+    }
+
+    private HttpRequest<Buffer> createRequest(String path, HttpMethod httpMethod) {
+        return getApp().mutiny().request(httpMethod, path);
+    }
+
+    private HttpResponse<Buffer> getResponse(Uni<HttpResponse<Buffer>> responseUni) {
+        return responseUni.subscribe().withSubscriber(UniAssertSubscriber.create()).awaitItem().assertCompleted().getItem();
+    }
+
+    private <T> List<T> parseJsonArrayResponse(HttpResponse<Buffer> response, Class<T> clazz) {
+        return response.bodyAsJsonArray().stream().map(value -> Json.decodeValue(value.toString(), clazz))
+                .collect(Collectors.toList());
+    }
+
+    protected abstract RestService getApp();
+}

--- a/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/MongoDbIT.java
+++ b/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/MongoDbIT.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import io.quarkus.test.bootstrap.MongoDbService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class MongoDbIT extends AbstractMongoDbIT {
+
+    @Container(image = "${mongodb.image}", port = 27017, expectedLog = "Waiting for connections")
+    static MongoDbService database = new MongoDbService();
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.mongodb.connection-string", database::getJdbcUrl);
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+}

--- a/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/OpenShiftMongoDbIT.java
+++ b/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/OpenShiftMongoDbIT.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import io.quarkus.test.bootstrap.MongoDbService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@OpenShiftScenario
+public class OpenShiftMongoDbIT extends AbstractMongoDbIT {
+
+    @Container(image = "${mongodb.image}", port = 27017, expectedLog = "Waiting for connections")
+    static MongoDbService database = new MongoDbService();
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.mongodb.connection-string", database::getJdbcUrl);
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+}

--- a/nosql-db/mongodb-reactive/src/test/resources/test.properties
+++ b/nosql-db/mongodb-reactive/src/test/resources/test.properties
@@ -1,0 +1,3 @@
+ts.app.log.enable=true
+ts.database.log.enable=true
+ts.database.openshift.use-internal-service-as-url=true

--- a/nosql-db/mongodb/pom.xml
+++ b/nosql-db/mongodb/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>nosqldb-mongodb</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: NoSQL Database: MongoDB</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mongodb-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-database</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
+        <profile>
+            <id>skip-tests-on-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/AbstractCodecMongoDao.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/AbstractCodecMongoDao.java
@@ -1,0 +1,36 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.bson.conversions.Bson;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+
+public abstract class AbstractCodecMongoDao<E> implements MongoDaoInterface {
+
+    @Inject
+    MongoClient mongoClient;
+
+    protected List<E> find(String collection, Bson filter, Bson projection, Class<E> clazz) {
+        List<E> list = new ArrayList<>();
+        try (MongoCursor<E> cursor = getCollection(collection, clazz).find(filter).projection(projection).iterator()) {
+            while (cursor.hasNext()) {
+                list.add(cursor.next());
+            }
+        }
+        return list;
+    }
+
+    protected void add(String collection, Class<E> clazz, E document) {
+        getCollection(collection, clazz).insertOne(document);
+    }
+
+    private MongoCollection<E> getCollection(String collection, Class<E> clazz) {
+        return mongoClient.getDatabase(FRUIT_DB_NAME).getCollection(collection, clazz);
+    }
+}

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/AbstractMongoDao.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/AbstractMongoDao.java
@@ -1,0 +1,38 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import javax.inject.Inject;
+
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+
+public abstract class AbstractMongoDao<E> implements MongoDaoInterface {
+
+    @Inject
+    MongoClient mongoClient;
+
+    protected List<E> find(String collection, Bson filter, Bson projection, Function<Document, E> converter) {
+        List<E> list = new ArrayList<>();
+        try (MongoCursor<Document> cursor = getCollection(collection).find(filter).projection(projection).iterator()) {
+            while (cursor.hasNext()) {
+                list.add(converter.apply(cursor.next()));
+            }
+        }
+        return list;
+    }
+
+    protected void add(String collection, Document document) {
+        getCollection(collection).insertOne(document);
+    }
+
+    private MongoCollection<Document> getCollection(String collection) {
+        return mongoClient.getDatabase(FRUIT_DB_NAME).getCollection(collection);
+    }
+}

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/CodecFruitBasketResource.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/CodecFruitBasketResource.java
@@ -1,0 +1,37 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/codec_fruit_baskets")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class CodecFruitBasketResource {
+
+    @Inject
+    CodecFruitBasketService fruitBasketService;
+
+    @GET
+    public List<FruitBasket> getAllFruitBaskets() {
+        return fruitBasketService.listFruitBaskets();
+    }
+
+    @GET
+    @Path("/find-items/{fruitBasketName}")
+    public List<FruitBasket> findFruitBasketAndGetItems(String fruitBasketName) {
+        return fruitBasketService.findFruitBasketsItemsOnly(fruitBasketName);
+    }
+
+    @POST
+    public List<FruitBasket> addFruitBasket(FruitBasket fruitBasket) {
+        fruitBasketService.addFruitBasket(fruitBasket);
+        return getAllFruitBaskets();
+    }
+}

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/CodecFruitBasketService.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/CodecFruitBasketService.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+
+@ApplicationScoped
+public class CodecFruitBasketService extends AbstractCodecMongoDao<FruitBasket> {
+    private static final String CODEC_FRUIT_BASKET_COLLECTION_NAME = "codec_fruit_basket";
+
+    public List<FruitBasket> listFruitBaskets() {
+        return find(CODEC_FRUIT_BASKET_COLLECTION_NAME, Filters.empty(), null, FruitBasket.class);
+    }
+
+    public List<FruitBasket> findFruitBasketsItemsOnly(String fruitBasketName) {
+        return find(CODEC_FRUIT_BASKET_COLLECTION_NAME, Filters.eq("name", fruitBasketName), Projections.include("items"),
+                FruitBasket.class);
+    }
+
+    public void addFruitBasket(FruitBasket fruitBasket) {
+        add(CODEC_FRUIT_BASKET_COLLECTION_NAME, FruitBasket.class, fruitBasket);
+    }
+
+}

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/CodecFruitResource.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/CodecFruitResource.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/codec_fruits")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class CodecFruitResource {
+
+    @Inject
+    CodecFruitService fruitService;
+
+    @GET
+    public List<Fruit> getAllFruits() {
+        return fruitService.listFruits();
+    }
+
+    @POST
+    public List<Fruit> addFruit(Fruit fruit) {
+        fruitService.addFruit(fruit);
+        return getAllFruits();
+    }
+}

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/CodecFruitService.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/CodecFruitService.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import com.mongodb.client.model.Filters;
+
+@ApplicationScoped
+public class CodecFruitService extends AbstractCodecMongoDao<Fruit> {
+
+    private static final String CODEC_FRUIT_COLLECTION_NAME = "codec_fruit";
+
+    public List<Fruit> listFruits() {
+        return find(CODEC_FRUIT_COLLECTION_NAME, Filters.empty(), null, Fruit.class);
+    }
+
+    public void addFruit(Fruit fruit) {
+        add(CODEC_FRUIT_COLLECTION_NAME, Fruit.class, fruit);
+    }
+}

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/Fruit.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/Fruit.java
@@ -1,0 +1,70 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.Objects;
+
+import org.bson.Document;
+
+public class Fruit {
+
+    private String name;
+    private String description;
+    private String id;
+
+    public Fruit() {
+    }
+
+    public Fruit(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Fruit)) {
+            return false;
+        }
+
+        Fruit other = (Fruit) obj;
+
+        return Objects.equals(other.name, this.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.name);
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public static Fruit fromDocument(Document document) {
+        return new Fruit(document.getString("name"), document.getString("description"));
+    }
+
+    public Document toDocument() {
+        return new Document()
+                .append("name", this.getName())
+                .append("description", this.getDescription());
+    }
+}

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/FruitBasket.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/FruitBasket.java
@@ -1,0 +1,74 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.bson.Document;
+
+public class FruitBasket {
+    private String name;
+    private List<Fruit> items;
+    private String id;
+
+    public FruitBasket() {
+    }
+
+    public FruitBasket(String name, List<Fruit> items) {
+        this.name = name;
+        this.items = items;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<Fruit> getItems() {
+        return items;
+    }
+
+    public void setItems(List<Fruit> items) {
+        this.items = items;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        FruitBasket that = (FruitBasket) o;
+        return Objects.equals(name, that.name) && Objects.equals(items, that.items);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, items);
+    }
+
+    public static FruitBasket fromDocument(Document document) {
+        final List<Document> items = document.getList("items", Document.class);
+        final List<Fruit> fruits = items == null ? null : items.stream().map(Fruit::fromDocument).collect(Collectors.toList());
+        return new FruitBasket(document.getString("name"), fruits);
+    }
+
+    public Document toDocument() {
+        List<Document> items = this.getItems() == null ? null
+                : this.getItems().stream().map(Fruit::toDocument).collect(Collectors.toList());
+        return new Document()
+                .append("name", this.getName())
+                .append("items", items);
+    }
+}

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/FruitBasketResource.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/FruitBasketResource.java
@@ -1,0 +1,37 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/fruit_baskets")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class FruitBasketResource {
+
+    @Inject
+    FruitBasketService fruitBasketService;
+
+    @GET
+    public List<FruitBasket> getAllFruitBaskets() {
+        return fruitBasketService.listFruitBaskets();
+    }
+
+    @GET
+    @Path("/find-items/{fruitBasketName}")
+    public List<FruitBasket> findFruitBasketAndGetItems(String fruitBasketName) {
+        return fruitBasketService.findFruitBasketsItemsOnly(fruitBasketName);
+    }
+
+    @POST
+    public List<FruitBasket> addFruitBasket(FruitBasket fruitBasket) {
+        fruitBasketService.addFruitBasket(fruitBasket);
+        return getAllFruitBaskets();
+    }
+}

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/FruitBasketService.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/FruitBasketService.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+
+@ApplicationScoped
+public class FruitBasketService extends AbstractMongoDao<FruitBasket> {
+
+    private static final String FRUIT_BASKET_COLLECTION_NAME = "fruit_basket";
+
+    public List<FruitBasket> listFruitBaskets() {
+        return find(FRUIT_BASKET_COLLECTION_NAME, Filters.empty(), null, FruitBasket::fromDocument);
+    }
+
+    public List<FruitBasket> findFruitBasketsItemsOnly(String fruitBasketName) {
+        return find(FRUIT_BASKET_COLLECTION_NAME, Filters.eq("name", fruitBasketName), Projections.include("items"),
+                FruitBasket::fromDocument);
+    }
+
+    public void addFruitBasket(FruitBasket fruitBasket) {
+        add(FRUIT_BASKET_COLLECTION_NAME, fruitBasket.toDocument());
+    }
+}

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/FruitResource.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/FruitResource.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/fruits")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class FruitResource {
+
+    @Inject
+    FruitService fruitService;
+
+    @GET
+    public List<Fruit> getAllFruits() {
+        return fruitService.listFruits();
+    }
+
+    @POST
+    public List<Fruit> addFruit(Fruit fruit) {
+        fruitService.addFruit(fruit);
+        return getAllFruits();
+    }
+}

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/FruitService.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/FruitService.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import com.mongodb.client.model.Filters;
+
+@ApplicationScoped
+public class FruitService extends AbstractMongoDao<Fruit> {
+
+    private static final String FRUIT_COLLECTION_NAME = "fruit";
+
+    public List<Fruit> listFruits() {
+        return find(FRUIT_COLLECTION_NAME, Filters.empty(), null, Fruit::fromDocument);
+    }
+
+    public void addFruit(Fruit fruit) {
+        add(FRUIT_COLLECTION_NAME, fruit.toDocument());
+    }
+}

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/MongoDaoInterface.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/MongoDaoInterface.java
@@ -1,0 +1,5 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+public interface MongoDaoInterface {
+    String FRUIT_DB_NAME = "fruit";
+}

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/codec/FruitBasketCodec.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/codec/FruitBasketCodec.java
@@ -1,0 +1,64 @@
+package io.quarkus.ts.nosqldb.mongodb.codec;
+
+import java.util.UUID;
+
+import org.bson.BsonReader;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.BsonWriter;
+import org.bson.Document;
+import org.bson.codecs.Codec;
+import org.bson.codecs.CollectibleCodec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+
+import com.mongodb.MongoClientSettings;
+
+import io.quarkus.ts.nosqldb.mongodb.FruitBasket;
+
+public class FruitBasketCodec implements CollectibleCodec<FruitBasket> {
+
+    private final Codec<Document> documentCodec;
+
+    public FruitBasketCodec() {
+        this.documentCodec = MongoClientSettings.getDefaultCodecRegistry().get(Document.class);
+    }
+
+    @Override
+    public void encode(BsonWriter writer, FruitBasket fruitBasket, EncoderContext encoderContext) {
+        documentCodec.encode(writer, fruitBasket.toDocument(), encoderContext);
+    }
+
+    @Override
+    public Class<FruitBasket> getEncoderClass() {
+        return FruitBasket.class;
+    }
+
+    @Override
+    public FruitBasket generateIdIfAbsentFromDocument(FruitBasket document) {
+        if (!documentHasId(document)) {
+            document.setId(UUID.randomUUID().toString());
+        }
+        return document;
+    }
+
+    @Override
+    public boolean documentHasId(FruitBasket document) {
+        return document.getId() != null;
+    }
+
+    @Override
+    public BsonValue getDocumentId(FruitBasket document) {
+        return new BsonString(document.getId());
+    }
+
+    @Override
+    public FruitBasket decode(BsonReader reader, DecoderContext decoderContext) {
+        Document document = documentCodec.decode(reader, decoderContext);
+        FruitBasket fruitBasket = FruitBasket.fromDocument(document);
+        if (document.getString("id") != null) {
+            fruitBasket.setId(document.getString("id"));
+        }
+        return fruitBasket;
+    }
+}

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/codec/FruitCodec.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/codec/FruitCodec.java
@@ -1,0 +1,64 @@
+package io.quarkus.ts.nosqldb.mongodb.codec;
+
+import java.util.UUID;
+
+import org.bson.BsonReader;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.BsonWriter;
+import org.bson.Document;
+import org.bson.codecs.Codec;
+import org.bson.codecs.CollectibleCodec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+
+import com.mongodb.MongoClientSettings;
+
+import io.quarkus.ts.nosqldb.mongodb.Fruit;
+
+public class FruitCodec implements CollectibleCodec<Fruit> {
+
+    private final Codec<Document> documentCodec;
+
+    public FruitCodec() {
+        this.documentCodec = MongoClientSettings.getDefaultCodecRegistry().get(Document.class);
+    }
+
+    @Override
+    public void encode(BsonWriter writer, Fruit fruit, EncoderContext encoderContext) {
+        documentCodec.encode(writer, fruit.toDocument(), encoderContext);
+    }
+
+    @Override
+    public Class<Fruit> getEncoderClass() {
+        return Fruit.class;
+    }
+
+    @Override
+    public Fruit generateIdIfAbsentFromDocument(Fruit document) {
+        if (!documentHasId(document)) {
+            document.setId(UUID.randomUUID().toString());
+        }
+        return document;
+    }
+
+    @Override
+    public boolean documentHasId(Fruit document) {
+        return document.getId() != null;
+    }
+
+    @Override
+    public BsonValue getDocumentId(Fruit document) {
+        return new BsonString(document.getId());
+    }
+
+    @Override
+    public Fruit decode(BsonReader reader, DecoderContext decoderContext) {
+        Document document = documentCodec.decode(reader, decoderContext);
+        Fruit fruit = Fruit.fromDocument(document);
+        if (document.getString("id") != null) {
+            fruit.setId(document.getString("id"));
+        }
+        return fruit;
+    }
+}

--- a/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/codec/FruitCodecProvider.java
+++ b/nosql-db/mongodb/src/main/java/io/quarkus/ts/nosqldb/mongodb/codec/FruitCodecProvider.java
@@ -1,0 +1,22 @@
+package io.quarkus.ts.nosqldb.mongodb.codec;
+
+import org.bson.codecs.Codec;
+import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+
+import io.quarkus.ts.nosqldb.mongodb.Fruit;
+import io.quarkus.ts.nosqldb.mongodb.FruitBasket;
+
+public class FruitCodecProvider implements CodecProvider {
+    @Override
+    public <T> Codec<T> get(Class<T> clazz, CodecRegistry registry) {
+        if (clazz == Fruit.class) {
+            return (Codec<T>) new FruitCodec();
+        }
+        if (clazz == FruitBasket.class) {
+            return (Codec<T>) new FruitBasketCodec();
+        }
+        return null;
+    }
+
+}

--- a/nosql-db/mongodb/src/main/resources/application.properties
+++ b/nosql-db/mongodb/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.mongodb.connection-string=mongodb://localhost:27017

--- a/nosql-db/mongodb/src/test/java/io/quarkus/ts/nosqldb/mongodb/MongoDbIT.java
+++ b/nosql-db/mongodb/src/test/java/io/quarkus/ts/nosqldb/mongodb/MongoDbIT.java
@@ -1,0 +1,113 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.quarkus.test.bootstrap.MongoDbService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
+
+@QuarkusScenario
+public class MongoDbIT {
+
+    @Container(image = "${mongodb.image}", port = 27017, expectedLog = "Waiting for connections")
+    static MongoDbService database = new MongoDbService();
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.mongodb.connection-string", database::getJdbcUrl);
+
+    @ParameterizedTest
+    @ValueSource(strings = { "/fruits", "/codec_fruits" })
+    public void fruitsEndpoints(String path) {
+        final Fruit fruit1 = new Fruit("fruit1", "fruit description 1");
+        final Fruit fruit2 = new Fruit("fruit2", "fruit description 2");
+
+        List<Fruit> fruits1 = postFruit(path, fruit1);
+        assertThat(fruits1).isNotNull();
+        assertThat(fruits1.size()).isEqualTo(1);
+        assertThat(fruits1).contains(fruit1);
+
+        fruits1 = postFruit(path, fruit2);
+        assertThat(fruits1.size()).isEqualTo(2);
+        assertThat(fruits1).contains(fruit1, fruit2);
+
+        List<Fruit> fruits2 = RestAssured.get(path)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().body().jsonPath().getList(".", Fruit.class);
+        assertThat(fruits2).isEqualTo(fruits1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "/fruit_baskets", "/codec_fruit_baskets" })
+    public void fruitBasketsEndpoints(String path) {
+        final Fruit fruit1 = new Fruit("fruit1", "fruit description 1");
+        final Fruit fruit2 = new Fruit("fruit2", "fruit description 2");
+        final FruitBasket fruitBasket1 = new FruitBasket("null", null);
+        final FruitBasket fruitBasket2 = new FruitBasket("empty", List.of());
+        final FruitBasket fruitBasket3 = new FruitBasket("full", List.of(fruit1, fruit2));
+
+        List<FruitBasket> fruitBaskets1 = postFruitBasket(path, fruitBasket1);
+        assertThat(fruitBaskets1).isNotNull();
+        assertThat(fruitBaskets1.size()).isEqualTo(1);
+        assertThat(fruitBaskets1).contains(fruitBasket1);
+        assertThat(fruitBaskets1.get(0).getItems()).isNull();
+
+        fruitBaskets1 = postFruitBasket(path, fruitBasket2);
+        assertThat(fruitBaskets1).isNotNull();
+        assertThat(fruitBaskets1.size()).isEqualTo(2);
+        assertThat(fruitBaskets1).contains(fruitBasket1, fruitBasket2);
+        assertThat(fruitBaskets1.get(1).getItems()).isEmpty();
+
+        fruitBaskets1 = postFruitBasket(path, fruitBasket3);
+        assertThat(fruitBaskets1).isNotNull();
+        assertThat(fruitBaskets1.size()).isEqualTo(3);
+        assertThat(fruitBaskets1).contains(fruitBasket1, fruitBasket2, fruitBasket3);
+        assertThat(fruitBaskets1.get(2).getItems()).contains(fruit1, fruit2);
+
+        List<FruitBasket> fruitBaskets2 = RestAssured.get(path)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().body().jsonPath().getList(".", FruitBasket.class);
+        assertThat(fruitBaskets2).isEqualTo(fruitBaskets1);
+
+        List<FruitBasket> fruitBaskets3 = RestAssured.get(path + "/find-items/" + fruitBasket3.getName())
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().body().jsonPath().getList(".", FruitBasket.class);
+        assertThat(fruitBaskets3).isNotNull();
+        assertThat(fruitBaskets3.size()).isEqualTo(1);
+        assertThat(fruitBaskets3.get(0).getName()).isNull();
+        assertThat(fruitBaskets3.get(0).getId()).isNull();
+        assertThat(fruitBaskets3.get(0).getItems()).isEqualTo(fruitBasket3.getItems());
+    }
+
+    private List<Fruit> postFruit(String path, Fruit fruit) {
+        return postEntity(path, fruit).getList(".", Fruit.class);
+    }
+
+    private List<FruitBasket> postFruitBasket(String path, FruitBasket fruitBasket) {
+        return postEntity(path, fruitBasket).getList(".", FruitBasket.class);
+    }
+
+    private <T> JsonPath postEntity(String path, T entity) {
+        return RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(entity)
+                .post(path)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().body().jsonPath();
+    }
+}

--- a/nosql-db/mongodb/src/test/java/io/quarkus/ts/nosqldb/mongodb/OpenShiftMongoDbIT.java
+++ b/nosql-db/mongodb/src/test/java/io/quarkus/ts/nosqldb/mongodb/OpenShiftMongoDbIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.nosqldb.mongodb;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftMongoDbIT extends MongoDbIT {
+}

--- a/nosql-db/mongodb/src/test/resources/test.properties
+++ b/nosql-db/mongodb/src/test/resources/test.properties
@@ -1,0 +1,3 @@
+ts.app.log.enable=true
+ts.database.log.enable=true
+ts.database.openshift.use-internal-service-as-url=true

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,7 @@
                                 <mssql.image>mcr.microsoft.com/mssql/rhel/server</mssql.image>
                                 <oracle.image>gvenzl/oracle-xe:18.4.0-slim</oracle.image>
                                 <db2.image>quay.io/quarkusqeteam/db2:11.5.5.0</db2.image>
+                                <mongodb.image>quay.io/bitnami/mongodb:5.0.2</mongodb.image>
                                 <redis.image>quay.io/bitnami/redis:6.0</redis.image>
                                 <wiremock.image>quay.io/ocpmetal/wiremock</wiremock.image>
                                 <consul.image>quay.io/bitnami/consul:1.9.3</consul.image>
@@ -443,6 +444,19 @@
                 <module>sql-db/panache-flyway</module>
                 <module>sql-db/vertx-sql</module>
                 <module>sql-db/reactive-vanilla</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>nosql-db-modules</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>all-modules</name>
+                </property>
+            </activation>
+            <modules>
+                <module>nosql-db/mongodb</module>
+                <module>nosql-db/mongodb-reactive</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
Adds 2 scenarios:
- `nosql-db/mongodb`
- `nosql-db/mongodb-reactive` - reactive equivalent of the prevoius one

Part of test development for QUARKUS-1061.

Backport of https://github.com/quarkus-qe/quarkus-test-suite/pull/255.