### PR TITLE
Check, that header *contains* application/json

### DIFF
--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpCustomHeadersIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpCustomHeadersIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.http.minimum.reactive;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 
 import javax.ws.rs.core.MediaType;
@@ -40,6 +41,6 @@ public class HttpCustomHeadersIT {
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("content", is("hello"))
-                .contentType(is(MediaType.APPLICATION_JSON));
+                .contentType(containsString(MediaType.APPLICATION_JSON));
     }
 }


### PR DESCRIPTION
### Summary
We expected Content-Type header to contain only "application/json".
But it can(and now does) contain other things,
namely "charset" and "boundary" fields[1].
Therefore, we need to fix our tests.

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)