### PR TITLE
Add FIPS/keycloak workaround

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HttpAdvancedReactiveIT.java
@@ -55,8 +55,10 @@ public class HttpAdvancedReactiveIT {
     private static final int KEYCLOAK_PORT = 8080;
     private static final int ASSERT_TIMEOUT_SECONDS = 10;
 
+    //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @Container(image = "${keycloak.image}", expectedLog = "Admin console listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
+            .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication(ssl = true)
     static RestService app = new RestService().withProperty("quarkus.oidc.auth-server-url",

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
@@ -55,8 +55,10 @@ public class HttpAdvancedIT {
     private static final int KEYCLOAK_PORT = 8080;
     private static final int ASSERT_TIMEOUT_SECONDS = 10;
 
+    //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @Container(image = "${keycloak.image}", expectedLog = "Admin console listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
+            .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication(ssl = true)
     static RestService app = new RestService().withProperty("quarkus.oidc.auth-server-url",

--- a/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/BaseMicrometerOidcSecurityIT.java
+++ b/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/BaseMicrometerOidcSecurityIT.java
@@ -29,8 +29,10 @@ public abstract class BaseMicrometerOidcSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
+    //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
+            .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     private AuthzClient authzClient;
 

--- a/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/KeycloakAuthzSecurityIT.java
+++ b/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/KeycloakAuthzSecurityIT.java
@@ -11,8 +11,10 @@ public class KeycloakAuthzSecurityIT extends BaseAuthzSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
+    //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
+            .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/KeycloakAuthzSecurityIT.java
+++ b/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/KeycloakAuthzSecurityIT.java
@@ -11,8 +11,10 @@ public class KeycloakAuthzSecurityIT extends BaseAuthzSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
+    //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
+            .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/KeycloakOidcJwtSecurityIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/KeycloakOidcJwtSecurityIT.java
@@ -10,8 +10,10 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakOidcJwtSecurityIT extends BaseOidcJwtSecurityIT {
     static final int KEYCLOAK_PORT = 8080;
 
+    //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
+            .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/KeycloakMultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/KeycloakMultiTenantSecurityIT.java
@@ -10,8 +10,10 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakMultiTenantSecurityIT extends BaseMultiTenantSecurityIT {
     static final int KEYCLOAK_PORT = 8080;
 
+    //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
+            .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/KeycloakOauth2SecurityIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/KeycloakOauth2SecurityIT.java
@@ -11,8 +11,10 @@ public class KeycloakOauth2SecurityIT extends BaseOauth2SecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
+    //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
+            .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/KeycloakOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/KeycloakOidcClientSecurityIT.java
@@ -10,8 +10,10 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakOidcClientSecurityIT extends BaseOidcClientSecurityIT {
     static final int KEYCLOAK_PORT = 8080;
 
+    //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
+            .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseIT.java
@@ -16,8 +16,10 @@ public abstract class BaseIT {
     static final String CLIENT_ID_DEFAULT = "test-application-client";
     static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
 
+    //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
+            .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/KeycloakWebappSecurityIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/KeycloakWebappSecurityIT.java
@@ -10,8 +10,10 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakWebappSecurityIT extends BaseWebappSecurityIT {
     static final int KEYCLOAK_PORT = 8080;
 
+    //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
+            .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/KeycloakOidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/KeycloakOidcSecurityIT.java
@@ -11,8 +11,10 @@ public class KeycloakOidcSecurityIT extends BaseOidcSecurityIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
+    //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
+            .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication
     static RestService app = new RestService()


### PR DESCRIPTION
### Summary

Keycloak docker container 16.1.x is not working over FIPS protocol. This issue is already [reported ](https://github.com/keycloak/keycloak/issues/9916).

This PR apply a suggested patch on the above PR in order to make Keycloak "work" over FIPS

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)