### PR TITLE
Disable quarkus plugin during prod run also

### DIFF
--- a/external-applications/pom.xml
+++ b/external-applications/pom.xml
@@ -21,7 +21,7 @@
         <plugins>
             <!-- Skip Quarkus Maven plugin build on JVM and Native since we're going to deploy external apps -->
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
Module "external apps" was failing during production tests, since they use maven plugin with `com.redhat.quarkus.platform` group and it was not disabled before this change.

### Summary
- [x] Bug fix (non-breaking change which fixes an issue) 
### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)