### PR TITLE
Testcontainer dependency was left over in infinispan-grpc-kafka module

### DIFF
--- a/messaging/infinispan-grpc-kafka/pom.xml
+++ b/messaging/infinispan-grpc-kafka/pom.xml
@@ -49,12 +49,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.strimzi</groupId>
-            <artifactId>strimzi-test-container</artifactId>
-            <version>0.25.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-infinispan</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
artifactId: `strimzi-test-container` is not directly used on this scenario
Instead we are using Quarkus test framework annotations:
```
@KafkaContainer(vendor = KafkaVendor.STRIMZI, protocol = KafkaProtocol.SASL)
    static final KafkaService kafkasasl = new KafkaService();
```