### PR TITLE
Test Spring Data JPA Interface-based Projection declared outside of Repo

### DIFF
--- a/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/primitivetypes/BookRepository.java
+++ b/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/primitivetypes/BookRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 import io.quarkus.ts.spring.data.primitivetypes.model.Book;
+import io.quarkus.ts.spring.data.primitivetypes.model.BookProjection;
 
 @RepositoryRestResource(exported = false)
 public interface BookRepository extends CrudRepository<Book, Integer> {
@@ -30,4 +31,7 @@ public interface BookRepository extends CrudRepository<Book, Integer> {
 
     //This is for regression test for https://github.com/quarkusio/quarkus/pull/13015
     List<Book> findByPublisherAddressZipCode(@Param("zipCode") String zipCode);
+
+    @Query("SELECT bid, publicationYear, isbn, name, publisherAddress FROM Book WHERE bid = :bid")
+    BookProjection getByBid(Integer bid);
 }

--- a/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/primitivetypes/BookResource.java
+++ b/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/primitivetypes/BookResource.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
 import io.quarkus.ts.spring.data.primitivetypes.model.Book;
+import io.quarkus.ts.spring.data.primitivetypes.model.BookProjection;
 
 @Path("/book")
 public class BookResource {
@@ -33,6 +34,13 @@ public class BookResource {
         verifyBookExists(id);
         book.setBid(id);
         return bookRepository.save(book);
+    }
+
+    @GET
+    @Produces("application/json")
+    @Path("/projection/{bid}")
+    public BookProjection getBookProjection(@PathParam("bid") Integer bid) {
+        return bookRepository.getByBid(bid);
     }
 
     @GET

--- a/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/primitivetypes/model/BookProjection.java
+++ b/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/primitivetypes/model/BookProjection.java
@@ -1,0 +1,15 @@
+package io.quarkus.ts.spring.data.primitivetypes.model;
+
+public interface BookProjection {
+
+    Integer getBid();
+
+    Integer getPublicationYear();
+
+    Long getIsbn();
+
+    Address getPublisherAddress();
+
+    String getName();
+
+}

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/SpringDataBookResourceIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/SpringDataBookResourceIT.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
+import static org.jboss.resteasy.spi.HttpResponseCodes.SC_OK;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.ts.spring.data.AbstractDbIT;
 import io.quarkus.ts.spring.data.primitivetypes.model.Book;
 import io.restassured.http.ContentType;
@@ -23,6 +25,22 @@ import io.restassured.response.Response;
 
 @QuarkusScenario
 public class SpringDataBookResourceIT extends AbstractDbIT {
+
+    @DisabledOnQuarkusVersion(version = "(2\\.[0-6]\\..*)|(2\\.7\\.[0-5]\\..*)|(2\\.8\\.0\\..*)", reason = "Fixed in Quarkus 2.8.1 and backported to 2.7.6.")
+    @Test
+    void testInterfaceBasedProjection() {
+        app
+                .given()
+                .get("/book/projection/6")
+                .then()
+                .statusCode(SC_OK)
+                .body("bid", is(6))
+                .body("publicationYear", is(2015))
+                .body("isbn", is(9789295055020L))
+                .body("name", is("The Silk Roads"))
+                .body("publisherAddress.id", is(1))
+                .body("publisherAddress.zipCode", is("28080"));
+    }
 
     @Test
     void testCustomFindPublicationYearPrimitiveInteger() {


### PR DESCRIPTION

### Summary

Verifies [Quarkus Issue 24800](https://github.com/quarkusio/quarkus/issues/24800). Calling repository methods returning interface-based projection defined outside of `PanacheRepository` causes a runtime exception. The issue was fixed in Quarkus 2.8.1 and backported to 2.7.6. The issue can be reproduced by commenting out `@DisabledOnQuarkusVersion` on the test and running `mvn clean verify -Dit.test=SpringDataBookResourceIT#testInterfaceBasedProjection -Dquarkus.platform.version=2.7.5.Final`.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)