### PR TITLE
FIPS workaround rollback

### DIFF
--- a/http/vertx-web-client/src/test/java/io/quarkus/qe/vertx/webclient/PureVertxHttpClientTest.java
+++ b/http/vertx-web-client/src/test/java/io/quarkus/qe/vertx/webclient/PureVertxHttpClientTest.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.http.TestHTTPResource;
@@ -18,8 +18,7 @@ import io.vertx.mutiny.ext.web.client.WebClient;
 import io.vertx.mutiny.ext.web.client.predicate.ResponsePredicate;
 
 @QuarkusTest
-//TODO: https://github.com/quarkusio/quarkus/issues/23865
-@Disabled
+@Tag("fips-incompatible") // Reported in https://github.com/quarkusio/quarkus/issues/23865
 public class PureVertxHttpClientTest {
 
     @TestHTTPResource

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/reactive/DB2DatabaseIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/reactive/DB2DatabaseIT.java
@@ -8,8 +8,6 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-// Reported in https://github.com/IBM/Db2/issues/43
-@Tag("fips-incompatible")
 @QuarkusScenario
 @Tag("fips-incompatible") // Reported in https://github.com/IBM/Db2/issues/43
 public class DB2DatabaseIT extends AbstractReactiveDatabaseIT {


### PR DESCRIPTION
As a result of a retrospective meeting, we conclude that all scenarios must be enabled (related to FIPS). So from now, we will not exclude any FIPS scenario by flags exclusions. 

Example,

```
mvn -B -V -Dopenshift -Dall-modules -DexcludedGroups=fips-incompatible
```

Remove `excludeGroups` property is done in other PR, related to CI jobs. 

Note: I decided to leave the tag `@Tag("fips-incompatible")` from now until be sure that all of these scenarios are fixed. This tag doesn't have any impact, is just for tracing proposes. 