### PR TITLE
Disable quarkus-cli scenarios on daily builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,13 +114,14 @@ jobs:
       - name: Build Quarkus CLI
         run: |
           git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && git checkout 2.7 && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
-      - name: Install Quarkus CLI
-        run: |
-          cat <<EOF > ./quarkus-dev-cli
-          #!/bin/bash
-          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
-          EOF
-          chmod +x ./quarkus-dev-cli
+# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
+#      - name: Install Quarkus CLI
+#        run: |
+#          cat <<EOF > ./quarkus-dev-cli
+#          #!/bin/bash
+#          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+#          EOF
+#          chmod +x ./quarkus-dev-cli
       - name: Build with Maven
         run: |
           MODULES_MAVEN_PARAM=""
@@ -129,7 +130,9 @@ jobs:
             MODULES_MAVEN_PARAM="-pl ${MODULES_ARG}"
           fi
 
-          mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dall-modules -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" $MODULES_MAVEN_PARAM
+          mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dall-modules $MODULES_MAVEN_PARAM
+# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
+# mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dall-modules -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" $MODULES_MAVEN_PARAM
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -168,24 +171,26 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-      - name: Build Quarkus CLI
-        run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && git checkout 2.7 && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
-      - name: Install Quarkus CLI
-        run: |
-          cat <<EOF > ./quarkus-dev-cli
-          #!/bin/bash
-          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
-          EOF
-          chmod +x ./quarkus-dev-cli
+# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
+#      - name: Build Quarkus CLI
+#        run: |
+#          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && git checkout 2.7 && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
+#      - name: Install Quarkus CLI
+#        run: |
+#          cat <<EOF > ./quarkus-dev-cli
+#          #!/bin/bash
+#          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+#          EOF
+#          chmod +x ./quarkus-dev-cli
       - name: Build with Maven
         run: |
           if [[ -n ${MODULES_ARG} ]]; then
             echo "Running modules: ${MODULES_ARG}"
             mvn -fae -V -B -s .github/mvn-settings.xml -fae -Dall-modules -Dquarkus.container-image.build=false \
-                        -pl $MODULES_ARG clean verify -Dnative -Dinclude.quarkus-cli-tests \
-                        -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
+                        -pl $MODULES_ARG clean verify -Dnative
           fi
+# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
+# -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
         if: failure()
         run: |

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -60,19 +60,22 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-      - name: Build Quarkus CLI
-        run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && git checkout 2.7 && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
-      - name: Install Quarkus CLI
-        run: |
-          cat <<EOF > ./quarkus-dev-cli
-          #!/bin/bash
-          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
-          EOF
-          chmod +x ./quarkus-dev-cli
+# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
+#      - name: Build Quarkus CLI
+#        run: |
+#          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && git checkout 2.7 && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
+#      - name: Install Quarkus CLI
+#        run: |
+#          cat <<EOF > ./quarkus-dev-cli
+#          #!/bin/bash
+#          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+#          EOF
+#          chmod +x ./quarkus-dev-cli
       - name: Test in JVM mode
         run: |
-          mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P ${{ matrix.profiles }} -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
+          mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P ${{ matrix.profiles }}
+# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
+#          -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -115,21 +118,23 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-      - name: Build Quarkus CLI
-        run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && git checkout 2.7 && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
-      - name: Install Quarkus CLI
-        run: |
-          cat <<EOF > ./quarkus-dev-cli
-          #!/bin/bash
-          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
-          EOF
-          chmod +x ./quarkus-dev-cli
+# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
+#      - name: Build Quarkus CLI
+#        run: |
+#          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && git checkout 2.7 && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
+#      - name: Install Quarkus CLI
+#        run: |
+#          cat <<EOF > ./quarkus-dev-cli
+#          #!/bin/bash
+#          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+#          EOF
+#          chmod +x ./quarkus-dev-cli
       - name: Test in Native mode
         run: |
           mvn -fae -V -B -s .github/mvn-settings.xml -P ${{ matrix.profiles }} -fae clean verify -Dnative \
-            -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }} \
-            -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
+            -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }}
+# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
+#            -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
         if: failure()
         run: |


### PR DESCRIPTION
### Summary

This PR disables Quarkus-cli daily build.
depends on: https://github.com/quarkusio/registry.quarkus.io/pull/97

### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)