### PR TITLE
Add Oracle DB dev mode and Dev Services tests

### DIFF
--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeOracleDevServiceUserExperienceIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeOracleDevServiceUserExperienceIT.java
@@ -1,0 +1,43 @@
+package io.quarkus.ts.sqldb.sqlapp;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.github.dockerjava.api.model.Image;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.test.utils.DockerUtils;
+import io.quarkus.test.utils.SocketUtils;
+
+@QuarkusScenario
+public class DevModeOracleDevServiceUserExperienceIT {
+
+    private static final String ORACLE_VERSION = "18.4.0-slim";
+    private static final String ORACLE_NAME = "gvenzl/oracle-xe";
+
+    @DevModeQuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.datasource.db-kind", "oracle")
+            .withProperty("quarkus.datasource.devservices.port", Integer.toString(SocketUtils.findAvailablePort()))
+            .withProperty("quarkus.datasource.devservices.image-name", ORACLE_NAME + ":" + ORACLE_VERSION)
+            .withProperty("quarkus.hibernate-orm.database.generation", "none")
+            .onPreStart(s -> DockerUtils.removeImage(ORACLE_NAME, ORACLE_VERSION));
+
+    @Test
+    public void verifyIfUserIsInformedAboutOracleDevServicePulling() {
+        app.logs().assertContains("Pulling docker image: " + ORACLE_NAME);
+        app.logs().assertContains("Please be patient; this may take some time but only needs to be done once");
+        app.logs().assertContains("Starting to pull image");
+        app.logs().assertContains("Dev Services for Oracle started");
+    }
+
+    @Test
+    public void verifyOracleImage() {
+        Image oracleImg = DockerUtils.getImage(ORACLE_NAME, ORACLE_VERSION);
+        Assertions.assertFalse(oracleImg.getId().isEmpty(), String.format("%s:%s not found. " +
+                "Notice that user set his own custom image by 'quarkus.datasource.devservices.image-name' property",
+                ORACLE_NAME, ORACLE_VERSION));
+    }
+}

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeOracleIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeOracleIT.java
@@ -1,0 +1,19 @@
+package io.quarkus.ts.sqldb.sqlapp;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+
+@QuarkusScenario
+public class DevModeOracleIT extends AbstractSqlDatabaseIT {
+
+    @DevModeQuarkusApplication
+    static RestService app = new RestService().withProperties("oracle.properties");
+
+    @Test
+    public void postgresqlContainerShouldBeStarted() {
+        app.logs().assertContains("Creating container for image: gvenzl/oracle-xe");
+    }
+}


### PR DESCRIPTION
Dev Services support for the Oracle DB has been implemented
in Quarkus: https://github.com/quarkusio/quarkus/pull/20959.