### PR TITLE
Add oidc TLS providers configuration coverage

### DIFF
--- a/security/oidc-client-mutual-tls/src/main/resources/application.properties
+++ b/security/oidc-client-mutual-tls/src/main/resources/application.properties
@@ -10,4 +10,9 @@ quarkus.oidc.tls.key-store-file=client-keystore.${ks-file-extension}
 quarkus.oidc.tls.trust-store-file=client-truststore.${ks-file-extension}
 quarkus.oidc.tls.key-store-password=${ks-pwd}
 quarkus.oidc.tls.trust-store-password=${ks-pwd}
+
+# TODO https://github.com/quarkusio/quarkus/issues/25972
+#quarkus.oidc.tls.trust-store-provider=SunRsaSign,SunJCE
+#quarkus.oidc.tls.key-store-provider=SunRsaSign,SunJCE
+
 quarkus.native.additional-build-args=-H:IncludeResources=.*\\.p12||.*\\.jks||.*\\.unknown-extension


### PR DESCRIPTION
### Summary

A new property `quarkus.oidc.tls.trust-store-provider` was added to Quarkus.
This PR verifies the correct behavior of this property

Please select the relevant options.

- [X] New scenario (non-breaking change which adds functionality)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)