### PR TITLE
Fix some DB devServices logs verification + Add flyway-mysql dependency

### DIFF
--- a/sql-db/panache-flyway/pom.xml
+++ b/sql-db/panache-flyway/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>quarkus-flyway</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-mysql</artifactId>
         </dependency>

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMariadbIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMariadbIT.java
@@ -16,6 +16,6 @@ public class DevModeMariadbIT extends AbstractSqlDatabaseIT {
 
     @Test
     public void mariadbContainerShouldBeStarted() {
-        app.logs().assertContains("Creating container for image: mariadb");
+        app.logs().assertContains("Creating container for image: docker.io/mariadb");
     }
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMysqlIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMysqlIT.java
@@ -16,6 +16,6 @@ public class DevModeMysqlIT extends AbstractSqlDatabaseIT {
 
     @Test
     public void mysqlContainerShouldBeStarted() {
-        app.logs().assertContains("Creating container for image: mysql");
+        app.logs().assertContains("Creating container for image: docker.io/mysql");
     }
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeOracleIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeOracleIT.java
@@ -14,6 +14,6 @@ public class DevModeOracleIT extends AbstractSqlDatabaseIT {
 
     @Test
     public void postgresqlContainerShouldBeStarted() {
-        app.logs().assertContains("Creating container for image: gvenzl/oracle-xe");
+        app.logs().assertContains("Creating container for image: docker.io/gvenzl/oracle-xe");
     }
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlIT.java
@@ -17,6 +17,6 @@ public class DevModePostgresqlIT extends AbstractSqlDatabaseIT {
 
     @Test
     public void postgresqlContainerShouldBeStarted() {
-        app.logs().assertContains("Creating container for image: postgres");
+        app.logs().assertContains("Creating container for image: docker.io/postgres");
     }
 }


### PR DESCRIPTION
Flyway 8.X needs `flyway-mysql` dependency. 

Doc Ref: https://flywaydb.org/documentation/database/mysql#java-usage

Issue Ref: https://github.com/quarkusio/quarkus/issues/22400