### PR TITLE
Correct usage of MP `@ConfigurationProperties`

### DIFF
--- a/properties/src/main/java/io/quarkus/qe/properties/bulk/BulkOfPropertiesResource.java
+++ b/properties/src/main/java/io/quarkus/qe/properties/bulk/BulkOfPropertiesResource.java
@@ -1,17 +1,14 @@
 package io.quarkus.qe.properties.bulk;
 
-import javax.enterprise.inject.Any;
-import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
-// TODO: Can't inject beans annotated with @ConfigProperties, see BulkOfPropertiesConfiguration.
-// Reported in https://github.com/quarkusio/quarkus/issues/20610.
-// @Path("/bulk-properties")
+import org.eclipse.microprofile.config.inject.ConfigProperties;
+
+@Path("/bulk-properties")
 public class BulkOfPropertiesResource {
 
-    @Any
-    @Inject
+    @ConfigProperties
     BulkOfPropertiesConfiguration config;
 
     @GET

--- a/properties/src/test/java/io/quarkus/qe/properties/bulk/BulkOfPropertiesIT.java
+++ b/properties/src/test/java/io/quarkus/qe/properties/bulk/BulkOfPropertiesIT.java
@@ -4,12 +4,10 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 
-@Disabled("Can't inject beans annotated with @ConfigProperties. Reported in https://github.com/quarkusio/quarkus/issues/20610")
 @QuarkusScenario
 public class BulkOfPropertiesIT {
 


### PR DESCRIPTION
These changes are based on the https://github.com/quarkusio/quarkus/issues/20610 issue and the https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.4#microprofile-config clarification in the migration guides.