### PR TITLE
Add flyway-mysql extension to scheduling/quartz

### DIFF
--- a/scheduling/quartz/pom.xml
+++ b/scheduling/quartz/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>quarkus-flyway</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-mysql</artifactId>
         </dependency>


### PR DESCRIPTION
Flyway 8.X needs flyway-mysql dependency.

Doc Ref: https://flywaydb.org/documentation/database/mysql#java-usage

Issue Ref: quarkusio/quarkus#22400