### PR TITLE
Add missing 'flyway-mysql' to vertx-sql module

### DIFF
--- a/sql-db/vertx-sql/pom.xml
+++ b/sql-db/vertx-sql/pom.xml
@@ -53,6 +53,10 @@
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
             <artifactId>flyway-sqlserver</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Flyway 8.X needs flyway-mysql dependency.

Doc Ref: https://flywaydb.org/documentation/database/mysql#java-usage

Issue Ref: quarkusio/quarkus#22400