### PR TITLE
Disable OpentelemetryReactiveIT in native mode

### DIFF
--- a/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpentelemetryReactiveIT.java
+++ b/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpentelemetryReactiveIT.java
@@ -18,12 +18,15 @@ import org.junit.jupiter.api.condition.OS;
 import io.quarkus.test.bootstrap.JaegerService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.JaegerContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.response.Response;
 
 @QuarkusScenario
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux Containers / Testcontainers")
+// TODO https://github.com/quarkusio/quarkus/issues/26083
+@DisabledOnNative(reason = "Native opentelemtry reported issue: NoSuchMethodException: UdsNettyChannelProvider")
 public class OpentelemetryReactiveIT {
     private static final int GRPC_COLLECTOR_PORT = 14250;
 


### PR DESCRIPTION
### Summary

Follow up #708, disabling another test for same reasons.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)