### PR TITLE
Add backport as an option in PR github template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@ Please select the relevant options.
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Dependency update
 - [ ] Refactoring
+- [ ] Backport
 - [ ] New scenario (non-breaking change which adds functionality)
 - [ ] This change requires a documentation update
 


### PR DESCRIPTION
### Summary

Add missing PR GitHub template option

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)


### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)