### PR TITLE
Enable `HttpAdvancedReactiveIT#uriPathTemplate` in Github workflows

### DIFF
--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/NinetyNineBottlesOfBeerResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/NinetyNineBottlesOfBeerResource.java
@@ -1,7 +1,7 @@
 package io.quarkus.ts.http.advanced.reactive;
 
-import static io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource.ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_NAME;
-import static io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource.ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_VAL;
+import static io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource.QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3;
+import static io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource.QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3_VAL;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import javax.ws.rs.GET;
@@ -9,21 +9,21 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 
-import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.arc.properties.UnlessBuildProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Uni;
 
 /**
  * {@link Path#value()} set in this resource contains characters that were causing the build time
- * validation failure. The issue was resolved in 2.8.3. with https://github.com/quarkusio/quarkus/issues/25258.
+ * validation failure. The issue was resolved in 2.8.3 with https://github.com/quarkusio/quarkus/issues/25258.
  */
 @RegisterForReflection
-@IfBuildProperty(name = ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_NAME, stringValue = ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_VAL)
+@UnlessBuildProperty(name = QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3, stringValue = QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3_VAL, enableIfMissing = true)
 @Path(NinetyNineBottlesOfBeerResource.PATH)
 public class NinetyNineBottlesOfBeerResource {
 
-    public static final String ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_NAME = "quarkus-platform-version-2.8.3-or-higher";
-    public static final String ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_VAL = "true";
+    public static final String QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3 = "quarkus-platform-version-less-than-2.8.3";
+    public static final String QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3_VAL = "true";
     public static final String FIRST_BOTTLE_RESPONSE = "1 bottle of beer on the wall, 1 bottle of beer. Take one down, pass it around, no more beer on the wall!";
     public static final String SECOND_BOTTLE_RESPONSE = "2 bottles of beer on the wall, 2 bottles of beer. Take one down, pass it around, 1 bottle of beer on the wall.";
     public static final String OTHER_BOTTLES_RESPONSE = "%d bottles of beer on the wall, %d bottles of beer. Take one down, pass it around, %d bottles of beer on the wall.";

--- a/http/http-advanced-reactive/src/main/resources/application.properties
+++ b/http/http-advanced-reactive/src/main/resources/application.properties
@@ -61,6 +61,6 @@ quarkus.oidc.token.lifespan-grace=60
 # Disable PremierLeagueContainerRequestFilter unless it should be applied
 pl-container-request-filter.enabled=false
 
-# Register MultipartFormDataReader as provider (used by io.quarkus.ts.http.advanced.reactive.HelloResource.post)
+# Register MultipartFormDataReader as provider (used by io.quarkus.ts.http.advanced.reactive.MultipartResource.multipartFormData)
 quarkus.index-dependency.resteasy-multipart.group-id=org.jboss.resteasy
 quarkus.index-dependency.resteasy-multipart.artifact-id=resteasy-multipart-provider

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HttpAdvancedReactiveIT.java
@@ -11,8 +11,8 @@ import static io.quarkus.ts.http.advanced.reactive.MediaTypeResource.MEDIA_TYPE_
 import static io.quarkus.ts.http.advanced.reactive.MultipartResource.FILE;
 import static io.quarkus.ts.http.advanced.reactive.MultipartResource.MULTIPART_FORM_PATH;
 import static io.quarkus.ts.http.advanced.reactive.MultipartResource.TEXT;
-import static io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource.ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_NAME;
-import static io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource.ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_VAL;
+import static io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource.QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3;
+import static io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource.QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3_VAL;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import javax.ws.rs.Path;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 
@@ -50,7 +51,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.Protocol;
@@ -78,8 +79,6 @@ import io.vertx.mutiny.ext.web.client.predicate.ResponsePredicateResult;
 @QuarkusScenario
 public class HttpAdvancedReactiveIT {
 
-    private static final String DISABLE_IF_NOT_QUARKUS_2_8_3_OR_HIGHER = "(2\\.[0-7]\\..*)|(2\\.8\\.[0-2]\\..*)";
-    private static final String TEST_REQUIRES_AT_LEAST_2_8_3 = "Fixed in Quarkus 2.8.3.Final";
     private static final String REALM_DEFAULT = "test-realm";
     private static final String ROOT_PATH = "/api";
     private static final String HELLO_ENDPOINT = ROOT_PATH + "/hello";
@@ -209,13 +208,14 @@ public class HttpAdvancedReactiveIT {
     }
 
     /**
-     * Test must be enabled with property {@link NinetyNineBottlesOfBeerResource#ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_NAME}
-     * set to {@link NinetyNineBottlesOfBeerResource#ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_VAL}.
+     * This test use special characters in {@link Path#value()}, that previously caused a validation error and build failure.
+     * The bug was fixed in 2.8.3. Disable test in previous Quarkus versions with property
+     * {@link NinetyNineBottlesOfBeerResource#QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3} set to
+     * {@link NinetyNineBottlesOfBeerResource#QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3_VAL}.
      *
      * @see NinetyNineBottlesOfBeerResource for more information
      */
-    @EnabledIfSystemProperty(matches = ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_VAL, named = ENABLED_ON_QUARKUS_2_8_3_OR_HIGHER_NAME, disabledReason = TEST_REQUIRES_AT_LEAST_2_8_3)
-    @DisabledOnQuarkusVersion(version = DISABLE_IF_NOT_QUARKUS_2_8_3_OR_HIGHER, reason = TEST_REQUIRES_AT_LEAST_2_8_3)
+    @DisabledIfSystemProperty(matches = QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3_VAL, named = QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3, disabledReason = "Fixed in Quarkus 2.8.3.Final")
     @DisplayName("JAX-RS URI path template test")
     @Test
     public void uriPathTemplate() {


### PR DESCRIPTION
Follow up to [PR 655](https://github.com/quarkus-qe/quarkus-test-suite/pull/655), one test must be disabled by build property in order to prevent build failure if run with Quarkus 2.7.5 and lesser.

### Summary

Class `io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource` breaks the build as `Path#value()` contain special characters as dash etc. [Issue 25258](https://github.com/quarkusio/quarkus/issues/25258) fixed the bug, the fix has been added to Quarkus since 2.7.6 and 2.8.3. The test resource is registered unless explicitly disabled with `-Dquarkus-platform-version-less-than-2.8.3=true`.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] Housekeeping

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)