### PR TITLE
Disable Consul Openshift scenario OpenShiftConsulConfigSourceIT

### DIFF
--- a/properties/src/test/java/io/quarkus/qe/properties/consul/OpenShiftConsulConfigSourceIT.java
+++ b/properties/src/test/java/io/quarkus/qe/properties/consul/OpenShiftConsulConfigSourceIT.java
@@ -1,7 +1,11 @@
 package io.quarkus.qe.properties.consul;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
+@Disabled
+//TODO https://github.com/quarkusio/quarkus/issues/24277
 public class OpenShiftConsulConfigSourceIT extends ConsulConfigSourceIT {
 }


### PR DESCRIPTION
Consul scenario is failing in openshift because of a reported issue that is not merged into Quarkus 2.7.x