### PR TITLE
Revert "Add workaround to Flyway 8.1.0 + SQL Server issue"

### DIFF
--- a/sql-db/vertx-sql/src/main/resources/application.properties
+++ b/sql-db/vertx-sql/src/main/resources/application.properties
@@ -6,9 +6,6 @@ app.selected.db=postgresql
 quarkus.http.port=8082
 quarkus.http.test.port=8081
 
-# TODO: workaround to https://github.com/quarkusio/quarkus/issues/21835
-quarkus.native.resources.includes=org/flywaydb/database/version.txt
-
 ## Postgresql
 ## Database
 quarkus.datasource.db-kind=postgresql


### PR DESCRIPTION
This reverts commit 30573cafb7f5223e379b9a811ea1daa0950ce918.

Follow-up to https://github.com/quarkus-qe/quarkus-test-suite/pull/399.
Reverts one of the commits with a workaround to https://github.com/quarkusio/quarkus/issues/21835, which has since been resolved.