### PR TITLE
Activate maven profile by property for compatibility with Windows env…

### DIFF
--- a/http/graphql-telemetry/pom.xml
+++ b/http/graphql-telemetry/pom.xml
@@ -28,6 +28,11 @@
     <profiles>
         <profile>
             <id>deploy-to-openshift-using-extension</id>
+            <activation>
+                <property>
+                    <name>deploy-to-openshift-using-extension</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/http/graphql/pom.xml
+++ b/http/graphql/pom.xml
@@ -28,6 +28,11 @@
     <profiles>
         <profile>
             <id>deploy-to-openshift-using-extension</id>
+            <activation>
+                <property>
+                    <name>deploy-to-openshift-using-extension</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/http/http-minimum-reactive/pom.xml
+++ b/http/http-minimum-reactive/pom.xml
@@ -19,6 +19,11 @@
     <profiles>
         <profile>
             <id>deploy-to-openshift-using-extension</id>
+            <activation>
+                <property>
+                    <name>deploy-to-openshift-using-extension</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/http/http-minimum/pom.xml
+++ b/http/http-minimum/pom.xml
@@ -19,6 +19,11 @@
     <profiles>
         <profile>
             <id>deploy-to-openshift-using-extension</id>
+            <activation>
+                <property>
+                    <name>deploy-to-openshift-using-extension</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/http/jaxrs-reactive/pom.xml
+++ b/http/jaxrs-reactive/pom.xml
@@ -27,6 +27,11 @@
     <profiles>
         <profile>
             <id>deploy-to-openshift-using-extension</id>
+            <activation>
+                <property>
+                    <name>deploy-to-openshift-using-extension</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/super-size/many-extensions/pom.xml
+++ b/super-size/many-extensions/pom.xml
@@ -229,6 +229,11 @@
         </profile>
         <profile>
             <id>deploy-to-openshift-using-extension</id>
+            <activation>
+                <property>
+                    <name>deploy-to-openshift-using-extension</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>


### PR DESCRIPTION

### Summary

[Following PR](https://github.com/quarkus-qe/quarkus-test-framework/pull/466) in [Quarkus Test Framework](https://github.com/quarkus-qe/quarkus-test-framework) introduced activation of the profile `deploy-to-openshift-using-extension` by property, this PR reflect the changes in Quarkus Test Suite and ensures `deploy-to-openshift-using-extension` will be activated.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)