### PR TITLE
`quarkus.openshift.expose` was deprecated

### DIFF
--- a/messaging/artemis-jta/src/main/resources/application.properties
+++ b/messaging/artemis-jta/src/main/resources/application.properties
@@ -2,7 +2,7 @@ quarkus.artemis.url=tcp://amq-broker-tcp:61616
 quarkus.artemis.username=quarkus
 quarkus.artemis.password=quarkus
 
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.quarkus.artemis.url=tcp://localhost:61616

--- a/messaging/kafka-avro-reactive-messaging/src/test/resources/strimzi-application.properties
+++ b/messaging/kafka-avro-reactive-messaging/src/test/resources/strimzi-application.properties
@@ -1,3 +1,3 @@
 # Configuration file - Quarkus profile: Strimzi
 
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true


### PR DESCRIPTION
In order to avoid the following warning:
```
[WARNING] [io.quarkus.kubernetes.deployment.KubernetesConfigUtil] Usage of quarkus.openshift.expose is deprecated in favor of quarkus.openshift.route.expose
```

Replace all `quarkus.openshift.expose` by `quarkus.openshift.route.expose`

Doc Ref: https://quarkus.io/guides/deploying-to-openshift#exposing_routes