### PR TITLE
Use images, which can be run on OpenShift without volumes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,9 +220,11 @@
                                 <mssql.image>mcr.microsoft.com/mssql/rhel/server:2019-latest</mssql.image>
                                 <oracle.image>docker.io/gvenzl/oracle-xe:21-slim</oracle.image>
                                 <db2.image>quay.io/quarkusqeteam/db2:11.5.7.0</db2.image>
-                                <mongodb.image>docker.io/library/mongo:5.0</mongodb.image>
+                                <mongodb.image>docker.io/bitnami/mongodb:5.0</mongodb.image>
                                 <redis.image>docker.io/library/redis:6.0</redis.image>
                                 <wiremock.image>quay.io/ocpmetal/wiremock</wiremock.image>
+                                <!-- TODO use official image when/if this fixed https://github.com/hashicorp/docker-consul/issues/184 -->
+                                <consul.image>docker.io/bitnami/consul:1.12.0</consul.image>
                                 <consul.image>docker.io/library/consul:1.11</consul.image>
                                 <infinispan.image>quay.io/infinispan/server:12.1</infinispan.image>
                                 <infinispan.expected-log>Infinispan Server.*started in</infinispan.expected-log>

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/AbstractDbIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/AbstractDbIT.java
@@ -13,7 +13,8 @@ public class AbstractDbIT {
             //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
             .withProperty("POSTGRES_USER", "user")
             .withProperty("POSTGRES_PASSWORD", "user")
-            .withProperty("POSTGRES_DB", "mydb");
+            .withProperty("POSTGRES_DB", "mydb")
+            .withProperty("PGDATA", "/tmp/psql");
 
     @QuarkusApplication
     public static final RestService app = new RestService()

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/reactive/PostgresqlDatabaseIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/reactive/PostgresqlDatabaseIT.java
@@ -22,7 +22,8 @@ public class PostgresqlDatabaseIT extends AbstractReactiveDatabaseIT {
             .withProperty("POSTGRES_DB", POSTGRES_DATABASE)
             .withUser(POSTGRES_USER)
             .withPassword(POSTGRES_PASSWORD)
-            .withDatabase(POSTGRES_DATABASE);
+            .withDatabase(POSTGRES_DATABASE)
+            .withProperty("PGDATA", "/tmp/psql");
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("postgresql.properties")

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
@@ -22,7 +22,8 @@ public class OpenShiftMultiplePersistenceIT extends AbstractMultiplePersistenceI
             //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
             .withProperty("POSTGRES_USER", "user")
             .withProperty("POSTGRES_PASSWORD", "user")
-            .withProperty("POSTGRES_DB", "mydb");
+            .withProperty("POSTGRES_DB", "mydb")
+            .withProperty("PGDATA", "/tmp/psql");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresql13DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresql13DatabaseIT.java
@@ -19,7 +19,8 @@ public class OpenShiftPostgresql13DatabaseIT extends AbstractSqlDatabaseIT {
             //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
             .withProperty("POSTGRES_USER", "user")
             .withProperty("POSTGRES_PASSWORD", "user")
-            .withProperty("POSTGRES_DB", "mydb");
+            .withProperty("POSTGRES_DB", "mydb")
+            .withProperty("PGDATA", "/tmp/psql");
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("postgresql.properties")


### PR DESCRIPTION
### Summary
Some of the images we used could not be used on OpenShift without mounted volumes. Since volumes can not be mounted via framework, we need workarounds for that.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)