### PR TITLE
Increase memory for Kafka Avro example to 6g

### DIFF
--- a/messaging/kafka-avro-reactive-messaging/pom.xml
+++ b/messaging/kafka-avro-reactive-messaging/pom.xml
@@ -9,6 +9,9 @@
     </parent>
     <artifactId>kafka-avro-reactive-messaging</artifactId>
     <name>Quarkus QE TS: Messaging: Reactive Kafka with Avro</name>
+    <properties>
+        <quarkus.native.native-image-xmx>6g</quarkus.native.native-image-xmx>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
It fails in Native due to out of memory:

```
Failed to build Quarkus artifacts. Caused by java.lang.RuntimeException: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
 [error]: Build step io.quarkus.deployment.pkg.steps.NativeImageBuildStep#build threw an exception: java.lang.RuntimeException: Failed to build native image
 at io.quarkus.deployment.pkg.steps.NativeImageBuildStep.build(NativeImageBuildStep.java:233)
 at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
 at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 at java.base/java.lang.reflect.Method.invoke(Method.java:566)
 at io.quarkus.deployment.ExtensionLoader$2.execute(ExtensionLoader.java:887)
 at io.quarkus.builder.BuildContext.run(BuildContext.java:277)
 at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
 at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
 at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1478)
 at java.base/java.lang.Thread.run(Thread.java:834)
 at org.jboss.threads.JBossThread.run(JBossThread.java:501)
Caused by: java.lang.RuntimeException: Image generation failed. Exit code was 137 which indicates an out of memory error. Consider increasing the Xmx value for native image generation by setting the "quarkus.native.native-image-xmx" property
 at io.quarkus.deployment.pkg.steps.NativeImageBuildStep.imageGenerationFailed(NativeImageBuildStep.java:364)
 at io.quarkus.deployment.pkg.steps.NativeImageBuildStep.build(NativeImageBuildStep.java:213)
 ... 11 more
```