### PR TITLE
[2.2] Docker file was restored for native runs and now uses supported base image

### DIFF
--- a/docker-build/src/main/docker/Dockerfile.native
+++ b/docker-build/src/main/docker/Dockerfile.native
@@ -1,0 +1,25 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode
+#
+# Before building the container image run:
+#
+# ./mvnw package -Pnative
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/getting-started .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/getting-started
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root target/*-runner /work/application
+EXPOSE 8080
+USER 1001
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]


### PR DESCRIPTION
Backport of https://github.com/quarkus-qe/quarkus-test-suite/pull/480