### PR TITLE
Use a non default devService Kafka version on user experience tests

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/DevModeKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/DevModeKafkaStreamIT.java
@@ -26,6 +26,6 @@ public class DevModeKafkaStreamIT extends BaseKafkaStreamTest {
 
     @Test
     public void kafkaContainerShouldBeStarted() {
-        app.logs().assertContains("Creating container for image: vectorized/redpanda");
+        app.logs().assertContains("Creating container for image: docker.io/vectorized/redpanda");
     }
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/DevModeRedPandaDevServiceUserExperienceIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/DevModeRedPandaDevServiceUserExperienceIT.java
@@ -15,7 +15,7 @@ import io.quarkus.test.utils.DockerUtils;
 @QuarkusScenario
 public class DevModeRedPandaDevServiceUserExperienceIT {
 
-    private static final String RED_PANDA_VERSION = "latest";
+    private static final String RED_PANDA_VERSION = "v21.10.3";
     private static final String RED_PANDA_IMAGE = "vectorized/redpanda";
 
     @DevModeQuarkusApplication


### PR DESCRIPTION
The daily build is failing because the user-experience Kafkadevservice scenario is failing. 

I could not reproduce the error locally but this scenario is checking the default log messages logged by kafka devservices. More in detail is checking the default messages when redpanda docker image doesn't exist. The scenario remove redpanda docker image as a previous test step. In order to avoid some conflicts with other scenarios that also are using this default image, let's use a custom image for this case. 

`kafkaContainerShouldBeStarted` test was failing because the started log has changed