### PR TITLE
Move to rhel8/mariadb-105, drop of rhscl/mariadb-102-rhel7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,6 @@
                                 <mysql.upstream.80.image>docker.io/library/mysql:8.0</mysql.upstream.80.image>
                                 <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7</mysql.80.image>
                                 <mariadb.10.image>docker.io/library/mariadb:10.6</mariadb.10.image>
-                                <mariadb.102.image>registry.access.redhat.com/rhscl/mariadb-102-rhel7</mariadb.102.image>
                                 <mssql.image>mcr.microsoft.com/mssql/rhel/server:2019-latest</mssql.image>
                                 <oracle.image>docker.io/gvenzl/oracle-xe:21-slim</oracle.image>
                                 <db2.image>quay.io/quarkusqeteam/db2:11.5.7.0</db2.image>
@@ -648,6 +647,7 @@
                                 <postgresql.10.image>registry.redhat.io/rhscl/postgresql-10-rhel7</postgresql.10.image>
                                 <postgresql.13.image>registry.redhat.io/rhscl/postgresql-13-rhel7</postgresql.13.image>
                                 <mariadb.103.image>registry.redhat.io/rhscl/mariadb-103-rhel7</mariadb.103.image>
+                                <mariadb.105.image>registry.redhat.io/rhel8/mariadb-105</mariadb.105.image>
                                 <amq-streams.image>registry.redhat.io/amq7/amq-streams-kafka-27-rhel7</amq-streams.image>
                                 <amq-streams.version>1.7.0</amq-streams.version>
                             </systemPropertyVariables>

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/boostrap/BookResourceSpringWebReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/boostrap/BookResourceSpringWebReactiveIT.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
@@ -21,13 +22,14 @@ import io.quarkus.ts.spring.web.reactive.reactive.AbstractDbReactiveIT;
 import io.restassured.response.Response;
 
 @QuarkusScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class BookResourceSpringWebReactiveIT extends AbstractDbReactiveIT {
 
     private static final String API_ROOT = "/api/books";
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.102.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.105.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/boostrap/OpenShiftBookResourceSpringWebReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/boostrap/OpenShiftBookResourceSpringWebReactiveIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.spring.web.reactive.reactive.boostrap;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -7,6 +9,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftBookResourceSpringWebReactiveIT extends BookResourceSpringWebReactiveIT {
 
     private static final String API_ROOT = "/api/books";

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/boostrap/OpenShiftQuteHomePageSpringWebReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/boostrap/OpenShiftQuteHomePageSpringWebReactiveIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.spring.web.reactive.reactive.boostrap;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -7,6 +9,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftQuteHomePageSpringWebReactiveIT extends QuteHomePageSpringWebReactiveIT {
 
     private static final String API_ROOT = "/api/books";

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/boostrap/QuteHomePageSpringWebReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/boostrap/QuteHomePageSpringWebReactiveIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.spring.web.reactive.reactive.boostrap;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -8,11 +10,12 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.spring.web.reactive.reactive.AbstractDbReactiveIT;
 
 @QuarkusScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class QuteHomePageSpringWebReactiveIT extends AbstractDbReactiveIT {
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.102.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.105.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/openapi/OpenApiReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/openapi/OpenApiReactiveIT.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvFileSource;
 
@@ -23,6 +24,7 @@ import io.restassured.response.Response;
 
 @QuarkusScenario
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenApiReactiveIT extends AbstractDbReactiveIT {
     private static Response response;
 
@@ -30,7 +32,7 @@ public class OpenApiReactiveIT extends AbstractDbReactiveIT {
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.102.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.105.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/openapi/OpenShiftOpenApiReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/openapi/OpenShiftOpenApiReactiveIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.spring.web.reactive.reactive.openapi;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -7,6 +9,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftOpenApiReactiveIT extends OpenApiReactiveIT {
 
     private static final String API_ROOT = "/api/books";

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/OpenShiftBookResourceIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/OpenShiftBookResourceIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.spring.web.reactive.boostrap;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -8,11 +10,12 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.spring.web.reactive.AbstractDbIT;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftBookResourceIT extends AbstractDbIT {
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.102.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.105.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/OpenShiftHomePageIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/OpenShiftHomePageIT.java
@@ -12,7 +12,7 @@ public class OpenShiftHomePageIT extends AbstractDbIT {
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.102.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.105.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/OpenShiftOpenApiIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/OpenShiftOpenApiIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.spring.web.reactive.openapi;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -8,11 +10,12 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.spring.web.reactive.AbstractDbIT;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftOpenApiIT extends AbstractDbIT {
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.102.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.105.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MariaDbDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MariaDbDatabaseHibernateReactiveIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.hibernate.reactive;
 
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.RestService;
@@ -9,6 +10,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class MariaDbDatabaseHibernateReactiveIT extends AbstractDatabaseHibernateReactiveIT {
 
     private static final String MYSQL_USER = "quarkus_test";
@@ -18,7 +20,7 @@ public class MariaDbDatabaseHibernateReactiveIT extends AbstractDatabaseHibernat
 
     // TODO At the time of writing, there is no specific connector for mariadb, so we are using MY SQL driver and service.
     // we need to change this, if this connector will be ever provided Additionally, we need to add an OpenShift test
-    @Container(image = "${mariadb.102.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.105.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
     static DefaultService database = new DefaultService()
             .withProperty("MYSQL_USER", MYSQL_USER)
             .withProperty("MYSQL_PASSWORD", MYSQL_PASSWORD)

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.sqldb.multiplepus;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.PostgresqlService;
 import io.quarkus.test.bootstrap.RestService;
@@ -8,6 +10,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftMultiplePersistenceIT extends AbstractMultiplePersistenceIT {
 
     static final int MYSQL_PORT = 3306;

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMariaDBDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMariaDBDatabaseIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -7,10 +9,11 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-public class OpenShiftMariaDB102DatabaseIT extends AbstractSqlDatabaseIT {
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
+public class OpenShiftMariaDBDatabaseIT extends AbstractSqlDatabaseIT {
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.102.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.105.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static MariaDbService database = new MariaDbService();
 
     @QuarkusApplication


### PR DESCRIPTION
Move to `rhel8/mariadb-105`, drop of `rhscl/mariadb-102-rhel7`

Also ensuring `ts.redhat.registry.enabled` property on tests which are using `mariadb-103-rhel7`

Checked `docker run -e MYSQL_USER=foo -e MYSQL_PASSWORD=bar -e MYSQL_DATABASE=db registry.redhat.io/rhel8/mariadb-105` to ensure the log check message is valid ++ executed `mvn clean verify -Predhat-registry -Dall-modules -pl sql-db/hibernate-reactive -Dit.test=MariaDbDatabaseHibernateReactiveIT`.

Alternative option - move fully to `rhel8/mariadb-105`, drop also `rhscl/mariadb-103-rhel7`

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] Refactoring 

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)