### PR TITLE
Stork extension properties config moved to the quarkus namespace

### DIFF
--- a/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PongReplicaResource.java
+++ b/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PongReplicaResource.java
@@ -21,15 +21,15 @@ public class PongReplicaResource {
 
     private static final String DEFAULT_PONG_REPLICA_RESPONSE = "pongReplica";
 
-    @ConfigProperty(name = "stork.pong-replica.service-discovery.consul-host", defaultValue = "localhost")
+    @ConfigProperty(name = "quarkus.stork.pong-replica.service-discovery.consul-host", defaultValue = "localhost")
     String host;
-    @ConfigProperty(name = "stork.pong-replica.service-discovery.consul-port", defaultValue = "8500")
+    @ConfigProperty(name = "quarkus.stork.pong-replica.service-discovery.consul-port", defaultValue = "8500")
     String port;
     @ConfigProperty(name = "pong-replica-service-port", defaultValue = "8080")
     String pongPort;
     @ConfigProperty(name = "pong-replica-service-host", defaultValue = "localhost")
     String pongHost;
-    @ConfigProperty(name = "stork.pong-replica.service-discovery", defaultValue = "consul")
+    @ConfigProperty(name = "quarkus.stork.pong-replica.service-discovery.type", defaultValue = "consul")
     String serviceDiscoveryType;
 
     public void init(@Observes StartupEvent ev, Vertx vertx) {

--- a/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PongResource.java
+++ b/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PongResource.java
@@ -24,15 +24,15 @@ public class PongResource {
     private static final String HEADER_ID = "x-id";
     private String instanceUniqueId;
 
-    @ConfigProperty(name = "stork.pong.service-discovery.consul-host", defaultValue = "localhost")
+    @ConfigProperty(name = "quarkus.stork.pong.service-discovery.consul-host", defaultValue = "localhost")
     String host;
-    @ConfigProperty(name = "stork.pong.service-discovery.consul-port", defaultValue = "8500")
+    @ConfigProperty(name = "quarkus.stork.pong.service-discovery.consul-port", defaultValue = "8500")
     String port;
     @ConfigProperty(name = "pong-service-port", defaultValue = "8080")
     String pongPort;
     @ConfigProperty(name = "pong-service-host", defaultValue = "localhost")
     String pongHost;
-    @ConfigProperty(name = "stork.pong.service-discovery", defaultValue = "consul")
+    @ConfigProperty(name = "quarkus.stork.pong.service-discovery.type", defaultValue = "consul")
     String serviceDiscoveryType;
 
     public void init(@Observes StartupEvent ev, Vertx vertx) {

--- a/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PungResource.java
+++ b/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PungResource.java
@@ -17,15 +17,15 @@ import io.vertx.mutiny.ext.consul.ConsulClient;
 @RouteBase(path = "/pung", produces = MediaType.TEXT_PLAIN)
 public class PungResource {
 
-    @ConfigProperty(name = "stork.pung.service-discovery.consul-host", defaultValue = "localhost")
+    @ConfigProperty(name = "quarkus.stork.pung.service-discovery.consul-host", defaultValue = "localhost")
     String host;
-    @ConfigProperty(name = "stork.pung.service-discovery.consul-port", defaultValue = "8500")
+    @ConfigProperty(name = "quarkus.stork.pung.service-discovery.consul-port", defaultValue = "8500")
     String port;
     @ConfigProperty(name = "pung-service-port", defaultValue = "8080")
     String pungPort;
     @ConfigProperty(name = "pung-service-host", defaultValue = "localhost")
     String pungHost;
-    @ConfigProperty(name = "stork.pung.service-discovery", defaultValue = "consul")
+    @ConfigProperty(name = "quarkus.stork.pung.service-discovery.type", defaultValue = "consul")
     String serviceDiscoveryType;
 
     public void init(@Observes StartupEvent ev, Vertx vertx) {

--- a/service-discovery/stork/src/test/java/io/quarkus/ts/stork/NativeStorkServiceDiscoveryIT.java
+++ b/service-discovery/stork/src/test/java/io/quarkus/ts/stork/NativeStorkServiceDiscoveryIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.stork;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
@@ -23,19 +24,21 @@ public class NativeStorkServiceDiscoveryIT extends AbstractCommonTestCases {
             .withProperty("quarkus.http.port", PUNG_PORT)
             .withProperty("pung-service-port", PUNG_PORT)
             .withProperty("pung-service-host", "localhost")
-            .withProperty("stork.pung.service-discovery", "consul")
-            .withProperty("stork.pung.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
-            .withProperty("stork.pung.service-discovery.consul-host", () -> getConsultEndpoint(consul.getConsulEndpoint()));
+            .withProperty("quarkus.stork.pung.service-discovery.type", "consul")
+            .withProperty("quarkus.stork.pung.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
+            .withProperty("quarkus.stork.pung.service-discovery.consul-host",
+                    () -> getConsultEndpoint(consul.getConsulEndpoint()));
 
     @QuarkusApplication(classes = { PingResource.class, MyBackendPungProxy.class, MyBackendPongProxy.class })
     static RestService pingService = new RestService()
-            .withProperty("stork.pung.service-discovery", "consul")
-            .withProperty("stork.pung.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
-            .withProperty("stork.pung.service-discovery.consul-host", () -> getConsultEndpoint(consul.getConsulEndpoint()));
+            .withProperty("quarkus.stork.pung.service-discovery.type", "consul")
+            .withProperty("quarkus.stork.pung.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
+            .withProperty("quarkus.stork.pung.service-discovery.consul-host",
+                    () -> getConsultEndpoint(consul.getConsulEndpoint()));
 
     @Test
     public void invokeServiceByName() {
         String response = makePingCall(pingService, "pung").extract().body().asString();
-        assertThat("Service discovery by name fail.", PREFIX + "pung", is(response));
+        assertThat("Service discovery by name fail.", PREFIX + "pung", is(equalToIgnoringCase(response)));
     }
 }

--- a/service-discovery/stork/src/test/java/io/quarkus/ts/stork/OpenShiftStorkServiceDiscoveryIT.java
+++ b/service-discovery/stork/src/test/java/io/quarkus/ts/stork/OpenShiftStorkServiceDiscoveryIT.java
@@ -37,21 +37,21 @@ public class OpenShiftStorkServiceDiscoveryIT extends AbstractCommonTestCases {
 
     @QuarkusApplication(classes = PungResource.class)
     static RestService pung = new RestService()
-            .withProperty("stork.pung.service-discovery", "kubernetes")
-            .withProperty("stork.pung.service-discovery.k8s-namespace", "all");
+            .withProperty("quarkus.stork.pung.service-discovery.type", "kubernetes")
+            .withProperty("quarkus.stork.pung.service-discovery.k8s-namespace", "all");
 
     @QuarkusApplication(classes = PongResource.class)
     static RestService pong = new RestService()
             .onPostStart(app -> openshift.scaleTo(app, PONG_INSTANCES_AMOUNT))
-            .withProperty("stork.pong.service-discovery", "kubernetes")
-            .withProperty("stork.pong.service-discovery.k8s-namespace", "all");
+            .withProperty("quarkus.stork.pong.service-discovery", "kubernetes")
+            .withProperty("quarkus.stork.pong.service-discovery.k8s-namespace", "all");
 
     @QuarkusApplication(classes = { PingResource.class, MyBackendPungProxy.class, MyBackendPongProxy.class })
     static RestService ping = new RestService().onPreStart(app -> setupClusterRoles())
-            .withProperty("stork.pong.service-discovery", "kubernetes")
-            .withProperty("stork.pong.service-discovery.k8s-namespace", "all")
-            .withProperty("stork.pung.service-discovery", "kubernetes")
-            .withProperty("stork.pung.service-discovery.k8s-namespace", "all");
+            .withProperty("quarkus.stork.pong.service-discovery.type", "kubernetes")
+            .withProperty("quarkus.stork.pong.service-discovery.k8s-namespace", "all")
+            .withProperty("quarkus.stork.pung.service-discovery", "kubernetes")
+            .withProperty("quarkus.stork.pung.service-discovery.k8s-namespace", "all");
 
     @AfterAll
     public static void tearDown() {

--- a/service-discovery/stork/src/test/java/io/quarkus/ts/stork/StorkLoadBalancerIT.java
+++ b/service-discovery/stork/src/test/java/io/quarkus/ts/stork/StorkLoadBalancerIT.java
@@ -35,35 +35,37 @@ public class StorkLoadBalancerIT extends AbstractCommonTestCases {
             .withProperty("quarkus.http.port", PONG_PORT)
             .withProperty("pong-service-port", PONG_PORT)
             .withProperty("pong-service-host", "localhost")
-            .withProperty("stork.pong.service-discovery.refresh-period", "1")
-            .withProperty("stork.pong.service-discovery", "consul")
-            .withProperty("stork.pong.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
-            .withProperty("stork.pong.service-discovery.consul-host", () -> getConsultEndpoint(consul.getConsulEndpoint()));
+            .withProperty("quarkus.stork.pong.service-discovery.refresh-period", "1")
+            .withProperty("quarkus.stork.pong.service-discovery.type", "consul")
+            .withProperty("quarkus.stork.pong.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
+            .withProperty("quarkus.stork.pong.service-discovery.consul-host",
+                    () -> getConsultEndpoint(consul.getConsulEndpoint()));
 
     @QuarkusApplication(classes = PongReplicaResource.class)
     static RestService pongReplicaService = new RestService()
             .withProperty("quarkus.http.port", PONG_REPLICA_PORT)
             .withProperty("pong-replica-service-port", PONG_REPLICA_PORT)
             .withProperty("pong-replica-service-host", "localhost")
-            .withProperty("stork.pong-replica.service-discovery.refresh-period", "1")
-            .withProperty("stork.pong-replica.service-discovery", "consul")
-            .withProperty("stork.pong-replica.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
-            .withProperty("stork.pong-replica.service-discovery.consul-host",
+            .withProperty("quarkus.stork.pong-replica.service-discovery.refresh-period", "1")
+            .withProperty("quarkus.stork.pong-replica.service-discovery.type", "consul")
+            .withProperty("quarkus.stork.pong-replica.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
+            .withProperty("quarkus.stork.pong-replica.service-discovery.consul-host",
                     () -> getConsultEndpoint(consul.getConsulEndpoint()));
 
     @QuarkusApplication(classes = { PingResource.class, MyBackendPungProxy.class, MyBackendPongProxy.class })
     static RestService mainPingService = new RestService()
-            .withProperty("stork.pong-replica.service-discovery", "consul")
-            .withProperty("stork.pong-replica.service-discovery.refresh-period", "1")
-            .withProperty("stork.pong-replica.load-balancer", "round-robin")
-            .withProperty("stork.pong-replica.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
-            .withProperty("stork.pong-replica.service-discovery.consul-host",
+            .withProperty("quarkus.stork.pong-replica.service-discovery.type", "consul")
+            .withProperty("quarkus.stork.pong-replica.service-discovery.refresh-period", "1")
+            .withProperty("quarkus.stork.pong-replica.load-balancer.type", "round-robin")
+            .withProperty("quarkus.stork.pong-replica.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
+            .withProperty("quarkus.stork.pong-replica.service-discovery.consul-host",
                     () -> getConsultEndpoint(consul.getConsulEndpoint()))
-            .withProperty("stork.pong.service-discovery", "consul")
-            .withProperty("stork.pong.service-discovery.refresh-period", "1")
-            .withProperty("stork.pong.load-balancer", "round-robin")
-            .withProperty("stork.pong.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
-            .withProperty("stork.pong.service-discovery.consul-host", () -> getConsultEndpoint(consul.getConsulEndpoint()));
+            .withProperty("quarkus.stork.pong.service-discovery.type", "consul")
+            .withProperty("quarkus.stork.pong.service-discovery.refresh-period", "1")
+            .withProperty("quarkus.stork.pong.load-balancer.type", "round-robin")
+            .withProperty("quarkus.stork.pong.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
+            .withProperty("quarkus.stork.pong.service-discovery.consul-host",
+                    () -> getConsultEndpoint(consul.getConsulEndpoint()));
 
     @Test
     public void storkLoadBalancerByRoundRobin() {


### PR DESCRIPTION
### Summary

Based on migration changes of Quarkus 2.8 Stork properties have moved under "quarkus.*"  prefix

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)