### PR TITLE
Upgrade Quarkus framework QE to 1.0.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.2.5.Final</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
-        <quarkus.qe.framework.version>1.0.4.Final</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.0.5.Final</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.27.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.2.5.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>


### PR DESCRIPTION
Upgrade Quarkus test framework to 1.0.5.Final. 

This upgrade will fix an issue that we have with external applications. When an application uses a quarkus maven plugin with a different version than quarkus platform, the scenario fails because of an issue with the test framework. 
