### PR TITLE
Move to Quarkus 999-SNAPSHOT including daily and PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           check-latest: true
-      - name: Build Quarkus 2.7
+      - name: Build Quarkus main
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && git checkout 2.7 && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Prelocations -pl devtools/cli -am
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Prelocations
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
@@ -111,17 +111,13 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-      - name: Build Quarkus CLI
+      - name: Install Quarkus CLI
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && git checkout 2.7 && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
-# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
-#      - name: Install Quarkus CLI
-#        run: |
-#          cat <<EOF > ./quarkus-dev-cli
-#          #!/bin/bash
-#          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
-#          EOF
-#          chmod +x ./quarkus-dev-cli
+          cat <<EOF > ./quarkus-dev-cli
+          #!/bin/bash
+          java -jar ~/.m2/repository/io/quarkus/quarkus-cli/999-SNAPSHOT/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+          EOF
+          chmod +x ./quarkus-dev-cli
       - name: Build with Maven
         run: |
           MODULES_MAVEN_PARAM=""
@@ -130,9 +126,7 @@ jobs:
             MODULES_MAVEN_PARAM="-pl ${MODULES_ARG}"
           fi
 
-          mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dall-modules $MODULES_MAVEN_PARAM
-# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
-# mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dall-modules -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" $MODULES_MAVEN_PARAM
+          mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dall-modules -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" $MODULES_MAVEN_PARAM -am
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -171,26 +165,21 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
-#      - name: Build Quarkus CLI
-#        run: |
-#          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && git checkout 2.7 && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
-#      - name: Install Quarkus CLI
-#        run: |
-#          cat <<EOF > ./quarkus-dev-cli
-#          #!/bin/bash
-#          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
-#          EOF
-#          chmod +x ./quarkus-dev-cli
+      - name: Install Quarkus CLI
+        run: |
+          cat <<EOF > ./quarkus-dev-cli
+          #!/bin/bash
+          java -jar ~/.m2/repository/io/quarkus/quarkus-cli/999-SNAPSHOT/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+          EOF
+          chmod +x ./quarkus-dev-cli
       - name: Build with Maven
         run: |
           if [[ -n ${MODULES_ARG} ]]; then
             echo "Running modules: ${MODULES_ARG}"
             mvn -fae -V -B -s .github/mvn-settings.xml -fae -Dall-modules -Dquarkus.container-image.build=false \
-                        -pl $MODULES_ARG clean verify -Dnative
+                        -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" \
+                        -pl $MODULES_ARG clean verify -Dnative -am
           fi
-# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
-# -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -235,7 +224,7 @@ jobs:
             MODULES_MAVEN_PARAM="-pl ${MODULES_ARG}"
           fi
 
-          mvn -fae -s .github/mvn-settings.xml clean verify -Dall-modules -Dquarkus.container-image.build=false $MODULES_MAVEN_PARAM
+          mvn -fae -s .github/mvn-settings.xml clean verify -Dall-modules -Dquarkus.container-image.build=false $MODULES_MAVEN_PARAM -am
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -20,9 +20,9 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           check-latest: true
-      - name: Build Quarkus 2.7
+      - name: Build Quarkus main
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && git checkout 2.7 && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Prelocations
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Prelocations
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
@@ -60,22 +60,16 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
-#      - name: Build Quarkus CLI
-#        run: |
-#          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && git checkout 2.7 && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
-#      - name: Install Quarkus CLI
-#        run: |
-#          cat <<EOF > ./quarkus-dev-cli
-#          #!/bin/bash
-#          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
-#          EOF
-#          chmod +x ./quarkus-dev-cli
+      - name: Install Quarkus CLI
+        run: |
+          cat <<EOF > ./quarkus-dev-cli
+          #!/bin/bash
+          java -jar ~/.m2/repository/io/quarkus/quarkus-cli/999-SNAPSHOT/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+          EOF
+          chmod +x ./quarkus-dev-cli
       - name: Test in JVM mode
         run: |
-          mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P ${{ matrix.profiles }}
-# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
-#          -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
+          mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P ${{ matrix.profiles }} -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -118,23 +112,18 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
-#      - name: Build Quarkus CLI
-#        run: |
-#          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && git checkout 2.7 && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
-#      - name: Install Quarkus CLI
-#        run: |
-#          cat <<EOF > ./quarkus-dev-cli
-#          #!/bin/bash
-#          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
-#          EOF
-#          chmod +x ./quarkus-dev-cli
+      - name: Install Quarkus CLI
+        run: |
+          cat <<EOF > ./quarkus-dev-cli
+          #!/bin/bash
+          java -jar ~/.m2/repository/io/quarkus/quarkus-cli/999-SNAPSHOT/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+          EOF
+          chmod +x ./quarkus-dev-cli
       - name: Test in Native mode
         run: |
           mvn -fae -V -B -s .github/mvn-settings.xml -P ${{ matrix.profiles }} -fae clean verify -Dnative \
-            -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }}
-# TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/632
-#            -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
+            -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }} \
+            -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
         if: failure()
         run: |

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/files/FileResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/files/FileResource.java
@@ -10,9 +10,9 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 import org.jboss.resteasy.reactive.MultipartForm;
+import org.jboss.resteasy.reactive.RestResponse;
 
 import io.quarkus.logging.Log;
 import io.smallrye.mutiny.Uni;
@@ -51,10 +51,10 @@ public class FileResource {
     @GET
     @Produces(MediaType.MULTIPART_FORM_DATA)
     @Path("/download-multipart")
-    public Response downloadMultipart() {
+    public RestResponse downloadMultipart() {
         FileWrapper wrapper = new FileWrapper();
         wrapper.file = FILE;
-        return Response.ok(wrapper).build();
+        return RestResponse.ok(wrapper);
     }
 
     @GET

--- a/messaging/kafka-confluent-avro-reactive-messaging/pom.xml
+++ b/messaging/kafka-confluent-avro-reactive-messaging/pom.xml
@@ -22,7 +22,7 @@
         <!-- with this, you don't have to use avro-maven-plugin -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-avro</artifactId>
+            <artifactId>quarkus-confluent-registry-avro</artifactId>
         </dependency>
         <!-- Confluent AVRO libraries -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <jjwt.version>0.11.5</jjwt.version>
         <camel-quarkus-bom.version>2.7.1</camel-quarkus-bom.version>
         <quarkiverse.config.version>1.0.2</quarkiverse.config.version>
+        <smallrye-stork.version>1.1.2</smallrye-stork.version>
         <profile.id>jvm</profile.id>
         <!-- S2i configuration -->
         <ts.global.s2i.quarkus.jvm.builder.image>registry.access.redhat.com/ubi8/openjdk-11:latest</ts.global.s2i.quarkus.jvm.builder.image>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <failsafe-plugin.version>2.22.2</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
+        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <quarkus.qe.framework.version>1.1.0.Final</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.32.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.6.1.Final</quarkus-ide-config.version>

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -47,10 +47,10 @@ import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 @DisabledIfSystemProperty(named = "profile.id", matches = "native", disabledReason = "Only for JVM verification")
 public class QuarkusCliCreateJvmApplicationIT {
 
-    static final String RESTEASY_EXTENSION = "quarkus-resteasy";
+    static final String RESTEASY_REACTIVE_EXTENSION = "quarkus-resteasy-reactive";
     static final String SMALLRYE_HEALTH_EXTENSION = "quarkus-smallrye-health";
     static final String SPRING_WEB_EXTENSION = "quarkus-spring-web";
-    static final String RESTEASY_JACKSON_EXTENSION = "quarkus-resteasy-jackson";
+    static final String RESTEASY_REACTIVE_JACKSON_EXTENSION = "quarkus-resteasy-reactive-jackson";
     static final String ROOT_FOLDER = "";
     static final String DOCKER_FOLDER = "/src/main/docker";
     static final String JDK_11 = "11";
@@ -78,7 +78,6 @@ public class QuarkusCliCreateJvmApplicationIT {
 
     @Tag("QUARKUS-1472")
     @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/24613")
     public void createAppShouldAutoDetectJavaVersion() {
         QuarkusCliRestService app = cliClient.createApplication("app", defaultWithFixedStream());
         assertExpectedJavaVersion(getFileFromApplication(app, ROOT_FOLDER, "pom.xml"), getSystemJavaVersion());
@@ -152,12 +151,13 @@ public class QuarkusCliCreateJvmApplicationIT {
         final String kogitoExtension = "kogito-quarkus-rules";
         final String prettytimeExtension = "quarkus-prettytime";
         QuarkusCliRestService app = cliClient.createApplication("app", defaultWithFixedStream().withExtensions(kogitoExtension,
-                prettytimeExtension, RESTEASY_EXTENSION, RESTEASY_JACKSON_EXTENSION));
+                prettytimeExtension, RESTEASY_REACTIVE_EXTENSION, RESTEASY_REACTIVE_JACKSON_EXTENSION));
 
         // Should build on Jvm
         Result result = app.buildOnJvm();
         assertTrue(result.isSuccessful(), "The application didn't build on JVM. Output: " + result.getOutput());
-        assertInstalledExtensions(app, kogitoExtension, prettytimeExtension, RESTEASY_EXTENSION, RESTEASY_JACKSON_EXTENSION);
+        assertInstalledExtensions(app, kogitoExtension, prettytimeExtension, RESTEASY_REACTIVE_EXTENSION,
+                RESTEASY_REACTIVE_JACKSON_EXTENSION);
     }
 
     @Tag("QUARKUS-1071")
@@ -165,10 +165,10 @@ public class QuarkusCliCreateJvmApplicationIT {
     public void shouldCreateApplicationWithCodeStarter() {
         // Create application with Resteasy Jackson + Spring Web (we need both for the app to run)
         QuarkusCliRestService app = cliClient.createApplication("app",
-                defaultWithFixedStream().withExtensions(RESTEASY_JACKSON_EXTENSION, SPRING_WEB_EXTENSION));
+                defaultWithFixedStream().withExtensions(RESTEASY_REACTIVE_JACKSON_EXTENSION, SPRING_WEB_EXTENSION));
 
-        // Verify By default, it installs only "quarkus-resteasy-jackson" and "quarkus-spring-web"
-        assertInstalledExtensions(app, RESTEASY_JACKSON_EXTENSION, SPRING_WEB_EXTENSION);
+        // Verify By default, it installs only "quarkus-resteasy-reactive-jackson" and "quarkus-spring-web"
+        assertInstalledExtensions(app, RESTEASY_REACTIVE_JACKSON_EXTENSION, SPRING_WEB_EXTENSION);
 
         // Start using DEV mode
         app.start();
@@ -183,14 +183,14 @@ public class QuarkusCliCreateJvmApplicationIT {
         QuarkusCliRestService app = cliClient.createApplication("app", defaults().withPlatformBom(gav));
 
         // By default, it installs only "quarkus-resteasy"
-        assertInstalledExtensions(app, RESTEASY_EXTENSION);
+        assertInstalledExtensions(app, RESTEASY_REACTIVE_EXTENSION);
 
         // Let's install Quarkus SmallRye Health
         Result result = app.installExtension(SMALLRYE_HEALTH_EXTENSION);
         assertTrue(result.isSuccessful(), SMALLRYE_HEALTH_EXTENSION + " was not installed. Output: " + result.getOutput());
 
         // Verify both extensions now
-        assertInstalledExtensions(app, RESTEASY_EXTENSION, SMALLRYE_HEALTH_EXTENSION);
+        assertInstalledExtensions(app, RESTEASY_REACTIVE_EXTENSION, SMALLRYE_HEALTH_EXTENSION);
 
         // The health endpoint should be now available
         app.start();
@@ -210,7 +210,7 @@ public class QuarkusCliCreateJvmApplicationIT {
     @Test
     public void shouldCreateJacocoReportsFromApplicationOnJvm() {
         QuarkusCliRestService app = cliClient.createApplication("app-with-jacoco",
-                defaultWithFixedStream().withExtensions("jacoco"));
+                defaultWithFixedStream().withExtensions("resteasy", "jacoco"));
 
         Result result = app.buildOnJvm();
         assertTrue(result.isSuccessful(), "The application didn't build on JVM. Output: " + result.getOutput());

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -226,7 +226,7 @@ public class QuarkusCliCreateJvmApplicationIT {
     @Test
     public void verifyRestEasyReactiveAndClassicResteasyCollisionUserMsg() {
         QuarkusCliRestService app = cliClient.createApplication("dependencyCollision",
-                defaults().withExtensions("resteasy", "resteasy-reactive"));
+                defaultWithFixedStream().withExtensions("resteasy", "resteasy-reactive"));
 
         Result buildResult = app.buildOnJvm();
 

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.quarkus.cli;
 
 import static io.quarkus.ts.quarkus.cli.QuarkusCliUtils.getCurrentStreamVersion;
+import static io.quarkus.ts.quarkus.cli.QuarkusCliUtils.isUpstream;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -44,31 +45,39 @@ public class QuarkusCliExtensionsIT {
 
     @Test
     public void shouldListExtensionsUsingDefaults() {
-        whenGetListExtensions("--stream", getCurrentStreamVersion());
+        whenGetListExtensions(getDefaultAppArgs().toArray(new String[0]));
         assertListDefaultOptionOutput();
     }
 
     @Test
     public void shouldListExtensionsUsingName() {
-        whenGetListExtensions("--stream", getCurrentStreamVersion(), "--name");
+        List<String> args = getDefaultAppArgs();
+        args.add("--name");
+        whenGetListExtensions(args.toArray(new String[0]));
         assertListNameOptionOutput();
     }
 
     @Test
     public void shouldListExtensionsUsingOrigins() {
-        whenGetListExtensions("--stream", getCurrentStreamVersion(), "--origins");
+        List<String> args = getDefaultAppArgs();
+        args.add("--origins");
+        whenGetListExtensions(args.toArray(new String[0]));
         assertListOriginsOptionOutput();
     }
 
     @Test
     public void shouldListExtensionsUsingConcise() {
-        whenGetListExtensions("--stream", getCurrentStreamVersion(), "--concise");
+        List<String> args = getDefaultAppArgs();
+        args.add("--concise");
+        whenGetListExtensions(args.toArray(new String[0]));
         assertListConciseOptionOutput();
     }
 
     @Test
     public void shouldListExtensionsUsingFull() {
-        whenGetListExtensions("--stream", getCurrentStreamVersion(), "--full");
+        List<String> args = getDefaultAppArgs();
+        args.add("--full");
+        whenGetListExtensions(args.toArray(new String[0]));
         assertListFullOptionOutput();
     }
 
@@ -103,7 +112,9 @@ public class QuarkusCliExtensionsIT {
 
     @Test
     public void shouldListExtensionsUsingInstallable() {
-        whenGetListExtensions("--stream", getCurrentStreamVersion(), "--installable");
+        List<String> args = getDefaultAppArgs();
+        args.add("--installable");
+        whenGetListExtensions(args.toArray(new String[0]));
         assertListDefaultOptionOutput();
     }
 
@@ -157,5 +168,15 @@ public class QuarkusCliExtensionsIT {
 
     private void assertResultIsSuccessful() {
         assertTrue(result.isSuccessful(), "Extensions list command didn't work. Output: " + result.getOutput());
+    }
+
+    private List<String> getDefaultAppArgs() {
+        String version = getCurrentStreamVersion();
+        List<String> args = new ArrayList<>();
+        if (!isUpstream(version)) {
+            args.addAll(Arrays.asList("--stream", version));
+        }
+
+        return args;
     }
 }

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
@@ -1,9 +1,13 @@
 package io.quarkus.ts.quarkus.cli;
 
 import static io.quarkus.ts.quarkus.cli.QuarkusCliUtils.getCurrentStreamVersion;
+import static io.quarkus.ts.quarkus.cli.QuarkusCliUtils.isUpstream;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -131,8 +135,9 @@ public class QuarkusCliSpecialCharsIT {
     }
 
     private void whenCreateAppAt(String folder) {
-        result = cliClient.run("create", "app", "--stream", getCurrentStreamVersion(), "--output-directory=" + folder,
-                ARTIFACT_ID);
+        List<String> args = getDefaultAppArgs("create", "app");
+        args.addAll(List.of("--output-directory=" + folder, ARTIFACT_ID));
+        result = cliClient.run(args.toArray(new String[args.size()]));
     }
 
     private void thenResultIsSuccessful() {
@@ -146,6 +151,17 @@ public class QuarkusCliSpecialCharsIT {
 
     private void deleteFolder(String folder) {
         FileUtils.deletePath(TARGET.resolve(folder));
+    }
+
+    private List<String> getDefaultAppArgs(String... defaultArgs) {
+        String version = getCurrentStreamVersion();
+        List<String> args = new ArrayList<>();
+        args.addAll(List.of(defaultArgs));
+        if (!isUpstream(version)) {
+            args.addAll(Arrays.asList("--stream", version));
+        }
+
+        return args;
     }
 
 }

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliUtils.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliUtils.java
@@ -4,21 +4,47 @@ import static io.quarkus.test.bootstrap.QuarkusCliClient.CreateApplicationReques
 
 import java.util.regex.Pattern;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.builder.Version;
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 
 public class QuarkusCliUtils {
 
+    public static final String QUARKUS_UPSTREAM_VERSION = "999-SNAPSHOT";
+    private static final Logger LOG = Logger.getLogger(QuarkusCliUtils.class);
+
     public static QuarkusCliClient.CreateApplicationRequest defaultWithFixedStream() {
-        return defaults().withStream(getCurrentStreamVersion());
+        String version = getCurrentStreamVersion();
+        if (isUpstream(version)) {
+            LOG.warn("fixed streams are not supported on upstream");
+            return defaults();
+        }
+
+        return defaults().withStream(version);
     }
 
     public static QuarkusCliClient.CreateExtensionRequest defaultNewExtensionArgsWithFixedStream() {
-        return QuarkusCliClient.CreateExtensionRequest.defaults().withStream(getCurrentStreamVersion());
+        String version = getCurrentStreamVersion();
+        if (isUpstream(version)) {
+            LOG.warn("fixed streams are not supported on upstream");
+            return QuarkusCliClient.CreateExtensionRequest.defaults();
+        }
+
+        return QuarkusCliClient.CreateExtensionRequest.defaults().withStream(version);
+    }
+
+    public static boolean isUpstream(String version) {
+        return version.equalsIgnoreCase(QUARKUS_UPSTREAM_VERSION);
     }
 
     public static String getCurrentStreamVersion() {
-        String[] version = Version.getVersion().split(Pattern.quote("."));
+        String rawVersion = Version.getVersion();
+        if (QUARKUS_UPSTREAM_VERSION.equalsIgnoreCase(rawVersion)) {
+            return QUARKUS_UPSTREAM_VERSION;
+        }
+
+        String[] version = rawVersion.split(Pattern.quote("."));
         return String.format("%s.%s", version[0], version[1]);
     }
 }

--- a/qute/multimodule/qute-test/src/main/resources/messages/alert_el.properties
+++ b/qute/multimodule/qute-test/src/main/resources/messages/alert_el.properties
@@ -1,2 +1,0 @@
-withoutParams=Γειά
-withParams=Γειά σου {name}

--- a/qute/multimodule/qute-test/src/main/resources/messages/msg_cs.properties
+++ b/qute/multimodule/qute-test/src/main/resources/messages/msg_cs.properties
@@ -1,2 +1,0 @@
-hello=Ahoj!
-hello_name=Ahoj {name}!

--- a/service-discovery/stork-custom/pom.xml
+++ b/service-discovery/stork-custom/pom.xml
@@ -29,6 +29,29 @@
             <artifactId>quarkus-rest-client-reactive</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.platform.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.smallrye.stork</groupId>
+                            <artifactId>stork-configuration-generator</artifactId>
+                            <version>${smallrye-stork.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
         <profile>

--- a/service-discovery/stork-custom/src/main/java/io/quarkus/ts/stork/custom/SimpleLoadBalancer.java
+++ b/service-discovery/stork-custom/src/main/java/io/quarkus/ts/stork/custom/SimpleLoadBalancer.java
@@ -12,7 +12,7 @@ public class SimpleLoadBalancer implements LoadBalancer {
 
     private final Random random;
 
-    public SimpleLoadBalancer(SimpleLoadBalancerProviderConfiguration config) {
+    public SimpleLoadBalancer(SimplelbConfiguration config) {
         random = new Random();
     }
 

--- a/service-discovery/stork-custom/src/main/java/io/quarkus/ts/stork/custom/SimpleLoadBalancerProvider.java
+++ b/service-discovery/stork-custom/src/main/java/io/quarkus/ts/stork/custom/SimpleLoadBalancerProvider.java
@@ -5,10 +5,10 @@ import io.smallrye.stork.api.ServiceDiscovery;
 import io.smallrye.stork.api.config.LoadBalancerType;
 import io.smallrye.stork.spi.LoadBalancerProvider;
 
-@LoadBalancerType("simple")
-public class SimpleLoadBalancerProvider implements LoadBalancerProvider<SimpleLoadBalancerProviderConfiguration> {
+@LoadBalancerType("simplelb")
+public class SimpleLoadBalancerProvider implements LoadBalancerProvider<SimplelbConfiguration> {
     @Override
-    public LoadBalancer createLoadBalancer(SimpleLoadBalancerProviderConfiguration config,
+    public LoadBalancer createLoadBalancer(SimplelbConfiguration config,
             ServiceDiscovery serviceDiscovery) {
         return new SimpleLoadBalancer(config);
     }

--- a/service-discovery/stork-custom/src/main/java/io/quarkus/ts/stork/custom/SimpleServiceDiscovery.java
+++ b/service-discovery/stork-custom/src/main/java/io/quarkus/ts/stork/custom/SimpleServiceDiscovery.java
@@ -14,7 +14,7 @@ import io.smallrye.stork.utils.ServiceInstanceIds;
 public class SimpleServiceDiscovery implements ServiceDiscovery {
     private static final Map<String, String> globalConfig = new HashMap<>();
 
-    public SimpleServiceDiscovery(SimpleServiceDiscoveryProviderConfiguration configuration) {
+    public SimpleServiceDiscovery(SimpleConfiguration configuration) {
         Optional
                 .ofNullable(configuration.getPongServiceHost())
                 .map(host -> globalConfig.put("pongHost", host));

--- a/service-discovery/stork-custom/src/main/java/io/quarkus/ts/stork/custom/SimpleServiceDiscoveryProvider.java
+++ b/service-discovery/stork-custom/src/main/java/io/quarkus/ts/stork/custom/SimpleServiceDiscoveryProvider.java
@@ -12,10 +12,10 @@ import io.smallrye.stork.spi.StorkInfrastructure;
 @ServiceDiscoveryAttribute(name = "pongServicePort", description = "Port of the pong service instance.", required = false)
 @ServiceDiscoveryAttribute(name = "pongReplicaServiceHost", description = "Host name of the pong service instance.", required = true)
 @ServiceDiscoveryAttribute(name = "pongReplicaServicePort", description = "Port of the pong service instance.", required = false)
-public class SimpleServiceDiscoveryProvider implements ServiceDiscoveryProvider<SimpleServiceDiscoveryProviderConfiguration> {
+public class SimpleServiceDiscoveryProvider implements ServiceDiscoveryProvider<SimpleConfiguration> {
     @Override
     public ServiceDiscovery createServiceDiscovery(
-            SimpleServiceDiscoveryProviderConfiguration config,
+            SimpleConfiguration config,
             String serviceName,
             ServiceConfig serviceConfig,
             StorkInfrastructure storkInfrastructure) {

--- a/service-discovery/stork-custom/src/main/resources/application.properties
+++ b/service-discovery/stork-custom/src/main/resources/application.properties
@@ -1,17 +1,17 @@
 #Un-comment the following properties if you want to do some verification
 
-#stork.pong.load-balancer=simple
-#stork.pong.service-discovery=simple
+#quarkus.stork.pong.load-balancer.type=simplelb
+#quarkus.stork.pong.service-discovery.type=simple
 # this properties make sense if you have a global service discovery state as a DB, for this scenario we are going to use an in-memory Map
-#stork.pong.service-discovery.host=localhost
-#stork.pong.service-discovery.port=8080
-#stork.pong.service-discovery.pongServiceHost=localhost
-#stork.pong.service-discovery.pongServicePort=8080
+#quarkus.stork.pong.service-discovery.host=localhost
+#quarkus.stork.pong.service-discovery.port=8080
+#quarkus.stork.pong.service-discovery.pongServiceHost=localhost
+#quarkus.stork.pong.service-discovery.pongServicePort=8080
 
-#stork.pong-replica.load-balancer=simple
-#stork.pong-replica.service-discovery=simple
+#quarkus.stork.pong-replica.load-balancer.type=simplelb
+#quarkus.stork.pong-replica.service-discovery.type=simple
 # this properties make sense if you have a global service discovery state as a DB, for this scenario we are going to use an in-memory Map
-#stork.pong-replica.service-discovery.host=localhost
-#stork.pong-replica.service-discovery.port=8080
-#stork.pong-replica.service-discovery.pongReplicaServiceHost=localhost
-#stork.pong-replica.service-discovery.pongReplicaServicePort=8080
+#quarkus.stork.pong-replica.service-discovery.host=localhost
+#quarkus.stork.pong-replica.service-discovery.port=8080
+#quarkus.stork.pong-replica.service-discovery.pongReplicaServiceHost=localhost
+#quarkus.stork.pong-replica.service-discovery.pongReplicaServicePort=8080

--- a/service-discovery/stork-custom/src/test/java/io/quarkus/ts/stork/custom/StorkCustomServiceDiscoveryAndLoadBalancerIT.java
+++ b/service-discovery/stork-custom/src/test/java/io/quarkus/ts/stork/custom/StorkCustomServiceDiscoveryAndLoadBalancerIT.java
@@ -40,12 +40,12 @@ public class StorkCustomServiceDiscoveryAndLoadBalancerIT {
 
     @QuarkusApplication
     static RestService mainPingService = new RestService()
-            .withProperty("stork.pong.load-balancer", "simple")
-            .withProperty("stork.pong.service-discovery", "simple")
-            .withProperty("stork.pong-replica.load-balancer", "simple")
-            .withProperty("stork.pong-replica.service-discovery", "simple")
-            .withProperty("stork.pong.service-discovery.pongServicePort", () -> "" + pongService.getPort())
-            .withProperty("stork.pong-replica.service-discovery.pongReplicaServicePort",
+            .withProperty("quarkus.stork.pong.load-balancer.type", "simplelb")
+            .withProperty("quarkus.stork.pong.service-discovery.type", "simple")
+            .withProperty("quarkus.stork.pong-replica.load-balancer.type", "simplelb")
+            .withProperty("quarkus.stork.pong-replica.service-discovery.type", "simple")
+            .withProperty("quarkus.stork.pong.service-discovery.pongServicePort", () -> "" + pongService.getPort())
+            .withProperty("quarkus.stork.pong-replica.service-discovery.pongReplicaServicePort",
                     () -> "" + pongReplicaService.getPort());
 
     @Test


### PR DESCRIPTION
### Summary

Move to Quarkus 999-SNAPSHOT including daily and PR CI

Changes in testSuite:
* Reactive resteasy multipart should return a [RestResponse](https://quarkus.io/guides/resteasy-reactive#setting-other-response-properties)
* Use [confluent AVRO registry extension](https://quarkus.io/guides/kafka-schema-registry-avro#creating-the-maven-project)
* Qute multimodule scenario has duplicate properties defined in both projects
* Missing Stork `stork-configuration-generator` path on `maven-compiler-plugin`
        -  https://github.com/quarkusio/quarkus/issues/25746 
* Add support to 999-SNAPSHOT - Quarkus-cli + the following issue resolution
        - https://github.com/quarkusio/quarkus/issues/25761  

Please select the relevant options.

- [X] Dependency update

### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)