### PR TITLE
Change MySQL 5.7 and PostgreSQL 9.6 due to flyway upgrade

### DIFF
--- a/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/BaseIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/BaseIT.java
@@ -8,7 +8,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public abstract class BaseIT {
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.57.image}", port = MYSQL_PORT, expectedLog = "ready for connections")
+    @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/dbpool/MySqlDatabaseTestResource.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/qe/sqldb/panacheflyway/dbpool/MySqlDatabaseTestResource.java
@@ -26,7 +26,7 @@ public class MySqlDatabaseTestResource implements QuarkusTestResourceLifecycleMa
     @Override
     public Map<String, String> start() {
         container = new MySQLContainer<>(
-                DockerImageName.parse("quay.io/bitnami/mysql:5.7.32").asCompatibleSubstituteFor(MYSQL));
+                DockerImageName.parse("registry.access.redhat.com/rhscl/mysql-80-rhel7").asCompatibleSubstituteFor(MYSQL));
         container.withUrlParam("currentSchema", DEFAULT_SCHEMA);
         container.start();
 

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/dbpool/PostgresqlResource.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/dbpool/PostgresqlResource.java
@@ -15,7 +15,7 @@ public class PostgresqlResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        postgresContainer = new GenericContainer<>(DockerImageName.parse("quay.io/debezium/postgres:latest"))
+        postgresContainer = new GenericContainer<>(DockerImageName.parse("quay.io/bitnami/postgresql:13.4.0"))
                 .withEnv("POSTGRES_USER", "test")
                 .withEnv("POSTGRES_PASSWORD", "test")
                 .withEnv("POSTGRES_DB", "amadeus")

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/MysqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/MysqlHandlerIT.java
@@ -10,7 +10,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class MysqlHandlerIT extends CommonTestCases {
     private static final String DATABASE = "amadeus";
 
-    @Container(image = "${mysql.57.image}", port = 3306, expectedLog = "ready for connections")
+    @Container(image = "${mysql.80.image}", port = 3306, expectedLog = "Only MySQL server logs after this point")
     static MySqlService mysql = new MySqlService()
             .with("test", "test", DATABASE);
 


### PR DESCRIPTION
Quarkus upgraded Flyway to 8.0 in https://github.com/quarkusio/quarkus/pull/20760 and Flyway 8.0 does not support MySQL anylonger:

```
Caused by: org.flywaydb.core.internal.license.FlywayEditionUpgradeRequiredException: Flyway Teams Edition or MySQL upgrade required: MySQL 5.7 is no longer supported by Flyway Community Edition, but still supported by Flyway Teams Edition.
```

PostgreSQL 9.6 is also unsupported:

```
Caused by: org.flywaydb.core.internal.license.FlywayEditionUpgradeRequiredException: Flyway Teams Edition or PostgreSQL upgrade required: PostgreSQL 9.6 is no longer supported by Flyway Community Edition, but still supported by Flyway Teams Edition.
```