### PR TITLE
Add flyway-sqlserver dependency

### DIFF
--- a/sql-db/vertx-sql/pom.xml
+++ b/sql-db/vertx-sql/pom.xml
@@ -52,6 +52,10 @@
             <artifactId>quarkus-flyway</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-sqlserver</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-openapi</artifactId>
         </dependency>

--- a/sql-db/vertx-sql/src/main/resources/application.properties
+++ b/sql-db/vertx-sql/src/main/resources/application.properties
@@ -6,6 +6,9 @@ app.selected.db=postgresql
 quarkus.http.port=8082
 quarkus.http.test.port=8081
 
+# TODO: workaround to https://github.com/quarkusio/quarkus/issues/21835
+quarkus.native.resources.includes=org/flywaydb/database/version.txt
+
 ## Postgresql
 ## Database
 quarkus.datasource.db-kind=postgresql

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/MssqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/MssqlHandlerIT.java
@@ -3,12 +3,10 @@ package io.quarkus.qe.vertx.sql.handlers;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.SqlServerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-@DisabledOnQuarkusSnapshot(reason = "https://github.com/quarkusio/quarkus/issues/21826")
 public class MssqlHandlerIT extends CommonTestCases {
     private static final int MSSQL_PORT = 1433;
 


### PR DESCRIPTION
After Quarkus' upgrade to Flyway 8.1.0, wherever `quarkus-flyway`
is used together with SQL Server, an external dependency
`org.flywaydb:flyway-sqlserver` (managed by Quarkus BOM) must be
also present.

https://github.com/quarkusio/quarkus/pull/21715#issuecomment-979587768