### PR TITLE
Update github actions versions for Setup-java and Checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,10 @@ jobs:
         java: [ 11 ]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -44,14 +38,8 @@ jobs:
         java: [ 11 ]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -105,21 +93,16 @@ jobs:
         java: [ 11 ]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Install JDK {{ matrix.java }}
         # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           check-latest: true
+          cache: 'maven'
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -167,21 +150,16 @@ jobs:
         java: [ 11 ]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Install JDK {{ matrix.java }}
         # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           check-latest: true
+          cache: 'maven'
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -227,18 +205,13 @@ jobs:
         java: [ 11 ]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           check-latest: true
+          cache: 'maven'
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         java: [ 11 ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Install JDK {{ matrix.java }}
@@ -37,7 +37,7 @@ jobs:
       matrix:
         java: [ 11 ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install JDK {{ matrix.java }}
         uses: actions/setup-java@v2
         with:
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build-dependencies, linux-validate-format ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - id: files
         uses: jitterbit/get-changed-files@v1
         continue-on-error: true
@@ -92,7 +92,7 @@ jobs:
       matrix:
         java: [ 11 ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Install JDK {{ matrix.java }}
@@ -149,7 +149,7 @@ jobs:
       matrix:
         java: [ 11 ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Install JDK {{ matrix.java }}
@@ -204,7 +204,7 @@ jobs:
       matrix:
         java: [ 11 ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install JDK {{ matrix.java }}
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -12,16 +12,10 @@ jobs:
         java: [ 11 ]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -49,20 +43,15 @@ jobs:
                    "messaging-modules,websockets-modules"]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           check-latest: true
+          cache: 'maven'
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -109,20 +98,15 @@ jobs:
                    "messaging-modules,websockets-modules"]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           check-latest: true
+          cache: 'maven'
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -165,18 +149,13 @@ jobs:
         java: [ 11, 17 ]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           check-latest: true
+          cache: 'maven'
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -211,18 +190,13 @@ jobs:
         graalvm-version: [ "21.2.0.java11"]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           check-latest: true
+          cache: 'maven'
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         java: [ 11 ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Install JDK {{ matrix.java }}
@@ -42,7 +42,7 @@ jobs:
                    "sql-db-modules",
                    "messaging-modules,websockets-modules"]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Install JDK {{ matrix.java }}
@@ -97,7 +97,7 @@ jobs:
                    "sql-db-modules",
                    "messaging-modules,websockets-modules"]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Install JDK {{ matrix.java }}
@@ -148,7 +148,7 @@ jobs:
       matrix:
         java: [ 11, 17 ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install JDK {{ matrix.java }}
         uses: actions/setup-java@v2
         with:
@@ -189,7 +189,7 @@ jobs:
         java: [ 11 ]
         graalvm-version: [ "21.2.0.java11"]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install JDK {{ matrix.java }}
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -35,7 +35,7 @@ jobs:
         run: sudo add-apt-repository ppa:rmescandon/yq && sudo apt update && sudo apt install yq -y
 
       - name: Set up Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: ${{ env.JAVA_VERSION }}
 


### PR DESCRIPTION
Setup-java@2 supports now caching, which behaves by default the same way as it was configured in our actions/cache@v1.
Performance improvement:
1. We don't need caching on **Build Dependencies** and **Validate Format**. **Build Dependencies** already performs zipping of the **~/.m2/repository** folder after the build and this zipped archive is unzipped in subsequent steps. Caching at this stage will only create a new cache key with only dependencies from Quarkus Build which we will hit all the time in the next steps (if any of the pom.xml files _was not_ changed!).
Performing caching at the stage of `Test Suite Build` will create a new cache key if any of the pom.xml was changed and will save to this cache all the resolved dependencies during the build (this was not the case before). This way we will have cached dependencies for the next CI run (e.x. when PR failed; the next Daily run)
Previously we were basically zipping and unzipping only dependencies resolved during the build and caching action was not helpful.
*Action/Cache creates a new key that _cannot be updated_.
2. Setup-java@2 now supports caching on our Daily build (basically on `scheduled` event)

Check the last 3 actions in https://github.com/kshpak/quarkus-test-suite/actions