### PR TITLE
Don't set OpenShift command in JVM mode (only set it in native)

### DIFF
--- a/lifecycle-application/src/main/resources/application.properties
+++ b/lifecycle-application/src/main/resources/application.properties
@@ -1,3 +1,1 @@
 quarkus.openshift.arguments=ARG1,ARG2
-# FIXME remove after https://issues.redhat.com/browse/QUARKUS-2005
-quarkus.openshift.command=/home/quarkus/application

--- a/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/LifecycleApplicationIT.java
+++ b/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/LifecycleApplicationIT.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 @QuarkusScenario
 public class LifecycleApplicationIT {
@@ -18,7 +19,8 @@ public class LifecycleApplicationIT {
     static final String LOGGING_PROPERTY = "-Djava.util.logging.manager=org.jboss.logmanager.LogManager";
 
     @QuarkusApplication
-    static RestService app = new RestService();
+    static RestService app = new RestService()
+            .withProperties(getAdditionalProperties());
 
     @Test
     public void shouldArgumentsNotContainLoggingProperty() {
@@ -34,5 +36,13 @@ public class LifecycleApplicationIT {
         String argumentsLine = app.getLogs().stream().collect(Collectors.joining());
         assertFalse(argumentsLine.contains(LOGGING_PROPERTY),
                 "Pod log contain unexpected properties. Actual content: " + argumentsLine);
+    }
+
+    /**
+     * Conditionally apply OpenShift properties if in Native mode.
+     * FIXME remove once https://github.com/quarkusio/quarkus/issues/24885 is resolved
+     */
+    private static String getAdditionalProperties() {
+        return QuarkusProperties.isNativePackageType() ? "native.properties" : "empty.properties";
     }
 }

--- a/lifecycle-application/src/test/resources/empty.properties
+++ b/lifecycle-application/src/test/resources/empty.properties
@@ -1,0 +1,1 @@
+# no additional properties need to be applied in JVM mode

--- a/lifecycle-application/src/test/resources/native.properties
+++ b/lifecycle-application/src/test/resources/native.properties
@@ -1,0 +1,2 @@
+# Set entrypoint in native mode
+quarkus.openshift.command=/home/quarkus/application


### PR DESCRIPTION
### Summary

My PR #645 fixed OpenShift container startup in native mode, however the command should not be applied in JVM mode as the entrypoint does not exist there and OpenShift command is used by Quarkus to start application (thus we should not override it without a good reason).

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)