### PR TITLE
Fix reactive-routes validation response format

### DIFF
--- a/http/reactive-routes/src/test/java/io/quarkus/ts/validation/utils/ValidationAssertions.java
+++ b/http/reactive-routes/src/test/java/io/quarkus/ts/validation/utils/ValidationAssertions.java
@@ -17,7 +17,7 @@ public class ValidationAssertions {
     }
 
     public static final void assertValidationErrorDetails(ValidationErrorResponse response) {
-        assertEquals("validation constraint violations", response.getDetails());
+        assertEquals("validation constraint violations", response.getDetail());
     }
 
     public static final void assertValidationErrorStatus(ValidationErrorResponse response, int expected) {

--- a/http/reactive-routes/src/test/java/io/quarkus/ts/validation/utils/ValidationErrorResponse.java
+++ b/http/reactive-routes/src/test/java/io/quarkus/ts/validation/utils/ValidationErrorResponse.java
@@ -2,7 +2,7 @@ package io.quarkus.ts.validation.utils;
 
 public class ValidationErrorResponse {
     private String title;
-    private String details;
+    private String detail;
     private int status;
     private ValidationError[] violations;
 
@@ -14,12 +14,12 @@ public class ValidationErrorResponse {
         this.title = title;
     }
 
-    public String getDetails() {
-        return details;
+    public String getDetail() {
+        return detail;
     }
 
-    public void setDetails(String details) {
-        this.details = details;
+    public void setDetail(String detail) {
+        this.detail = detail;
     }
 
     public int getStatus() {


### PR DESCRIPTION
Property renamed according to
https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.6#bean-validation-json-format