### PR TITLE
Fix Hibernate generation in Oracle DB

### DIFF
--- a/sql-db/sql-app/src/test/resources/oracle.properties
+++ b/sql-db/sql-app/src/test/resources/oracle.properties
@@ -1,3 +1,3 @@
 quarkus.datasource.db-kind=oracle
 quarkus.hibernate-orm.sql-load-script=oracle_import.sql
-quarkus.hibernate-orm.database.generation=create
+quarkus.hibernate-orm.database.generation=drop-and-create


### PR DESCRIPTION
### Summary

`drop-and-create` causes Oracle to complain about dropping non-existent
objects, but it ensures empty DB, in case there are concerns about test
isolation.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)