### PR TITLE
Workaround in properties module for #issues/20610

### DIFF
--- a/properties/src/main/java/io/quarkus/qe/properties/bulk/BulkOfPropertiesResource.java
+++ b/properties/src/main/java/io/quarkus/qe/properties/bulk/BulkOfPropertiesResource.java
@@ -5,7 +5,9 @@ import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
-@Path("/bulk-properties")
+// TODO: Can't inject beans annotated with @ConfigProperties, see BulkOfPropertiesConfiguration.
+// Reported in https://github.com/quarkusio/quarkus/issues/20610.
+// @Path("/bulk-properties")
 public class BulkOfPropertiesResource {
 
     @Any

--- a/properties/src/test/java/io/quarkus/qe/properties/bulk/BulkOfPropertiesIT.java
+++ b/properties/src/test/java/io/quarkus/qe/properties/bulk/BulkOfPropertiesIT.java
@@ -4,10 +4,12 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 
+@Disabled("Can't inject beans annotated with @ConfigProperties. Reported in https://github.com/quarkusio/quarkus/issues/20610")
 @QuarkusScenario
 public class BulkOfPropertiesIT {
 


### PR DESCRIPTION
We can't inject beans annotated with @ConfigProperties anylonger. Reported in https://github.com/quarkusio/quarkus/issues/20610