### PR TITLE
Add Quarkus-cli Java18 coverage

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -55,6 +55,7 @@ public class QuarkusCliCreateJvmApplicationIT {
     static final String DOCKER_FOLDER = "/src/main/docker";
     static final String JDK_11 = "11";
     static final String JDK_17 = "17";
+    static final String JDK_18 = "18";
     static final String DOCKERFILE_JVM = "Dockerfile.jvm";
 
     @Inject
@@ -97,6 +98,14 @@ public class QuarkusCliCreateJvmApplicationIT {
     @Test
     public void shouldCreateAnApplicationForcingJavaVersion17() {
         CreateApplicationRequest args = defaultWithFixedStream().withExtraArgs("--java=" + JDK_17);
+        QuarkusCliRestService app = cliClient.createApplication("app", args);
+        assertExpectedJavaVersion(getFileFromApplication(app, ROOT_FOLDER, "pom.xml"), JDK_17);
+        assertDockerJavaVersion(getFileFromApplication(app, DOCKER_FOLDER, DOCKERFILE_JVM), JDK_17);
+    }
+
+    @Test
+    public void quarkusCreatedWithJava18ShouldUseJava17() {
+        CreateApplicationRequest args = defaultWithFixedStream().withExtraArgs("--java=" + JDK_18);
         QuarkusCliRestService app = cliClient.createApplication("app", args);
         assertExpectedJavaVersion(getFileFromApplication(app, ROOT_FOLDER, "pom.xml"), JDK_17);
         assertDockerJavaVersion(getFileFromApplication(app, DOCKER_FOLDER, DOCKERFILE_JVM), JDK_17);


### PR DESCRIPTION
### Summary

When a Quarkus app is created with Java 18 will use Java 17 and not Java 11


Please select the relevant options.
- [X] New scenario (non-breaking change which adds functionality)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)