### PR TITLE
FormAuthN Coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,11 @@ Verifies the simplest way of doing authn/authz.
 Authentication is HTTP `Basic`, with users/passwords/roles defined in `application.properties`.
 Authorization is based on roles, restrictions are defined using common annotations (`@RolesAllowed` etc.).
 
+### `security/form-authn`
+
+Verifies form-based authentication.
+Verifies that Basic Authentication is not used as a fallback option when it is explicitly disabled.
+
 ### `security/jwt`
 
 Verifies token-based authn and role-based authz.

--- a/pom.xml
+++ b/pom.xml
@@ -391,6 +391,7 @@
             </activation>
             <modules>
                 <module>security/basic</module>
+                <module>security/form-authn</module>
                 <module>security/https</module>
                 <module>security/jwt</module>
                 <module>security/keycloak</module>

--- a/security/form-authn/pom.xml
+++ b/security/form-authn/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>security-form-authn</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: Security: form-authn</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/security/form-authn/src/main/java/io/quarkus/ts/security/form/authn/UserResource.java
+++ b/security/form-authn/src/main/java/io/quarkus/ts/security/form/authn/UserResource.java
@@ -1,0 +1,16 @@
+package io.quarkus.ts.security.form.authn;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+
+@Path("/user")
+@RolesAllowed("user")
+public class UserResource {
+    @GET
+    public String get(@Context SecurityContext security) {
+        return "Hello, user " + security.getUserPrincipal().getName();
+    }
+}

--- a/security/form-authn/src/main/resources/application.properties
+++ b/security/form-authn/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+#Basic AuthN
+quarkus.http.auth.basic=false
+
+# Roles
+quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.plain-text=true
+quarkus.security.users.embedded.users.isaac=N3wt0N
+quarkus.security.users.embedded.roles.isaac=user

--- a/security/form-authn/src/test/java/io/quarkus/ts/security/form/authn/BasicAuthnIT.java
+++ b/security/form-authn/src/test/java/io/quarkus/ts/security/form/authn/BasicAuthnIT.java
@@ -1,0 +1,37 @@
+package io.quarkus.ts.security.form.authn;
+
+import static io.restassured.RestAssured.given;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+
+@Tag("QUARKUS-1540")
+@QuarkusScenario
+public class BasicAuthnIT {
+    static final String USER_USERNAME = "isaac";
+    static final String USER_PASSWORD = "N3wt0N";
+
+    @QuarkusApplication
+    static RestService app = new RestService().withProperties("basicAuthN.properties");
+
+    @Test
+    public void basicAuthDisabled() {
+        basicAuthRequest("/user", USER_USERNAME, USER_PASSWORD).statusCode(HttpStatus.SC_FORBIDDEN);
+    }
+
+    private ValidatableResponse basicAuthRequest(String url, String username, String password) {
+        RequestSpecification test = given();
+        if (username != null && password != null) {
+            test = test.auth().basic(username, password);
+        }
+
+        return test.when().get(url).then();
+    }
+}

--- a/security/form-authn/src/test/java/io/quarkus/ts/security/form/authn/FormAuthnIT.java
+++ b/security/form-authn/src/test/java/io/quarkus/ts/security/form/authn/FormAuthnIT.java
@@ -1,0 +1,69 @@
+package io.quarkus.ts.security.form.authn;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.StringContains.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.filter.cookie.CookieFilter;
+
+@QuarkusScenario
+public class FormAuthnIT {
+    static final String USER_USERNAME = "isaac";
+    static final String USER_PASSWORD = "N3wt0N";
+
+    @QuarkusApplication
+    static RestService app = new RestService().withProperties("formAuthN.properties");
+
+    @Test
+    public void formAuthN() {
+        CookieFilter cookies = new CookieFilter();
+        given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .get("/user")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/login"))
+                .cookie("quarkus-redirect-location", containsString("/user"));
+    }
+
+    @Test
+    public void formAuthNWrongPassword() {
+        CookieFilter cookies = new CookieFilter();
+        given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", USER_USERNAME)
+                .formParam("j_password", "wrongpassword")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/error"));
+    }
+
+    @Test
+    public void testFormBasedAuthSuccessLandingPage() {
+        CookieFilter cookies = new CookieFilter();
+        given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", USER_USERNAME)
+                .formParam("j_password", USER_PASSWORD)
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/landing"))
+                .cookie("quarkus-credential", notNullValue());
+    }
+}

--- a/security/form-authn/src/test/resources/basicAuthN.properties
+++ b/security/form-authn/src/test/resources/basicAuthN.properties
@@ -1,0 +1,5 @@
+#Basic AuthN
+quarkus.http.auth.basic=false
+
+# Form AuthN
+quarkus.http.auth.form.enabled=false

--- a/security/form-authn/src/test/resources/formAuthN.properties
+++ b/security/form-authn/src/test/resources/formAuthN.properties
@@ -1,0 +1,5 @@
+# Form AuthN
+quarkus.http.auth.form.enabled=true
+quarkus.http.auth.form.login-page=login
+quarkus.http.auth.form.error-page=error
+quarkus.http.auth.form.landing-page=landing


### PR DESCRIPTION
- Don't enable basic auth as a fallback if it has been disabled
- Basic coverage of Quarkus Form authN. 
 
Doc: https://quarkus.io/guides/security-built-in-authentication#form-auth