### PR TITLE
[2.2] Replace Vertx HttpClient by restAssurance in PostgresPoolTest scenario

### DIFF
--- a/sql-db/vertx-sql/pom.xml
+++ b/sql-db/vertx-sql/pom.xml
@@ -65,8 +65,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sql-db/vertx-sql/src/main/resources/application.properties
+++ b/sql-db/vertx-sql/src/main/resources/application.properties
@@ -4,7 +4,6 @@ app.selected.db=postgresql
 
 # Quarkus
 quarkus.http.port=8082
-quarkus.http.test.port=8081
 
 ## Postgresql
 ## Database


### PR DESCRIPTION
backport: #533