### PR TITLE
Support JDK 17

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -43,7 +43,7 @@ jobs:
     needs: build-dependencies
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 11, 17 ]
         profiles: [ "root-modules,http-modules,security-modules,monitoring-modules,spring-modules,test-tooling-modules",
                    "sql-db-modules",
                    "messaging-modules"]
@@ -162,7 +162,7 @@ jobs:
     needs: build-dependencies
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 11, 17 ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1


### PR DESCRIPTION
Add JDK 17 to GitHub CI

- Quarkus Upstream is still using JDK 11 
- JVM test (Linuz/Win) runs over JDK17
- Native runs over JDK 11