### PR TITLE
Test Reactive RestClient with @Path is not included in OpenAPI Document

### DIFF
--- a/http/rest-client-reactive/pom.xml
+++ b/http/rest-client-reactive/pom.xml
@@ -21,6 +21,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jaxb</artifactId>
         </dependency>
         <dependency>

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.http.restclient.reactive;
 
 import static io.quarkus.ts.http.restclient.reactive.PlainBookResource.SEARCH_TERM_VAL;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.http.HttpStatus;
@@ -130,5 +131,16 @@ public class ReactiveRestClientIT {
                 .get("/client/book/quick-search/encoded");
         assertEquals(HttpStatus.SC_OK, response.statusCode());
         assertEquals(HEMINGWAY_BOOKS, response.getBody().asString());
+    }
+
+    /**
+     * Test class annotated with {@link javax.ws.rs.Path} and registered as client via
+     * {@link org.eclipse.microprofile.rest.client.inject.RegisterRestClient} must not be included in OpenAPI Document.
+     */
+    @DisabledOnQuarkusVersion(version = "(2\\.[0-6]\\..*)|(2\\.7\\.[0-5]\\..*)", reason = "Fixed in Quarkus 2.7.6.")
+    @Test
+    public void restClientIsNotIncludedInOpenApiDocument() {
+        // Path '/books/author/profession/name' is unique to AuthorClient#getProfession() and should not be part of OpenAPI document
+        app.given().get("/q/openapi?format=json").then().body("paths.\"/books/author/profession/name\"", nullValue());
     }
 }


### PR DESCRIPTION
### Summary

Verifies [Quarkus Issue 24344](https://github.com/quarkusio/quarkus/issues/24344). Test class annotated with `javax.ws.rs.Path` and registered as client via `org.eclipse.microprofile.rest.client.inject.RegisterRestClient` must not be included in OpenAPI Document.

Issue reproducer:
If you comment out
`//    @DisabledOnQuarkusVersion(version = "(2\\.[0-6]\\..*)|(2\\.7\\.[0-5]\\..*)", reason = "Fixed in Quarkus 2.7.6.")`
and run
`mvn clean verify -Dit.test=ReactiveRestClientIT#restClientIsNotIncludedInOpenApiDocument -Dquarkus.platform.version=2.7.4.Final`
the test will fail because clients paths are added to the OpenAPI Document. The same test passes in 2.7.6 and higher.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)