### PR TITLE
Bump formatter-maven-plugin from 2.18.0 to 2.19.0

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HttpAdvancedReactiveIT.java
@@ -140,7 +140,7 @@ public class HttpAdvancedReactiveIT {
     public void http2ClientSync() throws Exception {
         HttpVersionClientService versionHttpClient = new RestClientServiceBuilder<HttpVersionClientService>(
                 getAppEndpoint()).withHostVerified(true).withPassword(PASSWORD).withKeyStorePath(KEY_STORE_PATH)
-                        .build(HttpVersionClientService.class);
+                .build(HttpVersionClientService.class);
 
         Response resp = versionHttpClient.getClientHttpVersion();
         assertEquals(SC_OK, resp.getStatus());
@@ -153,7 +153,7 @@ public class HttpAdvancedReactiveIT {
     public void http2ClientAsync() throws Exception {
         HttpVersionClientServiceAsync clientServiceAsync = new RestClientServiceBuilder<HttpVersionClientServiceAsync>(
                 getAppEndpoint()).withHostVerified(true).withPassword(PASSWORD).withKeyStorePath(KEY_STORE_PATH)
-                        .build(HttpVersionClientServiceAsync.class);
+                .build(HttpVersionClientServiceAsync.class);
 
         Response resp = clientServiceAsync.getClientHttpVersion().await().atMost(Duration.ofSeconds(ASSERT_TIMEOUT_SECONDS));
 

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
@@ -104,7 +104,7 @@ public class HttpAdvancedIT {
     public void http2ClientSync() throws Exception {
         HttpVersionClientService versionHttpClient = new RestClientServiceBuilder<HttpVersionClientService>(
                 getAppEndpoint()).withHostVerified(true).withPassword(PASSWORD).withKeyStorePath(KEY_STORE_PATH)
-                        .build(HttpVersionClientService.class);
+                .build(HttpVersionClientService.class);
 
         Response resp = versionHttpClient.getClientHttpVersion();
         assertEquals(HttpStatus.SC_OK, resp.getStatus());
@@ -117,7 +117,7 @@ public class HttpAdvancedIT {
     public void http2ClientAsync() throws Exception {
         HttpVersionClientServiceAsync clientServiceAsync = new RestClientServiceBuilder<HttpVersionClientServiceAsync>(
                 getAppEndpoint()).withHostVerified(true).withPassword(PASSWORD).withKeyStorePath(KEY_STORE_PATH)
-                        .build(HttpVersionClientServiceAsync.class);
+                .build(HttpVersionClientServiceAsync.class);
 
         Response resp = clientServiceAsync.getClientHttpVersion().await().atMost(Duration.ofSeconds(ASSERT_TIMEOUT_SECONDS));
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <quarkus-ide-config.version>2.6.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>
         <confluent.kafka-avro-serializer.version>7.0.3</confluent.kafka-avro-serializer.version>
-        <formatter-maven-plugin.version>2.18.0</formatter-maven-plugin.version>
+        <formatter-maven-plugin.version>2.19.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.7.0</impsort-maven-plugin.version>
         <xml-format-maven-plugin.version>3.2.1</xml-format-maven-plugin.version>
         <checkstyle.version>10.2</checkstyle.version>


### PR DESCRIPTION
Bump formatter-maven-plugin from 2.18.0 to 2.19.0

Replaces https://github.com/quarkus-qe/quarkus-test-suite/pull/678

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)