### PR TITLE
Resolve conflict between reactive and classic resteasy libs

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -160,12 +160,10 @@ public class QuarkusCliCreateJvmApplicationIT {
     @Tag("QUARKUS-1071")
     @Test
     public void shouldCreateApplicationWithCodeStarter() {
-        // Create application with Resteasy Jackson + Spring Web (we need both for the app to run)
         QuarkusCliRestService app = cliClient.createApplication("app",
-                defaultWithFixedStream().withExtensions(RESTEASY_JACKSON_EXTENSION, SPRING_WEB_EXTENSION));
+                defaultWithFixedStream().withExtensions(SPRING_WEB_EXTENSION));
 
-        // Verify By default, it installs only "quarkus-resteasy-jackson" and "quarkus-spring-web"
-        assertInstalledExtensions(app, RESTEASY_JACKSON_EXTENSION, SPRING_WEB_EXTENSION);
+        assertInstalledExtensions(app, SPRING_WEB_EXTENSION);
 
         // Start using DEV mode
         app.start();


### PR DESCRIPTION
### Summary

The reactive flavor is the default one on Quarkus 2.7. This PR resolver a lib conflict on Quarkus-cli module

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)