### PR TITLE
Introduce reactive counterparts of http-minimum and rest-client modules under /http

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,14 @@ It also verifies multiple deployment strategies like:
 - Using OpenShift quarkus extension
 - Using OpenShift quarkus extension and Docker Build strategy
 
+### `http/http-minimum-reactive`
+Reactive equivalent of the http/http-minimum module
+
 ### `http/http-advanced`
 Verifies Server/Client http_2/1.1, Grpc and http redirections.
+
+### `http/http-advanced-reactive`
+Reactive equivalent of the http/http-advanced module
 
 ### `http/http-static`
 Verifies access to static pages and big static files over http.
@@ -163,6 +169,10 @@ Verifies Rest Client configuration using `quarkus-rest-client-jaxb` (XML support
 This module will setup a very minimal configuration (only `quarkus-resteasy`) and have four endpoints:
 - Two endpoints to get a book in JSON and XML formats.
 - Two endpoints to get the value of the previous endpoints using the rest client interface.
+
+### `http/rest-client-reactive`
+Reactive equivalent of the http/rest-client module.  
+Exclusions: XML test. Reason: https://quarkus.io/blog/resteasy-reactive/#what-jax-rs-features-are-missing
 
 ### `http/hibernate-validator`
 Verifies HTTP endpoints validation using `quarkus-hibernate-validator` works correctly in Resteasy Classic and Resteasy Reactive.

--- a/http/http-minimum-reactive/pom.xml
+++ b/http/http-minimum-reactive/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>http-minimum-reactive</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: HTTP: Minimum Reactive</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <profile>
+            <id>deploy-to-openshift-using-extension</id>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-openshift</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+</project>

--- a/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/Hello.java
+++ b/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/Hello.java
@@ -1,0 +1,17 @@
+package io.quarkus.ts.http.minimum.reactive;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class Hello {
+
+    private final String content;
+
+    public Hello(String content) {
+        this.content = content;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/HelloResource.java
+++ b/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/HelloResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.http.minimum.reactive;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/hello")
+public class HelloResource {
+    private static final String TEMPLATE = "Hello, %s!";
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Uni<Hello> get(@QueryParam("name") @DefaultValue("World") String name) {
+        return Uni.createFrom().item(new Hello(String.format(TEMPLATE, name)));
+    }
+}

--- a/http/http-minimum-reactive/src/main/resources/application.properties
+++ b/http/http-minimum-reactive/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+quarkus.application.name=test-http
+quarkus.http.root-path=/api
+%ServerlessExtensionOpenShiftHttpMinimumReactiveIT.quarkus.kubernetes.deployment-target=knative
+%ServerlessExtensionOpenShiftHttpMinimumReactiveIT.quarkus.container-image.registry=image-registry.openshift-image-registry.svc:5000
+%ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumReactiveIT.quarkus.kubernetes.deployment-target=knative
+%ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumReactiveIT.quarkus.container-image.registry=image-registry.openshift-image-registry.svc:5000
+# Only run tests annotated with @QuarkusTest
+%DevModeHttpMinimumReactiveIT.quarkus.test.type=quarkus-test
+# Test Framework expects the dev UI to be at /q/dev, not /api/q/dev
+%DevModeHttpMinimumReactiveIT.quarkus.http.root-path=/

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/DevModeHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/DevModeHttpMinimumReactiveIT.java
@@ -1,0 +1,72 @@
+package io.quarkus.ts.http.minimum.reactive;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.DevModeQuarkusService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.test.utils.AwaitilityUtils;
+
+@Tag("QUARKUS-1026")
+@QuarkusScenario
+@DisabledOnQuarkusVersion(version = "1\\..*", reason = "Continuous Testing was entered in 2.x")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class DevModeHttpMinimumReactiveIT {
+
+    static final String HELLO_IN_ENGLISH = "Hello, %s!";
+    static final String HELLO_IN_SPANISH = "Hola, %s!";
+    static final String WORLD = "World";
+    static final String HELLO_RESOURCE_JAVA = "src/main/java/io/quarkus/ts/http/minimum/reactive/HelloResource.java";
+
+    @DevModeQuarkusApplication
+    static DevModeQuarkusService app = new DevModeQuarkusService();
+
+    @BeforeEach
+    public void setup() {
+        // Replace hello resource java with the original content
+        app.copyFile(HELLO_RESOURCE_JAVA, HELLO_RESOURCE_JAVA);
+    }
+
+    @Test
+    @Order(1)
+    public void shouldDetectNewTests() {
+        // At first, there are no tests annotated with @QuarkusTest
+        app.logs().assertContains("Tests paused");
+        // Now, we enable continuous testing via DEV UI
+        app.enableContinuousTesting();
+        // We add a new test
+        app.copyFile("src/test/resources/HelloResourceTest.java.template", "src/test/java/HelloResourceTest.java");
+        app.copyFile("src/test/resources/NoFunctionalTest.java.template", "src/test/java/NoFunctionalTest.java");
+        // So good so far!
+        app.logs().assertContains("All 2 tests are passing");
+        // Modify Hello to Hola
+        app.modifyFile(HELLO_RESOURCE_JAVA, content -> content.replace(HELLO_IN_ENGLISH, HELLO_IN_SPANISH));
+        // Then the NoFunctionalTest should not have been executed as it's not affected, only HelloResourceTest
+        app.logs().assertContains("Running 1/1. Running: io.quarkus.ts.http.minimum.HelloResourceTest#HelloResourceTest");
+    }
+
+    @Test
+    @Order(2)
+    public void shouldDetectChanges() {
+        // Should say first Hello (the default name)
+        app.given().get("/hello").then().statusCode(HttpStatus.SC_OK)
+                .body("content", is(String.format(HELLO_IN_ENGLISH, WORLD)));
+
+        // Modify Hello to Hola
+        app.modifyFile(HELLO_RESOURCE_JAVA, content -> content.replace(HELLO_IN_ENGLISH, HELLO_IN_SPANISH));
+
+        // Now, the app should say Manuel
+        AwaitilityUtils.untilAsserted(
+                () -> app.given().get("/hello").then().statusCode(HttpStatus.SC_OK)
+                        .body("content", is(String.format(HELLO_IN_SPANISH, WORLD))));
+    }
+}

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpMinimumReactiveIT.java
@@ -1,0 +1,18 @@
+package io.quarkus.ts.http.minimum.reactive;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+
+@QuarkusScenario
+public class HttpMinimumReactiveIT {
+
+    @Test
+    public void httpServer() {
+        given().get("/api/hello").then().statusCode(HttpStatus.SC_OK).body("content", is("Hello, World!"));
+    }
+}

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftHttpMinimumReactiveIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.ts.http.minimum.reactive;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftHttpMinimumReactiveIT extends HttpMinimumReactiveIT {
+
+}

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumReactiveIT.java
@@ -1,0 +1,12 @@
+package io.quarkus.ts.http.minimum.reactive;
+
+import org.junit.jupiter.api.Tag;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@Tag("use-quarkus-openshift-extension")
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
+public class OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumReactiveIT extends HttpMinimumReactiveIT {
+
+}

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionHttpMinimumReactiveIT.java
@@ -1,0 +1,12 @@
+package io.quarkus.ts.http.minimum.reactive;
+
+import org.junit.jupiter.api.Tag;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@Tag("use-quarkus-openshift-extension")
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
+public class OpenShiftUsingExtensionHttpMinimumReactiveIT extends HttpMinimumReactiveIT {
+
+}

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumReactiveIT.java
@@ -1,0 +1,13 @@
+package io.quarkus.ts.http.minimum.reactive;
+
+import org.junit.jupiter.api.Tag;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@Tag("use-quarkus-openshift-extension")
+@Tag("serverless")
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
+public class ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumReactiveIT extends HttpMinimumReactiveIT {
+
+}

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionOpenShiftHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionOpenShiftHttpMinimumReactiveIT.java
@@ -1,0 +1,12 @@
+package io.quarkus.ts.http.minimum.reactive;
+
+import org.junit.jupiter.api.Tag;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@Tag("use-quarkus-openshift-extension")
+@Tag("serverless")
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
+public class ServerlessExtensionOpenShiftHttpMinimumReactiveIT extends HttpMinimumReactiveIT {
+}

--- a/http/http-minimum-reactive/src/test/resources/HelloResourceTest.java.template
+++ b/http/http-minimum-reactive/src/test/resources/HelloResourceTest.java.template
@@ -1,0 +1,15 @@
+package io.quarkus.ts.http.minimum;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class HelloResourceTest {
+    @Test
+    public void shouldBeOk() {
+        RestAssured.given().get("/hello").then().statusCode(HttpStatus.SC_OK);
+    }
+}

--- a/http/http-minimum-reactive/src/test/resources/NoFunctionalTest.java.template
+++ b/http/http-minimum-reactive/src/test/resources/NoFunctionalTest.java.template
@@ -1,0 +1,16 @@
+package io.quarkus.ts.http.minimum;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class NoFunctionalTest {
+    @Test
+    public void alwaysPass() {
+        Assertions.assertTrue(true);
+    }
+}

--- a/http/rest-client-reactive/pom.xml
+++ b/http/rest-client-reactive/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>http-rest-client-reactive</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: HTTP: Rest Client Reactive</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxb</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/ReactiveClientBookResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/ReactiveClientBookResource.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.http.restclient.reactive;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.quarkus.ts.http.restclient.reactive.json.Book;
+import io.smallrye.mutiny.Uni;
+
+@Path("/client/book")
+public class ReactiveClientBookResource {
+
+    @Inject
+    @RestClient
+    ReactiveRestInterface restInterface;
+
+    @GET
+    @Path("/json")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Uni<Book> getAsJson() {
+        return restInterface.getAsJson();
+    }
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestInterface.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestInterface.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.http.restclient.reactive;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.ts.http.restclient.reactive.json.Book;
+import io.smallrye.mutiny.Uni;
+
+@RegisterRestClient
+@Path("/book")
+@RegisterClientHeaders
+public interface ReactiveRestInterface {
+
+    @GET
+    @Path("/json")
+    @Produces(MediaType.APPLICATION_JSON)
+    Uni<Book> getAsJson();
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/json/Book.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/json/Book.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.http.restclient.reactive.json;
+
+public class Book {
+
+    private String title;
+
+    public Book() {
+    }
+
+    public Book(String title) {
+        this.title = title;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/json/BookAsJsonResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/json/BookAsJsonResource.java
@@ -1,0 +1,18 @@
+package io.quarkus.ts.http.restclient.reactive.json;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.smallrye.mutiny.Uni;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/book/json")
+public class BookAsJsonResource {
+
+    @GET
+    public Uni<String> get() {
+        return Uni.createFrom().item("{\"title\":\"Title in Json\"}");
+    }
+}

--- a/http/rest-client-reactive/src/main/resources/application.properties
+++ b/http/rest-client-reactive/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+io.quarkus.ts.http.restclient.reactive.ReactiveRestInterface/mp-rest/url=http://localhost:${quarkus.http.port}

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ClientBookResourceIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ClientBookResourceIT.java
@@ -1,0 +1,19 @@
+package io.quarkus.ts.http.restclient.reactive;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+
+@QuarkusScenario
+public class ClientBookResourceIT {
+
+    @Test
+    public void shouldGetBookFromRestClientJson() {
+        given().get("/client/book/json").then().statusCode(HttpStatus.SC_OK)
+                .body(is("{\"title\":\"Title in Json\"}"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,7 @@
             </activation>
             <modules>
                 <module>http/http-minimum</module>
+                <module>http/http-minimum-reactive</module>
                 <module>http/http-advanced</module>
                 <module>http/http-advanced-reactive</module>
                 <module>http/http-static</module>

--- a/pom.xml
+++ b/pom.xml
@@ -374,6 +374,7 @@
                 <module>http/jaxrs-reactive</module>
                 <module>http/reactive-routes</module>
                 <module>http/rest-client</module>
+                <module>http/rest-client-reactive</module>
                 <module>http/servlet-undertow</module>
                 <module>http/vertx-web-client</module>
                 <module>http/hibernate-validator</module>


### PR DESCRIPTION
Main things to look at:
1. Parent pom.xml references
2. New reactive package in counterparts
3. Test classes name should reflect they're Reactive
4. Update endpoints from blocking to non-blocking signature
5. Update dependencies in the module's POM
