### PR TITLE
Add gdb debugging sources scenario

### DIFF
--- a/docker-build/src/main/resources/application.properties
+++ b/docker-build/src/main/resources/application.properties
@@ -1,5 +1,9 @@
 quarkus.container-image.build=true
 quarkus.container-image.group=qe
-// DON'T remove the spaces that are at the end of quarkus app name
+# DON'T remove the spaces that are at the end of quarkus app name
 quarkus.application.name=hello-world-app      
 quarkus.container-image.tag=1.0.0
+
+# native debug configuration
+quarkus.native.debug.enabled=true
+quarkus.native.additional-build-args=-H:GenerateDebugInfo=1, -H:-SpawnIsolates, -H:DebugInfoSourceCacheRoot=test

--- a/docker-build/src/test/java/io/quarkus/ts/docker/NativeConfigurationIT.java
+++ b/docker-build/src/test/java/io/quarkus/ts/docker/NativeConfigurationIT.java
@@ -1,0 +1,25 @@
+package io.quarkus.ts.docker;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.EnabledOnNative;
+
+@QuarkusScenario
+@EnabledOnNative
+public class NativeConfigurationIT {
+
+    private static final String TARGET_NAME = "target";
+    private static final String NATIVE_APP_SOURCES_PARENT_FOLDER_NAME = "docker-build-1.0.0-SNAPSHOT-native-image-source-jar";
+    private static final String CUSTOM_SOURCE_FOLDER_NAME = "test";
+
+    @Test
+    public void verifyNativeSourceFolder() {
+        Path sourceFolder = Paths.get(TARGET_NAME, NATIVE_APP_SOURCES_PARENT_FOLDER_NAME, CUSTOM_SOURCE_FOLDER_NAME);
+        Assertions.assertTrue(sourceFolder.toFile().exists(), "sources folder must exist on debug mode");
+    }
+}


### PR DESCRIPTION
Native image generation scenario:

Verify that a cache is created alongside the generated native image in a subdirectory named `test`. Note that folder "test" was created with an additional argument `-H:DebugInfoSourceCacheRoot=test` supported by this commit: https://github.com/oracle/graal/commit/dee66ca6e28fd519cef061130d20e28ec35d1a1f 