### PR TITLE
Add a missing RegisterForReflexion annotation on a java pojo

### DIFF
--- a/config/src/main/java/io/quarkus/ts/configmap/api/server/Hello.java
+++ b/config/src/main/java/io/quarkus/ts/configmap/api/server/Hello.java
@@ -1,5 +1,8 @@
 package io.quarkus.ts.configmap.api.server;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public class Hello {
     private final String content;
 


### PR DESCRIPTION
### Summary

OCP native runs are failing because we are missing a required `@RegisterForReflection`

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)