### PR TITLE
Adjustment for execution against registry.quarkus.redhat.com

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -54,6 +54,7 @@ public class QuarkusCliCreateJvmApplicationIT {
 
     @Tag("QUARKUS-1071")
     @Test
+    @DisabledOnQuarkusVersion(version = ".*redhat.*", reason = "Do not run on productized bits - https://issues.redhat.com/browse/QUARKUS-1740")
     public void shouldCreateApplicationWithGradleOnJvm() {
 
         // Create application

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -18,6 +18,7 @@ import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 /**
  * Note that the extensions list enhancements have been already reported as part
@@ -91,7 +92,11 @@ public class QuarkusCliExtensionsIT {
     public void shouldListExtensionsUsingStream() {
         String streamVersion = getCurrentStreamVersion();
         whenGetListExtensions("--stream", streamVersion);
-        assertTrue(result.getOutput().contains("io.quarkus.platform:quarkus-bom::pom:" + streamVersion));
+        if (QuarkusProperties.getVersion().contains("redhat")) {
+            assertTrue(result.getOutput().contains("com.redhat.quarkus.platform:quarkus-bom::pom:" + streamVersion));
+        } else {
+            assertTrue(result.getOutput().contains("io.quarkus.platform:quarkus-bom::pom:" + streamVersion));
+        }
     }
 
     @Test

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliVersionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliVersionIT.java
@@ -17,6 +17,7 @@ import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 @Tag("quarkus-cli")
 @QuarkusScenario
 @DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus CLI has been reworked in 2.x")
+@DisabledOnQuarkusVersion(version = ".*redhat.*", reason = "Do not run CLI version check on productized bits")
 @DisabledIfSystemProperty(named = "profile.id", matches = "native", disabledReason = "Only for JVM verification")
 public class QuarkusCliVersionIT {
 


### PR DESCRIPTION
Adjustment for execution against registry.quarkus.redhat.com

executed command: 
```
cd quarkus-cli 
mvn clean verify -Dit.test=QuarkusCli\* -Dquarkus.platform.group-id=com.redhat.quarkus.platform  -Dquarkus.platform.artifact-id=quarkus-bom -Dquarkus.platform.version=2.2.3.SP2-redhat-00001
```

confi.yaml
```
registries:
- registry.quarkus.redhat.com
- registry.quarkus.io
```
