### PR TITLE
[2.7] Backport 2.7

### DIFF
--- a/cache/caffeine/src/test/java/io/quarkus/ts/cache/caffeine/cache/caffeine/CaffeineCacheIT.java
+++ b/cache/caffeine/src/test/java/io/quarkus/ts/cache/caffeine/cache/caffeine/CaffeineCacheIT.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import io.quarkus.test.scenarios.QuarkusScenario;
 
 @QuarkusScenario
-public class ServiceWithCacheResourceIT {
+public class CaffeineCacheIT {
 
     private static final String SERVICE_APPLICATION_SCOPE_PATH = "/services/" + APPLICATION_SCOPE_SERVICE_PATH;
     private static final String SERVICE_REQUEST_SCOPE_PATH = "/services/" + REQUEST_SCOPE_SERVICE_PATH;

--- a/cache/caffeine/src/test/java/io/quarkus/ts/cache/caffeine/cache/caffeine/OpenShiftCaffeineCacheIT.java
+++ b/cache/caffeine/src/test/java/io/quarkus/ts/cache/caffeine/cache/caffeine/OpenShiftCaffeineCacheIT.java
@@ -3,5 +3,5 @@ package io.quarkus.ts.cache.caffeine.cache.caffeine;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-public class OpenShiftServiceWithCacheResourceIT extends ServiceWithCacheResourceIT {
+public class OpenShiftCaffeineCacheIT extends CaffeineCacheIT {
 }

--- a/cache/spring/src/test/java/io/quarkus/ts/cache/spring/OpenShiftSpringCacheIT.java
+++ b/cache/spring/src/test/java/io/quarkus/ts/cache/spring/OpenShiftSpringCacheIT.java
@@ -3,5 +3,5 @@ package io.quarkus.ts.cache.spring;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-public class OpenShiftServiceWithCacheResourceIT extends ServiceWithCacheResourceIT {
+public class OpenShiftSpringCacheIT extends SpringCacheIT {
 }

--- a/cache/spring/src/test/java/io/quarkus/ts/cache/spring/SpringCacheIT.java
+++ b/cache/spring/src/test/java/io/quarkus/ts/cache/spring/SpringCacheIT.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import io.quarkus.test.scenarios.QuarkusScenario;
 
 @QuarkusScenario
-public class ServiceWithCacheResourceIT {
+public class SpringCacheIT {
 
     private static final String SERVICE_APPLICATION_SCOPE_PATH = "/services/" + APPLICATION_SCOPE_SERVICE_PATH;
     private static final String SERVICE_REQUEST_SCOPE_PATH = "/services/" + REQUEST_SCOPE_SERVICE_PATH;

--- a/http/graphql-telemetry/src/test/java/io/quarkus/ts/http/graphql/telemetry/GraphQLTelemetryIT.java
+++ b/http/graphql-telemetry/src/test/java/io/quarkus/ts/http/graphql/telemetry/GraphQLTelemetryIT.java
@@ -41,7 +41,7 @@ public class GraphQLTelemetryIT {
         await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(10)).untilAsserted(() -> {
             String operation = "graphql";
             Response traces = given().when()
-                    .queryParam("operationName", operation)
+                    .queryParam("operation", operation)
                     .queryParam("lookback", "1h")
                     .queryParam("limit", 10)
                     .queryParam("service", "graphql-telemetry")

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpCustomHeadersReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpCustomHeadersReactiveIT.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.scenarios.QuarkusScenario;
 
 @QuarkusScenario
-public class HttpCustomHeadersIT {
+public class HttpCustomHeadersReactiveIT {
 
     @Tag("QUARKUS-1574")
     @Test

--- a/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/OpenShiftRESTEasyReactiveMultipartIT.java
+++ b/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/OpenShiftRESTEasyReactiveMultipartIT.java
@@ -3,5 +3,5 @@ package io.quarkus.ts.http.jaxrs.reactive;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-public class OpenShiftMultipartResourceIT extends MultipartResourceIT {
+public class OpenShiftRESTEasyReactiveMultipartIT extends RESTEasyReactiveMultipartIT {
 }

--- a/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/RESTEasyReactiveMultipartCharsetIT.java
+++ b/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/RESTEasyReactiveMultipartCharsetIT.java
@@ -17,7 +17,7 @@ import io.restassured.specification.MultiPartSpecification;
 
 @Tag("QUARKUS-1075")
 @QuarkusScenario
-public class AsciiMultipartResourceIT {
+public class RESTEasyReactiveMultipartCharsetIT {
 
     public static final String TEXT_WITH_DIACRITICS = "Přikrášlený žloťoučký kůň úpěl ďábelské ódy.";
     private static final String EXPECTED_ASCII_TEXT = new String(TEXT_WITH_DIACRITICS.getBytes(StandardCharsets.UTF_8),
@@ -27,7 +27,7 @@ public class AsciiMultipartResourceIT {
     static RestService app = new RestService().withProperties("us-asscii.properties");
 
     @Test
-    public void testMultipartText() {
+    public void textInMultipartRequestEncodedWithDefaultCharset() {
         MultiPartSpecification multiPartSpecification = new MultiPartSpecBuilder(TEXT_WITH_DIACRITICS)
                 .controlName("text")
                 .header("Content-Type", "text/plain")

--- a/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/RESTEasyReactiveMultipartIT.java
+++ b/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/RESTEasyReactiveMultipartIT.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.http.jaxrs;
+package io.quarkus.ts.http.jaxrs.reactive;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -13,6 +13,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -22,8 +23,9 @@ import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.MultiPartSpecification;
 
+@Tag("QUARKUS-1075")
 @QuarkusScenario
-public class MultipartResourceIT {
+public class RESTEasyReactiveMultipartIT {
 
     private static final String IMAGE_FILE_NAME = "/quarkus.png";
     private static final String TEXT_WITH_DIACRITICS = "Přikrášlený žloťoučký kůň úpěl ďábelské ódy.";
@@ -33,8 +35,8 @@ public class MultipartResourceIT {
 
     @BeforeAll
     public static void beforeAll() throws IOException {
-        imageFile = new File(MultipartResourceIT.class.getResource(IMAGE_FILE_NAME).getFile());
-        imageBytes = IOUtils.toByteArray(MultipartResourceIT.class.getResourceAsStream(IMAGE_FILE_NAME));
+        imageFile = new File(RESTEasyReactiveMultipartIT.class.getResource(IMAGE_FILE_NAME).getFile());
+        imageBytes = IOUtils.toByteArray(RESTEasyReactiveMultipartIT.class.getResourceAsStream(IMAGE_FILE_NAME));
         new Random().nextBytes(randomBytes);
     }
 

--- a/http/jaxrs/src/test/java/io/quarkus/ts/http/jaxrs/OpenShiftRESTEasyMultipartIT.java
+++ b/http/jaxrs/src/test/java/io/quarkus/ts/http/jaxrs/OpenShiftRESTEasyMultipartIT.java
@@ -3,5 +3,5 @@ package io.quarkus.ts.http.jaxrs;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-public class OpenShiftMultipartResourceIT extends MultipartResourceIT {
+public class OpenShiftRESTEasyMultipartIT extends RESTEasyMultipartIT {
 }

--- a/http/jaxrs/src/test/java/io/quarkus/ts/http/jaxrs/RESTEasyMultipartCharsetIT.java
+++ b/http/jaxrs/src/test/java/io/quarkus/ts/http/jaxrs/RESTEasyMultipartCharsetIT.java
@@ -15,7 +15,7 @@ import io.restassured.http.ContentType;
 import io.restassured.specification.MultiPartSpecification;
 
 @QuarkusScenario
-public class AsciiMultipartResourceIT {
+public class RESTEasyMultipartCharsetIT {
 
     public static final String TEXT_WITH_DIACRITICS = "Přikrášlený žloťoučký kůň úpěl ďábelské ódy.";
     private static final String EXPECTED_ASCII_TEXT = new String(TEXT_WITH_DIACRITICS.getBytes(StandardCharsets.UTF_8),
@@ -25,7 +25,7 @@ public class AsciiMultipartResourceIT {
     static RestService app = new RestService().withProperties("us-asscii.properties");
 
     @Test
-    public void testMultipartText() {
+    public void textInMultipartRequestEncodedWithDefaultCharset() {
         MultiPartSpecification multiPartSpecification = new MultiPartSpecBuilder(TEXT_WITH_DIACRITICS)
                 .controlName("text")
                 .header("Content-Type", "text/plain")

--- a/http/jaxrs/src/test/java/io/quarkus/ts/http/jaxrs/RESTEasyMultipartIT.java
+++ b/http/jaxrs/src/test/java/io/quarkus/ts/http/jaxrs/RESTEasyMultipartIT.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.http.jaxrs.reactive;
+package io.quarkus.ts.http.jaxrs;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -13,7 +13,6 @@ import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -23,9 +22,8 @@ import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.MultiPartSpecification;
 
-@Tag("QUARKUS-1075")
 @QuarkusScenario
-public class MultipartResourceIT {
+public class RESTEasyMultipartIT {
 
     private static final String IMAGE_FILE_NAME = "/quarkus.png";
     private static final String TEXT_WITH_DIACRITICS = "Přikrášlený žloťoučký kůň úpěl ďábelské ódy.";
@@ -35,8 +33,8 @@ public class MultipartResourceIT {
 
     @BeforeAll
     public static void beforeAll() throws IOException {
-        imageFile = new File(MultipartResourceIT.class.getResource(IMAGE_FILE_NAME).getFile());
-        imageBytes = IOUtils.toByteArray(MultipartResourceIT.class.getResourceAsStream(IMAGE_FILE_NAME));
+        imageFile = new File(RESTEasyMultipartIT.class.getResource(IMAGE_FILE_NAME).getFile());
+        imageBytes = IOUtils.toByteArray(RESTEasyMultipartIT.class.getResourceAsStream(IMAGE_FILE_NAME));
         new Random().nextBytes(randomBytes);
     }
 

--- a/http/rest-client/pom.xml
+++ b/http/rest-client/pom.xml
@@ -23,5 +23,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-jsonb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/http/rest-client/src/test/java/io/quarkus/ts/http/restclient/ClientBookResourceIT.java
+++ b/http/rest-client/src/test/java/io/quarkus/ts/http/restclient/ClientBookResourceIT.java
@@ -8,29 +8,43 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
 public class ClientBookResourceIT {
 
+    @QuarkusApplication
+    static RestService app = new RestService();
+
+    @QuarkusApplication
+    static RestService appWithMicrometerDisabled = new RestService().withProperty("quarkus.micrometer.enabled", "false");
+
     @Test
     public void shouldGetBookFromRestClientXml() {
-        given().get("/client/book/xml").then().statusCode(HttpStatus.SC_OK)
+        app.given().get("/client/book/xml").then().statusCode(HttpStatus.SC_OK)
                 .body(is(
                         "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><book><title>Title in Xml</title></book>"));
     }
 
     @Test
     public void shouldGetBookFromRestClientJson() {
-        given().get("/client/book/json").then().statusCode(HttpStatus.SC_OK)
+        app.given().get("/client/book/json").then().statusCode(HttpStatus.SC_OK)
                 .body(is("{\"title\":\"Title in Json\"}"));
     }
 
     @Test
     @Tag("QUARKUS-1376")
     public void notFoundShouldNotReturnAnyResteasyImplementationDetails() {
-        String body = given().get("/notFound").then().statusCode(HttpStatus.SC_NOT_FOUND).extract().body().asString();
+        String body = app.given().get("/notFound").then().statusCode(HttpStatus.SC_NOT_FOUND).extract().body().asString();
         Assertions.assertFalse(body.contains("RESTEASY"),
                 "Not found resource should not return any Resteasy implementation details, but was: " + body);
+    }
+
+    @Test
+    @Tag("QUARKUS-2127")
+    public void noNullPointerExceptionForRestClientUsageWithDisabledMicrometer() {
+        appWithMicrometerDisabled.given().get("/client/book/xml").then().statusCode(HttpStatus.SC_OK);
     }
 }

--- a/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/reactive/AbstractMongoClientReactiveIT.java
+++ b/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/reactive/AbstractMongoClientReactiveIT.java
@@ -18,10 +18,10 @@ import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.ext.web.client.HttpRequest;
 import io.vertx.mutiny.ext.web.client.HttpResponse;
 
-public abstract class AbstractMongoDbIT {
+public abstract class AbstractMongoClientReactiveIT {
     @ParameterizedTest
     @ValueSource(strings = { "/reactive_fruits" })
-    public void fruitsEndpoints(String path) {
+    public void insertAndGetSimpleEntity(String path) {
         final Fruit fruit1 = new Fruit("fruit1", "fruit description 1");
         final Fruit fruit2 = new Fruit("fruit2", "fruit description 2");
 
@@ -40,7 +40,7 @@ public abstract class AbstractMongoDbIT {
 
     @ParameterizedTest
     @ValueSource(strings = { "/reactive_fruit_baskets" })
-    public void fruitBasketsEndpoints(String path) {
+    public void insertAndGetCompositeEntity(String path) {
         final Fruit fruit1 = new Fruit("fruit1", "fruit description 1");
         final Fruit fruit2 = new Fruit("fruit2", "fruit description 2");
         final FruitBasket fruitBasket1 = new FruitBasket("null", null);

--- a/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/reactive/MongoClientReactiveIT.java
+++ b/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/reactive/MongoClientReactiveIT.java
@@ -2,12 +2,12 @@ package io.quarkus.ts.nosqldb.mongodb.reactive;
 
 import io.quarkus.test.bootstrap.MongoDbService;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-@OpenShiftScenario
-public class OpenShiftMongoDbIT extends AbstractMongoDbIT {
+@QuarkusScenario
+public class MongoClientReactiveIT extends AbstractMongoClientReactiveIT {
 
     @Container(image = "${mongodb.image}", port = 27017, expectedLog = "Waiting for connections")
     static MongoDbService database = new MongoDbService();

--- a/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/reactive/OpenShiftMongoClientReactiveIT.java
+++ b/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/reactive/OpenShiftMongoClientReactiveIT.java
@@ -2,12 +2,12 @@ package io.quarkus.ts.nosqldb.mongodb.reactive;
 
 import io.quarkus.test.bootstrap.MongoDbService;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-@QuarkusScenario
-public class MongoDbIT extends AbstractMongoDbIT {
+@OpenShiftScenario
+public class OpenShiftMongoClientReactiveIT extends AbstractMongoClientReactiveIT {
 
     @Container(image = "${mongodb.image}", port = 27017, expectedLog = "Waiting for connections")
     static MongoDbService database = new MongoDbService();

--- a/nosql-db/mongodb/src/test/java/io/quarkus/ts/nosqldb/mongodb/MongoClientIT.java
+++ b/nosql-db/mongodb/src/test/java/io/quarkus/ts/nosqldb/mongodb/MongoClientIT.java
@@ -5,8 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.MongoDbService;
 import io.quarkus.test.bootstrap.RestService;
@@ -18,7 +17,7 @@ import io.restassured.http.ContentType;
 import io.restassured.path.json.JsonPath;
 
 @QuarkusScenario
-public class MongoDbIT {
+public class MongoClientIT {
 
     @Container(image = "${mongodb.image}", port = 27017, expectedLog = "Waiting for connections")
     static MongoDbService database = new MongoDbService();
@@ -27,9 +26,17 @@ public class MongoDbIT {
     static RestService app = new RestService()
             .withProperty("quarkus.mongodb.connection-string", database::getJdbcUrl);
 
-    @ParameterizedTest
-    @ValueSource(strings = { "/fruits", "/codec_fruits" })
-    public void fruitsEndpoints(String path) {
+    @Test
+    public void insertAndGetSimpleEntity() {
+        insertAndGetSimpleEntity("/fruits");
+    }
+
+    @Test
+    public void insertAndGetSimpleEntityWithBsonCodec() {
+        insertAndGetSimpleEntity("/codec_fruits");
+    }
+
+    public void insertAndGetSimpleEntity(String path) {
         final Fruit fruit1 = new Fruit("fruit1", "fruit description 1");
         final Fruit fruit2 = new Fruit("fruit2", "fruit description 2");
 
@@ -49,9 +56,17 @@ public class MongoDbIT {
         assertThat(fruits2).isEqualTo(fruits1);
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = { "/fruit_baskets", "/codec_fruit_baskets" })
-    public void fruitBasketsEndpoints(String path) {
+    @Test
+    public void insertAndGetCompositeEntity() {
+        insertAndGetCompositeEntity("/fruit_baskets");
+    }
+
+    @Test
+    public void insertAndGetCompositeEntityWithBsonCodec() {
+        insertAndGetCompositeEntity("/codec_fruit_baskets");
+    }
+
+    public void insertAndGetCompositeEntity(String path) {
         final Fruit fruit1 = new Fruit("fruit1", "fruit description 1");
         final Fruit fruit2 = new Fruit("fruit2", "fruit description 2");
         final FruitBasket fruitBasket1 = new FruitBasket("null", null);

--- a/nosql-db/mongodb/src/test/java/io/quarkus/ts/nosqldb/mongodb/OpenShiftMongoClientIT.java
+++ b/nosql-db/mongodb/src/test/java/io/quarkus/ts/nosqldb/mongodb/OpenShiftMongoClientIT.java
@@ -3,5 +3,5 @@ package io.quarkus.ts.nosqldb.mongodb;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-public class OpenShiftMongoDbIT extends MongoDbIT {
+public class OpenShiftMongoClientIT extends MongoClientIT {
 }

--- a/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/BaseAuthzSecurityReactiveIT.java
+++ b/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/BaseAuthzSecurityReactiveIT.java
@@ -19,7 +19,7 @@ import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.ext.web.client.HttpRequest;
 import io.vertx.mutiny.ext.web.client.HttpResponse;
 
-public abstract class BaseAuthzSecurityIT {
+public abstract class BaseAuthzSecurityReactiveIT {
 
     static final String NORMAL_USER = "test-normal-user";
     static final String ADMIN_USER = "test-admin-user";

--- a/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/KeycloakAuthzSecurityReactiveIT.java
+++ b/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/KeycloakAuthzSecurityReactiveIT.java
@@ -1,22 +1,20 @@
 package io.quarkus.ts.security.keycloak.authz.reactive;
 
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-@OpenShiftScenario
-@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
-public class OpenShiftRhSsoAuthzSecurityIT extends BaseAuthzSecurityIT {
+@QuarkusScenario
+public class KeycloakAuthzSecurityReactiveIT extends BaseAuthzSecurityReactiveIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    @Container(image = "${rhsso.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
-            .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
+    //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
+    @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
+            .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/OpenShiftRhSsoAuthzSecurityReactiveIT.java
+++ b/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/OpenShiftRhSsoAuthzSecurityReactiveIT.java
@@ -1,20 +1,22 @@
 package io.quarkus.ts.security.keycloak.authz.reactive;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-@QuarkusScenario
-public class KeycloakAuthzSecurityIT extends BaseAuthzSecurityIT {
+@OpenShiftScenario
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
+public class OpenShiftRhSsoAuthzSecurityReactiveIT extends BaseAuthzSecurityReactiveIT {
 
     static final int KEYCLOAK_PORT = 8080;
 
-    //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @Container(image = "${keycloak.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
-            .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
+    @Container(image = "${rhsso.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
+    static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
+            .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseOidcIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseOidcIT.java
@@ -8,7 +8,7 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-public abstract class BaseIT {
+public abstract class BaseOidcIT {
     static final String USER = "test-user";
 
     static final int KEYCLOAK_PORT = 8080;

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OidcRestClientIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OidcRestClientIT.java
@@ -15,7 +15,7 @@ import io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.model.Scor
 import io.restassured.http.ContentType;
 
 @QuarkusScenario
-public class RestClientInPingPongResourcesIT extends BaseIT {
+public class OidcRestClientIT extends BaseOidcIT {
 
     static final String PING_ENDPOINT = "/%s-ping";
     static final String PONG_ENDPOINT = "/%s-pong";

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenApiStoreSchemaIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenApiStoreSchemaIT.java
@@ -22,7 +22,7 @@ import io.smallrye.openapi.runtime.io.Format;
 import io.vertx.core.json.JsonObject;
 
 @QuarkusScenario
-public class OpenApiIT extends BaseIT {
+public class OpenApiStoreSchemaIT extends BaseOidcIT {
 
     private static String directory = "target/generated/jax-rs/";
     private static final String OPEN_API_DOT = "openapi.";

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftOidcRestClientIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftOidcRestClientIT.java
@@ -3,5 +3,5 @@ package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-public class OpenShiftRestClientInPingPongResourcesIT extends RestClientInPingPongResourcesIT {
+public class OpenShiftOidcRestClientIT extends OidcRestClientIT {
 }

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/SecurityClaimsIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/SecurityClaimsIT.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.scenarios.QuarkusScenario;
 
 @QuarkusScenario
-public class SecuredResourceIT extends BaseIT {
+public class SecurityClaimsIT extends BaseOidcIT {
 
     private static final String SECURED_PATH = "/secured";
     private static final String CLAIMS_FROM_BEANS_PATH = "/getClaimsFromBeans";

--- a/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/di/ListInjectionBean.java
+++ b/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/di/ListInjectionBean.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.spring.data.di;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.quarkus.arc.All;
+import io.quarkus.arc.properties.IfBuildProperty;
+
+@ApplicationScoped
+// Bean causes build error on unpatched Quarkus => enable only on demand to avoid interference with other tests.
+@IfBuildProperty(name = ListInjectionBean.LIST_INJECTION_BEAN_ENABLED, stringValue = ListInjectionBean.LIST_INJECTION_BEAN_ENABLED_VALUE)
+public class ListInjectionBean {
+    public static final String LIST_INJECTION_BEAN_ENABLED = "io.quarkus.ts.spring.data.di.ListInjectionBean.enabled";
+    public static final String LIST_INJECTION_BEAN_ENABLED_VALUE = "true";
+
+    List<Service> constructorInjectServices;
+
+    @Autowired
+    @All
+    List<Service> fieldInjectServices;
+
+    ListInjectionBean(@All List<Service> constructorInjectServices) {
+        this.constructorInjectServices = constructorInjectServices;
+    }
+
+    interface Service {
+    }
+}

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/di/ListInjectionIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/di/ListInjectionIT.java
@@ -1,0 +1,25 @@
+package io.quarkus.ts.spring.data.di;
+
+import static io.quarkus.ts.spring.data.di.ListInjectionBean.LIST_INJECTION_BEAN_ENABLED;
+import static io.quarkus.ts.spring.data.di.ListInjectionBean.LIST_INJECTION_BEAN_ENABLED_VALUE;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@Tag("QUARKUS-2095")
+@QuarkusScenario
+public class ListInjectionIT {
+
+    @QuarkusApplication(classes = ListInjectionBean.class)
+    static RestService app = new RestService().withProperty(LIST_INJECTION_BEAN_ENABLED, LIST_INJECTION_BEAN_ENABLED_VALUE);
+
+    @Test
+    public void appStartsWhenUsingFieldInjectionWithAllAnnotationOnList() {
+        Assertions.assertTrue(app.isRunning());
+    }
+}

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/OpenShiftSpringDataCompositeEntityIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/OpenShiftSpringDataCompositeEntityIT.java
@@ -3,5 +3,5 @@ package io.quarkus.ts.spring.data.primitivetypes;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-public class OpenShiftBookResourceIT extends SpringDataBookResourceIT {
+public class OpenShiftSpringDataCompositeEntityIT extends SpringDataCompositeEntityIT {
 }

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/OpenShiftSpringDataSimpleEntityIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/OpenShiftSpringDataSimpleEntityIT.java
@@ -3,5 +3,5 @@ package io.quarkus.ts.spring.data.primitivetypes;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-public class OpenShiftCatResourceIT extends SpringDataCatResourceIT {
+public class OpenShiftSpringDataSimpleEntityIT extends SpringDataSimpleEntityIT {
 }

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/SpringDataCompositeEntityIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/SpringDataCompositeEntityIT.java
@@ -24,7 +24,7 @@ import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
 @QuarkusScenario
-public class SpringDataBookResourceIT extends AbstractDbIT {
+public class SpringDataCompositeEntityIT extends AbstractDbIT {
 
     @DisabledOnQuarkusVersion(version = "(2\\.[0-6]\\..*)|(2\\.7\\.[0-5]\\..*)|(2\\.8\\.0\\..*)", reason = "Fixed in Quarkus 2.8.1 and backported to 2.7.6.")
     @Test

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/SpringDataSimpleEntityIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/SpringDataSimpleEntityIT.java
@@ -15,7 +15,7 @@ import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
 @QuarkusScenario
-public class SpringDataCatResourceIT extends AbstractDbIT {
+public class SpringDataSimpleEntityIT extends AbstractDbIT {
     @Test
     void testCustomFindPublicationYearObjectBoolean() {
         app.given().get("/cat/customFindDistinctiveObject/2").then()

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/rest/CrudRepositoryRestResourceIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/rest/CrudRepositoryRestResourceIT.java
@@ -10,7 +10,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.ts.spring.data.AbstractDbIT;
 
 @QuarkusScenario
-public class LibraryRepositoryIT extends AbstractDbIT {
+public class CrudRepositoryRestResourceIT extends AbstractDbIT {
     @Test
     void testAllRepositoryMethods() throws InterruptedException {
 

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/rest/OpenShiftCrudRepositoryRestResourceIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/rest/OpenShiftCrudRepositoryRestResourceIT.java
@@ -3,5 +3,5 @@ package io.quarkus.ts.spring.data.rest;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-public class OpenShiftArticleRepositoryIT extends ArticleRepositoryIT {
+public class OpenShiftCrudRepositoryRestResourceIT extends CrudRepositoryRestResourceIT {
 }

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/rest/OpenShiftPagingAndSortingRepositoryRestResourceIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/rest/OpenShiftPagingAndSortingRepositoryRestResourceIT.java
@@ -3,5 +3,5 @@ package io.quarkus.ts.spring.data.rest;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-public class OpenShiftLibraryRepositoryIT extends LibraryRepositoryIT {
+public class OpenShiftPagingAndSortingRepositoryRestResourceIT extends PagingAndSortingRepositoryRestResourceIT {
 }

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/rest/PagingAndSortingRepositoryRestResourceIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/rest/PagingAndSortingRepositoryRestResourceIT.java
@@ -17,7 +17,7 @@ import io.quarkus.ts.spring.data.AbstractDbIT;
 import io.restassured.response.Response;
 
 @QuarkusScenario
-class ArticleRepositoryIT extends AbstractDbIT {
+class PagingAndSortingRepositoryRestResourceIT extends AbstractDbIT {
 
     @Test
     void testAllRepositoryMethods() throws InterruptedException {

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/MariaDBConstants.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/MariaDBConstants.java
@@ -1,0 +1,9 @@
+package io.quarkus.ts.spring.web.reactive;
+
+public class MariaDBConstants {
+    public static final int PORT = 3306;
+    public static final String START_LOG_10 = "socket: '/run/mysqld/mysqld.sock'  port: " + PORT;
+    public static final String START_LOG_105 = "Only MySQL server logs after this point";
+    public static final String IMAGE_10 = "${mariadb.10.image}";
+    public static final String IMAGE_105 = "${mariadb.105.image}";
+}

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/MariaDBUtils.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/MariaDBUtils.java
@@ -1,6 +1,0 @@
-package io.quarkus.ts.spring.web.reactive;
-
-public class MariaDBUtils {
-    public static final int PORT = 3306;
-    public static final String START_LOG = "socket: '/run/mysqld/mysqld.sock'  port: " + PORT;
-}

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/AbstractSpringWebQuteIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/AbstractSpringWebQuteIT.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.spring.web.reactive;
+package io.quarkus.ts.spring.web.reactive.boostrap;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 import io.quarkus.test.bootstrap.RestService;
 import io.restassured.http.ContentType;
 
-public abstract class AbstractDbIT {
+public abstract class AbstractSpringWebQuteIT {
 
     private static final String APP_NAME = "Bootstrap Spring Boot";
 

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/AbstractSpringWebRestIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/AbstractSpringWebRestIT.java
@@ -11,29 +11,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
-import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.ts.spring.web.reactive.AbstractDbIT;
-import io.quarkus.ts.spring.web.reactive.MariaDBUtils;
 import io.quarkus.ts.spring.web.reactive.boostrap.persistence.model.Book;
 import io.restassured.response.Response;
 
-@QuarkusScenario
-public class BookResourceIT extends AbstractDbIT {
-
+public abstract class AbstractSpringWebRestIT {
     private static final String API_ROOT = "/api/books";
 
-    @Container(image = "${mariadb.10.image}", port = MariaDBUtils.PORT, expectedLog = MariaDBUtils.START_LOG)
-    static final MariaDbService database = new MariaDbService();
-
-    @QuarkusApplication
-    private static final RestService app = new RestService()
-            .withProperty("quarkus.datasource.username", database.getUser())
-            .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+    protected abstract RestService getApp();
 
     @Test
     public void whenGetAllBooks_thenOK() {
@@ -140,10 +125,5 @@ public class BookResourceIT extends AbstractDbIT {
                 .post(API_ROOT);
         return API_ROOT + "/" + response.jsonPath()
                 .get("id");
-    }
-
-    @Override
-    public RestService getApp() {
-        return app;
     }
 }

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/OpenShiftSpringWebQuteIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/OpenShiftSpringWebQuteIT.java
@@ -1,18 +1,19 @@
 package io.quarkus.ts.spring.web.reactive.boostrap;
 
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.IMAGE_105;
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.PORT;
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.START_LOG_105;
+
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.ts.spring.web.reactive.AbstractDbIT;
 
 @OpenShiftScenario
-public class OpenShiftHomePageIT extends AbstractDbIT {
+public class OpenShiftSpringWebQuteIT extends AbstractSpringWebQuteIT {
 
-    static final int MARIADB_PORT = 3306;
-
-    @Container(image = "${mariadb.105.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = IMAGE_105, port = PORT, expectedLog = START_LOG_105)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/OpenShiftSpringWebRestIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/OpenShiftSpringWebRestIT.java
@@ -1,4 +1,8 @@
-package io.quarkus.ts.spring.web.reactive.openapi;
+package io.quarkus.ts.spring.web.reactive.boostrap;
+
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.IMAGE_105;
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.PORT;
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.START_LOG_105;
 
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
@@ -7,15 +11,12 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.ts.spring.web.reactive.AbstractDbIT;
 
 @OpenShiftScenario
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
-public class OpenShiftOpenApiIT extends AbstractDbIT {
+public class OpenShiftSpringWebRestIT extends AbstractSpringWebRestIT {
 
-    static final int MARIADB_PORT = 3306;
-
-    @Container(image = "${mariadb.105.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = IMAGE_105, port = PORT, expectedLog = START_LOG_105)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/SpringWebQuteIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/SpringWebQuteIT.java
@@ -1,0 +1,29 @@
+package io.quarkus.ts.spring.web.reactive.boostrap;
+
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.IMAGE_10;
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.PORT;
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.START_LOG_10;
+
+import io.quarkus.test.bootstrap.MariaDbService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class SpringWebQuteIT extends AbstractSpringWebQuteIT {
+
+    @Container(image = IMAGE_10, port = PORT, expectedLog = START_LOG_10)
+    static final MariaDbService database = new MariaDbService();
+
+    @QuarkusApplication
+    private static final RestService app = new RestService()
+            .withProperty("quarkus.datasource.username", database.getUser())
+            .withProperty("quarkus.datasource.password", database.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+
+    @Override
+    public RestService getApp() {
+        return app;
+    }
+}

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/SpringWebRestIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/boostrap/SpringWebRestIT.java
@@ -1,21 +1,19 @@
 package io.quarkus.ts.spring.web.reactive.boostrap;
 
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.IMAGE_10;
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.PORT;
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.START_LOG_10;
 
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.ts.spring.web.reactive.AbstractDbIT;
 
-@OpenShiftScenario
-@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
-public class OpenShiftBookResourceIT extends AbstractDbIT {
+@QuarkusScenario
+public class SpringWebRestIT extends AbstractSpringWebRestIT {
 
-    static final int MARIADB_PORT = 3306;
-
-    @Container(image = "${mariadb.105.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = IMAGE_10, port = PORT, expectedLog = START_LOG_10)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication
@@ -25,7 +23,7 @@ public class OpenShiftBookResourceIT extends AbstractDbIT {
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
 
     @Override
-    public RestService getApp() {
+    protected RestService getApp() {
         return app;
     }
 }

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/AbstractSpringWebOpenApiIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/AbstractSpringWebOpenApiIT.java
@@ -6,43 +6,21 @@ import java.util.stream.Stream;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvFileSource;
 
-import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
-import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.ts.spring.web.reactive.AbstractDbIT;
-import io.quarkus.ts.spring.web.reactive.MariaDBUtils;
 import io.restassured.response.Response;
 
-@QuarkusScenario
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class OpenApiIT extends AbstractDbIT {
+public abstract class AbstractSpringWebOpenApiIT {
     private static Response response;
 
-    @Container(image = "${mariadb.10.image}", port = MariaDBUtils.PORT, expectedLog = MariaDBUtils.START_LOG)
-    static final MariaDbService database = new MariaDbService();
-
-    @QuarkusApplication
-    private static final RestService app = new RestService()
-            .withProperty("quarkus.datasource.username", database.getUser())
-            .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
-
-    @Override
-    public RestService getApp() {
-        return app;
-    }
+    protected abstract RestService getApp();
 
     private void callOpenApiEndpoint() {
-        response = app.given().get("/q/openapi?format=JSON");
+        response = getApp().given().get("/q/openapi?format=JSON");
     }
 
     @Order(1)
@@ -75,4 +53,5 @@ public class OpenApiIT extends AbstractDbIT {
         Assertions.assertEquals(1, objectMap.keySet().size());
         Assertions.assertEquals(type, objectMap.keySet().iterator().next());
     }
+
 }

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/OpenShiftSpringWebOpenApiIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/OpenShiftSpringWebOpenApiIT.java
@@ -1,0 +1,35 @@
+package io.quarkus.ts.spring.web.reactive.openapi;
+
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.IMAGE_105;
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.PORT;
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.START_LOG_105;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import io.quarkus.test.bootstrap.MariaDbService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@OpenShiftScenario
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
+public class OpenShiftSpringWebOpenApiIT extends AbstractSpringWebOpenApiIT {
+
+    @Container(image = IMAGE_105, port = PORT, expectedLog = START_LOG_105)
+    static final MariaDbService database = new MariaDbService();
+
+    @QuarkusApplication
+    private static final RestService app = new RestService()
+            .withProperty("quarkus.datasource.username", database.getUser())
+            .withProperty("quarkus.datasource.password", database.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+
+    @Override
+    public RestService getApp() {
+        return app;
+    }
+}

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/SpringWebOpenApiIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/SpringWebOpenApiIT.java
@@ -1,17 +1,25 @@
-package io.quarkus.ts.spring.web.reactive.boostrap;
+package io.quarkus.ts.spring.web.reactive.openapi;
+
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.IMAGE_10;
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.PORT;
+import static io.quarkus.ts.spring.web.reactive.MariaDBConstants.START_LOG_10;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.ts.spring.web.reactive.AbstractDbIT;
-import io.quarkus.ts.spring.web.reactive.MariaDBUtils;
+import io.restassured.response.Response;
 
 @QuarkusScenario
-public class HomePageIT extends AbstractDbIT {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class SpringWebOpenApiIT extends AbstractSpringWebOpenApiIT {
+    private static Response response;
 
-    @Container(image = "${mariadb.10.image}", port = MariaDBUtils.PORT, expectedLog = MariaDBUtils.START_LOG)
+    @Container(image = IMAGE_10, port = PORT, expectedLog = START_LOG_10)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication


### PR DESCRIPTION
### Summary

- [Ensure no NPE is thrown when using RestClient with Micrometer disabled](https://github.com/quarkus-qe/quarkus-test-suite/pull/698)
- [Test ArC @All list injection](https://github.com/quarkus-qe/quarkus-test-suite/pull/699)
- [Fix OpenShiftGraphQLTelemetryIT - filter Jaeger traces by operation name](https://github.com/quarkus-qe/quarkus-test-suite/pull/702)
- [Refactoring/rename tests](https://github.com/quarkus-qe/quarkus-test-suite/pull/701)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)