### PR TITLE
Mutiny `collectItems` is not supported anymore

### DIFF
--- a/security/vertx-jwt/src/main/java/io/quarkus/ts/security/vertx/services/AbstractRedisDao.java
+++ b/security/vertx-jwt/src/main/java/io/quarkus/ts/security/vertx/services/AbstractRedisDao.java
@@ -45,7 +45,7 @@ public abstract class AbstractRedisDao<E extends Record> {
     public Uni<List<E>> get() {
         Multi<E> objects = getKeys().onItem().transformToUniAndMerge(
                 key -> redisClient.get(key).onItem().ifNotNull().transform(item -> Record.decodeJSON(item.toString(), type)));
-        return objects.collectItems().in(ArrayList::new, List::add);
+        return objects.collect().in(ArrayList::new, List::add);
     }
 
     public Uni<Boolean> delete(String... key) {


### PR DESCRIPTION
Related to: https://github.com/quarkusio/quarkus/commit/8243740c44f8bf8fc11c47c33bab8d679ed8f906
Doc Ref (Mutiny 1.3.0): https://github.com/smallrye/smallrye-mutiny/releases
Take a look to  "Breaking Changes" :

```
method MultiCollect<T> Multi<T>::collectItems() has been removed
```

Quarkus Doc issue: https://github.com/quarkusio/quarkus/issues/22843