### PR TITLE
Disable kafka-streams and kafka-strimzi scenarios and qute/multimodule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -422,9 +422,10 @@
                 <module>messaging/artemis-jta</module>
                 <module>messaging/amqp-reactive</module>
                 <module>messaging/qpid</module>
-                <module>messaging/kafka-streams-reactive-messaging</module>
+                <!-- https://github.com/quarkus-qe/quarkus-test-framework/issues/400 -->
+                <!-- <module>messaging/kafka-streams-reactive-messaging</module> -->
                 <module>messaging/kafka-confluent-avro-reactive-messaging</module>
-                <module>messaging/kafka-strimzi-avro-reactive-messaging</module>
+                <!-- <module>messaging/kafka-strimzi-avro-reactive-messaging</module> -->
                 <module>messaging/kafka-producer</module>
                 <module>messaging/infinispan-grpc-kafka</module>
             </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -356,7 +356,8 @@
                 <module>kamelet</module>
                 <module>logging/jboss</module>
                 <module>cache/caffeine</module>
-                <module>qute/multimodule</module>
+                <!-- TODO needs to be updated to reflect https://issues.redhat.com/browse/QUARKUS-1695 discussion and attached PR -->
+                <!-- <module>qute/multimodule</module> -->
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
Disable kafka-streams and kafka-strimzi scenarios and qute/multimodule scenarios, we need green ci to spot other issues without need for daily checks of the logs

They are not working after move to strimzi-test-container 0.100.0 in Quarkus main

https://github.com/quarkus-qe/quarkus-test-framework/issues/400

qute/multimodule is related to https://issues.redhat.com/browse/QUARKUS-1695 (@fedinskiy please make sure this get re-enabled in few days)