### PR TITLE
Add docker image name with empty spaces scenario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,8 +182,9 @@ jobs:
         run: |
           if [[ -n ${MODULES_ARG} ]]; then
             echo "Running modules: ${MODULES_ARG}"
-            mvn -fae -V -B -s .github/mvn-settings.xml -fae -Dall-modules -pl $MODULES_ARG clean verify -Dnative \
-                        -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
+            mvn -fae -V -B -s .github/mvn-settings.xml -fae -Dall-modules -Dquarkus.container-image.build=false \
+                        -pl $MODULES_ARG clean verify -Dnative -Dinclude.quarkus-cli-tests \
+                        -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
           fi
       - name: Zip Artifacts
         if: failure()
@@ -229,7 +230,7 @@ jobs:
             MODULES_MAVEN_PARAM="-pl ${MODULES_ARG}"
           fi
 
-          mvn -fae -s .github/mvn-settings.xml clean verify -Dall-modules $MODULES_MAVEN_PARAM
+          mvn -fae -s .github/mvn-settings.xml clean verify -Dall-modules -Dquarkus.container-image.build=false $MODULES_MAVEN_PARAM
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -167,7 +167,7 @@ jobs:
       - name: Build in JVM mode
         shell: bash
         run: |
-          mvn -fae -s .github/mvn-settings.xml clean verify
+          mvn -fae -s .github/mvn-settings.xml clean verify -Dquarkus.container-image.build=false
       - name: Zip Artifacts
         shell: bash
         if: failure()
@@ -224,7 +224,7 @@ jobs:
         shell: bash
         run: |
           # Running only http/http-minimum as after some time, it gives disk full in Windows when running on Native.
-          mvn -fae -s .github/mvn-settings.xml clean verify -Dall-modules -Dnative -Dquarkus.native.container-build=false -pl http/http-minimum
+          mvn -fae -s .github/mvn-settings.xml clean verify -Dall-modules -Dnative -Dquarkus.container-image.build=false -Dquarkus.native.container-build=false -pl http/http-minimum
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/README.md
+++ b/README.md
@@ -385,6 +385,9 @@ Tests:
 Checks that the application can read configuration from a ConfigMap and a Secret.
 The ConfigMap/Secret is exposed by mounting it into the container file system or the Kubernetes API server.
 
+### `docker-build`
+Checks that an application can generate a Docker image based on some configuration parameters.
+
 ### `lifecycle-application`
 Verifies lifecycle application features like `@QuarkusMain` and `@CommandLineArguments`.
 Also ensures maven profile activation with properties and additional repository definition propagation into Quarkus maven plugin.

--- a/docker-build/pom.xml
+++ b/docker-build/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>docker-build</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: Docker-build</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-docker</artifactId>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
+        <profile>
+            <id>skip-tests-on-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/docker-build/src/main/docker/Dockerfile.jvm
+++ b/docker-build/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,41 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the container image run:
+#
+# ./mvnw package
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/getting-started-jvm .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/getting-started-jvm
+#
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
+#
+# Then run the container using :
+#
+# docker run -i --rm -p 8080:8080 quarkus/getting-started-jvm
+#
+###
+FROM registry.access.redhat.com/ubi8/openjdk-11-runtime:1.10
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+
+# We make four distinct layers so if there are application changes the library layers can be re-used
+COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/
+COPY --chown=185 target/quarkus-app/*.jar /deployments/
+COPY --chown=185 target/quarkus-app/app/ /deployments/app/
+COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8080
+USER 185
+
+ENTRYPOINT [ "java", "-jar", "/deployments/quarkus-run.jar" ]
+

--- a/docker-build/src/main/docker/Dockerfile.legacy-jar
+++ b/docker-build/src/main/docker/Dockerfile.legacy-jar
@@ -1,0 +1,37 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the container image run:
+#
+# ./mvnw package -Dquarkus.package.type=legacy-jar
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/getting-started-legacy-jar .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/getting-started-legacy-jar
+#
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
+#
+# Then run the container using :
+#
+# docker run -i --rm -p 8080:8080 quarkus/getting-started-legacy-jar
+#
+###
+FROM registry.access.redhat.com/ubi8/openjdk-11-runtime:1.10
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+
+COPY target/lib/* /deployments/lib/
+COPY target/*-runner.jar /deployments/quarkus-run.jar
+
+EXPOSE 8080
+USER 185
+
+ENTRYPOINT [ "java", "-jar", "/deployments/quarkus-run.jar" ]

--- a/docker-build/src/main/docker/Dockerfile.native
+++ b/docker-build/src/main/docker/Dockerfile.native
@@ -1,0 +1,27 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode
+#
+# Before building the container image run:
+#
+# ./mvnw package -Pnative
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/getting-started .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/getting-started
+#
+###
+FROM quay.io/quarkus/quarkus-micro-image:1.0
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root target/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/docker-build/src/main/docker/Dockerfile.native-distroless
+++ b/docker-build/src/main/docker/Dockerfile.native-distroless
@@ -1,0 +1,23 @@
+####
+# This Dockerfile is used in order to build a distroless container that runs the Quarkus application in native (no JVM) mode
+#
+# Before building the container image run:
+#
+# ./mvnw package -Pnative
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native-distroless -t quarkus/getting-started .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/getting-started
+#
+###
+FROM quay.io/quarkus/quarkus-distroless-image:1.0
+COPY target/*-runner /application
+
+EXPOSE 8080
+USER nonroot
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/docker-build/src/main/java/io/quarkus/ts/docker/HelloResource.java
+++ b/docker-build/src/main/java/io/quarkus/ts/docker/HelloResource.java
@@ -1,0 +1,16 @@
+package io.quarkus.ts.docker;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/hello")
+public class HelloResource {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response get() {
+        return Response.ok("hello World").build();
+    }
+}

--- a/docker-build/src/main/resources/application.properties
+++ b/docker-build/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+quarkus.container-image.build=true
+quarkus.container-image.group=qe
+// DON'T remove the spaces that are at the end of quarkus app name
+quarkus.application.name=hello-world-app      
+quarkus.container-image.tag=1.0.0

--- a/docker-build/src/test/java/io/quarkus/ts/docker/DockerBuildIT.java
+++ b/docker-build/src/test/java/io/quarkus/ts/docker/DockerBuildIT.java
@@ -1,0 +1,33 @@
+package io.quarkus.ts.docker;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Objects;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import com.github.dockerjava.api.model.Image;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.utils.DockerUtils;
+
+@QuarkusScenario
+@DisabledOnNative(reason = "Due to reduce native execution time")
+public class DockerBuildIT {
+
+    private static final String DOCKER_IMG_NAME = "hello-world-app";
+    private static final String DOCKER_IMG_VERSION = "1.0.0";
+
+    @AfterAll
+    public static void tearDown() {
+        DockerUtils.removeImage(DOCKER_IMG_NAME, DOCKER_IMG_VERSION);
+    }
+
+    @Test
+    public void buildDockerImage() {
+        Image dockerImg = DockerUtils.getImage(DOCKER_IMG_NAME, DOCKER_IMG_VERSION);
+        assertTrue(Objects.nonNull(dockerImg.getId()) && !dockerImg.getId().isEmpty(), "Docker image was not created");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,7 @@
             <modules>
                 <module>config</module>
                 <module>properties</module>
+                <module>docker-build</module>
                 <module>javaee-like-getting-started</module>
                 <module>scaling</module>
                 <module>lifecycle-application</module>


### PR DESCRIPTION
issue Ref: https://github.com/quarkusio/quarkus/pull/19958

A Quarkus app that uses the extension `container-image-docker` fails if the docker image name (`quarkus.application.name`) contains some spaces at the end. 

The issue has been fixed.  Verified by this PR. 