### PR TITLE
Bump DB2 image from 11.5.5.0 to 11.5.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
                                 <mariadb.102.image>registry.access.redhat.com/rhscl/mariadb-102-rhel7</mariadb.102.image>
                                 <mssql.image>mcr.microsoft.com/mssql/rhel/server:2019-latest</mssql.image>
                                 <oracle.image>gvenzl/oracle-xe:21-slim</oracle.image>
-                                <db2.image>quay.io/quarkusqeteam/db2:11.5.5.0</db2.image>
+                                <db2.image>quay.io/quarkusqeteam/db2:11.5.7.0</db2.image>
                                 <mongodb.image>quay.io/bitnami/mongodb:5.0</mongodb.image>
                                 <redis.image>quay.io/bitnami/redis:6.0</redis.image>
                                 <wiremock.image>quay.io/ocpmetal/wiremock</wiremock.image>


### PR DESCRIPTION
New version fixes log4j vulnerability.