### PR TITLE
Fix quarkus-artemis-jms and quarkus-config-consul dependency

### DIFF
--- a/messaging/artemis-jta/pom.xml
+++ b/messaging/artemis-jta/pom.xml
@@ -12,7 +12,7 @@
     <name>Quarkus QE TS: Messaging: Artemis + JTA</name>
     <dependencies>
         <dependency>
-            <groupId>io.quarkus</groupId>
+            <groupId>io.quarkiverse.artemis</groupId>
             <artifactId>quarkus-artemis-jms</artifactId>
         </dependency>
         <dependency>

--- a/messaging/artemis/pom.xml
+++ b/messaging/artemis/pom.xml
@@ -12,7 +12,7 @@
     <name>Quarkus QE TS: Messaging: Artemis</name>
     <dependencies>
         <dependency>
-            <groupId>io.quarkus</groupId>
+            <groupId>io.quarkiverse.artemis</groupId>
             <artifactId>quarkus-artemis-jms</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <checkstyle.version>9.1</checkstyle.version>
         <jjwt.version>0.11.2</jjwt.version>
         <quarkus-artemis-jms.version>1.0.1</quarkus-artemis-jms.version>
+        <quarkus-config-consul.version>1.0.0</quarkus-config-consul.version>
         <camel-quarkus-bom.version>2.5.0</camel-quarkus-bom.version>
         <profile.id>jvm</profile.id>
         <!-- S2i configuration -->
@@ -108,6 +109,11 @@
                 <groupId>io.quarkiverse.artemis</groupId>
                 <artifactId>quarkus-artemis-jms</artifactId>
                 <version>${quarkus-artemis-jms.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.config</groupId>
+                <artifactId>quarkus-config-consul</artifactId>
+                <version>${quarkus-config-consul.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <xml-format-maven-plugin.version>3.2.0</xml-format-maven-plugin.version>
         <checkstyle.version>9.1</checkstyle.version>
         <jjwt.version>0.11.2</jjwt.version>
+        <quarkus-artemis-jms.version>1.0.1</quarkus-artemis-jms.version>
         <camel-quarkus-bom.version>2.5.0</camel-quarkus-bom.version>
         <profile.id>jvm</profile.id>
         <!-- S2i configuration -->
@@ -98,6 +99,15 @@
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-jackson</artifactId>
                 <version>${jjwt.version}</version>
+            </dependency>
+            <!--
+            TODO: Replace `quarkus-artemis-jms` with `quarkus-artemis-bom` once
+                https://github.com/quarkiverse/quarkus-artemis/pull/10 gets released.
+             -->
+            <dependency>
+                <groupId>io.quarkiverse.artemis</groupId>
+                <artifactId>quarkus-artemis-jms</artifactId>
+                <version>${quarkus-artemis-jms.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/properties/pom.xml
+++ b/properties/pom.xml
@@ -32,8 +32,8 @@
             <artifactId>quarkus-config-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-consul-config</artifactId>
+            <groupId>io.quarkiverse.config</groupId>
+            <artifactId>quarkus-config-consul</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>

--- a/super-size/many-extensions/pom.xml
+++ b/super-size/many-extensions/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
+            <groupId>io.quarkiverse.artemis</groupId>
             <artifactId>quarkus-artemis-jms</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
After https://github.com/quarkusio/quarkus/pull/21736,
`quarkus-artemis-jms` moved from Quarkus core to Quarkiverse. As a
result, dependencies need to be updated according to the extension's
documentation:
https://github.com/quarkiverse/quarkus-artemis/blob/1.0.1/docs/modules/ROOT/pages/index.adoc

See also https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.6

Dependency `quarkus-config-consul` moved out of Quarkus core in
quarkusio/quarkus#21736.
Updated according to the migration guide:
https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.6#extensions-included-inside-the-platform-bom