### PR TITLE
Log min level must overwrite

### DIFF
--- a/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/DefaultMinLogLevelIT.java
+++ b/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/DefaultMinLogLevelIT.java
@@ -1,0 +1,28 @@
+package io.quarkus.ts.logging.jboss;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class DefaultMinLogLevelIT {
+
+    @QuarkusApplication
+    static RestService app = new RestService();
+
+    @Test
+    public void checkDefaultLogMinLevel() {
+        app.given().when().get("/log").then().statusCode(204);
+
+        app.logs().assertContains("Fatal log example");
+        app.logs().assertContains("Error log example");
+        app.logs().assertContains("Warn log example");
+        app.logs().assertContains("Info log example");
+        app.logs().assertContains("Debug log example");
+
+        // the value of minimum logging level overrides the logging level
+        app.logs().assertDoesNotContain("Trace log example");
+    }
+}

--- a/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/LogResourceIT.java
+++ b/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/LogResourceIT.java
@@ -4,7 +4,6 @@ import java.util.function.BiConsumer;
 
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -70,23 +69,6 @@ public class LogResourceIT {
         // Now, the message should be shown only in the logger of the custom category
         app.logs().assertDoesNotContain(MESSAGE + "field2");
         app.logs().assertContains(MESSAGE + "category2");
-    }
-
-    @Test
-    // TODO
-    // https://github.com/quarkusio/quarkus/issues/20066
-    @Disabled
-    public void checkDefaultLogMinLevel() {
-        app.given().when().get("/log").then().statusCode(204);
-
-        app.logs().assertContains("Fatal log example");
-        app.logs().assertContains("Error log example");
-        app.logs().assertContains("Warn log example");
-        app.logs().assertContains("Info log example");
-        app.logs().assertContains("Debug log example");
-
-        // the value of minimum logging level overrides the logging level
-        app.logs().assertDoesNotContain("Trace log example");
     }
 
     private void verifyLoggingRules(BiConsumer<Logger.Level, String> writer) {


### PR DESCRIPTION
We need to create a new scenario called `DefaultMinLogLevelIT` because the existing one is forcing the log level to `info`

```
 @BeforeEach
    public void setup() {
        // Reset level to INFO
        setLogLevelTo(Logger.Level.INFO);
    }
```

And in our scenario is important to check the default `quarkus.log.min-level`  is set to `DEFAULT`