### PR TITLE
Remove some RegisterForReflection annotation that are not required any more

### DIFF
--- a/config/src/main/java/io/quarkus/ts/configmap/api/server/Hello.java
+++ b/config/src/main/java/io/quarkus/ts/configmap/api/server/Hello.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.configmap.api.server;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
-
-@RegisterForReflection
 public class Hello {
     private final String content;
 

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/Hello.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/Hello.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.http.advanced.reactive;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
-
-@RegisterForReflection
 public class Hello {
     private final String content;
 

--- a/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/Hello.java
+++ b/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/Hello.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.http.advanced;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
-
-@RegisterForReflection
 public class Hello {
     private final String content;
 

--- a/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/Cluster.java
+++ b/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/Cluster.java
@@ -1,0 +1,114 @@
+package io.quarkus.ts.http.minimum.reactive;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Cluster {
+    private static final String TEAM_ID = "qe";
+    private static final String PROVIDER_ID = "quarkus.io";
+    private static final String REGION_ID = "EU";
+    private static final String NAME = "QE";
+    private static final String NETWORK_ID = "qe";
+
+    @JsonProperty("team_id")
+    public String teamId;
+    @JsonProperty("provider_id")
+    public String providerId;
+    @JsonProperty("region_id")
+    public String regionId;
+    @JsonProperty("name")
+    public String name;
+    @JsonProperty("network_id")
+    public String networkId;
+    @JsonProperty("major_version")
+    public Integer majorVersion;
+    @JsonProperty("storage")
+    public Integer storage;
+    public Integer cpu;
+    public Integer memory;
+
+    public static Cluster createDefault() {
+        return new Cluster(TEAM_ID, PROVIDER_ID, REGION_ID, NAME, NETWORK_ID);
+    }
+
+    public Cluster(String teamId, String providerId, String regionId, String name, String networkId) {
+        this.teamId = teamId;
+        this.providerId = providerId;
+        this.regionId = regionId;
+        this.name = name;
+        this.networkId = networkId;
+    }
+
+    public String getTeamId() {
+        return teamId;
+    }
+
+    public void setTeamId(String teamId) {
+        this.teamId = teamId;
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public void setProviderId(String providerId) {
+        this.providerId = providerId;
+    }
+
+    public String getRegionId() {
+        return regionId;
+    }
+
+    public void setRegionId(String regionId) {
+        this.regionId = regionId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNetworkId() {
+        return networkId;
+    }
+
+    public void setNetworkId(String networkId) {
+        this.networkId = networkId;
+    }
+
+    public Integer getMajorVersion() {
+        return majorVersion;
+    }
+
+    public void setMajorVersion(Integer majorVersion) {
+        this.majorVersion = majorVersion;
+    }
+
+    public Integer getStorage() {
+        return storage;
+    }
+
+    public void setStorage(Integer storage) {
+        this.storage = storage;
+    }
+
+    public Integer getCpu() {
+        return cpu;
+    }
+
+    public void setCpu(Integer cpu) {
+        this.cpu = cpu;
+    }
+
+    public Integer getMemory() {
+        return memory;
+    }
+
+    public void setMemory(Integer memory) {
+        this.memory = memory;
+    }
+}

--- a/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/ClusterResource.java
+++ b/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/ClusterResource.java
@@ -1,0 +1,18 @@
+package io.quarkus.ts.http.minimum.reactive;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/cluster")
+public class ClusterResource {
+    @GET
+    @Path("/default")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Uni<Clusters> get() {
+        return Uni.createFrom().item(new Clusters(Cluster.createDefault()));
+    }
+}

--- a/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/Clusters.java
+++ b/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/Clusters.java
@@ -1,0 +1,29 @@
+package io.quarkus.ts.http.minimum.reactive;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Clusters {
+    @JsonProperty("clusters")
+    List<Cluster> clusterList;
+
+    public Clusters() {
+    }
+
+    public Clusters(Cluster cluster) {
+        clusterList = List.of(cluster);
+    }
+
+    public Clusters(List<Cluster> clusterList) {
+        this.clusterList = clusterList;
+    }
+
+    public List<Cluster> getClusterList() {
+        return clusterList;
+    }
+
+    public void setClusterList(List<Cluster> clusterList) {
+        this.clusterList = clusterList;
+    }
+}

--- a/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/Hello.java
+++ b/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/Hello.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.http.minimum.reactive;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
-
-@RegisterForReflection
 public class Hello {
 
     private final String content;

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpMinimumReactiveIT.java
@@ -2,8 +2,10 @@ package io.quarkus.ts.http.minimum.reactive;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -14,5 +16,17 @@ public class HttpMinimumReactiveIT {
     @Test
     public void httpServer() {
         given().get("/api/hello").then().statusCode(HttpStatus.SC_OK).body("content", is("Hello, World!"));
+    }
+
+    @Test
+    @Tag("QUARKUS-1543")
+    public void nativeListSerialization() {
+        String teamId = (String) given().get("/api/cluster/default").then().statusCode(HttpStatus.SC_OK)
+                .extract()
+                .jsonPath()
+                .getMap("clusters[0]")
+                .get("team_id");
+
+        assertEquals("qe", teamId);
     }
 }

--- a/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/Hello.java
+++ b/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/Hello.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.http.minimum;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
-
-@RegisterForReflection
 public class Hello {
 
     private final String content;

--- a/http/jaxrs-reactive/src/main/java/io/quarkus/ts/jaxrs/reactive/json/UnquotedFields.java
+++ b/http/jaxrs-reactive/src/main/java/io/quarkus/ts/jaxrs/reactive/json/UnquotedFields.java
@@ -7,9 +7,6 @@ import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
-
-@RegisterForReflection
 public class UnquotedFields implements BiFunction<ObjectMapper, Type, ObjectWriter> {
     @Override
     public ObjectWriter apply(ObjectMapper objectMapper, Type type) {

--- a/http/vertx-web-client/src/main/java/io/quarkus/qe/vertx/webclient/model/Joke.java
+++ b/http/vertx-web-client/src/main/java/io/quarkus/qe/vertx/webclient/model/Joke.java
@@ -3,10 +3,7 @@ package io.quarkus.qe.vertx.webclient.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
-
 @JsonIgnoreProperties(ignoreUnknown = true)
-@RegisterForReflection
 public class Joke {
 
     @JsonProperty("id")

--- a/messaging/kafka-avro-reactive-messaging/src/main/java/io/quarkus/ts/messaging/kafka/StockPriceDto.java
+++ b/messaging/kafka-avro-reactive-messaging/src/main/java/io/quarkus/ts/messaging/kafka/StockPriceDto.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.messaging.kafka;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
-
-@RegisterForReflection
 public class StockPriceDto {
     private String id;
     private double value;

--- a/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/model/Score.java
+++ b/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/model/Score.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.model;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
-
-@RegisterForReflection
 public class Score {
     private int teamA;
     private int teamB;

--- a/sql-db/reactive-vanilla/src/main/java/io/quarkus/qe/model/Book.java
+++ b/sql-db/reactive-vanilla/src/main/java/io/quarkus/qe/model/Book.java
@@ -2,7 +2,6 @@ package io.quarkus.qe.model;
 
 import java.util.List;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.pgclient.PgPool;
@@ -10,7 +9,6 @@ import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
 
-@RegisterForReflection
 public class Book extends Record {
 
     private static final String TITLE = "title";

--- a/sql-db/reactive-vanilla/src/main/java/io/quarkus/qe/model/NoteBook.java
+++ b/sql-db/reactive-vanilla/src/main/java/io/quarkus/qe/model/NoteBook.java
@@ -2,7 +2,6 @@ package io.quarkus.qe.model;
 
 import java.util.List;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.mysqlclient.MySQLPool;
@@ -10,7 +9,6 @@ import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.sqlclient.PropertyKind;
 
-@RegisterForReflection
 public class NoteBook extends Record {
     private final static PropertyKind<Long> LAST_INSERTED_ID = PropertyKind.create("last-inserted-id", Long.class);
 

--- a/sql-db/reactive-vanilla/src/main/java/io/quarkus/qe/model/Record.java
+++ b/sql-db/reactive-vanilla/src/main/java/io/quarkus/qe/model/Record.java
@@ -3,12 +3,10 @@ package io.quarkus.qe.model;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.Json;
 
-@RegisterForReflection
 public class Record {
 
     protected static final String QUALIFIED_ID = "id";

--- a/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Address.java
+++ b/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Address.java
@@ -9,11 +9,9 @@ import java.util.stream.Stream;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import io.quarkus.qe.vertx.sql.services.DbPoolService;
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Uni;
 
 @Schema(name = "Address", description = "Address entity")
-@RegisterForReflection
 public class Address extends Record {
     private String street;
     private String blockNumber;

--- a/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Airline.java
+++ b/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Airline.java
@@ -8,14 +8,12 @@ import java.util.Objects;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import io.quarkus.qe.vertx.sql.services.DbPoolService;
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 
 @Schema(name = "Airline", description = "Airline entity")
-@RegisterForReflection
 public class Airline extends Record {
 
     private static final String QUALIFIED_CODE_NAME = "iata_code";

--- a/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Airport.java
+++ b/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Airport.java
@@ -7,14 +7,12 @@ import java.util.Objects;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import io.quarkus.qe.vertx.sql.services.DbPoolService;
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 
 @Schema(name = "Airport", description = "Airport entity")
-@RegisterForReflection
 public class Airport extends Record {
 
     private static final String QUALIFIED_CODE_NAME = "iata_code";

--- a/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Basket.java
+++ b/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Basket.java
@@ -9,12 +9,10 @@ import java.util.stream.Stream;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import io.quarkus.qe.vertx.sql.services.DbPoolService;
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.SqlClientHelper;
 
 @Schema(name = "Basket", description = "Basket entity")
-@RegisterForReflection
 public class Basket extends Record {
 
     private String flight;

--- a/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Flight.java
+++ b/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Flight.java
@@ -7,14 +7,12 @@ import java.util.Objects;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import io.quarkus.qe.vertx.sql.services.DbPoolService;
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 
 @Schema(name = "Flight", description = "Flight entity")
-@RegisterForReflection
 public class Flight extends Record {
 
     private static final String QUALIFIED_ORIGIN_NAME = "origin";

--- a/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Passenger.java
+++ b/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Passenger.java
@@ -9,12 +9,10 @@ import java.util.stream.Stream;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import io.quarkus.qe.vertx.sql.services.DbPoolService;
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.SqlClientHelper;
 
 @Schema(name = "Passenger", description = "Passenger entity")
-@RegisterForReflection
 public class Passenger extends Record {
     private String nif;
     private String name;

--- a/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/PricingRules.java
+++ b/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/PricingRules.java
@@ -8,14 +8,12 @@ import java.util.function.Predicate;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import io.quarkus.qe.vertx.sql.services.DbPoolService;
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 
 @Schema(name = "PricingRules", description = "PricingRules entity")
-@RegisterForReflection
 public class PricingRules extends Record {
     private static final String QUALIFIED_FROM_NAME = "days_to_departure";
     @Schema(description = "days_to_departure")

--- a/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/QueryFlightSearch.java
+++ b/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/QueryFlightSearch.java
@@ -5,10 +5,8 @@ import java.util.Objects;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.vertx.core.json.Json;
 
-@RegisterForReflection
 public class QueryFlightSearch {
     @Min(0)
     public int adult;

--- a/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Record.java
+++ b/sql-db/vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Record.java
@@ -4,10 +4,8 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.vertx.core.json.Json;
 
-@RegisterForReflection
 public class Record {
 
     protected static final String QUALIFIED_ID = "id";


### PR DESCRIPTION
This PR talks about native mode

Some `RegisterForReflection` annotations are not required based on this commit: https://github.com/quarkusio/quarkus/pull/20225

Also, we have added a new scenario with a data structure as is described on this issue:
https://github.com/quarkusio/quarkus/issues/20200