### PR TITLE
Disable mTLS test suite with FIPS

### DIFF
--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/DeclaredKsFileTypeOidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/DeclaredKsFileTypeOidcMtlsIT.java
@@ -2,6 +2,8 @@ package io.quarkus.ts.security.oidcclient.mtls;
 
 import static io.quarkus.ts.security.oidcclient.mtls.MutualTlsKeycloakService.newKeycloakInstance;
 
+import org.junit.jupiter.api.Tag;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -12,6 +14,7 @@ import io.quarkus.test.services.QuarkusApplication;
  * If keystore/truststore file type can't be detected from file extension, user can explicitly
  * declare file type in application properties.
  */
+@Tag("fips-incompatible")
 @QuarkusScenario
 public class DeclaredKsFileTypeOidcMtlsIT extends KeycloakMtlsAuthN {
 

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/IncorrectKsFileTypeOidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/IncorrectKsFileTypeOidcMtlsIT.java
@@ -4,6 +4,7 @@ import static io.quarkus.ts.security.oidcclient.mtls.MutualTlsKeycloakService.ne
 import static io.restassured.RestAssured.given;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -16,6 +17,7 @@ import io.quarkus.test.services.QuarkusApplication;
  * If keystore/truststore file type does not match declared one, communication between OIDC server
  * and client should fail.
  */
+@Tag("fips-incompatible")
 @QuarkusScenario
 public class IncorrectKsFileTypeOidcMtlsIT extends BaseOidcMtlsIT {
 

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/JksOidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/JksOidcMtlsIT.java
@@ -2,12 +2,15 @@ package io.quarkus.ts.security.oidcclient.mtls;
 
 import static io.quarkus.ts.security.oidcclient.mtls.MutualTlsKeycloakService.newKeycloakInstance;
 
+import org.junit.jupiter.api.Tag;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
+@Tag("fips-incompatible")
 @QuarkusScenario
 public class JksOidcMtlsIT extends KeycloakMtlsAuthN {
 

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/Pkcs12OidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/Pkcs12OidcMtlsIT.java
@@ -2,6 +2,8 @@ package io.quarkus.ts.security.oidcclient.mtls;
 
 import static io.quarkus.ts.security.oidcclient.mtls.MutualTlsKeycloakService.newKeycloakInstance;
 
+import org.junit.jupiter.api.Tag;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -12,6 +14,7 @@ import io.quarkus.test.services.QuarkusApplication;
  * Keystore file type is automatically detected in following tests by its extension in quarkus-oidc.
  * Extension declared here is used by tests only.
  */
+@Tag("fips-incompatible")
 @QuarkusScenario
 public class Pkcs12OidcMtlsIT extends KeycloakMtlsAuthN {
 


### PR DESCRIPTION
### Summary

Some Mutual TLS scenarios are not FIPS compatible, one way around this is using `BouncyCastleFipsProvider`, however we should still have scenarios without provider set and [upstream issue](https://github.com/quarkusio/quarkus/pull/25234) that enabled us to set provider is not in latest RHBQ (2.7.5.ER4). I will provide tests for FIPS scenario in a separate PR.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)