### PR TITLE
Switch to bitnami elasticsearch image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,8 @@
                                 <keycloak.image>quay.io/keycloak/keycloak:16.1.0</keycloak.image>
                                 <rhsso.73.image>registry.access.redhat.com/redhat-sso-7/sso73-openshift</rhsso.73.image>
                                 <postgresql.13.image>docker.io/library/postgres:13.6</postgresql.13.image>
-                                <elastic.71.image>docker.io/library/elasticsearch:7.17.2</elastic.71.image>
+                                <!-- TODO: investigate further in https://github.com/quarkus-qe/quarkus-test-suite/issues/627 -->
+                                <elastic.71.image>docker.io/bitnami/elasticsearch:7.17.2</elastic.71.image>
                                 <!--TODO change into 5.7 when this fixed https://github.com/docker-library/mysql/issues/844 -->
                                 <mysql.57.image>docker.io/library/mysql:5.7.36</mysql.57.image>
                                 <!-- TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/609 -->


### PR DESCRIPTION
### Summary

Workaround for memory issues with the official Elasticsearch image.
https://github.com/quarkus-qe/quarkus-test-suite/issues/627

The official image uses maximum available memory when started
without memory restrictions. That caused problems in testing environment
(Jenkins nodes) and the container kept exitting on OOM (container exit
code 137).
The bitnami image (identical release) is more conservative in memory
management and tends to constantly use ~1.3 GB.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)