### PR TITLE
Add RESTEasy extensions to CLI apps with Kogito

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -60,13 +60,15 @@ public class QuarkusCliCreateJvmApplicationIT {
         // 2. Prettytime dependencies
         // It will result into several boms added: quarkus-bom and kogito-bom.
         // Also, it verifies that quarkiverse dependencies can be added too.
-        QuarkusCliRestService app = cliClient.createApplication("app",
-                defaults().withExtensions("kogito-quarkus-rules", "prettytime"));
+        final String kogitoExtension = "kogito-quarkus-rules";
+        final String prettytimeExtension = "quarkus-prettytime";
+        QuarkusCliRestService app = cliClient.createApplication("app", defaults().withExtensions(kogitoExtension,
+                prettytimeExtension, RESTEASY_EXTENSION, RESTEASY_JACKSON_EXTENSION));
 
         // Should build on Jvm
         QuarkusCliClient.Result result = app.buildOnJvm();
         assertTrue(result.isSuccessful(), "The application didn't build on JVM. Output: " + result.getOutput());
-        assertInstalledExtensions(app, "kogito-quarkus-rules", "quarkus-prettytime");
+        assertInstalledExtensions(app, kogitoExtension, prettytimeExtension, RESTEASY_EXTENSION, RESTEASY_JACKSON_EXTENSION);
     }
 
     @Tag("QUARKUS-1071")


### PR DESCRIPTION
The CLI test generates an app with `kogito-quarkus-rules` extension.
After https://github.com/kiegroup/kogito-runtimes/pull/1643, Kogito
needs both `quarkus-resteasy` and `quarkus-resteasy-jackson` to be
able to build with tests - tests invoke REST endpoint.
The Kogito PR was merged in Kogito `1.13.0.Final` (in Quarkus Platform
`2.5.0.CR1`)