### PR TITLE
Enable and fix rest-client-reactive multipart test

### DIFF
--- a/http/jaxrs-reactive/src/main/java/io/quarkus/ts/jaxrs/reactive/client/PojoData.java
+++ b/http/jaxrs-reactive/src/main/java/io/quarkus/ts/jaxrs/reactive/client/PojoData.java
@@ -1,5 +1,8 @@
 package io.quarkus.ts.jaxrs.reactive.client;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public class PojoData {
     public String foo;
     public Integer bar;

--- a/http/jaxrs-reactive/src/test/java/io/quarkus/ts/jaxrs/reactive/client/MultipartClientResourceIT.java
+++ b/http/jaxrs-reactive/src/test/java/io/quarkus/ts/jaxrs/reactive/client/MultipartClientResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.ts.jaxrs.reactive.client;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -18,8 +18,8 @@ public class MultipartClientResourceIT {
                 .when().post("/client/multipart")
                 .then()
                 .statusCode(200)
-                .body(containsString("Content-Disposition: form-data; name=\"data\""),
-                        containsString("Content-Type: application/json"),
-                        containsString("{\"foo\":\"test1\",\"bar\":1}"));
+                .body(containsStringIgnoringCase("Content-Disposition: form-data; name=\"pojoData\""),
+                        containsStringIgnoringCase("Content-Type: application/json"),
+                        containsStringIgnoringCase("{\"foo\":\"test1\",\"bar\":1}"));
     }
 }

--- a/http/jaxrs-reactive/src/test/java/io/quarkus/ts/jaxrs/reactive/client/MultipartClientResourceIT.java
+++ b/http/jaxrs-reactive/src/test/java/io/quarkus/ts/jaxrs/reactive/client/MultipartClientResourceIT.java
@@ -3,15 +3,12 @@ package io.quarkus.ts.jaxrs.reactive.client;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 
-// TODO: Failing because of https://github.com/quarkusio/quarkus/issues/19892, enable after the issue is resolved
 @Tag("QUARKUS-1225")
-@Disabled
 @QuarkusScenario
 public class MultipartClientResourceIT {
 


### PR DESCRIPTION
### Summary

Re-enable disabled rest-client-reactive multipart test.
Fix bugs in the test:
- Typo in expected response body.
- Wrong assumption about letter case in names of response headers: filed names are case-insesitive.
- Missing `@RegisterForReflection` in `PojoData` class.

This test is reproducer for https://issues.redhat.com/browse/QUARKUS-1225.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)