### PR TITLE
Add auto generated group ID scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,11 +530,13 @@ Kafka streams pipeline is configured by `quarkus.kafka-streams.ssl` prefix prope
 
 ### `messaging/kafka-avro-reactive-messaging`
 
-Verifies that `Quarkus Kafka` + `Apicurio Kakfa Registry`(AVRO) and `Quarkus SmallRye Reactive Messaging` extensions work as expected. 
+- Verifies that `Quarkus Kafka` + `Apicurio Kakfa Registry`(AVRO) and `Quarkus SmallRye Reactive Messaging` extensions work as expected. 
 
 There is an EventsProducer that generate stock prices events every 1s. The events are typed by an AVRO schema.  
 A Kafka consumer will read these events serialized by AVRO and change an `status` property to `COMPLETED`. 
 The streams of completed events will be exposed through an SSE endpoint. 
+
+- Verify random kafka group id 
 
 ### `messaging/kafka-producer`
 

--- a/messaging/kafka-avro-reactive-messaging/src/main/java/io/quarkus/ts/messaging/kafka/KStockPriceProducer.java
+++ b/messaging/kafka-avro-reactive-messaging/src/main/java/io/quarkus/ts/messaging/kafka/KStockPriceProducer.java
@@ -28,7 +28,7 @@ public class KStockPriceProducer {
 
     private Random random = new Random();
 
-    @Scheduled(every = "1s")
+    @Scheduled(cron = "{cron.expr}")
     public void generate() {
         IntStream.range(0, BATCH_SIZE).forEach(next -> {
             StockPrice event = StockPrice.newBuilder()

--- a/messaging/kafka-avro-reactive-messaging/src/main/java/io/quarkus/ts/messaging/kafka/StockPriceDto.java
+++ b/messaging/kafka-avro-reactive-messaging/src/main/java/io/quarkus/ts/messaging/kafka/StockPriceDto.java
@@ -1,0 +1,33 @@
+package io.quarkus.ts.messaging.kafka;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class StockPriceDto {
+    private String id;
+    private double value;
+
+    public StockPrice toAvro() {
+        return StockPrice.newBuilder()
+                .setId(id)
+                .setPrice(value)
+                .setStatus(status.PENDING)
+                .build();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public void setValue(double value) {
+        this.value = value;
+    }
+}

--- a/messaging/kafka-avro-reactive-messaging/src/main/java/io/quarkus/ts/messaging/kafka/StockPriceEndpoint.java
+++ b/messaging/kafka-avro-reactive-messaging/src/main/java/io/quarkus/ts/messaging/kafka/StockPriceEndpoint.java
@@ -2,16 +2,25 @@ package io.quarkus.ts.messaging.kafka;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.OnOverflow;
 import org.jboss.resteasy.annotations.SseElementType;
 import org.reactivestreams.Publisher;
 
 @Path("/stock-price")
 public class StockPriceEndpoint {
+
+    @Inject
+    @Channel("source-stock-price")
+    @OnOverflow(value = OnOverflow.Strategy.DROP)
+    Emitter<StockPrice> stockPriceEmitter;
 
     @Inject
     @Channel("price-stream")
@@ -23,5 +32,11 @@ public class StockPriceEndpoint {
     @SseElementType(MediaType.APPLICATION_JSON)
     public Publisher<String> stream() {
         return stockPrices;
+    }
+
+    @POST
+    public Response addStockPrice(StockPriceDto stockPrice) {
+        stockPriceEmitter.send(stockPrice.toAvro());
+        return Response.accepted().build();
     }
 }

--- a/messaging/kafka-avro-reactive-messaging/src/main/resources/application.properties
+++ b/messaging/kafka-avro-reactive-messaging/src/main/resources/application.properties
@@ -2,17 +2,23 @@
 %dev.kafka.bootstrap.servers=localhost:9092
 #TODO: Disable health check because of https://github.com/quarkusio/quarkus/issues/15464
 %dev.quarkus.reactive-messaging.health.enabled=false
+
+%dev.cron.expr=*/1 * * * * ?
+%dev.mp.messaging.outgoing.source-stock-price.merge=true
+
 %dev.mp.messaging.connector.smallrye-kafka.apicurio.registry.url=http://localhost:8081/apis/registry/v2
+
 %dev.mp.messaging.outgoing.source-stock-price.connector=smallrye-kafka
 %dev.mp.messaging.outgoing.source-stock-price.topic=stock-price
 %dev.mp.messaging.outgoing.source-stock-price.value.serializer=io.apicurio.registry.serde.avro.AvroKafkaSerializer
 %dev.mp.messaging.outgoing.source-stock-price.apicurio.registry.avro-datum-provider=io.apicurio.registry.serde.avro.ReflectAvroDatumProvider
 %dev.mp.messaging.outgoing.source-stock-price.apicurio.registry.auto-register=true
 
+%dev.mp.messaging.incoming.channel-stock-price.group.id=${quarkus.uuid}
 %dev.mp.messaging.incoming.channel-stock-price.connector=smallrye-kafka
 %dev.mp.messaging.incoming.channel-stock-price.topic=stock-price
-%dev.mp.messaging.incoming.channel-stock-price.specific.avro.reader=true
+#%dev.mp.messaging.incoming.channel-stock-price.specific.avro.reader=true
 %dev.mp.messaging.incoming.channel-stock-price.value.deserializer=io.apicurio.registry.serde.avro.AvroKafkaDeserializer
+%dev.mp.messaging.incoming.channel-stock-price.apicurio.registry.avro-datum-provider=io.apicurio.registry.serde.avro.ReflectAvroDatumProvider
 %dev.mp.messaging.incoming.channel-stock-price.auto.offset.reset=earliest
 %dev.mp.messaging.incoming.channel-stock-price.enable.auto.commit=true
-%dev.mp.messaging.incoming.channel-stock-price.apicurio.registry.avro-datum-provider=io.apicurio.registry.serde.avro.ReflectAvroDatumProvider

--- a/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/BaseKafkaAvroGroupIdIT.java
+++ b/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/BaseKafkaAvroGroupIdIT.java
@@ -1,0 +1,104 @@
+package io.quarkus.ts.messaging.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.sse.SseEventSource;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.restassured.http.ContentType;
+
+abstract class BaseKafkaAvroGroupIdIT {
+    private static final int TIMEOUT_SEC = 3;
+    private static final int EVENTS_AMOUNT = 5;
+
+    private String endpoint;
+    private Client client = ClientBuilder.newClient();
+    private List<String> receive = new CopyOnWriteArrayList<>();
+    private boolean completed;
+    private Random rand = new Random();
+
+    @Test
+    public void testAlertMonitorEventStream() throws InterruptedException {
+        GivenSomeStockPrices(getAppA(), EVENTS_AMOUNT);
+        AndApplicationEndpoint(getEndpoint(getAppA()) + "/stock-price/stream");
+        whenRequestSomeEvents(EVENTS_AMOUNT);
+        thenVerifyAllEventsArrived();
+        // Application B should have a different auto-generated group ID so,
+        // double the number of events
+        GivenSomeStockPrices(getAppB(), EVENTS_AMOUNT);
+        AndApplicationEndpoint(getEndpoint(getAppB()) + "/stock-price/stream");
+        whenRequestSomeEvents(EVENTS_AMOUNT + EVENTS_AMOUNT);
+        thenVerifyAllEventsArrived();
+    }
+
+    protected abstract RestService getAppA();
+
+    protected abstract RestService getAppB();
+
+    private void GivenSomeStockPrices(RestService app, int amount) {
+        IntStream.range(0, amount).forEach(i -> app.given()
+                .contentType(ContentType.JSON)
+                .body(randomStockPrice())
+                .post("/stock-price")
+                .then()
+                .statusCode(202));
+    }
+
+    private void AndApplicationEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    private void whenRequestSomeEvents(int expectedAmount) {
+        AtomicInteger totalAmountReceived = new AtomicInteger(0);
+        try {
+            WebTarget target = client.target(endpoint);
+            CountDownLatch latch = new CountDownLatch(expectedAmount);
+            SseEventSource source = SseEventSource.target(target).build();
+            source.register(inboundSseEvent -> {
+                receive.add(inboundSseEvent.readData(String.class, MediaType.APPLICATION_JSON_TYPE));
+                totalAmountReceived.incrementAndGet();
+            });
+
+            source.open();
+            latch.await(TIMEOUT_SEC, TimeUnit.SECONDS);
+            source.close();
+        } catch (InterruptedException ex) {
+            // Force a timeout in order to double-check if we receive more events than the expected ones
+        } finally {
+            int received = totalAmountReceived.get();
+            assertEquals(expectedAmount, received, "You should not process more msg than the expected ones");
+            completed = expectedAmount == received;
+        }
+    }
+
+    private void thenVerifyAllEventsArrived() {
+        assertTrue(completed, "Not all expected kafka events has been consumed.");
+    }
+
+    private String getEndpoint(RestService app) {
+        return app.getHost() + ":" + app.getPort();
+    }
+
+    private StockPriceDto randomStockPrice() {
+        StockPriceDto stockPriceDto = new StockPriceDto();
+        stockPriceDto.setId(UUID.randomUUID().toString());
+        stockPriceDto.setValue(rand.nextInt());
+        return stockPriceDto;
+    }
+}

--- a/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/ConfluentKafkaAvroGroupIdIT.java
+++ b/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/ConfluentKafkaAvroGroupIdIT.java
@@ -1,0 +1,42 @@
+package io.quarkus.ts.messaging.kafka;
+
+import org.junit.jupiter.api.Tag;
+
+import io.quarkus.test.bootstrap.KafkaService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KafkaContainer;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.containers.model.KafkaVendor;
+
+@Tag("QUARKUS-1089")
+@QuarkusScenario
+public class ConfluentKafkaAvroGroupIdIT extends BaseKafkaAvroGroupIdIT {
+
+    @KafkaContainer(vendor = KafkaVendor.CONFLUENT, withRegistry = true)
+    static final KafkaService kafka = new KafkaService();
+
+    @QuarkusApplication
+    static RestService appGroupIdA = new RestService()
+            .withProperties("confluent-application.properties")
+            .withProperty("cron.expr", "0 0 0 ? * * *")
+            .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
+            .withProperty("confluent.registry.url", kafka::getRegistryUrl);
+
+    @QuarkusApplication
+    static RestService appGroupIdB = new RestService()
+            .withProperties("confluent-application.properties")
+            .withProperty("cron.expr", "0 0 0 ? * * *")
+            .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
+            .withProperty("confluent.registry.url", kafka::getRegistryUrl);
+
+    @Override
+    public RestService getAppA() {
+        return appGroupIdA;
+    }
+
+    @Override
+    public RestService getAppB() {
+        return appGroupIdB;
+    }
+}

--- a/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/StrimziKafkaAvroGroupIdIT.java
+++ b/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/StrimziKafkaAvroGroupIdIT.java
@@ -1,0 +1,42 @@
+package io.quarkus.ts.messaging.kafka;
+
+import org.junit.jupiter.api.Tag;
+
+import io.quarkus.test.bootstrap.KafkaService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KafkaContainer;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.containers.model.KafkaVendor;
+
+@Tag("QUARKUS-1089")
+@QuarkusScenario
+public class StrimziKafkaAvroGroupIdIT extends BaseKafkaAvroGroupIdIT {
+
+    @KafkaContainer(vendor = KafkaVendor.STRIMZI, withRegistry = true, registryPath = "/apis/registry/v2")
+    static KafkaService kafka = new KafkaService();
+
+    @QuarkusApplication
+    static RestService appGroupIdA = new RestService()
+            .withProperties("strimzi-application.properties")
+            .withProperty("cron.expr", "0 0 0 ? * * *")
+            .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
+            .withProperty("kafka.registry.url", kafka::getRegistryUrl);
+
+    @QuarkusApplication
+    static RestService appGroupIdB = new RestService()
+            .withProperties("strimzi-application.properties")
+            .withProperty("cron.expr", "0 0 0 ? * * *")
+            .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
+            .withProperty("kafka.registry.url", kafka::getRegistryUrl);
+
+    @Override
+    public RestService getAppA() {
+        return appGroupIdA;
+    }
+
+    @Override
+    public RestService getAppB() {
+        return appGroupIdB;
+    }
+}

--- a/messaging/kafka-avro-reactive-messaging/src/test/resources/confluent-application.properties
+++ b/messaging/kafka-avro-reactive-messaging/src/test/resources/confluent-application.properties
@@ -1,6 +1,8 @@
+cron.expr=*/1 * * * * ?
 kafka.bootstrap.servers=kafka-broker-1:9092
 kafka.registry.url=${confluent.registry.url}
 mp.messaging.connector.smallrye-kafka.schema.registry.url=${confluent.registry.url}
+mp.messaging.outgoing.source-stock-price.merge=true
 mp.messaging.outgoing.source-stock-price.connector=smallrye-kafka
 mp.messaging.outgoing.source-stock-price.schema.registry.url=${confluent.registry.url}
 mp.messaging.outgoing.source-stock-price.topic=stock-price
@@ -9,6 +11,7 @@ mp.messaging.outgoing.source-stock-price.value.serializer=io.confluent.kafka.ser
 mp.messaging.incoming.channel-stock-price.connector=smallrye-kafka
 mp.messaging.incoming.channel-stock-price.schema.registry.url=${confluent.registry.url}
 mp.messaging.incoming.channel-stock-price.topic=stock-price
+mp.messaging.incoming.channel-stock-price.group.id=${quarkus.uuid}
 mp.messaging.incoming.channel-stock-price.specific.avro.reader=true
 mp.messaging.incoming.channel-stock-price.value.deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer
 mp.messaging.incoming.channel-stock-price.auto.offset.reset=earliest

--- a/messaging/kafka-avro-reactive-messaging/src/test/resources/strimzi-application.properties
+++ b/messaging/kafka-avro-reactive-messaging/src/test/resources/strimzi-application.properties
@@ -3,9 +3,11 @@ kafka.bootstrap.servers=kafka-broker-1:9092
 mp.messaging.outgoing.source-stock-price.connector=smallrye-kafka
 # TODO: Disable health check because of https://github.com/quarkusio/quarkus/issues/15464
 quarkus.reactive-messaging.health.enabled=false
+cron.expr=*/1 * * * * ?
 
 mp.messaging.connector.smallrye-kafka.apicurio.registry.url=${kafka.registry.url}
 
+mp.messaging.outgoing.source-stock-price.merge=true
 mp.messaging.outgoing.source-stock-price.value.serializer=io.apicurio.registry.serde.avro.AvroKafkaSerializer
 mp.messaging.outgoing.source-stock-price.apicurio.registry.avro-datum-provider=io.apicurio.registry.serde.avro.ReflectAvroDatumProvider
 mp.messaging.outgoing.source-stock-price.apicurio.registry.auto-register=true
@@ -13,6 +15,7 @@ mp.messaging.outgoing.source-stock-price.topic=stock-price
 
 mp.messaging.incoming.channel-stock-price.connector=smallrye-kafka
 mp.messaging.incoming.channel-stock-price.topic=stock-price
+mp.messaging.incoming.channel-stock-price.group.id=${quarkus.uuid}
 mp.messaging.incoming.channel-stock-price.auto.offset.reset=earliest
 mp.messaging.incoming.channel-stock-price.enable.auto.commit=true
 mp.messaging.incoming.channel-stock-price.value.deserializer=io.apicurio.registry.serde.avro.AvroKafkaDeserializer


### PR DESCRIPTION
Doc: https://quarkus.io/guides/kafka#using-unique-consumer-groups

We have added a scenario Strimzi/confluent in order to check that an auto-generated Kafka groupId is created when an application starts. 