### PR TITLE
Fix Spring Data and Panache flyway by adding resteasy links

### DIFF
--- a/spring/spring-data/pom.xml
+++ b/spring/spring-data/pom.xml
@@ -35,6 +35,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
+        <!-- Related to https://github.com/quarkusio/quarkus/pull/20874#issuecomment-947448452 -->
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-links</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-database</artifactId>

--- a/sql-db/panache-flyway/pom.xml
+++ b/sql-db/panache-flyway/pom.xml
@@ -31,6 +31,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
+        <!-- Related to https://github.com/quarkusio/quarkus/pull/20874#issuecomment-947448452 -->
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-links</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>


### PR DESCRIPTION
This change is caused by https://github.com/quarkusio/quarkus/pull/20874.
I've asked for adding it to the migration guide and for more information in https://github.com/quarkusio/quarkus/pull/20874#issuecomment-947448452.