### PR TITLE
Test that ParamConverter classes can access request scoped beans

### DIFF
--- a/sql-db/hibernate-reactive/src/main/java/io/quarkus/ts/hibernate/reactive/http/BookCountWrapper.java
+++ b/sql-db/hibernate-reactive/src/main/java/io/quarkus/ts/hibernate/reactive/http/BookCountWrapper.java
@@ -1,0 +1,22 @@
+package io.quarkus.ts.hibernate.reactive.http;
+
+import io.quarkus.ts.hibernate.reactive.database.Book;
+import io.smallrye.mutiny.Uni;
+
+public class BookCountWrapper {
+
+    private final Uni<Long> numOfBooks;
+
+    private BookCountWrapper(Uni<Long> numOfBooks) {
+        this.numOfBooks = numOfBooks;
+    }
+
+    public Uni<Long> getNumOfBooks() {
+        return numOfBooks;
+    }
+
+    static BookCountWrapper valueOf(String bookName) {
+        return new BookCountWrapper(Book.find("title = ?1", bookName).count());
+    }
+
+}

--- a/sql-db/hibernate-reactive/src/main/java/io/quarkus/ts/hibernate/reactive/http/PanacheEndpoint.java
+++ b/sql-db/hibernate-reactive/src/main/java/io/quarkus/ts/hibernate/reactive/http/PanacheEndpoint.java
@@ -7,6 +7,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -57,6 +58,12 @@ public class PanacheEndpoint {
                         ? Response.status(Response.Status.NOT_FOUND)
                         : Response.ok(book.getISBN()))
                 .map(Response.ResponseBuilder::build);
+    }
+
+    @GET
+    @Path("books/count/{bookName}")
+    public Uni<Long> countBooksByName(@PathParam("bookName") BookCountWrapper bookCountWrapper) {
+        return bookCountWrapper.getNumOfBooks();
     }
 
     @PUT

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/AbstractDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/AbstractDatabaseHibernateReactiveIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.hibernate.reactive;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -112,6 +113,17 @@ public abstract class AbstractDatabaseHibernateReactiveIT {
                 .when().get("/library/authors")
                 .then()
                 .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Tag("QUARKUS-2111")
+    @Test
+    public void paramConverterHasAccessToScopedBeans() {
+        // count books by name inside path parameter converter
+        getApp().given()
+                .when().get("/library/books/count/Slovník")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is("1"));
     }
 
     @Test


### PR DESCRIPTION
Verifies [#25527](https://github.com/quarkusio/quarkus/pull/25527)  - endpoint param converter must be able to access request scoped beans, verified over Panache static method as that's how bug was discovered.

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)