### PR TITLE
Replace Vertx HttpClient by restAssurance in PostgresPoolTest scenario

### DIFF
--- a/sql-db/vertx-sql/pom.xml
+++ b/sql-db/vertx-sql/pom.xml
@@ -73,8 +73,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sql-db/vertx-sql/src/main/resources/application.properties
+++ b/sql-db/vertx-sql/src/main/resources/application.properties
@@ -4,7 +4,6 @@ app.selected.db=postgresql
 
 # Quarkus
 quarkus.http.port=8082
-quarkus.http.test.port=8081
 
 ## Postgresql
 ## Database


### PR DESCRIPTION
Vertx-sql module is failing with FIPS enabled. The issue is related to the test itself, looks that Mutiny HTTPClient fails with a default configuration. 

Replace Vertx HttpClient by RestAssurance