### PR TITLE
Disable Quarkus-cli getAllExtension by streams

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -87,6 +87,9 @@ public class QuarkusCliExtensionsIT {
     }
 
     @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not pushed into the platform site")
+    @DisabledOnQuarkusVersion(version = "2.7.5.Final", reason = "Quarkus 2.7 stream was removed from code.quarkus.io")
+    //TODO Currently code.quarkus and quarkusCli are pointing to the same set of defined streams.
+    // ZULIP ref: https://quarkusio.zulipchat.com/#narrow/stream/191168-core-team/topic/streams.20on.20registry.20.2F.20code.2Equarkus/near/280456392
     @Test
     public void shouldListExtensionsUsingStream() {
         String streamVersion = getCurrentStreamVersion();


### PR DESCRIPTION
### Summary

Quarkus-cli gets extensions + streamsId moves to Quarkus 2.8+ , so Quarkus-cli 2.7 get extension is not supported anymore. 
This PR disables this scenario in Quarkus 2.7

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)