### PR TITLE
Revert "Increase native build memory limit 4 -> 5 GB"

### DIFF
--- a/sql-db/sql-app/pom.xml
+++ b/sql-db/sql-app/pom.xml
@@ -10,10 +10,6 @@
     <artifactId>sqldb-sqlapp</artifactId>
     <packaging>jar</packaging>
     <name>Quarkus QE TS: SQL Database: Application</name>
-    <properties>
-        <!-- TODO: https://github.com/quarkus-qe/quarkus-test-suite/issues/372 -->
-        <quarkus.native.native-image-xmx>5g</quarkus.native.native-image-xmx>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
This reverts commit 5b8319a41b612d65f80312702aa6794eb0390994.

An unnecessary workaround.