### PR TITLE
Bump Keycloak version to 16.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
                                 <ts.global.s2i.quarkus.jvm.builder.image>${ts.global.s2i.quarkus.jvm.builder.image}</ts.global.s2i.quarkus.jvm.builder.image>
                                 <ts.global.s2i.quarkus.native.builder.image>${ts.global.s2i.quarkus.native.builder.image}</ts.global.s2i.quarkus.native.builder.image>
                                 <!-- Services used in test suite -->
-                                <keycloak.image>quay.io/keycloak/keycloak:15.0.1</keycloak.image>
+                                <keycloak.image>quay.io/keycloak/keycloak:16.1.0</keycloak.image>
                                 <rhsso.73.image>registry.access.redhat.com/redhat-sso-7/sso73-openshift</rhsso.73.image>
                                 <postgresql.13.image>quay.io/bitnami/postgresql:13.5.0</postgresql.13.image>
                                 <elastic.71.image>quay.io/bitnami/elasticsearch:7.10.2</elastic.71.image>


### PR DESCRIPTION
### Summary

Quarkus 2.7.x has moved to [Keycloak 16.1.0](https://github.com/quarkusio/quarkus/blob/2733bae7cb7ded76d324b41a3a9f4e81b89ee122/bom/application/pom.xml#L186) as a default supported Keykloak.

This PR bump keycloak version according to these changes. 
Upgrade Keycloak container: 15.0.1 -> 16.1.0

Please select the relevant options.
- [X] Dependency update

### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)