### PR TITLE
Fix scheduling/quartz ++ Use Log.error instead of System.out in Websockets modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,9 @@
                                 <rhsso.73.image>registry.access.redhat.com/redhat-sso-7/sso73-openshift</rhsso.73.image>
                                 <postgresql.13.image>quay.io/bitnami/postgresql:13.4.0</postgresql.13.image>
                                 <mysql.57.image>quay.io/bitnami/mysql:5.7.32</mysql.57.image>
+                                <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7</mysql.80.image>
                                 <mariadb.10.image>quay.io/quarkusqeteam/mariadb:10.6.4</mariadb.10.image>
+                                <mariadb.102.image>registry.access.redhat.com/rhscl/mariadb-102-rhel7</mariadb.102.image>
                                 <mssql.image>mcr.microsoft.com/mssql/rhel/server</mssql.image>
                                 <oracle.image>gvenzl/oracle-xe:18.4.0-slim</oracle.image>
                                 <db2.image>quay.io/quarkusqeteam/db2:11.5.5.0</db2.image>
@@ -572,11 +574,9 @@
                                 <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                 <!-- Product Services -->
                                 <rhsso.74.image>registry.redhat.io/rh-sso-7/sso74-openshift-rhel8</rhsso.74.image>
-                                <postgresql.10.image>registry.access.redhat.com/rhscl/postgresql-10-rhel7</postgresql.10.image>
+                                <postgresql.10.image>registry.redhat.io/rhscl/postgresql-10-rhel7</postgresql.10.image>
                                 <postgresql.12.image>registry.redhat.io/rhscl/postgresql-12-rhel7</postgresql.12.image>
-                                <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7</mysql.80.image>
                                 <mariadb.103.image>registry.redhat.io/rhscl/mariadb-103-rhel7</mariadb.103.image>
-                                <mariadb.102.image>registry.access.redhat.com/rhscl/mariadb-102-rhel7</mariadb.102.image>
                                 <amq-streams.image>registry.redhat.io/amq7/amq-streams-kafka-27-rhel7</amq-streams.image>
                                 <amq-streams.version>1.7.0</amq-streams.version>
                             </systemPropertyVariables>

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMariaDB102DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMariaDB102DatabaseIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -9,11 +7,10 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftMariaDB102DatabaseIT extends AbstractSqlDatabaseIT {
-    static final int MYSQL_PORT = 3306;
+    static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.102.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.102.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/websockets/quarkus-websockets/src/main/java/io/quarkus/ts/Chat.java
+++ b/websockets/quarkus-websockets/src/main/java/io/quarkus/ts/Chat.java
@@ -51,11 +51,13 @@ public class Chat {
 
     private void broadcast(String message) {
         sessions.values().forEach(s -> {
-            s.getAsyncRemote().sendObject(message, result -> {
-                if (result.getException() != null) {
-                    System.out.println("Unable to send message: " + result.getException());
-                }
-            });
+            if (s.isOpen()) {
+                s.getAsyncRemote().sendObject(message, result -> {
+                    if (!result.isOK()) {
+                        LOG.error("Unable to send message: " + result.getException());
+                    }
+                });
+            }
         });
     }
 }

--- a/websockets/websockets-client/src/main/java/io/quarkus/ts/Chat.java
+++ b/websockets/websockets-client/src/main/java/io/quarkus/ts/Chat.java
@@ -51,11 +51,13 @@ public class Chat {
 
     private void broadcast(String message) {
         sessions.values().forEach(s -> {
-            s.getAsyncRemote().sendObject(message, result -> {
-                if (result.getException() != null) {
-                    System.out.println("Unable to send message: " + result.getException());
-                }
-            });
+            if (s.isOpen()) {
+                s.getAsyncRemote().sendObject(message, result -> {
+                    if (!result.isOK()) {
+                        LOG.error("Unable to send message: " + result.getException());
+                    }
+                });
+            }
         });
     }
 }


### PR DESCRIPTION
- Use Log.error instead of System.out in Websockets modules
- Fix scheduling/quartz due to regression in #296

Regression entered in https://github.com/quarkus-qe/quarkus-test-suite/pull/296.
Where mariadb.102 and mysql 80 images were wrongly marked as redhat registry private which they are open.