### PR TITLE
Disable Vertx PostgresPoolTest QuarkusTest scenario over Openshift

### DIFF
--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/di/SpringDiTest.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/di/SpringDiTest.java
@@ -19,7 +19,7 @@ import io.quarkus.test.junit.QuarkusTest;
 // Not converted into @QuarkusScenario, because invoking javax.enterprise.inject.spi.CDI / io.quarkus.arc.Arc is not supported.
 // TODO: Workaround by implementing REST endpoints which expose all necessary information.
 @QuarkusTest
-public class SpringDiIT {
+public class SpringDiTest {
 
     private static Stream<Class<?>> beanClassProvider() {
         return Stream.of(

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/dbpool/PostgresPoolTest.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/dbpool/PostgresPoolTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
@@ -29,6 +30,7 @@ import io.vertx.mutiny.sqlclient.RowSet;
 @QuarkusTest
 @TestProfile(PostgresqlTestProfile.class)
 @TestMethodOrder(OrderAnnotation.class)
+@DisabledIfSystemProperty(named = "openshift", matches = "true", disabledReason = "Only for JVM verification")
 public class PostgresPoolTest {
 
     private static final int EVENTS = 25000;


### PR DESCRIPTION
### Summary

PostgresPoolTest is a baremetal test and should be excluded from Openshift runs.

Also QuarkusTest SpringDiIT was renamed to SpringDiTest 

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)