### PR TITLE
Fix OpenShiftGraphQLTelemetryIT - filter Jaeger traces by operation name

### DIFF
--- a/http/graphql-telemetry/src/test/java/io/quarkus/ts/http/graphql/telemetry/GraphQLTelemetryIT.java
+++ b/http/graphql-telemetry/src/test/java/io/quarkus/ts/http/graphql/telemetry/GraphQLTelemetryIT.java
@@ -41,7 +41,7 @@ public class GraphQLTelemetryIT {
         await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(10)).untilAsserted(() -> {
             String operation = "/graphql";
             Response traces = given().when()
-                    .queryParam("operationName", operation)
+                    .queryParam("operation", operation)
                     .queryParam("lookback", "1h")
                     .queryParam("limit", 10)
                     .queryParam("service", "graphql-telemetry")


### PR DESCRIPTION
### Summary

Currently traces are filtered by `operationName` which is not valid filter parameter and operations are not filtered by this. That causes problem in OpenShift where there are other calls (other operations with different names, e.g. `HTTP GET` - probably probe check). Problem can be easily reproduced locally on `GraphQLTelemetryIT` when you call GET to `/` couple of times, which leads to test failure.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)