### PR TITLE
Auto-detect serializers and deserializers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ This scenario covers the fix for [QUARKUS-858](https://issues.redhat.com/browse/
 The test will confirm that no messages are lost when the `grateful-shutdown` is enabled. In the other hand, when this property is disabled, messages might be lost.
 
 - Reactive Kafka and Kafka Streams SSL
+- Auto-detect serializers and deserializers for the Reactive Messaging Kafka Connector
 
 All current tests are running under a secured Kafka by SSL. 
 Kafka streams pipeline is configured by `quarkus.kafka-streams.ssl` prefix property, but reactive Kafka producer/consumer is configured by `kafka` prefix as you can see on `SslStrimziKafkaTestResource` 

--- a/messaging/kafka-streams-reactive-messaging/src/main/resources/application.properties
+++ b/messaging/kafka-streams-reactive-messaging/src/main/resources/application.properties
@@ -5,21 +5,18 @@ login.denied.windows.sec=3
 quarkus.reactive-messaging.health.enabled=false
 
 mp.messaging.outgoing.login-http-response-values.connector=smallrye-kafka
-mp.messaging.outgoing.login-http-response-values.key.serializer=org.apache.kafka.common.serialization.StringSerializer
-mp.messaging.outgoing.login-http-response-values.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+# QUARKUS-1083
+# Don't add serializers / deserializer to these properties
 
 mp.messaging.incoming.login-denied.connector=smallrye-kafka
-mp.messaging.incoming.login-denied.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
-mp.messaging.incoming.login-denied.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.login-denied.enable.auto.commit=true
 
 # Kafka shutdown config
 mp.messaging.outgoing.slow-topic.connector=smallrye-kafka
 mp.messaging.outgoing.slow-topic.topic=slow
-mp.messaging.outgoing.slow-topic.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 
 mp.messaging.incoming.slow.connector=smallrye-kafka
-mp.messaging.incoming.slow.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 
 quarkus.kafka-streams.application-id=login-denied-aggregator
 quarkus.kafka-streams.application-server=localhost:${quarkus.http.port}

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/KafkaGratefulShutdownIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/KafkaGratefulShutdownIT.java
@@ -25,6 +25,8 @@ import io.quarkus.ts.messaging.kafka.shutdown.SlowTopicResource;
 public class KafkaGratefulShutdownIT {
 
     private static final int TOTAL_MESSAGES = 10;
+    private static final String STRING_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
+    private static final String STRING_DESERIALIZER = "org.apache.kafka.common.serialization.StringDeserializer";
     private static final String GRATEFUL_SHUTDOWN_PROPERTY = "mp.messaging.incoming.slow.graceful-shutdown";
     private static final String KAFKA_LOG_PROPERTY = "quarkus.log.category.\"io.smallrye.reactive.messaging.kafka\".level";
     private static final String LAST_MESSAGE_LOG = "Processed Message " + TOTAL_MESSAGES;
@@ -37,6 +39,12 @@ public class KafkaGratefulShutdownIT {
     static RestService app = new RestService()
             .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
             .withProperty("quarkus.kafka-streams.bootstrap-servers", kafka::getBootstrapUrl)
+            .withProperty("mp.messaging.outgoing.login-http-response-values.key.serializer", STRING_SERIALIZER)
+            .withProperty("mp.messaging.outgoing.login-http-response-values.value.serializer", STRING_SERIALIZER)
+            .withProperty("mp.messaging.incoming.login-denied.value.deserializer", STRING_DESERIALIZER)
+            .withProperty("mp.messaging.incoming.login-denied.key.deserializer", STRING_DESERIALIZER)
+            .withProperty("mp.messaging.outgoing.slow-topic.value.serializer", STRING_SERIALIZER)
+            .withProperty("mp.messaging.incoming.slow.value.deserializer", STRING_DESERIALIZER)
             .withProperty(KAFKA_LOG_PROPERTY, Level.DEBUG.getName());
 
     @Test


### PR DESCRIPTION
Auto-detect serializers and deserializers for the Reactive Messaging Kafka Connector scenario.

- tested over KStreams with String serializer + Strimzi/apicurio

Related issues: quarkus-qe/quarkus-test-framework#278