### PR TITLE
Upgrade Quarkus test framework to 1.1.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
-        <quarkus.qe.framework.version>1.1.0.Beta2</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.1.0.Beta3</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.32.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.6.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>


### PR DESCRIPTION
### Summary

Quarkus test framework upgrade: 1.1.0.Beta2 -> 1.1.0.Beta3

Please select the relevant options.

- [X] Dependency update

### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)