### PR TITLE
Add RequireThis rule if there is overlapping on java checkstyle

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -7,5 +7,8 @@
         <!-- See https://checkstyle.org/config_imports.html -->
         <module name="AvoidStarImport"/>
         <module name="RedundantImport"/>
+        <module name="RequireThis">
+            <property name="validateOnlyOverlapping" value="true"/>
+        </module>
     </module>
 </module>


### PR DESCRIPTION
### Summary

Currently, there is no java style rule that verifies `this.` overlapping

For example:

```
public class Test {
    private int a;
    private int b;
    private int c;
  
    public Test(int a) {
    this.a = a; //make sense
    a = a; //Technically will compile, but doesn't make sense because there is an overlapping between property `this.a` and local variable `a`
  }
}
```

This PR creates a rule that validates these cases.

### Checklist:
- [X] Commits are well encapsulated and follow [team agreetments](https://gitlab.cee.redhat.com/quarkus-qe/signpost/-/blob/main/pull-requests.md)