### PR TITLE
[2.2] `quay.io/bitnami/postgresql:latest` is not available anymore

### DIFF
--- a/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/dbpool/PostgresqlResource.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/dbpool/PostgresqlResource.java
@@ -15,7 +15,7 @@ public class PostgresqlResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        postgresContainer = new GenericContainer<>(DockerImageName.parse("quay.io/debezium/postgres:latest"))
+        postgresContainer = new GenericContainer<>(DockerImageName.parse("quay.io/bitnami/postgresql:13.4.0"))
                 .withEnv("POSTGRES_USER", "test")
                 .withEnv("POSTGRES_PASSWORD", "test")
                 .withEnv("POSTGRES_DB", "amadeus")


### PR DESCRIPTION
`quay.io/bitnami/postgresql:latest` was removed. Move on to version 13.4.0 as the main branch