### PR TITLE
Set a fixed stream version on Quarkus-cli commands

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.quarkus.cli;
 
+import static io.quarkus.ts.quarkus.cli.QuarkusCliUtils.defaultNewExtensionArgsWithFixedStream;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javax.inject.Inject;
@@ -21,7 +22,7 @@ public class QuarkusCliCreateExtensionIT {
     @Test
     public void shouldCreateAndBuildExtension() {
         // Create extension
-        QuarkusCliDefaultService app = cliClient.createExtension("extension-abc");
+        QuarkusCliDefaultService app = cliClient.createExtension("extension-abc", defaultNewExtensionArgsWithFixedStream());
 
         // Should build on Jvm
         QuarkusCliClient.Result result = app.buildOnJvm();

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.quarkus.cli;
 
 import static io.quarkus.test.bootstrap.QuarkusCliClient.CreateApplicationRequest.defaults;
 import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
+import static io.quarkus.ts.quarkus.cli.QuarkusCliUtils.defaultWithFixedStream;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -61,7 +62,7 @@ public class QuarkusCliCreateJvmApplicationIT {
     @Test
     public void shouldCreateApplicationOnJvm() {
         // Create application
-        QuarkusCliRestService app = cliClient.createApplication("app");
+        QuarkusCliRestService app = cliClient.createApplication("app", defaultWithFixedStream());
 
         // Should build on Jvm
         QuarkusCliClient.Result result = app.buildOnJvm();
@@ -76,7 +77,7 @@ public class QuarkusCliCreateJvmApplicationIT {
     @Test
     @Disabled("https://github.com/quarkusio/quarkus/issues/24613")
     public void createAppShouldAutoDetectJavaVersion() {
-        QuarkusCliRestService app = cliClient.createApplication("app");
+        QuarkusCliRestService app = cliClient.createApplication("app", defaultWithFixedStream());
         assertExpectedJavaVersion(getFileFromApplication(app, ROOT_FOLDER, "pom.xml"), getSystemJavaVersion());
         assertDockerJavaVersion(getFileFromApplication(app, DOCKER_FOLDER, DOCKERFILE_JVM), getSystemJavaVersion());
     }
@@ -84,7 +85,7 @@ public class QuarkusCliCreateJvmApplicationIT {
     @Tag("QUARKUS-1472")
     @Test
     public void shouldCreateAnApplicationForcingJavaVersion11() {
-        QuarkusCliClient.CreateApplicationRequest args = defaults().withExtraArgs("--java=" + JDK_11);
+        QuarkusCliClient.CreateApplicationRequest args = defaultWithFixedStream().withExtraArgs("--java=" + JDK_11);
         QuarkusCliRestService app = cliClient.createApplication("app", args);
         assertExpectedJavaVersion(getFileFromApplication(app, ROOT_FOLDER, "pom.xml"), JDK_11);
         assertDockerJavaVersion(getFileFromApplication(app, DOCKER_FOLDER, DOCKERFILE_JVM), JDK_11);
@@ -93,7 +94,7 @@ public class QuarkusCliCreateJvmApplicationIT {
     @Tag("QUARKUS-1472")
     @Test
     public void shouldCreateAnApplicationForcingJavaVersion17() {
-        QuarkusCliClient.CreateApplicationRequest args = defaults().withExtraArgs("--java=" + JDK_17);
+        QuarkusCliClient.CreateApplicationRequest args = defaultWithFixedStream().withExtraArgs("--java=" + JDK_17);
         QuarkusCliRestService app = cliClient.createApplication("app", args);
         assertExpectedJavaVersion(getFileFromApplication(app, ROOT_FOLDER, "pom.xml"), JDK_17);
         assertDockerJavaVersion(getFileFromApplication(app, DOCKER_FOLDER, DOCKERFILE_JVM), JDK_17);
@@ -105,7 +106,7 @@ public class QuarkusCliCreateJvmApplicationIT {
     public void shouldCreateApplicationWithGradleOnJvm() {
 
         // Create application
-        QuarkusCliRestService app = cliClient.createApplication("app", defaults().withExtraArgs("--gradle"));
+        QuarkusCliRestService app = cliClient.createApplication("app", defaultWithFixedStream().withExtraArgs("--gradle"));
 
         // Should build on Jvm
         QuarkusCliClient.Result result = app.buildOnJvm();
@@ -123,7 +124,7 @@ public class QuarkusCliCreateJvmApplicationIT {
     public void shouldCreateApplicationWithJbangOnJvm() {
 
         // Create application
-        QuarkusCliRestService app = cliClient.createApplication("app", defaults().withExtraArgs("--jbang"));
+        QuarkusCliRestService app = cliClient.createApplication("app", defaultWithFixedStream().withExtraArgs("--jbang"));
 
         // Should build on Jvm
         QuarkusCliClient.Result result = app.buildOnJvm("--verbose");
@@ -147,7 +148,7 @@ public class QuarkusCliCreateJvmApplicationIT {
         // Also, it verifies that quarkiverse dependencies can be added too.
         final String kogitoExtension = "kogito-quarkus-rules";
         final String prettytimeExtension = "quarkus-prettytime";
-        QuarkusCliRestService app = cliClient.createApplication("app", defaults().withExtensions(kogitoExtension,
+        QuarkusCliRestService app = cliClient.createApplication("app", defaultWithFixedStream().withExtensions(kogitoExtension,
                 prettytimeExtension, RESTEASY_EXTENSION, RESTEASY_JACKSON_EXTENSION));
 
         // Should build on Jvm
@@ -161,7 +162,7 @@ public class QuarkusCliCreateJvmApplicationIT {
     public void shouldCreateApplicationWithCodeStarter() {
         // Create application with Resteasy Jackson + Spring Web (we need both for the app to run)
         QuarkusCliRestService app = cliClient.createApplication("app",
-                defaults().withExtensions(RESTEASY_JACKSON_EXTENSION, SPRING_WEB_EXTENSION));
+                defaultWithFixedStream().withExtensions(RESTEASY_JACKSON_EXTENSION, SPRING_WEB_EXTENSION));
 
         // Verify By default, it installs only "quarkus-resteasy-jackson" and "quarkus-spring-web"
         assertInstalledExtensions(app, RESTEASY_JACKSON_EXTENSION, SPRING_WEB_EXTENSION);
@@ -205,7 +206,8 @@ public class QuarkusCliCreateJvmApplicationIT {
     @Tag("QUARKUS-1255")
     @Test
     public void shouldCreateJacocoReportsFromApplicationOnJvm() {
-        QuarkusCliRestService app = cliClient.createApplication("app-with-jacoco", defaults().withExtensions("jacoco"));
+        QuarkusCliRestService app = cliClient.createApplication("app-with-jacoco",
+                defaultWithFixedStream().withExtensions("jacoco"));
 
         QuarkusCliClient.Result result = app.buildOnJvm();
         assertTrue(result.isSuccessful(), "The application didn't build on JVM. Output: " + result.getOutput());

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateNativeApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateNativeApplicationIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.quarkus.cli;
 
+import static io.quarkus.ts.quarkus.cli.QuarkusCliUtils.defaultWithFixedStream;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javax.inject.Inject;
@@ -28,7 +29,7 @@ public class QuarkusCliCreateNativeApplicationIT {
     @Test
     public void shouldBuildApplicationOnNative() {
         // Create application
-        QuarkusCliRestService app = cliClient.createApplication("app");
+        QuarkusCliRestService app = cliClient.createApplication("app", defaultWithFixedStream());
 
         // Should build on Native
         QuarkusCliClient.Result result = app.buildOnNative();

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -1,11 +1,11 @@
 package io.quarkus.ts.quarkus.cli;
 
+import static io.quarkus.ts.quarkus.cli.QuarkusCliUtils.getCurrentStreamVersion;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
@@ -44,31 +44,31 @@ public class QuarkusCliExtensionsIT {
 
     @Test
     public void shouldListExtensionsUsingDefaults() {
-        whenGetListExtensions();
+        whenGetListExtensions("--stream", getCurrentStreamVersion());
         assertListDefaultOptionOutput();
     }
 
     @Test
     public void shouldListExtensionsUsingName() {
-        whenGetListExtensions("--name");
+        whenGetListExtensions("--stream", getCurrentStreamVersion(), "--name");
         assertListNameOptionOutput();
     }
 
     @Test
     public void shouldListExtensionsUsingOrigins() {
-        whenGetListExtensions("--origins");
+        whenGetListExtensions("--stream", getCurrentStreamVersion(), "--origins");
         assertListOriginsOptionOutput();
     }
 
     @Test
     public void shouldListExtensionsUsingConcise() {
-        whenGetListExtensions("--concise");
+        whenGetListExtensions("--stream", getCurrentStreamVersion(), "--concise");
         assertListConciseOptionOutput();
     }
 
     @Test
     public void shouldListExtensionsUsingFull() {
-        whenGetListExtensions("--full");
+        whenGetListExtensions("--stream", getCurrentStreamVersion(), "--full");
         assertListFullOptionOutput();
     }
 
@@ -103,7 +103,7 @@ public class QuarkusCliExtensionsIT {
 
     @Test
     public void shouldListExtensionsUsingInstallable() {
-        whenGetListExtensions("--installable");
+        whenGetListExtensions("--stream", getCurrentStreamVersion(), "--installable");
         assertListDefaultOptionOutput();
     }
 
@@ -157,10 +157,5 @@ public class QuarkusCliExtensionsIT {
 
     private void assertResultIsSuccessful() {
         assertTrue(result.isSuccessful(), "Extensions list command didn't work. Output: " + result.getOutput());
-    }
-
-    private String getCurrentStreamVersion() {
-        String[] version = Version.getVersion().split(Pattern.quote("."));
-        return String.format("%s.%s", version[0], version[1]);
     }
 }

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.quarkus.cli;
 
+import static io.quarkus.ts.quarkus.cli.QuarkusCliUtils.getCurrentStreamVersion;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -130,7 +131,8 @@ public class QuarkusCliSpecialCharsIT {
     }
 
     private void whenCreateAppAt(String folder) {
-        result = cliClient.run("create", "app", "--output-directory=" + folder, ARTIFACT_ID);
+        result = cliClient.run("create", "app", "--stream", getCurrentStreamVersion(), "--output-directory=" + folder,
+                ARTIFACT_ID);
     }
 
     private void thenResultIsSuccessful() {

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliUtils.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliUtils.java
@@ -1,0 +1,24 @@
+package io.quarkus.ts.quarkus.cli;
+
+import static io.quarkus.test.bootstrap.QuarkusCliClient.CreateApplicationRequest.defaults;
+
+import java.util.regex.Pattern;
+
+import io.quarkus.builder.Version;
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+
+public class QuarkusCliUtils {
+
+    public static QuarkusCliClient.CreateApplicationRequest defaultWithFixedStream() {
+        return defaults().withStream(getCurrentStreamVersion());
+    }
+
+    public static QuarkusCliClient.CreateExtensionRequest defaultNewExtensionArgsWithFixedStream() {
+        return QuarkusCliClient.CreateExtensionRequest.defaults().withStream(getCurrentStreamVersion());
+    }
+
+    public static String getCurrentStreamVersion() {
+        String[] version = Version.getVersion().split(Pattern.quote("."));
+        return String.format("%s.%s", version[0], version[1]);
+    }
+}


### PR DESCRIPTION
### Summary

We are going to fix Quarkus streams to a fixed version in most of the quarkusClient scenarios in order to avoid some registry configuration issues.

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)