### PR TITLE
Fix `VertxWebClientIT` condition assertion & correct Span operation name

### DIFF
--- a/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
+++ b/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
@@ -51,6 +51,7 @@ public class VertxWebClientIT {
 
     private static final int REST_PORT = 16686;
     private static final int TRACE_PORT = 14250;
+    private static final String TRACE_PING_PATH = "/trace/ping";
 
     private Response resp;
 
@@ -106,38 +107,36 @@ public class VertxWebClientIT {
     @Test
     public void endpointShouldTrace() {
         final int pageLimit = 50;
-        final String expectedOperationName = "trace/ping";
         await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
             whenIMakePingRequest();
-            thenRetrieveTraces(pageLimit, "1h", getServiceName(), expectedOperationName);
+            thenRetrieveTraces(pageLimit, "1h", getServiceName(), TRACE_PING_PATH);
             thenStatusCodeMustBe(HttpStatus.SC_OK);
             thenTraceDataSizeMustBe(greaterThan(0));
             thenTraceSpanSizeMustBe(greaterThan(0));
             thenTraceSpanTagsSizeMustBe(greaterThan(0));
             thenTraceSpansOperationNameMustBe(not(empty()));
-            thenCheckOperationNamesIsEqualTo(expectedOperationName);
+            thenCheckOperationNamesIsEqualTo(TRACE_PING_PATH);
         });
     }
 
     @Test
     public void httpClientShouldHaveHisOwnSpan() {
         final int pageLimit = 50;
-        final String expectedOperationName = "trace/ping";
         await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
             whenIMakePingRequest();
-            thenRetrieveTraces(pageLimit, "1h", getServiceName(), expectedOperationName);
+            thenRetrieveTraces(pageLimit, "1h", getServiceName(), TRACE_PING_PATH);
             thenStatusCodeMustBe(HttpStatus.SC_OK);
             thenTraceDataSizeMustBe(greaterThan(0));
             thenTraceSpanSizeMustBe(greaterThan(1));
             thenTraceSpanTagsSizeMustBe(greaterThan(0));
             thenTraceSpansOperationNameMustBe(not(empty()));
-            thenCheckOperationNamesIsEqualTo(expectedOperationName);
+            thenCheckOperationNamesIsEqualTo(TRACE_PING_PATH);
         });
     }
 
     private void whenIMakePingRequest() {
         given().when()
-                .get("/trace/ping")
+                .get(TRACE_PING_PATH)
                 .then()
                 .statusCode(HttpStatus.SC_OK).body(equalToIgnoringCase("ping-pong"));
     }

--- a/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
+++ b/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
@@ -4,13 +4,13 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static io.restassured.RestAssured.given;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static java.util.Objects.requireNonNull;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.StringContains.containsString;
 import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
 
 import java.io.File;
@@ -18,7 +18,10 @@ import java.net.HttpURLConnection;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import org.apache.http.HttpStatus;
 import org.hamcrest.Matcher;
@@ -26,6 +29,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.client.WireMock;
 
 import io.quarkus.test.bootstrap.DefaultService;
@@ -142,7 +147,7 @@ public class VertxWebClientIT {
                 .queryParam("limit", pageLimit)
                 .queryParam("lookback", lookBack)
                 .queryParam("service", serviceName)
-                .queryParam("operationName", operationName)
+                .queryParam("operation", operationName)
                 .get(jaeger.getRestUrl());
     }
 
@@ -167,8 +172,21 @@ public class VertxWebClientIT {
     }
 
     private void thenCheckOperationNamesIsEqualTo(String expectedOperationName) {
-        List<String> operationNames = resp.then().extract().jsonPath().getList("data.spans.operationName", String.class);
-        assertThat(operationNames, hasItem(containsString(expectedOperationName)));
+        var body = resp.then().extract().jsonPath();
+        IntStream
+                .range(0, body.getList("data").size())
+                .mapToObj(i -> body.getList("data[" + i + "].spans", Span.class))
+                .map(TreeSet::new)
+                .forEach(spans -> {
+                    var prevSpan = requireNonNull(spans.pollFirst());
+                    // assert that operation of the root span element is the expected one
+                    Assertions.assertEquals(expectedOperationName, prevSpan.operationName);
+                    // assert all other span elements are children (pingRequest endpoint calls pong endpoint and returns result)
+                    for (Span span : spans) {
+                        Assertions.assertTrue(prevSpan.hasChild(span));
+                        prevSpan = span;
+                    }
+                });
     }
 
     @Test
@@ -198,5 +216,49 @@ public class VertxWebClientIT {
 
     private WireMock wireMockClient() {
         return new WireMock(wiremock.getHost().substring("http://".length()), wiremock.getPort());
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static final class Span implements Comparable<Span> {
+
+        private static final String SPAN_ID = "spanID";
+
+        @JsonProperty
+        String operationName;
+
+        @JsonProperty
+        String spanID;
+
+        private String parentSpanID;
+
+        @JsonProperty("references")
+        void setParentSpanID(List<Map<String, Object>> references) {
+            // has reference to a parent element -> is not root element
+            if (nonNull(references) && !references.isEmpty() && nonNull(references.get(0))) {
+                parentSpanID = (String) references.get(0).get(SPAN_ID);
+            }
+        }
+
+        @Override
+        public int compareTo(Span otherSpan) {
+            // leaf node > branch node > root
+            if (isRootElement()) {
+                return -1;
+            }
+            if (otherSpan.isRootElement()) {
+                return 1;
+            } else {
+                return hasChild(otherSpan) ? -1 : 1;
+            }
+        }
+
+        boolean hasChild(Span otherSpan) {
+            return spanID.equals(otherSpan.parentSpanID);
+        }
+
+        private boolean isRootElement() {
+            return isNull(parentSpanID);
+        }
+
     }
 }

--- a/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpentelemetryReactiveIT.java
+++ b/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpentelemetryReactiveIT.java
@@ -50,7 +50,7 @@ public class OpentelemetryReactiveIT {
     @Test
     public void testContextPropagation() {
         int pageLimit = 10;
-        String operationName = "ping/pong";
+        String operationName = "/ping/pong";
         String[] operations = new String[] { "/ping/pong", "/hello", "/hello" };
 
         await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {

--- a/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpentelemetryReactiveIT.java
+++ b/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpentelemetryReactiveIT.java
@@ -70,7 +70,7 @@ public class OpentelemetryReactiveIT {
 
     private void thenRetrieveTraces(int pageLimit, String lookBack, String serviceName, String operationName) {
         resp = given().when()
-                .queryParam("operationName", operationName)
+                .queryParam("operation", operationName)
                 .queryParam("lookback", lookBack)
                 .queryParam("limit", pageLimit)
                 .queryParam("service", serviceName)

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpentelemetryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpentelemetryIT.java
@@ -70,7 +70,7 @@ public class OpentelemetryIT {
 
     private void thenRetrieveTraces(int pageLimit, String lookBack, String serviceName, String operationName) {
         resp = given().when()
-                .queryParam("operationName", operationName)
+                .queryParam("operation", operationName)
                 .queryParam("lookback", lookBack)
                 .queryParam("limit", pageLimit)
                 .queryParam("service", serviceName)

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpentelemetryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpentelemetryIT.java
@@ -50,7 +50,7 @@ public class OpentelemetryIT {
     @Test
     public void testContextPropagation() {
         int pageLimit = 10;
-        String operationName = "ping/pong";
+        String operationName = "/ping/pong";
         String[] operations = new String[] { "/ping/pong", "/hello", "/hello" };
 
         await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {


### PR DESCRIPTION
### Summary

List of all traces were always retrieved as query parameter is in fact called [operation](https://github.com/jaegertracing/jaeger/blob/main/cmd/query/app/query_parser.go#L36) instead of `operationName`. Condition `thenCheckOperationNamesIsEqualTo` has been adjusted as previously it wasn't asserting that all checked operation names were equal to the expected one. `JsonPath` expression returned f.e. `[[chuck/pong, HTTP GET, trace/ping], [HTTP GET, trace/ping, chuck/pong], [chuck/pong, HTTP GET, trace/ping]]` mapped to `List<String>`, thus condition did assert that just one of the operation names contained operation name, not all of them. It's important to realize that traces filtered by operation name are returning traces with that operation name and their children traces (e.g. if you use rest client from Resource method), this is nicely visualized by Jaeger UI and thus expected behavior for Jaeger internal API we are using.

Expected operation name is prefixed with forward slash now as span name creation strategy has [recently changed](https://github.com/quarkusio/quarkus/pull/24017)

There are 2 commits intentionally as **only** `
Filter traces by operation name and correct VertxWebClientIT assertion` should be backported, but both all file changes must be part of this PR. Please **do not** backport `Make Span name consistent with http.route.name`.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)