### PR TITLE
Fix DevModeGrpcIntegration and OpentelemetryIT tests

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/utils/GrpcWebSocketListener.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/utils/GrpcWebSocketListener.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.http.advanced;
+package io.quarkus.ts.http.advanced.utils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,8 +14,8 @@ import okhttp3.WebSocketListener;
 
 public class GrpcWebSocketListener extends WebSocketListener {
 
-    static Map<Integer, List<String>> serviceOutputMessagesMap = new ConcurrentHashMap<>();
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final Map<Integer, List<String>> serviceOutputMessagesMap = new ConcurrentHashMap<>();
 
     @Override
     public void onMessage(WebSocket webSocket, String text) {
@@ -29,5 +29,9 @@ public class GrpcWebSocketListener extends WebSocketListener {
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public Map<Integer, List<String>> getServiceOutputMessagesMap() {
+        return serviceOutputMessagesMap;
     }
 }

--- a/monitoring/micrometer-prometheus-kafka/pom.xml
+++ b/monitoring/micrometer-prometheus-kafka/pom.xml
@@ -7,9 +7,9 @@
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
-    <artifactId>micrometer-prometheus-kafka</artifactId>
+    <artifactId>monitoring-micrometer-prometheus-kafka</artifactId>
     <packaging>jar</packaging>
-    <name>Quarkus QE TS: Micrometer: Prometheus with Kafka</name>
+    <name>Quarkus QE TS: Monitoring: Micrometer + Prometheus with Kafka</name>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/monitoring/micrometer-prometheus-oidc/pom.xml
+++ b/monitoring/micrometer-prometheus-oidc/pom.xml
@@ -7,9 +7,9 @@
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
-    <artifactId>micrometer-prometheus-oidc</artifactId>
+    <artifactId>monitoring-micrometer-prometheus-oidc</artifactId>
     <packaging>jar</packaging>
-    <name>Quarkus QE TS: Micrometer: OIDC</name>
+    <name>Quarkus QE TS: Monitoring: Micrometer + OIDC</name>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/monitoring/micrometer-prometheus/pom.xml
+++ b/monitoring/micrometer-prometheus/pom.xml
@@ -7,9 +7,9 @@
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
-    <artifactId>micrometer-prometheus</artifactId>
+    <artifactId>monitoring-micrometer-prometheus</artifactId>
     <packaging>jar</packaging>
-    <name>Quarkus QE TS: Micrometer: Prometheus</name>
+    <name>Quarkus QE TS: Monitoring: Micrometer + Prometheus</name>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/monitoring/microprofile-opentracing/pom.xml
+++ b/monitoring/microprofile-opentracing/pom.xml
@@ -7,9 +7,9 @@
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
-    <artifactId>microprofile-opentracing</artifactId>
+    <artifactId>monitoring-microprofile-opentracing</artifactId>
     <packaging>jar</packaging>
-    <name>Quarkus QE TS: MicroProfile</name>
+    <name>Quarkus QE TS: Monitoring: MicroProfile + OpenTracing</name>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/monitoring/opentelemetry/pom.xml
+++ b/monitoring/opentelemetry/pom.xml
@@ -7,9 +7,9 @@
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
-    <artifactId>opentelemetry</artifactId>
+    <artifactId>monitoring-opentelemetry</artifactId>
     <packaging>jar</packaging>
-    <name>Quarkus QE TS: OpenTelemetry</name>
+    <name>Quarkus QE TS: Monitoring: OpenTelemetry</name>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpentelemetryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpentelemetryIT.java
@@ -32,7 +32,7 @@ public class OpentelemetryIT {
     @JaegerContainer(restPort = GRPC_COLLECTOR_PORT, expectedLog = "\"Health Check state change\",\"status\":\"ready\"")
     static final JaegerService jaeger = new JaegerService();
 
-    @QuarkusApplication(classes = PongResource.class)
+    @QuarkusApplication(classes = PongResource.class, properties = "pong.properties")
     static final RestService pongservice = new RestService()
             .withProperty("quarkus.application.name", "pongservice")
             .withProperty("quarkus.opentelemetry.tracer.exporter.jaeger.endpoint", jaeger::getRestUrl);

--- a/monitoring/opentracing-reactive-grpc/pom.xml
+++ b/monitoring/opentracing-reactive-grpc/pom.xml
@@ -7,8 +7,8 @@
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
-    <artifactId>opentracing-reactive-grpc</artifactId>
-    <name>Quarkus QE TS: OpenTracing reactive GRPC</name>
+    <artifactId>monitoring-opentracing-reactive-grpc</artifactId>
+    <name>Quarkus QE TS: Monitoring: OpenTracing reactive GRPC</name>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
- Fix OpentelemetryIT as is now checking if nested properties do exist
This change is only affecting 999-SNAPSHOT (due to some enhancements in arc)
- Change DevModeGrpcIntegration route to io.quarkus.quarkus-grpc/grpc-test
The `/q/dev/grpc-test` route has been changed by https://github.com/quarkusio/quarkus/pull/20465. It's now `/q/dev/io.quarkus.quarkus-grpc/grpc-test` ++ Moved GrpcWebSocketListener as it's a test source.
- Fix monitoring modules with correct artifact and description