### PR TITLE
Missing UdsNettyChannelProvider register for reflexion on http/graphql-telemetry

### DIFF
--- a/http/graphql-telemetry/src/main/resources/application.properties
+++ b/http/graphql-telemetry/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 smallrye.graphql.allowGet=true
 quarkus.application.name=graphql-telemetry
+
+#TODO https://github.com/quarkusio/quarkus/issues/26083
+quarkus.native.additional-build-args=--allow-incomplete-classpath, -H:ReflectionConfigurationFiles=reflection-config.json

--- a/http/graphql-telemetry/src/main/resources/reflection-config.json
+++ b/http/graphql-telemetry/src/main/resources/reflection-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "io.grpc.netty.UdsNettyChannelProvider",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  }
+]


### PR DESCRIPTION
### Summary

Related to: https://github.com/quarkusio/quarkus/issues/26083

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)