### PR TITLE
Quarkus-cli --version only returns version value

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliVersionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliVersionIT.java
@@ -26,9 +26,9 @@ public class QuarkusCliVersionIT {
     @Test
     public void shouldVersionMatchQuarkusVersion() {
         // Using option
-        assertEquals("Client Version " + Version.getVersion(), cliClient.run("version").getOutput());
+        assertEquals(Version.getVersion(), cliClient.run("version").getOutput());
 
         // Using shortcut
-        assertEquals("Client Version " + Version.getVersion(), cliClient.run("-v").getOutput());
+        assertEquals(Version.getVersion(), cliClient.run("-v").getOutput());
     }
 }


### PR DESCRIPTION
Amend test  in order to fit this commit:

https://github.com/quarkusio/quarkus/commit/47c2d948d01dc8bea0262f495f29e5ea85ab1c1c#diff-ffe15562f1c91992754190c19745597d15b171f0868bd7970990b8d08a4c33a1

`quarkus-cli --version` only return version value instead of  `client Version {{ version value }}`