### PR TITLE
Keep PEM files in native mode

### DIFF
--- a/security/jwt/src/main/resources/application.properties
+++ b/security/jwt/src/main/resources/application.properties
@@ -3,3 +3,4 @@ mp.jwt.verify.publickey.location=public-key.pem
 mp.jwt.verify.issuer=https://my.auth.server/
 smallrye.jwt.expiration.grace=120
 quarkus.security.deny-unannotated-members=true
+quarkus.native.additional-build-args=-H:IncludeResources=.*\\.pem


### PR DESCRIPTION
### Summary

PEM files `private-key.pem` and `public-key.pem` were not kept, thus f.e. `OpenShiftCookieJwtSecurityIT#securedEveryoneViewGroup` was failing.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)