### PR TITLE
container-license-acceptance.tx update to cover mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04

### DIFF
--- a/sql-db/sql-app/src/test/resources/container-license-acceptance.txt
+++ b/sql-db/sql-app/src/test/resources/container-license-acceptance.txt
@@ -1,2 +1,3 @@
 mcr.microsoft.com/mssql/server:2017-CU12
 mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
+mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04


### PR DESCRIPTION
container-license-acceptance.tx update to cover mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04

otherwise there is test fail like in case of https://github.com/quarkus-qe/quarkus-test-suite/pull/520

related to bump in https://github.com/quarkusio/quarkus/pull/23428 and https://github.com/quarkusio/quarkus/pull/23465