### PR TITLE
Fix container startup in native mode with Openshift arguments set

### DIFF
--- a/lifecycle-application/src/main/resources/application.properties
+++ b/lifecycle-application/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 quarkus.openshift.arguments=ARG1,ARG2
+# FIXME remove after https://issues.redhat.com/browse/QUARKUS-2005
+quarkus.openshift.command=/home/quarkus/application


### PR DESCRIPTION
### Summary

Setting [quarkus.openshift.arguments](https://quarkus.io/guides/deploying-to-openshift#quarkus-openshift-openshift-config_quarkus.openshift.arguments) in native mode iff [entrypoint](https://docs.openshift.com/container-platform/4.10/applications/deployments/managing-deployment-processes.html#deployments-exe-cmd-in-container_deployment-operations) is not set nor overriden by [quarkus.openshift.command](https://quarkus.io/guides/deploying-to-openshift#quarkus-openshift-openshift-config_quarkus.openshift.command) leads to `CreateContainerError`. The behavior is nicely explained [here](https://github.com/openshift/origin/issues/21547#issuecomment-442863354). Tested with OpenShift 4.10 and 4.6, but I suspect the same behavior will affect Kubernetes. Tested both with 2.7.5.CR1 and upstream. Tested with Docker container runtime. After reading of `io.quarkus.container.image.openshift.deployment.OpenshiftProcessor#openshiftRequirementsNative` I found easy workaround - just set `quarkus.openshift.command` to entrypoint and the problem's fixed. Thus for default `io.quarkus.container.image.openshift.deployment.OpenshiftBaseNativeImage#QUARKUS` set `quarkus.openshift.command=/home/quarkus/application`.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)

### Reproducer

Prior to this commit, test fails for command:
```bash
mvn -B -V clean verify -Dts.openshift.ephemeral.namespaces.enabled=true -fae -Dnative -Dquarkus.native.container-runtime=docker -Dquarkus.native.builder-image=registry-proxy.engineering.redhat.com/rh-osbs/quarkus-mandrel-21-rhel8:21.3 -Dopenshift -Dall-modules -Dinclude.operator-scenarios -Dinclude.serverless -Dit.test=OpenShiftLifecycleApplicationIT -Dmaven.repo.local=/home/mvavrik/Downloads/275CR1/rh-quarkus-2.7.5.GA-maven-repository/maven-repository
```

and does not fail with
```bash
mvn -B -V clean verify -Dts.openshift.ephemeral.namespaces.enabled=true -fae -Dnative -Dquarkus.native.container-runtime=docker -Dquarkus.native.builder-image=registry-proxy.engineering.redhat.com/rh-osbs/quarkus-mandrel-21-rhel8:21.3 -Dopenshift -Dall-modules -Dinclude.operator-scenarios -Dinclude.serverless -Dit.test=OpenShiftLifecycleApplicationIT -Dmaven.repo.local=/home/mvavrik/Downloads/275CR1/rh-quarkus-2.7.5.GA-maven-repository/maven-repository -Dquarkus.openshift.command=home/quarkus/application
```