### PR TITLE
[2.2] Use default Jaeger image specified in test-framework

### DIFF
--- a/http/vertx-web-client/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceIT.java
+++ b/http/vertx-web-client/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceIT.java
@@ -49,7 +49,7 @@ public class ChuckNorrisResourceIT {
 
     private Response resp;
 
-    @JaegerContainer(image = "jaegertracing/all-in-one:latest", tracePort = TRACE_PORT, restPort = REST_PORT, expectedLog = "\"Health Check state change\",\"status\":\"ready\"")
+    @JaegerContainer(tracePort = TRACE_PORT, restPort = REST_PORT, expectedLog = "\"Health Check state change\",\"status\":\"ready\"")
     static final JaegerService jaeger = new JaegerService();
 
     @Container(image = "${wiremock.image}", port = 8080, expectedLog = "verbose")


### PR DESCRIPTION
Update: Use default Jaeger image specified in test-framework

Was:
Currently during Quarkus 2.2.5 testing on IBM Z, the default Jaeger container image, `jaegertracing/all-in-one:1.21.0`, is not supported on both s390x/ppc64le. Proposing a change to use the latest Jaeger container which is supports all 3 architectures similar to this [line](https://github.com/quarkus-qe/quarkus-test-suite/blob/330118b66868495962b26e3d0118fb3c2b44d7fa/http/vertx-web-client/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceIT.java#L52) in another test. 