### PR TITLE
Disable fail-fast in Ecosystem CI

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'quarkusbot' || github.actor == 'Sgitario' || github.actor == 'rsvoboda'
     strategy:
+      fail-fast: false
       matrix:
         profiles: [ "root-modules,monitoring-modules,spring-modules,test-tooling-modules",
                     "http-modules",


### PR DESCRIPTION
So that the other tests are run to completion when one failed.

See https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/1804675252 for a good example of why we don't want this option enabled.