### PR TITLE
Improve Kafka-producer resilience

### DIFF
--- a/messaging/kafka-producer/src/main/resources/application.properties
+++ b/messaging/kafka-producer/src/main/resources/application.properties
@@ -4,5 +4,5 @@ kafka.bootstrap.servers=localhost:9092
 mp.messaging.outgoing.test.connector=smallrye-kafka
 mp.messaging.outgoing.test.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.test.value.serializer=org.apache.kafka.common.serialization.StringSerializer
-mp.messaging.outgoing.test.max.block.ms=100
+mp.messaging.outgoing.test.max.block.ms=1000
 mp.messaging.outgoing.test.retries=0

--- a/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/BlockingProducerIT.java
+++ b/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/BlockingProducerIT.java
@@ -20,9 +20,9 @@ import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 public class BlockingProducerIT {
     private static final int TIMEOUT_SEC = 5;
     private static final int EVENTS = 100;
-    static final long KAFKA_MAX_BLOCK_MS = 100;
-    static final long DEVIATION_ERROR_MS = 80;
-    static final long KAFKA_MAX_BLOCK_TIME_MS = KAFKA_MAX_BLOCK_MS + DEVIATION_ERROR_MS;
+    static final long KAFKA_MAX_BLOCK_MS = 1000;
+    static final long NETWORK_DELAY_MS = 300;
+    static final long KAFKA_MAX_BLOCK_TIME_MS = KAFKA_MAX_BLOCK_MS + NETWORK_DELAY_MS;
 
     static CustomStrimziKafkaContainer kafkaContainer;
 


### PR DESCRIPTION
- Increase Network test delay threshold from 80 ms to 300 ms
- Kafka `max.block.ms` from 100 ms to 1 sec (this param will not make the test more resilient) but make more sense for this scenario. So, Kafka producer will be waiting for a response up to 1 sec, and then return an error (because the topic doesn't exist). The test will success if this response time takes less than 300 ms. 