### PR TITLE
Add coverage of `quarkus-test-security` extension

### DIFF
--- a/security/basic/pom.xml
+++ b/security/basic/pom.xml
@@ -19,5 +19,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-elytron-security-properties-file</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-security</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/security/basic/src/main/java/io/quarkus/ts/openshift/security/basic/UnannotatedResource.java
+++ b/security/basic/src/main/java/io/quarkus/ts/openshift/security/basic/UnannotatedResource.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.openshift.security.basic;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+
+@Path("/unannotated")
+public class UnannotatedResource {
+    @GET
+    public String get(@Context SecurityContext security) {
+        return "Hello!";
+    }
+}

--- a/security/basic/src/test/java/io/quarkus/ts/openshift/security/basic/SecurityTest.java
+++ b/security/basic/src/test/java/io/quarkus/ts/openshift/security/basic/SecurityTest.java
@@ -1,0 +1,71 @@
+package io.quarkus.ts.openshift.security.basic;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.containsString;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.security.TestSecurity;
+
+@Tag("QUARKUS-1584")
+@QuarkusTest
+@TestProfile(SecurityTestProfile.class)
+public class SecurityTest {
+
+    private static final String TEST_USER = "testUser";
+    private static final String USER_ROLE = "user";
+    private static final String ADMIN_ROLE = "admin";
+
+    @Test
+    public void permitAll() {
+        given().get("/permit-all")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo("Hello!"));
+    }
+
+    @Test
+    public void denyAll() {
+        given().get("/deny-all")
+                .then()
+                .statusCode(HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    public void denyUnannotated() {
+        given().get("/unannotated")
+                .then()
+                .statusCode(HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    @TestSecurity(authorizationEnabled = false)
+    public void allowUnannotated() {
+        given().get("/unannotated")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo("Hello!"));
+    }
+
+    @Test
+    @TestSecurity(user = TEST_USER, roles = USER_ROLE)
+    public void allowUserRole() {
+        given().get("/user")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString(TEST_USER));
+    }
+
+    @Test
+    @TestSecurity(user = TEST_USER, roles = ADMIN_ROLE)
+    public void denyAdminRole() {
+        given().get("/user")
+                .then()
+                .statusCode(HttpStatus.SC_FORBIDDEN);
+    }
+}

--- a/security/basic/src/test/java/io/quarkus/ts/openshift/security/basic/SecurityTestProfile.java
+++ b/security/basic/src/test/java/io/quarkus/ts/openshift/security/basic/SecurityTestProfile.java
@@ -1,0 +1,19 @@
+package io.quarkus.ts.openshift.security.basic;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class SecurityTestProfile implements QuarkusTestProfile {
+    public static final String PROFILE = "security-test";
+
+    @Override
+    public String getConfigProfile() {
+        return PROFILE;
+    }
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("quarkus.security.jaxrs.deny-unannotated-endpoints", "true");
+    }
+}


### PR DESCRIPTION
Verifies that the `quarkus.security.jaxrs.deny-unannotated-endpoints`
property and  `@TestSecurity` annotation work correctly together and in
combination with Basic Auth.