### PR TITLE
Fix Kafka AVRO GroupdId flaky test

### DIFF
--- a/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/BaseKafkaAvroGroupIdIT.java
+++ b/messaging/kafka-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/BaseKafkaAvroGroupIdIT.java
@@ -24,7 +24,7 @@ import io.quarkus.test.bootstrap.RestService;
 import io.restassured.http.ContentType;
 
 abstract class BaseKafkaAvroGroupIdIT {
-    private static final int TIMEOUT_SEC = 3;
+    private static final int TIMEOUT_SEC = 25;
     private static final int EVENTS_AMOUNT = 5;
 
     private String endpoint;


### PR DESCRIPTION
Github daily action fails on Kafka AVRO grupId test because doesn't retrieve the expected records in a given amount of time. This PR tries to make more resilience this test. 