### PR TITLE
[2.7] Quarkus-cli verify resteasy collision test should use a fixed stream 2.7

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -226,7 +226,7 @@ public class QuarkusCliCreateJvmApplicationIT {
     @Test
     public void verifyRestEasyReactiveAndClassicResteasyCollisionUserMsg() {
         QuarkusCliRestService app = cliClient.createApplication("dependencyCollision",
-                defaults().withExtensions("resteasy", "resteasy-reactive"));
+                defaultWithFixedStream().withExtensions("resteasy", "resteasy-reactive"));
 
         Result buildResult = app.buildOnJvm();
 


### PR DESCRIPTION
### Summary

Quarkus-cli `QuarkusCliCreateJvmApplicationIT#verifyRestEasyReactiveAndClassicResteasyCollisionUserMsg` was using a default Quarkus stream (the latest one) when an application was created. This PR changed this behavior on this scenario in order to follow the same pattern of the rest Quarkus-cli test. 

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)