### PR TITLE
Test field injection of JAX-RS Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ It also verifies multiple deployment strategies like:
 Reactive equivalent of the http/http-minimum module
 
 ### `http/http-advanced`
-Verifies Server/Client http_2/1.1, Grpc and http redirections.
+Verifies Server/Client http_2/1.1, Grpc and http redirections and JAX-RS provider field injection.
 
 ### `http/http-advanced-reactive`
 Reactive equivalent of the http/http-advanced module

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/PremierLeagueContainerRequestFilter.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/PremierLeagueContainerRequestFilter.java
@@ -1,0 +1,47 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import java.util.Objects;
+
+import javax.enterprise.inject.Instance;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.vertx.core.http.HttpServerRequest;
+
+@Provider
+public class PremierLeagueContainerRequestFilter implements ContainerRequestFilter {
+
+    public static final String REQ_PARAM_NAME = "footballer-name";
+
+    @ConfigProperty(name = "pl-container-request-filter.enabled")
+    Instance<Boolean> filterEnabled;
+
+    @Context
+    HttpServerRequest httpRequest;
+
+    @Context
+    UriInfo uriInfo;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+
+        if (filterEnabled.stream().findAny().orElse(Boolean.FALSE)) {
+
+            var nameFromHttpRequest = httpRequest.getParam(REQ_PARAM_NAME);
+            var nameFromUriInfo = uriInfo.getQueryParameters().getFirst(REQ_PARAM_NAME);
+            if (!Objects.equals(nameFromHttpRequest, nameFromUriInfo)) {
+                throw new IllegalStateException("Values from uriInfo and httpRequest differ");
+            }
+            if (nameFromHttpRequest == null) {
+                requestContext.abortWith(Response.status(Status.CONFLICT).build());
+            }
+        }
+    }
+}

--- a/http/http-advanced-reactive/src/main/resources/application.properties
+++ b/http/http-advanced-reactive/src/main/resources/application.properties
@@ -51,3 +51,6 @@ quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 # tolerate 1 minute of clock skew between the Keycloak server and the application
 quarkus.oidc.token.lifespan-grace=60
+
+# Disable PremierLeagueContainerRequestFilter unless it should be applied
+pl-container-request-filter.enabled=false

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/ContainerRequestFilterReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/ContainerRequestFilterReactiveIT.java
@@ -1,0 +1,44 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import static io.quarkus.ts.http.advanced.reactive.PremierLeagueContainerRequestFilter.REQ_PARAM_NAME;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.RestAssured;
+
+@Tag("QUARKUS-1546")
+@QuarkusScenario
+public class ContainerRequestFilterReactiveIT {
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.oidc.enabled", "false")
+            .withProperty("quarkus.keycloak.policy-enforcer.enable", "false")
+            .withProperty("quarkus.keycloak.devservices.enabled", "false")
+            .withProperty("pl-container-request-filter.enabled", "true");
+
+    @Test
+    void testReqFilterIsAppliedAndReqSucceed() {
+        RestAssured
+                .given()
+                .queryParam(REQ_PARAM_NAME, "CR7")
+                .get("/api/hello")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    void testReqFilterIsAppliedAndReqDenied() {
+        RestAssured
+                .given()
+                .get("/api/hello")
+                .then()
+                .statusCode(HttpStatus.SC_CONFLICT);
+    }
+
+}

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftContainerRequestFilterReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftContainerRequestFilterReactiveIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftContainerRequestFilterReactiveIT extends ContainerRequestFilterReactiveIT {
+
+}

--- a/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/PremierLeagueContainerRequestFilter.java
+++ b/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/PremierLeagueContainerRequestFilter.java
@@ -1,0 +1,46 @@
+package io.quarkus.ts.http.advanced;
+
+import java.util.Objects;
+
+import javax.enterprise.inject.Instance;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.resteasy.spi.HttpRequest;
+
+@Provider
+public class PremierLeagueContainerRequestFilter implements ContainerRequestFilter {
+
+    public static final String REQ_PARAM_NAME = "footballer-name";
+
+    @ConfigProperty(name = "pl-container-request-filter.enabled")
+    Instance<Boolean> filterEnabled;
+
+    @Context
+    HttpRequest httpRequest;
+
+    @Context
+    UriInfo uriInfo;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+
+        if (filterEnabled.stream().findAny().orElse(Boolean.FALSE)) {
+
+            var nameFromHttpRequest = httpRequest.getUri().getQueryParameters().getFirst(REQ_PARAM_NAME);
+            var nameFromUriInfo = uriInfo.getQueryParameters().getFirst(REQ_PARAM_NAME);
+            if (!Objects.equals(nameFromHttpRequest, nameFromUriInfo)) {
+                throw new IllegalStateException("Values from uriInfo and httpRequest differ");
+            }
+            if (nameFromHttpRequest == null) {
+                requestContext.abortWith(Response.status(Status.CONFLICT).build());
+            }
+        }
+    }
+}

--- a/http/http-advanced/src/main/resources/application.properties
+++ b/http/http-advanced/src/main/resources/application.properties
@@ -51,3 +51,6 @@ quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 # tolerate 1 minute of clock skew between the Keycloak server and the application
 quarkus.oidc.token.lifespan-grace=60
+
+# Disable PremierLeagueContainerRequestFilter unless it should be applied
+pl-container-request-filter.enabled=false

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/ContainerRequestFilterIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/ContainerRequestFilterIT.java
@@ -1,0 +1,44 @@
+package io.quarkus.ts.http.advanced;
+
+import static io.quarkus.ts.http.advanced.PremierLeagueContainerRequestFilter.REQ_PARAM_NAME;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.RestAssured;
+
+@Tag("QUARKUS-1546")
+@QuarkusScenario
+public class ContainerRequestFilterIT {
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.oidc.enabled", "false")
+            .withProperty("quarkus.keycloak.policy-enforcer.enable", "false")
+            .withProperty("quarkus.keycloak.devservices.enabled", "false")
+            .withProperty("pl-container-request-filter.enabled", "true");
+
+    @Test
+    void testReqFilterIsAppliedAndReqSucceed() {
+        RestAssured
+                .given()
+                .queryParam(REQ_PARAM_NAME, "CR7")
+                .get("/api/hello")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    void testReqFilterIsAppliedAndReqDenied() {
+        RestAssured
+                .given()
+                .get("/api/hello")
+                .then()
+                .statusCode(HttpStatus.SC_CONFLICT);
+    }
+
+}

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftContainerRequestFilterIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftContainerRequestFilterIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.ts.http.advanced;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftContainerRequestFilterIT extends ContainerRequestFilterIT {
+
+}


### PR DESCRIPTION
### Summary

`javax.ws.rs.core.Context` field injection in classes annotated by `javax.ws.rs.ext.Provider` in Quarkus 2.2.4 and lesser in a native mode. This PR adds a new tests that cover `@Context` field injection for both JAX-RS RESTEasy Reactive and JAX-RS RESTEasy.

#### Related links

- [Upstream issue](https://github.com/quarkusio/quarkus/issues/20161)

- [JAX-RS reference guide, chapter Four](https://download.oracle.com/otn-pub/jcp/jaxrs-1.0-fr-eval-oth-JSpec/jaxrs-1.0-final-spec.pdf?AuthParam=1652777207_5a0cbee43bdc95478115076c1aec592d)

- [StackOverflow summarization on Providers](https://stackoverflow.com/questions/13557442/what-does-provider-in-jax-rs-mean)

- [Red Hat Fuse ContainerRequestContext example](https://access.redhat.com/documentation/en-us/red_hat_fuse/7.4/html/apache_cxf_development_guide/jaxrs20filters)

- [An upstream documentation example](https://quarkus.io/guides/security-customization#jaxrs-security-context)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)