### PR TITLE
Fix jaeger operation name query param

### DIFF
--- a/http/graphql-telemetry/src/test/java/io/quarkus/ts/http/graphql/telemetry/GraphQLTelemetryIT.java
+++ b/http/graphql-telemetry/src/test/java/io/quarkus/ts/http/graphql/telemetry/GraphQLTelemetryIT.java
@@ -41,7 +41,7 @@ public class GraphQLTelemetryIT {
         await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(10)).untilAsserted(() -> {
             String operation = "/graphql";
             Response traces = given().when()
-                    .queryParam("operation", operation)
+                    .queryParam("operationName", operation)
                     .queryParam("lookback", "1h")
                     .queryParam("limit", 10)
                     .queryParam("service", "graphql-telemetry")

--- a/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
+++ b/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
@@ -102,7 +102,7 @@ public class VertxWebClientIT {
     public void endpointShouldTrace() {
         final int pageLimit = 50;
         final String expectedOperationName = "/trace/ping";
-        await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
+        await().atMost(3, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
             whenIMakePingRequest();
             thenRetrieveTraces(pageLimit, "1h", getServiceName(), expectedOperationName);
             thenStatusCodeMustBe(HttpStatus.SC_OK);
@@ -118,7 +118,7 @@ public class VertxWebClientIT {
     public void httpClientShouldHaveHisOwnSpan() {
         final int pageLimit = 50;
         final String expectedOperationName = "/trace/ping";
-        await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
+        await().atMost(3, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
             whenIMakePingRequest();
             thenRetrieveTraces(pageLimit, "1h", getServiceName(), expectedOperationName);
             thenStatusCodeMustBe(HttpStatus.SC_OK);
@@ -142,7 +142,7 @@ public class VertxWebClientIT {
                 .queryParam("limit", pageLimit)
                 .queryParam("lookback", lookBack)
                 .queryParam("service", serviceName)
-                .queryParam("operation", operationName)
+                .queryParam("operationName", operationName)
                 .get(jaeger.getRestUrl());
     }
 


### PR DESCRIPTION
### Summary

Jaeger openation name has changed:

operation -> operationName

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)