### PR TITLE
Test MessageBodyWriter receives right accepted Media Type with Response

### DIFF
--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MultipleResponseSerializersResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MultipleResponseSerializersResource.java
@@ -1,0 +1,106 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import static io.quarkus.ts.http.advanced.reactive.MultipleResponseSerializersResource.MULTIPLE_RESPONSE_SERIALIZERS_PATH;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
+import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
+import static javax.ws.rs.core.MediaType.TEXT_HTML;
+import static javax.ws.rs.core.MediaType.TEXT_HTML_TYPE;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import io.vertx.core.http.HttpServerRequest;
+
+@Path(MULTIPLE_RESPONSE_SERIALIZERS_PATH)
+public class MultipleResponseSerializersResource {
+
+    public static final String MULTIPLE_RESPONSE_SERIALIZERS_PATH = "/multiple-response-serializers";
+
+    /**
+     * Response serializers are applied if request query param is true,
+     * e.g. /multiple-response-serializers?apply-response-serializer=true
+     */
+    public static final String APPLY_RESPONSE_SERIALIZER_PARAM_FLAG = "apply-response-serializer";
+
+    @GET
+    @Produces({ TEXT_HTML, APPLICATION_OCTET_STREAM, TEXT_PLAIN, APPLICATION_JSON })
+    public Response getMediaTypeAcceptedBySerializer() {
+        // Actual response is streamed by a response type serializer
+        return Response.ok("").build();
+    }
+
+    @Provider
+    public static class TextHtmlSerializer extends StringResponseSerializer {
+
+        protected TextHtmlSerializer() {
+            super(TEXT_HTML_TYPE);
+        }
+    }
+
+    @Provider
+    public static class ApplicationOctetStreamSerializer extends StringResponseSerializer {
+
+        protected ApplicationOctetStreamSerializer() {
+            super(APPLICATION_OCTET_STREAM_TYPE);
+        }
+    }
+
+    @Provider
+    public static class TextPlainSerializer extends StringResponseSerializer {
+
+        protected TextPlainSerializer() {
+            super(TEXT_PLAIN_TYPE);
+        }
+    }
+
+    @Provider
+    public static class ApplicationJsonSerializer extends StringResponseSerializer {
+
+        protected ApplicationJsonSerializer() {
+            super(APPLICATION_JSON_TYPE);
+        }
+    }
+
+    private static abstract class StringResponseSerializer implements MessageBodyWriter<String> {
+
+        @Context
+        HttpServerRequest httpRequest;
+
+        private final MediaType acceptedMediaType;
+
+        protected StringResponseSerializer(MediaType acceptedMediaType) {
+            this.acceptedMediaType = acceptedMediaType;
+        }
+
+        @Override
+        public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return type.equals(String.class) && mediaType.isCompatible(acceptedMediaType)
+            // Prevent applying a serializer unintentionally
+                    && Boolean.parseBoolean(httpRequest.getParam(APPLY_RESPONSE_SERIALIZER_PARAM_FLAG));
+        }
+
+        @Override
+        public void writeTo(String s, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+                throws IOException, WebApplicationException {
+            entityStream.write(acceptedMediaType.toString().getBytes());
+        }
+    }
+}

--- a/http/http-advanced-reactive/src/main/resources/application.properties
+++ b/http/http-advanced-reactive/src/main/resources/application.properties
@@ -45,6 +45,8 @@ quarkus.keycloak.policy-enforcer.paths.version.enforcement-mode=DISABLED
 # Application endpoints
 quarkus.keycloak.policy-enforcer.paths.99-bottles-of-beer.path=/api/99-bottles-of-beer/*
 quarkus.keycloak.policy-enforcer.paths.99-bottles-of-beer.enforcement-mode=DISABLED
+quarkus.keycloak.policy-enforcer.paths.multiple-response-serializers.path=/api/multiple-response-serializers/*
+quarkus.keycloak.policy-enforcer.paths.multiple-response-serializers.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.media-type.path=/api/media-type
 quarkus.keycloak.policy-enforcer.paths.media-type.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.multipart-form-data.path=/api/multipart-form-data

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HttpAdvancedReactiveIT.java
@@ -11,6 +11,8 @@ import static io.quarkus.ts.http.advanced.reactive.MediaTypeResource.MEDIA_TYPE_
 import static io.quarkus.ts.http.advanced.reactive.MultipartResource.FILE;
 import static io.quarkus.ts.http.advanced.reactive.MultipartResource.MULTIPART_FORM_PATH;
 import static io.quarkus.ts.http.advanced.reactive.MultipartResource.TEXT;
+import static io.quarkus.ts.http.advanced.reactive.MultipleResponseSerializersResource.APPLY_RESPONSE_SERIALIZER_PARAM_FLAG;
+import static io.quarkus.ts.http.advanced.reactive.MultipleResponseSerializersResource.MULTIPLE_RESPONSE_SERIALIZERS_PATH;
 import static io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource.QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3;
 import static io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource.QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3_VAL;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -307,6 +309,27 @@ public class HttpAdvancedReactiveIT {
         testResponseContentType(MULTIPART_FORM_DATA, MULTIPART_FORM_DATA);
         testResponseContentType(IMAGE_PNG, IMAGE_PNG);
         testResponseContentType(IMAGE_JPEG, IMAGE_JPEG);
+    }
+
+    @DisabledOnQuarkusVersion(version = "(2\\.[0-6]\\..*)|(2\\.7\\.[0-5]\\..*)|(2\\.8\\.0\\..*)", reason = "Fixed in Quarkus 2.8.1 and backported to 2.7.6.")
+    @Test
+    public void testMediaTypePassedToMessageBodyWriter() {
+        // Accepted Media Type must be passed to 'MessageBodyWriter'
+        // 'MessageBodyWriter' then returns passed Media Type for a verification
+        assertAcceptedMediaTypeEqualsResponseBody(APPLICATION_JSON);
+        assertAcceptedMediaTypeEqualsResponseBody(TEXT_HTML);
+        assertAcceptedMediaTypeEqualsResponseBody(TEXT_PLAIN);
+        assertAcceptedMediaTypeEqualsResponseBody(APPLICATION_OCTET_STREAM);
+    }
+
+    private void assertAcceptedMediaTypeEqualsResponseBody(String acceptedMediaType) {
+        app
+                .given()
+                .accept(acceptedMediaType)
+                .queryParam(APPLY_RESPONSE_SERIALIZER_PARAM_FLAG, Boolean.TRUE)
+                .get(ROOT_PATH + MULTIPLE_RESPONSE_SERIALIZERS_PATH)
+                .then()
+                .body(is(acceptedMediaType));
     }
 
     private void testResponseContentType(String acceptedContentType, String expectedContentType) {


### PR DESCRIPTION
### Summary

Verifies [Quarkus Issue 22119](https://github.com/quarkusio/quarkus/issues/22119). According to JAX-RS standard, if request specifies accepted Media type, the type should be passed to `javax.ws.rs.ext.MessageBodyWriter`, however for use case when `javax.ws.rs.core.Response` is returned, that was only fixed in Quarkus 2.8.1 and backported to 2.7.6. Previously, if multiple media types were defined in `@Produces`, the first one was taken. This test verifies that a value of `Accept` HTTP header is same as the media type passed to `MessageBodyWriter` when endpoint response type is `Response`.

#### Reproducer

`mvn clean verify -Dit.test=HttpAdvancedReactiveIT#testMediaTypePassedToMessageBodyWriter -Dquarkus.platform.version=2.8.0.Final -Dquarkus-platform-version-less-than-2.8.3=true` with commented out `@DisabledOnQuarkusVersion`.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)