### PR TITLE
Fix Vertx-WebClient / jaeger scenario

### DIFF
--- a/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
+++ b/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
@@ -101,8 +101,8 @@ public class VertxWebClientIT {
     @Test
     public void endpointShouldTrace() {
         final int pageLimit = 50;
-        final String expectedOperationName = "/trace/ping";
-        await().atMost(3, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
+        final String expectedOperationName = "trace/ping";
+        await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
             whenIMakePingRequest();
             thenRetrieveTraces(pageLimit, "1h", getServiceName(), expectedOperationName);
             thenStatusCodeMustBe(HttpStatus.SC_OK);
@@ -117,8 +117,8 @@ public class VertxWebClientIT {
     @Test
     public void httpClientShouldHaveHisOwnSpan() {
         final int pageLimit = 50;
-        final String expectedOperationName = "/trace/ping";
-        await().atMost(3, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
+        final String expectedOperationName = "trace/ping";
+        await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
             whenIMakePingRequest();
             thenRetrieveTraces(pageLimit, "1h", getServiceName(), expectedOperationName);
             thenStatusCodeMustBe(HttpStatus.SC_OK);


### PR DESCRIPTION
### Summary

Jaeger operationName doesn't start with slash anymore

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)