### PR TITLE
Add `quarkus-jackson` alongside `quarkus-vertx`

### DIFF
--- a/security/vertx-jwt/pom.xml
+++ b/security/vertx-jwt/pom.xml
@@ -21,6 +21,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-redis-client</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
As a result of https://github.com/quarkusio/quarkus/pull/21142,
`io.quarkus:quarkus-jackson` has to be added manually alongside
`io.quarkus:quarkus-vertx` if we want to use
`com.fasterxml.jackson.databind` classes or other
`quarkus-jackson`-provided functionality.
In case of `security/vertx-jwt`, the use of property
`quarkus.jackson.fail-on-empty-beans` in `application.properties`
requires this dependency.

Related to https://github.com/quarkus-qe/beefy-scenarios/pull/262.