### PR TITLE
Fix VertxWebClient + jaeger, some spans/childSpans doesn't include expected operationName

### DIFF
--- a/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
+++ b/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
@@ -8,8 +8,8 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.Every.everyItem;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
 
@@ -110,7 +110,7 @@ public class VertxWebClientIT {
             thenTraceSpanSizeMustBe(greaterThan(0));
             thenTraceSpanTagsSizeMustBe(greaterThan(0));
             thenTraceSpansOperationNameMustBe(not(empty()));
-            thenCheckThatAllOperationNamesAreEqualTo(expectedOperationName);
+            thenCheckOperationNamesIsEqualTo(expectedOperationName);
         });
     }
 
@@ -126,7 +126,7 @@ public class VertxWebClientIT {
             thenTraceSpanSizeMustBe(greaterThan(1));
             thenTraceSpanTagsSizeMustBe(greaterThan(0));
             thenTraceSpansOperationNameMustBe(not(empty()));
-            thenCheckThatAllOperationNamesAreEqualTo(expectedOperationName);
+            thenCheckOperationNamesIsEqualTo(expectedOperationName);
         });
     }
 
@@ -166,9 +166,9 @@ public class VertxWebClientIT {
         resp.then().body("data.spans.operationName", matcher);
     }
 
-    private void thenCheckThatAllOperationNamesAreEqualTo(String expectedOperationName) {
+    private void thenCheckOperationNamesIsEqualTo(String expectedOperationName) {
         List<String> operationNames = resp.then().extract().jsonPath().getList("data.spans.operationName", String.class);
-        assertThat(operationNames, everyItem(containsString(expectedOperationName)));
+        assertThat(operationNames, hasItem(containsString(expectedOperationName)));
     }
 
     @Test


### PR DESCRIPTION
### Summary

Seems that not always all spans or child spans include the expected operation names, for example

https://github.com/quarkus-qe/quarkus-test-suite/runs/6809549627?check_suite_focus=true

```
Expected: every item is a string containing "trace/ping"
     but: an item was "[HTTP GET, /chuck/bodyCodec]" within 1 minutes.
```
Note: This operation ID come from an other test: `public void getChuckJokeByJsonBodyCodec()`

Maybe when the current scenario that is failing was created, this other test doesn't exist and at that time all the spans has the expected operation name


Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)