### PR TITLE
RestEasy clasic is not included by default

### DIFF
--- a/cache/spring/pom.xml
+++ b/cache/spring/pom.xml
@@ -19,5 +19,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/scheduling/spring/pom.xml
+++ b/scheduling/spring/pom.xml
@@ -18,5 +18,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/spring/spring-cloud-config/pom.xml
+++ b/spring/spring-cloud-config/pom.xml
@@ -17,6 +17,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-cloud-config-client</artifactId>
         </dependency>
     </dependencies>

--- a/spring/spring-properties/pom.xml
+++ b/spring/spring-properties/pom.xml
@@ -19,5 +19,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/spring/spring-web/pom.xml
+++ b/spring/spring-web/pom.xml
@@ -25,6 +25,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-mariadb</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Is already documented: https://github.com/quarkusio/quarkus/commit/992dc5dd8701cfe412ae8e323ccb38ae00829e18
