### PR TITLE
Bump to Quarkus 2.7.3.Final

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build with Maven
         run: |
-          mvn -fae -V -B -s .github/mvn-settings.xml verify -Dall-modules -Dvalidate-format -DskipTests -DskipITs
+          mvn -V -B -s .github/mvn-settings.xml verify -Dall-modules -Dvalidate-format -DskipTests -DskipITs
   detect-test-suite-modules:
     name: Detect Modules in PR
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           check-latest: true
       - name: Build Quarkus 2.7
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && git checkout 2.7 && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Prelocations
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && git checkout 2.7 && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Prelocations -pl devtools/cli -am
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository

--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -39,7 +39,7 @@
                 </property>
             </activation>
             <properties>
-                <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+                <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
             </properties>
             <repositories>
                 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -356,7 +356,7 @@
                 <module>kamelet</module>
                 <module>logging/jboss</module>
                 <module>cache/caffeine</module>
-                <module>qute/multimodule</module>
+                <!--                <module>qute/multimodule</module> -->
             </modules>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <failsafe-plugin.version>2.22.2</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <quarkus.qe.framework.version>1.1.0.Beta.1</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.32.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.6.1.Final</quarkus-ide-config.version>


### PR DESCRIPTION
 - Bump to Quarkus 2.7.3.Final
 - Build just deps for CLI
 - Fast fail for format issues
 - Qute module drop for now
