### PR TITLE
Ensure no NPE  is thrown when using RestClient with Micrometer disabled

### DIFF
--- a/http/rest-client/pom.xml
+++ b/http/rest-client/pom.xml
@@ -23,5 +23,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-jsonb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/http/rest-client/src/test/java/io/quarkus/ts/http/restclient/ClientBookResourceIT.java
+++ b/http/rest-client/src/test/java/io/quarkus/ts/http/restclient/ClientBookResourceIT.java
@@ -8,29 +8,43 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
 public class ClientBookResourceIT {
 
+    @QuarkusApplication
+    static RestService app = new RestService();
+
+    @QuarkusApplication
+    static RestService appWithMicrometerDisabled = new RestService().withProperty("quarkus.micrometer.enabled", "false");
+
     @Test
     public void shouldGetBookFromRestClientXml() {
-        given().get("/client/book/xml").then().statusCode(HttpStatus.SC_OK)
+        app.given().get("/client/book/xml").then().statusCode(HttpStatus.SC_OK)
                 .body(is(
                         "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><book><title>Title in Xml</title></book>"));
     }
 
     @Test
     public void shouldGetBookFromRestClientJson() {
-        given().get("/client/book/json").then().statusCode(HttpStatus.SC_OK)
+        app.given().get("/client/book/json").then().statusCode(HttpStatus.SC_OK)
                 .body(is("{\"title\":\"Title in Json\"}"));
     }
 
     @Test
     @Tag("QUARKUS-1376")
     public void notFoundShouldNotReturnAnyResteasyImplementationDetails() {
-        String body = given().get("/notFound").then().statusCode(HttpStatus.SC_NOT_FOUND).extract().body().asString();
+        String body = app.given().get("/notFound").then().statusCode(HttpStatus.SC_NOT_FOUND).extract().body().asString();
         Assertions.assertFalse(body.contains("RESTEASY"),
                 "Not found resource should not return any Resteasy implementation details, but was: " + body);
+    }
+
+    @Test
+    @Tag("QUARKUS-2127")
+    public void noNullPointerExceptionForRestClientUsageWithDisabledMicrometer() {
+        appWithMicrometerDisabled.given().get("/client/book/xml").then().statusCode(HttpStatus.SC_OK);
     }
 }


### PR DESCRIPTION
Ensure no NPE  is thrown when using RestClient with Micrometer disabled

relates to https://github.com/quarkusio/quarkus/pull/25646/commits/f485a52c334a2d6a42bbba1caab85d27220fc5e0

FAIL: `mvn clean verify -f http/rest-client -Dquarkus.platform.version=2.7.5.Final`
PASS: `mvn clean verify -f http/rest-client -Dquarkus.platform.version=2.7.6.Final`

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)