### PR TITLE
Disable infinispan scenarios on FIPS

### DIFF
--- a/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/qe/messaging/infinispan/InfinispanKafkaIT.java
+++ b/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/qe/messaging/infinispan/InfinispanKafkaIT.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 
 import org.apache.http.HttpStatus;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.messaging.infinispan.books.Book;
@@ -24,6 +25,8 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 import io.restassured.http.ContentType;
 
 @QuarkusScenario
+// TODO https://github.com/quarkusio/quarkus/issues/25136
+@Tag("fips-incompatible")
 public class InfinispanKafkaIT {
 
     private static final String BOOK_TITLE = "testBook";

--- a/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/qe/messaging/infinispan/InfinispanKafkaSaslIT.java
+++ b/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/qe/messaging/infinispan/InfinispanKafkaSaslIT.java
@@ -5,6 +5,7 @@ import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 
 import org.hamcrest.core.StringContains;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.InfinispanService;
@@ -18,6 +19,8 @@ import io.quarkus.test.services.containers.model.KafkaProtocol;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @QuarkusScenario
+// TODO https://github.com/quarkusio/quarkus/issues/25136
+@Tag("fips-incompatible")
 public class InfinispanKafkaSaslIT {
     /**
      * We can't rename this file to use the default SSL settings part of KafkaService.

--- a/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/qe/messaging/infinispan/InfinispanKafkaSslIT.java
+++ b/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/qe/messaging/infinispan/InfinispanKafkaSslIT.java
@@ -5,6 +5,7 @@ import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 
 import org.hamcrest.core.StringContains;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.InfinispanService;
@@ -19,6 +20,8 @@ import io.quarkus.test.services.containers.model.KafkaProtocol;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @QuarkusScenario
+// TODO https://github.com/quarkusio/quarkus/issues/25136
+@Tag("fips-incompatible")
 @DisabledOnNative(reason = "https://github.com/quarkusio/quarkus/issues/25098")
 public class InfinispanKafkaSslIT {
 


### PR DESCRIPTION
Infinispan doesn't support FIPS on this relea

Add "fips-incompatible" tag to infinispan scenarios

### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)