### PR TITLE
Add coverage for case-insensitive HTTP `Accept` header

### DIFF
--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/HttpCustomHeadersIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/HttpCustomHeadersIT.java
@@ -1,0 +1,25 @@
+package io.quarkus.ts.http.minimum;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+
+@Tag("QUARKUS-1574")
+@QuarkusScenario
+public class HttpCustomHeadersIT {
+
+    @Test
+    public void caseInsensitiveAcceptHeader() {
+        given()
+                .accept("Application/json")
+                .get("/api/hello")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("content", is("Hello, World!"));
+    }
+}


### PR DESCRIPTION
Backport of https://github.com/quarkus-qe/quarkus-test-suite/pull/441.

Contrary to the original PR, this backport covers only RESTEasy Classic (`http/http-minimum`) and not RESTEasy Reactive, because `http/http-minimum-reactive` is not present in `2.2` branch.