### PR TITLE
Add RESTEasy Classic dependencies in spring-web modules

### DIFF
--- a/cache/spring/pom.xml
+++ b/cache/spring/pom.xml
@@ -19,5 +19,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -32,7 +32,8 @@ public class QuarkusCliCreateJvmApplicationIT {
 
     static final String RESTEASY_EXTENSION = "quarkus-resteasy";
     static final String SMALLRYE_HEALTH_EXTENSION = "quarkus-smallrye-health";
-    static final String RESTEASY_SPRING_WEB_EXTENSION = "quarkus-spring-web";
+    static final String SPRING_WEB_EXTENSION = "quarkus-spring-web";
+    static final String RESTEASY_JACKSON_EXTENSION = "quarkus-resteasy-jackson";
     static final String SMALLRYE_OPENAPI = "quarkus-smallrye-openapi";
     static final int CMD_DELAY_SEC = 3;
 
@@ -76,12 +77,12 @@ public class QuarkusCliCreateJvmApplicationIT {
     @Tag("QUARKUS-1071")
     @Test
     public void shouldCreateApplicationWithCodeStarter() {
-        // Create application with Resteasy Jackson
+        // Create application with Resteasy Jackson + Spring Web (we need both for the app to run)
         QuarkusCliRestService app = cliClient.createApplication("app",
-                defaults().withExtensions(RESTEASY_SPRING_WEB_EXTENSION));
+                defaults().withExtensions(RESTEASY_JACKSON_EXTENSION, SPRING_WEB_EXTENSION));
 
-        // Verify By default, it installs only "quarkus-resteasy"
-        assertInstalledExtensions(app, RESTEASY_SPRING_WEB_EXTENSION);
+        // Verify By default, it installs only "quarkus-resteasy-jackson" and "quarkus-spring-web"
+        assertInstalledExtensions(app, RESTEASY_JACKSON_EXTENSION, SPRING_WEB_EXTENSION);
 
         // Start using DEV mode
         app.start();

--- a/scheduling/spring/pom.xml
+++ b/scheduling/spring/pom.xml
@@ -18,5 +18,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/spring/spring-cloud-config/pom.xml
+++ b/spring/spring-cloud-config/pom.xml
@@ -17,6 +17,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-cloud-config-client</artifactId>
         </dependency>
     </dependencies>

--- a/spring/spring-properties/pom.xml
+++ b/spring/spring-properties/pom.xml
@@ -19,5 +19,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/spring/spring-web/pom.xml
+++ b/spring/spring-web/pom.xml
@@ -17,6 +17,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-openapi</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
RESTEasy Classic dependencies were added to all modules using
`quarkus-spring-web`, as RESTEasy Classic and `quarkus-spring-web`
were decoupled.
quarkusio/quarkus#21089.