### PR TITLE
[#390] Removing personal images from test suite

### DIFF
--- a/sql-db/vertx-sql/src/test/resources/docker-compose.yaml
+++ b/sql-db/vertx-sql/src/test/resources/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       MYSQL_DATABASE: amadeus
 
   db2:
-    image: quay.io/pjgg/db2:11.5.5.0
+    image: quay.io/quarkusqeteam/db2:11.5.5.0
     hostname: db2
     container_name: db2
     privileged: true


### PR DESCRIPTION
* Making the docker-compose file in `sql-db/vertx-sql` use
  `quarkusqeteam` image rather than the personal one.

Fixes #390.