### PR TITLE
[2.2] Refactor Infinispan to delete cluster when startup failures

### DIFF
--- a/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/BaseOpenShiftInfinispanIT.java
+++ b/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/BaseOpenShiftInfinispanIT.java
@@ -1,0 +1,99 @@
+package io.quarkus.ts.infinispan.client;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+
+import io.quarkus.test.bootstrap.inject.OpenShiftClient;
+import io.quarkus.test.utils.Command;
+
+public abstract class BaseOpenShiftInfinispanIT {
+    protected static final String TARGET_RESOURCES = "target/test-classes/";
+    protected static final String CLUSTER_SECRET = "clientcert_secret.yaml";
+    protected static final String CLUSTER_CONFIG = "infinispan_cluster_config.yaml";
+    protected static final String CLUSTER_CONFIGMAP = "infinispan_cluster_configmap.yaml";
+    protected static final String CONNECT_SECRET = "connect_secret.yaml";
+    protected static final String TLS_SECRET = "tls_secret.yaml";
+    protected static final String CLUSTER_NAMESPACE_NAME = "datagrid-cluster";
+    protected static String NEW_CLUSTER_NAME = null;
+
+    private static final String ORIGIN_CLUSTER_NAME = "totally-random-infinispan-cluster-name";
+
+    @Inject
+    static OpenShiftClient ocClient;
+
+    @AfterAll
+    public static void deleteInfinispanCluster() {
+        deleteYaml(CLUSTER_CONFIGMAP);
+        deleteYaml(CLUSTER_CONFIG);
+        adjustYml(CLUSTER_CONFIG, NEW_CLUSTER_NAME, ORIGIN_CLUSTER_NAME);
+        adjustYml(CLUSTER_CONFIGMAP, NEW_CLUSTER_NAME, ORIGIN_CLUSTER_NAME);
+    }
+
+    protected static void adjustYml(String yamlFile, String originString, String newString) {
+        try {
+            Path yamlPath = Paths.get(TARGET_RESOURCES + yamlFile);
+            Charset charset = StandardCharsets.UTF_8;
+
+            String yamlContent = new String(Files.readAllBytes(yamlPath), charset);
+            yamlContent = yamlContent.replace(originString, newString);
+            Files.write(yamlPath, yamlContent.getBytes(charset));
+        } catch (IOException ex) {
+            Assertions.fail("Fail to adjust YAML file. Caused by: " + ex.getMessage());
+        }
+    }
+
+    /**
+     * Apply the YAML file.
+     */
+    protected static void applyYaml(String yamlFile) {
+        try {
+            new Command("oc", "apply", "-f", Paths.get(TARGET_RESOURCES + yamlFile).toString()).runAndWait();
+        } catch (Exception e) {
+            Assertions.fail("Failed to apply YAML file. Caused by: " + e.getMessage());
+        }
+    }
+
+    protected static void createInfinispanCluster() {
+        applyYaml(CLUSTER_SECRET);
+        applyYaml(CONNECT_SECRET);
+        applyYaml(TLS_SECRET);
+
+        // there should be unique name for every created infinispan cluster to be able parallel runs
+        NEW_CLUSTER_NAME = ocClient.project() + "-infinispan-cluster";
+
+        // rename infinispan cluster and configmap
+        adjustYml(CLUSTER_CONFIG, ORIGIN_CLUSTER_NAME, NEW_CLUSTER_NAME);
+        applyYaml(CLUSTER_CONFIG);
+        adjustYml(CLUSTER_CONFIGMAP, ORIGIN_CLUSTER_NAME, NEW_CLUSTER_NAME);
+        applyYaml(CLUSTER_CONFIGMAP);
+
+        try {
+            new Command("oc", "-n", CLUSTER_NAMESPACE_NAME, "wait", "--for", "condition=wellFormed", "--timeout=300s",
+                    "infinispan/" + NEW_CLUSTER_NAME).runAndWait();
+        } catch (Exception e) {
+            deleteInfinispanCluster();
+            Assertions.fail("Fail to wait Infinispan resources to start. Caused by: " + e.getMessage());
+        }
+    }
+
+    /**
+     *
+     * Delete the YAML file.
+     */
+    private static void deleteYaml(String yamlFile) {
+        try {
+            new Command("oc", "delete", "-f", Paths.get(TARGET_RESOURCES + yamlFile).toString()).runAndWait();
+        } catch (Exception e) {
+            Assertions.fail("Failed to delete YAML file. Caused by: " + e.getMessage());
+        }
+    }
+}

--- a/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanObjectsIT.java
+++ b/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanObjectsIT.java
@@ -6,23 +6,13 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.inject.Inject;
-
 import org.apache.http.HttpStatus;
 import org.hamcrest.Matcher;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -30,29 +20,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.bootstrap.inject.OpenShiftClient;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.test.utils.Command;
 import io.quarkus.ts.infinispan.client.serialized.ShopItem;
 import io.restassured.response.Response;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class OperatorOpenShiftInfinispanObjectsIT {
-
-    private static final String ORIGIN_CLUSTER_NAME = "totally-random-infinispan-cluster-name";
-
-    private static final String TARGET_RESOURCES = "target/test-classes/";
-    private static final String CLUSTER_SECRET = "clientcert_secret.yaml";
-    private static final String CLUSTER_CONFIG = "infinispan_cluster_config.yaml";
-    private static final String CLUSTER_CONFIGMAP = "infinispan_cluster_configmap.yaml";
-    private static final String CONNECT_SECRET = "connect_secret.yaml";
-    private static final String TLS_SECRET = "tls_secret.yaml";
-
-    private static final String CLUSTER_NAMESPACE_NAME = "datagrid-cluster";
-    private static String NEW_CLUSTER_NAME = null;
+public class OperatorOpenShiftInfinispanObjectsIT extends BaseOpenShiftInfinispanIT {
 
     private static final int CACHE_ENTRY_MAX = 5;
     private static final int CACHE_LIFESPAN_SEC = 10;
@@ -68,12 +44,9 @@ public class OperatorOpenShiftInfinispanObjectsIT {
             new ShopItem("Item 4", 400, ShopItem.Type.MECHANICAL),
             new ShopItem("Item 5", 500, ShopItem.Type.MECHANICAL));
 
-    @Inject
-    static OpenShiftClient ocClient;
-
     @QuarkusApplication
     static RestService one = new RestService()
-            .onPreStart(OperatorOpenShiftInfinispanObjectsIT::createInfinispanCluster);
+            .onPreStart(s -> createInfinispanCluster());
 
     @AfterEach
     public void afterEach() {
@@ -134,14 +107,6 @@ public class OperatorOpenShiftInfinispanObjectsIT {
         });
     }
 
-    @AfterAll
-    public static void deleteInfinispanCluster() {
-        deleteYaml(CLUSTER_CONFIGMAP);
-        deleteYaml(CLUSTER_CONFIG);
-        adjustYml(CLUSTER_CONFIG, NEW_CLUSTER_NAME, ORIGIN_CLUSTER_NAME);
-        adjustYml(CLUSTER_CONFIGMAP, NEW_CLUSTER_NAME, ORIGIN_CLUSTER_NAME);
-    }
-
     private void clearCache() {
         given().get("/items/clear-cache").then().statusCode(HttpStatus.SC_NO_CONTENT);
     }
@@ -193,61 +158,4 @@ public class OperatorOpenShiftInfinispanObjectsIT {
         response.then().body("isEmpty()", is(true));
     }
 
-    private static void createInfinispanCluster(io.quarkus.test.bootstrap.Service service) {
-        applyYaml(CLUSTER_SECRET);
-        applyYaml(CONNECT_SECRET);
-        applyYaml(TLS_SECRET);
-
-        // there should be unique name for every created infinispan cluster to be able parallel runs
-        NEW_CLUSTER_NAME = ocClient.project() + "-infinispan-cluster";
-
-        // rename infinispan cluster and configmap
-        adjustYml(CLUSTER_CONFIG, ORIGIN_CLUSTER_NAME, NEW_CLUSTER_NAME);
-        applyYaml(CLUSTER_CONFIG);
-        adjustYml(CLUSTER_CONFIGMAP, ORIGIN_CLUSTER_NAME, NEW_CLUSTER_NAME);
-        applyYaml(CLUSTER_CONFIGMAP);
-
-        try {
-            new Command("oc", "-n", CLUSTER_NAMESPACE_NAME, "wait", "--for", "condition=wellFormed", "--timeout=300s",
-                    "infinispan/" + NEW_CLUSTER_NAME).runAndWait();
-        } catch (Exception e) {
-            Assertions.fail("Fail to wait Infinispan resources to start. Caused by: " + e.getMessage());
-        }
-    }
-
-    private static void adjustYml(String yamlFile, String originString, String newString) {
-        try {
-            Path yamlPath = Paths.get(TARGET_RESOURCES + yamlFile);
-            Charset charset = StandardCharsets.UTF_8;
-
-            String yamlContent = new String(Files.readAllBytes(yamlPath), charset);
-            yamlContent = yamlContent.replace(originString, newString);
-            Files.write(yamlPath, yamlContent.getBytes(charset));
-        } catch (IOException ex) {
-            Assertions.fail("Fail to adjust YAML file. Caused by: " + ex.getMessage());
-        }
-    }
-
-    /**
-     * Apply the YAML file.
-     */
-    private static void applyYaml(String yamlFile) {
-        try {
-            new Command("oc", "apply", "-f", Paths.get(TARGET_RESOURCES + yamlFile).toString()).runAndWait();
-        } catch (Exception e) {
-            Assertions.fail("Failed to apply YAML file. Caused by: " + e.getMessage());
-        }
-    }
-
-    /**
-     *
-     * Delete the YAML file.
-     */
-    private static void deleteYaml(String yamlFile) {
-        try {
-            new Command("oc", "delete", "-f", Paths.get(TARGET_RESOURCES + yamlFile).toString()).runAndWait();
-        } catch (Exception e) {
-            Assertions.fail("Failed to delete YAML file. Caused by: " + e.getMessage());
-        }
-    }
 }


### PR DESCRIPTION
++ To move all the common functionality into a base class.

Backport of https://github.com/quarkus-qe/quarkus-test-suite/pull/332