### PR TITLE
Test RESTEasy Reactive issues

### DIFF
--- a/http/http-advanced-reactive/pom.xml
+++ b/http/http-advanced-reactive/pom.xml
@@ -66,6 +66,10 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-multipart-provider</artifactId>
+        </dependency>
     </dependencies>
     <profiles>
         <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/Hello.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/Hello.java
@@ -10,4 +10,5 @@ public class Hello {
     public String getContent() {
         return content;
     }
+
 }

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/HelloAllResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/HelloAllResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.http.advanced.reactive;
 
+import static io.quarkus.ts.http.advanced.reactive.HelloResource.NAME;
+
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -10,14 +12,15 @@ import javax.ws.rs.core.MediaType;
 import io.smallrye.mutiny.Uni;
 
 @Path("/hello")
-public class HelloResource {
+public class HelloAllResource {
+    private static final String TEMPLATE = "Hello all, %s!";
+    public static final String ALL_ENDPOINT_PATH = "/all";
 
-    private static final String TEMPLATE = "Hello, %s!";
-    public static final String NAME = "name";
-
+    @Path(ALL_ENDPOINT_PATH)
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<Hello> get(@QueryParam(NAME) @DefaultValue("World") String name) {
         return Uni.createFrom().item(new Hello(String.format(TEMPLATE, name)));
     }
+
 }

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MediaTypeResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MediaTypeResource.java
@@ -1,0 +1,68 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import static io.quarkus.ts.http.advanced.reactive.MediaTypeResource.MEDIA_TYPE_PATH;
+import static javax.ws.rs.core.HttpHeaders.ACCEPT_ENCODING;
+import static javax.ws.rs.core.HttpHeaders.ACCEPT_LANGUAGE;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
+import static javax.ws.rs.core.MediaType.APPLICATION_XML;
+import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
+import static javax.ws.rs.core.MediaType.TEXT_HTML;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+import java.io.IOException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import io.quarkus.vertx.web.RouteFilter;
+import io.vertx.ext.web.RoutingContext;
+
+@Path(MEDIA_TYPE_PATH)
+public class MediaTypeResource {
+
+    public static final String MEDIA_TYPE_PATH = "/media-type";
+    private static final String IMAGE_PNG = "image/png";
+    private static final String IMAGE_JPEG = "image/jpeg";
+    private static final String TEXT_CSS = "text/css";
+    private static final String TEXT_XML = "text/xml";
+    public static final String APPLICATION_YAML = "application/yaml";
+    public static final String ENGLISH = "en";
+    public static final String JAPANESE = "ja";
+    public static final String ANY_ENCODING = "*";
+
+    @Produces({ APPLICATION_JSON, APPLICATION_XML, TEXT_HTML, TEXT_PLAIN, APPLICATION_OCTET_STREAM,
+            MULTIPART_FORM_DATA, IMAGE_PNG, IMAGE_JPEG, APPLICATION_YAML, TEXT_CSS, TEXT_XML })
+    @GET
+    public Response getMediaType() {
+        return Response.ok(new MediaTypeWrapper()).build();
+    }
+
+    public static class ContentNegotiationRoutingFilter {
+        @RouteFilter
+        void addHeaders(final RoutingContext rc) {
+            rc.response().headers().add(HttpHeaders.VARY, ACCEPT_LANGUAGE);
+            rc.response().headers().add(ACCEPT_LANGUAGE, ENGLISH);
+            rc.next();
+        }
+    }
+
+    @Provider
+    public static class ContentNegotiationContainerResponseFilter implements
+            ContainerResponseFilter {
+        @Override
+        public void filter(final ContainerRequestContext requestContext, final ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add(HttpHeaders.VARY, ACCEPT_ENCODING);
+            responseContext.getHeaders().add(ACCEPT_ENCODING, ANY_ENCODING);
+            responseContext.getHeaders().add(ACCEPT_LANGUAGE, JAPANESE);
+        }
+    }
+}

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MediaTypeWrapper.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MediaTypeWrapper.java
@@ -1,0 +1,19 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class MediaTypeWrapper {
+
+    private MediaType mediaType;
+
+    public MediaType getMediaType() {
+        return mediaType;
+    }
+
+    public void setMediaType(MediaType mediaType) {
+        this.mediaType = mediaType;
+    }
+}

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MediaTypeWrapperSerializer.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MediaTypeWrapperSerializer.java
@@ -1,0 +1,33 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Provider
+public class MediaTypeWrapperSerializer implements MessageBodyWriter<MediaTypeWrapper> {
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations,
+            MediaType mediaType) {
+        return type == MediaTypeWrapper.class;
+    }
+
+    @Override
+    public void writeTo(MediaTypeWrapper mediaTypeWrapper, Class<?> type,
+            Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+            throws IOException, WebApplicationException {
+        mediaTypeWrapper.setMediaType(mediaType);
+        entityStream.write(new ObjectMapper().writeValueAsBytes(mediaTypeWrapper));
+    }
+}

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MultipartFormDataDTO.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MultipartFormDataDTO.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class MultipartFormDataDTO {
+
+    private final String text;
+    private final String file;
+
+    public MultipartFormDataDTO(String text, String file) {
+        this.text = text;
+        this.file = file;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public String getFile() {
+        return file;
+    }
+}

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MultipartResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MultipartResource.java
@@ -1,0 +1,48 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import static io.quarkus.ts.http.advanced.reactive.MultipartResource.MULTIPART_FORM_PATH;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.commons.io.IOUtils;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
+
+@Path(MULTIPART_FORM_PATH)
+public class MultipartResource {
+
+    private static final Logger LOGGER = Logger.getLogger(MediaTypeResource.class);
+    public static final String TEXT = "text";
+    public static final String FILE = "file";
+    public static final String MULTIPART_FORM_PATH = "/multipart-form-data";
+
+    @POST
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response multipartFormData(final MultipartFormDataInput input) {
+        var inputPartText = input.getFormDataMap().get(TEXT).stream().findAny().orElse(null);
+        if (inputPartText != null) {
+            try {
+                String fileContent = IOUtils.toString(input.getFormDataPart(FILE, InputStream.class, null),
+                        StandardCharsets.UTF_8);
+                String text = inputPartText.getBodyAsString();
+                return Response.ok(new MultipartFormDataDTO(text, fileContent)).build();
+            } catch (IOException e) {
+                LOGGER.errorf("Failed to retrieve form field value: %s", e.getMessage());
+            }
+        } else {
+            LOGGER.warnf("Multipart Form Data does not contain value of form field '%s'.", TEXT);
+        }
+        return Response.status(Status.BAD_REQUEST).build();
+    }
+}

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/NinetyNineBottlesOfBeerResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/NinetyNineBottlesOfBeerResource.java
@@ -1,0 +1,62 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import static io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource.ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_NAME;
+import static io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource.ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_VAL;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * {@link Path#value()} set in this resource contains characters that were causing the build time
+ * validation failure. The issue was resolved in 2.8.3. with https://github.com/quarkusio/quarkus/issues/25258.
+ */
+@RegisterForReflection
+@IfBuildProperty(name = ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_NAME, stringValue = ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_VAL)
+@Path(NinetyNineBottlesOfBeerResource.PATH)
+public class NinetyNineBottlesOfBeerResource {
+
+    public static final String ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_NAME = "quarkus-platform-version-2.8.3-or-higher";
+    public static final String ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_VAL = "true";
+    public static final String FIRST_BOTTLE_RESPONSE = "1 bottle of beer on the wall, 1 bottle of beer. Take one down, pass it around, no more beer on the wall!";
+    public static final String SECOND_BOTTLE_RESPONSE = "2 bottles of beer on the wall, 2 bottles of beer. Take one down, pass it around, 1 bottle of beer on the wall.";
+    public static final String OTHER_BOTTLES_RESPONSE = "%d bottles of beer on the wall, %d bottles of beer. Take one down, pass it around, %d bottles of beer on the wall.";
+    public static final String PATH = "/99-bottles-of-beer/bottle";
+    private static final String EXCEPTION_MESSAGE = "%s: expected path parameter value '%s' differ from '%s'.";
+
+    @Produces(APPLICATION_JSON)
+    @GET
+    @Path("/{bottle-number:1}")
+    public Uni<String> getFirstBottle(@PathParam("bottle-number") Integer bottleNumber) {
+        if (bottleNumber != null && bottleNumber.equals(1)) {
+            return Uni.createFrom().item(FIRST_BOTTLE_RESPONSE);
+        }
+        throw new IllegalStateException(String.format(EXCEPTION_MESSAGE, "getFirstBottle", 1, bottleNumber));
+    }
+
+    @Produces(APPLICATION_JSON)
+    @GET
+    @Path("/{2-nd-bottle-number:[^0-1,3-9]}")
+    public Uni<String> getSecondBottle(@PathParam("2-nd-bottle-number") Integer bottleNumber) {
+        if (bottleNumber != null && bottleNumber.equals(2)) {
+            return Uni.createFrom().item(SECOND_BOTTLE_RESPONSE);
+        }
+        throw new IllegalStateException(String.format(EXCEPTION_MESSAGE, "getSecondBottle", 2, bottleNumber));
+    }
+
+    @Produces(APPLICATION_JSON)
+    @GET
+    @Path("/{_bottle.number:[3-9]|[1-9][0-9]}")
+    public Uni<String> getOtherBottles(@PathParam("_bottle.number") Integer bottleNumber) {
+        if (bottleNumber != null && bottleNumber >= 3 && bottleNumber <= 99) {
+            return Uni.createFrom().item(String.format(OTHER_BOTTLES_RESPONSE, bottleNumber, bottleNumber, bottleNumber - 1));
+        }
+        throw new IllegalStateException(String.format(EXCEPTION_MESSAGE, "getOtherBottles", "3-99", bottleNumber));
+    }
+}

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/ReflectionConfiguration.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/ReflectionConfiguration.java
@@ -1,0 +1,8 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection(classNames = "javax.ws.rs.core.MediaType")
+public class ReflectionConfiguration {
+
+}

--- a/http/http-advanced-reactive/src/main/resources/application.properties
+++ b/http/http-advanced-reactive/src/main/resources/application.properties
@@ -43,6 +43,12 @@ quarkus.keycloak.policy-enforcer.paths.health.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.version.path=/api/httpVersion/*
 quarkus.keycloak.policy-enforcer.paths.version.enforcement-mode=DISABLED
 # Application endpoints
+quarkus.keycloak.policy-enforcer.paths.99-bottles-of-beer.path=/api/99-bottles-of-beer/*
+quarkus.keycloak.policy-enforcer.paths.99-bottles-of-beer.enforcement-mode=DISABLED
+quarkus.keycloak.policy-enforcer.paths.media-type.path=/api/media-type
+quarkus.keycloak.policy-enforcer.paths.media-type.enforcement-mode=DISABLED
+quarkus.keycloak.policy-enforcer.paths.multipart-form-data.path=/api/multipart-form-data
+quarkus.keycloak.policy-enforcer.paths.multipart-form-data.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.hello.path=/api/hello/*
 quarkus.keycloak.policy-enforcer.paths.hello.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.grpc.path=/api/grpc/*
@@ -54,3 +60,7 @@ quarkus.oidc.token.lifespan-grace=60
 
 # Disable PremierLeagueContainerRequestFilter unless it should be applied
 pl-container-request-filter.enabled=false
+
+# Register MultipartFormDataReader as provider (used by io.quarkus.ts.http.advanced.reactive.HelloResource.post)
+quarkus.index-dependency.resteasy-multipart.group-id=org.jboss.resteasy
+quarkus.index-dependency.resteasy-multipart.artifact-id=resteasy-multipart-provider

--- a/http/http-advanced-reactive/src/test/resources/file.txt
+++ b/http/http-advanced-reactive/src/test/resources/file.txt
@@ -1,0 +1,1 @@
+File content

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/BookClient.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/BookClient.java
@@ -11,6 +11,7 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import io.quarkus.ts.http.restclient.reactive.json.Book;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 @RegisterRestClient
@@ -64,5 +65,13 @@ public interface BookClient {
         @Path("/name")
         String getName();
     }
+
+    @GET
+    @Path("/クイック検索/% # [ ] + = & @ : ! * ( ) ' $ , ?/- _ . ~")
+    Multi<String> getByDecodedSearchTerm(@QueryParam("searchTerm") String searchTerm);
+
+    @GET
+    @Path("/%E3%82%AF%E3%82%A4%E3%83%83%E3%82%AF%E6%A4%9C%E7%B4%A2/%25%20%23%20%5B%20%5D%20+%20=%20&%20@%20:%20!%20*%20(%20)%20'%20$%20,%20%3F/-%20_%20.%20~")
+    Multi<String> getByEncodedSearchTerm(@QueryParam("searchTerm") String searchTerm);
 
 }

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/PlainBookResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/PlainBookResource.java
@@ -10,10 +10,13 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import io.quarkus.ts.http.restclient.reactive.json.Book;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 @Path("/books")
 public class PlainBookResource {
+
+    public static final String SEARCH_TERM_VAL = "Ernest Hemingway";
 
     @GET
     @Path("/map")
@@ -49,5 +52,24 @@ public class PlainBookResource {
     @Path("/author/profession/wage/currency/name")
     public Uni<String> getCurrency() {
         return Uni.createFrom().item("USD");
+    }
+
+    /**
+     * Characters in foreign language: '%E3%82%AF%E3%82%A4%E3%83%83%E3%82%AF%E6%A4%9C%E7%B4%A2' -> 'クイック検索' -> 'quick-search'
+     * Reserved characters: '%25%20%23%20%5B%20%5D%20+%20=%20&%20@%20:%20!%20*%20(%20)%20'%20$%20,%20%3F' -> "% # [ ] + = & @ :
+     * ! * ( ) ' $ , ?",
+     * characters '=', '+', '@', ':', '!', '*', '(', ')', '\'', ',' are not encoded as it's not necessary.
+     * Unreserved characters: - _ . ~
+     */
+    @GET
+    @Path("/%E3%82%AF%E3%82%A4%E3%83%83%E3%82%AF%E6%A4%9C%E7%B4%A2/%25%20%23%20%5B%20%5D%20+%20=%20&%20@%20:%20!%20*%20(%20)%20'%20$%20,%20%3F/-%20_%20.%20~")
+    public Multi<String> getBySearchTerm(@QueryParam("searchTerm") String searchTerm) {
+        if (SEARCH_TERM_VAL.equals(searchTerm)) {
+            return Multi.createFrom().items("In Ou"
+                    + "r Time", ", ", "The Sun Also Rises", ", ", "A Farewell to Arms", ", ",
+                    "The Old Man and the Sea");
+        } else {
+            return Multi.createFrom().empty();
+        }
     }
 }

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/ReactiveClientBookResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/ReactiveClientBookResource.java
@@ -13,6 +13,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import io.quarkus.ts.http.restclient.reactive.json.Book;
 import io.quarkus.ts.http.restclient.reactive.json.IdBeanParam;
 import io.quarkus.ts.http.restclient.reactive.json.JsonRestInterface;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 @Path("/client/book")
@@ -63,5 +64,17 @@ public class ReactiveClientBookResource {
     @Path("/currency")
     public String getLastResource() {
         return bookInterface.getAuthor().getProfession().getWage().getCurrency().getName();
+    }
+
+    @GET
+    @Path("/quick-search/decoded")
+    public Multi<String> getDecodedPath(@QueryParam("searchTerm") String searchTerm) {
+        return bookInterface.getByDecodedSearchTerm(searchTerm);
+    }
+
+    @GET
+    @Path("/quick-search/encoded")
+    public Multi<String> getEncodedPath(@QueryParam("searchTerm") String searchTerm) {
+        return bookInterface.getByEncodedSearchTerm(searchTerm);
     }
 }

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/files/FileResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/files/FileResource.java
@@ -51,7 +51,7 @@ public class FileResource {
     @GET
     @Produces(MediaType.MULTIPART_FORM_DATA)
     @Path("/download-multipart")
-    public RestResponse downloadMultipart() {
+    public RestResponse<FileWrapper> downloadMultipart() {
         FileWrapper wrapper = new FileWrapper();
         wrapper.file = FILE;
         return RestResponse.ok(wrapper);

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.http.restclient.reactive;
 
+import static io.quarkus.ts.http.restclient.reactive.PlainBookResource.SEARCH_TERM_VAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.http.HttpStatus;
@@ -11,11 +12,16 @@ import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.response.Response;
 
 @QuarkusScenario
 public class ReactiveRestClientIT {
+
+    private static final String HEMINGWAY_BOOKS = "In Our Time, The Sun Also Rises, A Farewell to Arms, The Old Man and the Sea";
+    private static final String DISABLE_IF_NOT_QUARKUS_2_7_6_OR_2_8_3_OR_HIGHER = "(2\\.[0-6]\\..*)|(2\\.7\\.[0-5]\\..*)|(2\\.8\\.[0-2]\\..*)";
+    private static final String FIXED_IN_2_7_6_AND_2_8_3 = "Fixed in Quarkus 2.8.3.Final and 2.7.6.Final";
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("modern.properties");
@@ -106,5 +112,23 @@ public class ReactiveRestClientIT {
         Response response = app.given().get("/client/book/currency");
         assertEquals(HttpStatus.SC_OK, response.statusCode());
         assertEquals("Heller", response.getBody().asString());
+    }
+
+    @DisabledOnQuarkusVersion(version = DISABLE_IF_NOT_QUARKUS_2_7_6_OR_2_8_3_OR_HIGHER, reason = FIXED_IN_2_7_6_AND_2_8_3)
+    @Test
+    public void decodedRequestPath() {
+        Response response = app.given().given().queryParam("searchTerm", SEARCH_TERM_VAL)
+                .get("/client/book/quick-search/decoded");
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+        assertEquals(HEMINGWAY_BOOKS, response.getBody().asString());
+    }
+
+    @DisabledOnQuarkusVersion(version = DISABLE_IF_NOT_QUARKUS_2_7_6_OR_2_8_3_OR_HIGHER, reason = FIXED_IN_2_7_6_AND_2_8_3)
+    @Test
+    public void encodedRequestPath() {
+        Response response = app.given().given().queryParam("searchTerm", SEARCH_TERM_VAL)
+                .get("/client/book/quick-search/encoded");
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+        assertEquals(HEMINGWAY_BOOKS, response.getBody().asString());
     }
 }


### PR DESCRIPTION
### Summary

Test coverage for [recently reported issues](https://github.com/quarkusio/quarkus/issues?q=is%3Aissue+author%3Asithmein+) related to a RESTEasy Reactive client and RESTEasy Reactive and the closest context.

#### RESTEasy Reactive client

- [Quarkus Issue #25326](https://github.com/quarkusio/quarkus/issues/25326) pointed out that special characters in a request path are not correctly encoded. `ReactiveRestClientIT#decodedRequestPath` checks that characters in foreign languages and reserved characters are encoded using a special subset of ASCII characters (Alphanumeric, Unereserved, Reserved). Must be tested with `mvn clean install -Dit.test=ReactiveRestClientIT#decodedRequestPath,ReactiveRestClientIT#encodedRequestPath -Dquarkus.platform.version=2.8.3.Final` as in 2.7.5.Final both encoded and decoded characters in request path are decoded by the client.

#### RESTEasy Reactive

Following tests must be run with `-Dquarkus-platform-version-2.8.3-or-higher=true`. This build time property enable `io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource` to be registered as a bean. `@Path#value()` validation was fixed in 2.8.3 and build fails in earlier Quarkus versions. The property must be added manually to all the relevant jobs/runs that should run this tests.

- According to [JAX-RS specification section 3.4.](https://download.oracle.com/otn-pub/jcp/jaxrs-2_0-fr-eval-spec/jsr339-jaxrs-2.0-final-spec.pdf?AuthParam=1653215184_88a21fd21b3459fc962038199675c61e) template parameters can contain dashes, underscores, ... which wasn't a case till 3.8.5. Issue was raised by [Quarkus #25258](https://github.com/quarkusio/quarkus/issues/25258). Added test `HttpAdvancedReactiveIT#uriPathTemplate` cover allowed characters as described in `javax.ws.rs.Path` Javadoc. Resource name inspired by [Donald Knuth 99 Bottles of Beer](https://en.wikipedia.org/wiki/99_Bottles_of_Beer#References_in_computer_science).

- [Media type formal parameter of the MessageBodyWriter#writeTo](https://github.com/quarkusio/quarkus/issues/25263) was always null with response type `Response`. Fixed in 2.7.6.Final. Tested by `HttpAdvancedReactiveIT#messageBodyWriter`.

- [Response Content type header](https://github.com/quarkusio/quarkus/issues/25295) should only have set charset with string media types. Fixed in 2.9.1.Final, tested with `mvn clean verify -Dquarkus.platform.version=2.9.1.Final -Dit.test=HttpAdvancedReactiveIT#responseContentType`.

- [Quarkus Issue 25312](https://github.com/quarkusio/quarkus/issues/25312) discuss Multipart Provider, `HttpAdvancedReactiveIT#multipartFormDataReader` test handling of multipart file and string form parameter.

- [When same header is set both in @RouterFilter and JAX-RS ContainerResponseFilter](https://github.com/quarkusio/quarkus/issues/25283), just the latter values are kept, fixed in Quarkus 2.10. Quarkus issue discuss setting `VARY` Http header, which is important f.e. for content negotiation, thus added test verify this scenario. The test must be run against upstream main as 2.10 wasn't released yet: `mvn clean verify -Dquarkus.platform.version=999-SNAPSHOT -Dit.test=HttpAdvancedReactiveIT#multipleResponseFilter`

- [Several Resources sharing a same path](https://github.com/quarkusio/quarkus/issues/25462) is compliant with JAX-RS (section 3.7.2) specification, as endpoint candidate can be determined from method `@Path`.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)