### PR TITLE
Fix "unexpected end of stream" error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,16 +453,16 @@ This might not be recommended for production, but is good enough for test.
 Container images used in the tests are:
 
 - PostgreSQL:
-  - version 13: `quay.io/bitnami/postgresql:13.4.0`
-  - version 12: `registry.redhat.io/rhscl/postgresql-12-rhel7` (only if `ts.redhat.registry.enabled` is set)
+  - version 13: `postgres:13.6`
+  - version 10: `registry.redhat.io/rhscl/postgresql-10-rhel7` (only if `ts.redhat.registry.enabled` is set)
 - MySQL:
-  - version 5.7: `quay.io/bitnami/mysql:5.7.32`
+  - version 5.7: `mysql:5.7`
   - version 8.0: `registry.access.redhat.com/rhscl/mysql-80-rhel7`
 - MariaDB:
-  - version 10.6: `quay.io/quarkusqeteam/mariadb:10.6.4`
+  - version 10.6: `mariadb:10.6`
 - MSSQL: `mcr.microsoft.com/mssql/rhel/server`
 - Oracle
-  - version 18c XE: `gvenzl/oracle-xe:18.4.0-slim`
+  - version 21 XE: `gvenzl/oracle-xe:21-slim`
 
 ### `sql-db/sql-app-oracle`
 Functionally identical to `sql-db/sql-app`, but using only `quarkus-jdbc-oracle` driver. This is a workaround for the missing native Oracle coverage in `sql-db/sql-app`.

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
@@ -45,7 +45,11 @@ public class OpenShiftWorkshopHeroesIT {
     private static final int POSTGRESQL_PORT = 5432;
 
     @Container(image = "${postgresql.13.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static PostgresqlService database = new PostgresqlService();
+    static PostgresqlService database = new PostgresqlService()
+            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
+            .withProperty("POSTGRES_USER", "user")
+            .withProperty("POSTGRES_PASSWORD", "user")
+            .withProperty("POSTGRES_DB", "mydb");
 
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-workshops.git", branch = "5bb433fb7a2c8d80dda88dac9dcabc50f7494dc3", contextDir = "quarkus-workshop-super-heroes/super-heroes/rest-heroes", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_VERSION}")
     static final RestService app = new RestService()

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopVillainsIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopVillainsIT.java
@@ -46,7 +46,11 @@ public class OpenShiftWorkshopVillainsIT {
     private static final int POSTGRESQL_PORT = 5432;
 
     @Container(image = "${postgresql.13.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static PostgresqlService database = new PostgresqlService();
+    static PostgresqlService database = new PostgresqlService()
+            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
+            .withProperty("POSTGRES_USER", "user")
+            .withProperty("POSTGRES_PASSWORD", "user")
+            .withProperty("POSTGRES_DB", "mydb");
 
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-workshops.git", contextDir = "quarkus-workshop-super-heroes/super-heroes/rest-villains", branch = "3d3425a15daacf1c774cb7f5bc24228c4a623256", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_VERSION}")
     static final RestService app = new RestService()

--- a/pom.xml
+++ b/pom.xml
@@ -201,20 +201,22 @@
                                 <!-- Services used in test suite -->
                                 <keycloak.image>quay.io/keycloak/keycloak:16.1.0</keycloak.image>
                                 <rhsso.73.image>registry.access.redhat.com/redhat-sso-7/sso73-openshift</rhsso.73.image>
-                                <postgresql.13.image>quay.io/bitnami/postgresql:13.5.0</postgresql.13.image>
-                                <elastic.71.image>quay.io/bitnami/elasticsearch:7.10.2</elastic.71.image>
-                                <mysql.57.image>quay.io/bitnami/mysql:5.7.32</mysql.57.image>
-                                <mysql.bitnami.80.image>quay.io/bitnami/mysql:8.0</mysql.bitnami.80.image>
+                                <postgresql.13.image>postgres:13.6</postgresql.13.image>
+                                <elastic.71.image>elasticsearch:7.17.2</elastic.71.image>
+                                <!--TODO change into 5.7 when this fixed https://github.com/docker-library/mysql/issues/844 -->
+                                <mysql.57.image>mysql:5.7.36</mysql.57.image>
+                                <!-- TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/609 -->
+                                <mysql.upstream.80.image>mysql:8.0</mysql.upstream.80.image>
                                 <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7</mysql.80.image>
                                 <mariadb.10.image>mariadb:10.6</mariadb.10.image>
                                 <mariadb.102.image>registry.access.redhat.com/rhscl/mariadb-102-rhel7</mariadb.102.image>
                                 <mssql.image>mcr.microsoft.com/mssql/rhel/server:2019-latest</mssql.image>
                                 <oracle.image>gvenzl/oracle-xe:21-slim</oracle.image>
                                 <db2.image>quay.io/quarkusqeteam/db2:11.5.7.0</db2.image>
-                                <mongodb.image>quay.io/bitnami/mongodb:5.0</mongodb.image>
-                                <redis.image>quay.io/bitnami/redis:6.0</redis.image>
+                                <mongodb.image>mongo:5.0</mongodb.image>
+                                <redis.image>redis:6.0</redis.image>
                                 <wiremock.image>quay.io/ocpmetal/wiremock</wiremock.image>
-                                <consul.image>quay.io/bitnami/consul:1.11.2</consul.image>
+                                <consul.image>consul:1.11</consul.image>
                                 <infinispan.image>quay.io/infinispan/server:12.1</infinispan.image>
                                 <infinispan.expected-log>Infinispan Server.*started in</infinispan.expected-log>
                                 <spring.cloud.server.image>quay.io/quarkusqeteam/spring-cloud-config-server:3.0</spring.cloud.server.image>

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/AbstractDbIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/AbstractDbIT.java
@@ -9,7 +9,11 @@ public class AbstractDbIT {
     static final int POSTGRESQL_PORT = 5432;
 
     @Container(image = "${postgresql.13.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static final PostgresqlService database = new PostgresqlService();
+    static final PostgresqlService database = new PostgresqlService()
+            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
+            .withProperty("POSTGRES_USER", "user")
+            .withProperty("POSTGRES_PASSWORD", "user")
+            .withProperty("POSTGRES_DB", "mydb");
 
     @QuarkusApplication
     public static final RestService app = new RestService()

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/MariaDBUtils.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/MariaDBUtils.java
@@ -1,0 +1,6 @@
+package io.quarkus.ts.spring.web;
+
+public class MariaDBUtils {
+    public static final int PORT = 3306;
+    public static final String START_LOG = "socket: '/run/mysqld/mysqld.sock'  port: " + PORT;
+}

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/boostrap/BookResourceIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/boostrap/BookResourceIT.java
@@ -17,6 +17,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.spring.web.AbstractDbIT;
+import io.quarkus.ts.spring.web.MariaDBUtils;
 import io.quarkus.ts.spring.web.boostrap.persistence.model.Book;
 import io.restassured.response.Response;
 
@@ -25,9 +26,7 @@ public class BookResourceIT extends AbstractDbIT {
 
     private static final String API_ROOT = "/api/books";
 
-    static final int MARIADB_PORT = 3306;
-
-    @Container(image = "${mariadb.10.image}", port = MARIADB_PORT, expectedLog = "ready for connections")
+    @Container(image = "${mariadb.10.image}", port = MariaDBUtils.PORT, expectedLog = MariaDBUtils.START_LOG)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication
@@ -111,7 +110,6 @@ public class BookResourceIT extends AbstractDbIT {
         assertEquals(HttpStatus.OK.value(), response.getStatusCode());
         assertEquals("newAuthor", response.jsonPath()
                 .get("author"));
-
     }
 
     @Test

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/boostrap/HomePageIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/boostrap/HomePageIT.java
@@ -6,13 +6,12 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.spring.web.AbstractDbIT;
+import io.quarkus.ts.spring.web.MariaDBUtils;
 
 @QuarkusScenario
 public class HomePageIT extends AbstractDbIT {
 
-    static final int MARIADB_PORT = 3306;
-
-    @Container(image = "${mariadb.10.image}", port = MARIADB_PORT, expectedLog = "ready for connections")
+    @Container(image = "${mariadb.10.image}", port = MariaDBUtils.PORT, expectedLog = MariaDBUtils.START_LOG)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/openapi/OpenApiIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/openapi/OpenApiIT.java
@@ -19,6 +19,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.spring.web.AbstractDbIT;
+import io.quarkus.ts.spring.web.MariaDBUtils;
 import io.restassured.response.Response;
 
 @QuarkusScenario
@@ -26,9 +27,7 @@ import io.restassured.response.Response;
 public class OpenApiIT extends AbstractDbIT {
     private static Response response;
 
-    static final int MARIADB_PORT = 3306;
-
-    @Container(image = "${mariadb.10.image}", port = MARIADB_PORT, expectedLog = "ready for connections")
+    @Container(image = "${mariadb.10.image}", port = MariaDBUtils.PORT, expectedLog = MariaDBUtils.START_LOG)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/qe/hibernate/search/MysqlMultitenantHibernateIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/qe/hibernate/search/MysqlMultitenantHibernateIT.java
@@ -12,13 +12,13 @@ public class MysqlMultitenantHibernateIT extends AbstractMultitenantIT {
     static final int ELASTIC_PORT = 9200;
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.bitnami.80.image}", port = MYSQL_PORT, expectedLog = "ready for connections")
+    @Container(image = "${mysql.upstream.80.image}", port = MYSQL_PORT, expectedLog = "ready for connections")
     static MySqlService base = new MySqlService().withDatabase("base");
 
-    @Container(image = "${mysql.bitnami.80.image}", port = MYSQL_PORT, expectedLog = "ready for connections")
+    @Container(image = "${mysql.upstream.80.image}", port = MYSQL_PORT, expectedLog = "ready for connections")
     static MySqlService company1 = new MySqlService().withDatabase("company1");
 
-    @Container(image = "${mysql.bitnami.80.image}", port = MYSQL_PORT, expectedLog = "ready for connections")
+    @Container(image = "${mysql.upstream.80.image}", port = MYSQL_PORT, expectedLog = "ready for connections")
     static MySqlService company2 = new MySqlService().withDatabase("company2");;
 
     @Container(image = "${elastic.71.image}", port = ELASTIC_PORT, expectedLog = "started")

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/qe/hibernate/search/PostgresqlMultitenantHibernateIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/qe/hibernate/search/PostgresqlMultitenantHibernateIT.java
@@ -17,7 +17,11 @@ public class PostgresqlMultitenantHibernateIT extends AbstractMultitenantIT {
     static DefaultService elastic = new DefaultService().withProperty("discovery.type", "single-node");
 
     @Container(image = "${postgresql.13.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static PostgresqlService database = new PostgresqlService();
+    static PostgresqlService database = new PostgresqlService()
+            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
+            .withProperty("POSTGRES_USER", "user")
+            .withProperty("POSTGRES_PASSWORD", "user")
+            .withProperty("POSTGRES_DB", "mydb");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/reactive/PostgresqlDatabaseIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/reactive/PostgresqlDatabaseIT.java
@@ -16,6 +16,10 @@ public class PostgresqlDatabaseIT extends AbstractReactiveDatabaseIT {
 
     @Container(image = "${postgresql.13.image}", port = POSTGRES_PORT, expectedLog = "listening on IPv4 address")
     static PostgresqlService database = new PostgresqlService()
+            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
+            .withProperty("POSTGRES_USER", POSTGRES_USER)
+            .withProperty("POSTGRES_PASSWORD", POSTGRES_PASSWORD)
+            .withProperty("POSTGRES_DB", POSTGRES_DATABASE)
             .withUser(POSTGRES_USER)
             .withPassword(POSTGRES_PASSWORD)
             .withDatabase(POSTGRES_DATABASE);

--- a/sql-db/hibernate/src/test/java/io/quarkus/qe/hibernate/ProdHibernateIT.java
+++ b/sql-db/hibernate/src/test/java/io/quarkus/qe/hibernate/ProdHibernateIT.java
@@ -12,7 +12,11 @@ public class ProdHibernateIT extends BaseHibernateIT {
     static final int POSTGRESQL_PORT = 5432;
 
     @Container(image = "${postgresql.13.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static final PostgresqlService database = new PostgresqlService();
+    static final PostgresqlService database = new PostgresqlService()
+            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
+            .withProperty("POSTGRES_USER", "user")
+            .withProperty("POSTGRES_PASSWORD", "user")
+            .withProperty("POSTGRES_DB", "mydb");
 
     @QuarkusApplication
     public static final RestService app = new RestService()

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiplePersistenceIT.java
@@ -18,7 +18,11 @@ public class MultiplePersistenceIT extends AbstractMultiplePersistenceIT {
     static MariaDbService mariadb = new MariaDbService();
 
     @Container(image = "${postgresql.13.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static PostgresqlService postgresql = new PostgresqlService();
+    static PostgresqlService postgresql = new PostgresqlService()
+            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
+            .withProperty("POSTGRES_USER", "user")
+            .withProperty("POSTGRES_PASSWORD", "user")
+            .withProperty("POSTGRES_DB", "mydb");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiplePersistenceIT.java
@@ -12,8 +12,9 @@ public class MultiplePersistenceIT extends AbstractMultiplePersistenceIT {
 
     static final int MARIADB_PORT = 3306;
     static final int POSTGRESQL_PORT = 5432;
+    private static final String MARIADB_START_LOG = "socket: '/run/mysqld/mysqld.sock'  port: " + MARIADB_PORT;
 
-    @Container(image = "${mariadb.10.image}", port = MARIADB_PORT, expectedLog = "ready for connections")
+    @Container(image = "${mariadb.10.image}", port = MARIADB_PORT, expectedLog = MARIADB_START_LOG)
     static MariaDbService mariadb = new MariaDbService();
 
     @Container(image = "${postgresql.13.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
@@ -18,7 +18,11 @@ public class OpenShiftMultiplePersistenceIT extends AbstractMultiplePersistenceI
     static MariaDbService mariadb = new MariaDbService();
 
     @Container(image = "${postgresql.13.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static PostgresqlService postgresql = new PostgresqlService();
+    static PostgresqlService postgresql = new PostgresqlService()
+            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
+            .withProperty("POSTGRES_USER", "user")
+            .withProperty("POSTGRES_PASSWORD", "user")
+            .withProperty("POSTGRES_DB", "mydb");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MySqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MySqlDatabaseIT.java
@@ -11,7 +11,7 @@ public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {
 
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.57.image}", port = MYSQL_PORT, expectedLog = "ready for connections")
+    @Container(image = "${mysql.57.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresql13DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresql13DatabaseIT.java
@@ -15,7 +15,11 @@ public class OpenShiftPostgresql13DatabaseIT extends AbstractSqlDatabaseIT {
     static final int POSTGRESQL_PORT = 5432;
 
     @Container(image = "${postgresql.13.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static PostgresqlService database = new PostgresqlService();
+    static PostgresqlService database = new PostgresqlService()
+            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
+            .withProperty("POSTGRES_USER", "user")
+            .withProperty("POSTGRES_PASSWORD", "user")
+            .withProperty("POSTGRES_DB", "mydb");
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("postgresql.properties")

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/Postgresql13DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/Postgresql13DatabaseIT.java
@@ -12,7 +12,11 @@ public class Postgresql13DatabaseIT extends AbstractSqlDatabaseIT {
     static final int POSTGRESQL_PORT = 5432;
 
     @Container(image = "${postgresql.13.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static PostgresqlService database = new PostgresqlService();
+    static PostgresqlService database = new PostgresqlService()
+            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
+            .withProperty("POSTGRES_USER", "user")
+            .withProperty("POSTGRES_PASSWORD", "user")
+            .withProperty("POSTGRES_DB", "mydb");
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("postgresql.properties")

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/dbpool/PostgresqlResource.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/dbpool/PostgresqlResource.java
@@ -15,7 +15,7 @@ public class PostgresqlResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        postgresContainer = new GenericContainer<>(DockerImageName.parse("quay.io/bitnami/postgresql:13.4.0"))
+        postgresContainer = new GenericContainer<>(DockerImageName.parse("postgres:13.6"))
                 .withEnv("POSTGRES_USER", "test")
                 .withEnv("POSTGRES_PASSWORD", "test")
                 .withEnv("POSTGRES_DB", "amadeus")

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/PostgresqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/PostgresqlHandlerIT.java
@@ -12,7 +12,10 @@ public class PostgresqlHandlerIT extends CommonTestCases {
 
     @Container(image = "${postgresql.13.image}", port = 5432, expectedLog = "listening on IPv4 address")
     static PostgresqlService postgres = new PostgresqlService()
-            .with("test", "test", POSTGRESQL_DATABASE);
+            .with("test", "test", POSTGRESQL_DATABASE)
+            .withProperty("POSTGRES_USER", "test") //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
+            .withProperty("POSTGRES_PASSWORD", "test")
+            .withProperty("POSTGRES_DB", POSTGRESQL_DATABASE);;
 
     @QuarkusApplication
     static final RestService app = new RestService()

--- a/sql-db/vertx-sql/src/test/resources/docker-compose.yaml
+++ b/sql-db/vertx-sql/src/test/resources/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       POSTGRES_DB: amadeus
 
   mysql:
-    image: quay.io/bitnami/mysql:5.7.32
+    image: mysql:5.7
     hostname: mysql
     container_name: mysql
     ports:


### PR DESCRIPTION
We check that MariaDB container started, by looking into log and waiting
for special lines. Before that change, we were looking for a line "ready for connections",
which was duplicated and its first appearance was right before a reload
of the container, so in some cases we were trying to connect to
non-working DBMS. Now we use a unique line.

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please select the relevant options.
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)