### PR TITLE
[2.2] quarkus.openshift.expose was deprecated

### DIFF
--- a/messaging/artemis-jta/src/main/resources/application.properties
+++ b/messaging/artemis-jta/src/main/resources/application.properties
@@ -2,7 +2,7 @@ quarkus.artemis.url=tcp://amq-broker-tcp:61616
 quarkus.artemis.username=quarkus
 quarkus.artemis.password=quarkus
 
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true
 quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
 
 %test.quarkus.artemis.url=tcp://localhost:61616

--- a/messaging/kafka-avro-reactive-messaging/src/test/resources/strimzi-application.properties
+++ b/messaging/kafka-avro-reactive-messaging/src/test/resources/strimzi-application.properties
@@ -21,4 +21,4 @@ mp.messaging.incoming.channel-stock-price.enable.auto.commit=true
 mp.messaging.incoming.channel-stock-price.value.deserializer=io.apicurio.registry.serde.avro.AvroKafkaDeserializer
 mp.messaging.incoming.channel-stock-price.apicurio.registry.avro-datum-provider=io.apicurio.registry.serde.avro.ReflectAvroDatumProvider
 
-quarkus.openshift.expose=true
+quarkus.openshift.route.expose=true


### PR DESCRIPTION
backport: #466 