### PR TITLE
[2.2] Add coverage for HTTP `Content-Type` response header

### DIFF
--- a/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/HelloResource.java
+++ b/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/HelloResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.http.minimum;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -15,5 +16,13 @@ public class HelloResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Hello get(@QueryParam("name") @DefaultValue("World") String name) {
         return new Hello(String.format(TEMPLATE, name));
+    }
+
+    @GET
+    @Path("/json")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Hello getJson() {
+        return new Hello("hello");
     }
 }

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/HttpCustomHeadersIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/HttpCustomHeadersIT.java
@@ -3,16 +3,18 @@ package io.quarkus.ts.http.minimum;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
+import javax.ws.rs.core.MediaType;
+
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 
-@Tag("QUARKUS-1574")
 @QuarkusScenario
 public class HttpCustomHeadersIT {
 
+    @Tag("QUARKUS-1574")
     @Test
     public void caseInsensitiveAcceptHeader() {
         given()
@@ -21,5 +23,23 @@ public class HttpCustomHeadersIT {
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("content", is("Hello, World!"));
+    }
+
+    @Tag("QUARKUS-1557")
+    @Test
+    public void correctContentType() {
+        getContentType("ApPlIcAtIoN/JsOn");
+        getContentType("application/json");
+        getContentType("APPLICATION/JSON");
+    }
+
+    public void getContentType(String contentType) {
+        given()
+                .contentType(contentType)
+                .get("/api/hello/json")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("content", is("hello"))
+                .contentType(is(MediaType.APPLICATION_JSON));
     }
 }


### PR DESCRIPTION
Verifies that the RESTEasy Classic handles the `Content-Type` response
header correctly and always sends properly formatted string.

Backport of https://github.com/quarkus-qe/quarkus-test-suite/pull/450.