### PR TITLE
Add jsoup dependency to http-advanced scenarios

### DIFF
--- a/http/http-advanced-reactive/pom.xml
+++ b/http/http-advanced-reactive/pom.xml
@@ -48,6 +48,14 @@
             <artifactId>quarkus-keycloak-authorization</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-multipart-provider</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-keycloak</artifactId>
             <scope>test</scope>
@@ -63,12 +71,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-multipart-provider</artifactId>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <profiles>

--- a/http/http-advanced/pom.xml
+++ b/http/http-advanced/pom.xml
@@ -66,6 +66,10 @@
             <classifier>osx-x86_64</classifier>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-keycloak</artifactId>
             <scope>test</scope>
@@ -81,8 +85,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -104,16 +104,15 @@
                 <version>${jjwt.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.jsoup</groupId>
+                <artifactId>jsoup</artifactId>
+                <version>${jsoup.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <scope>test</scope>
                 <version>${assertj.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jsoup</groupId>
-                <artifactId>jsoup</artifactId>
-                <scope>test</scope>
-                <version>${jsoup.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <xml-format-maven-plugin.version>3.2.1</xml-format-maven-plugin.version>
         <checkstyle.version>10.3</checkstyle.version>
         <jjwt.version>0.11.5</jjwt.version>
+        <jsoup.version>1.15.1</jsoup.version>
         <camel-quarkus-bom.version>2.9.0</camel-quarkus-bom.version>
         <quarkiverse.config.version>1.0.2</quarkiverse.config.version>
         <smallrye-stork.version>1.1.2</smallrye-stork.version>
@@ -107,6 +108,12 @@
                 <artifactId>assertj-core</artifactId>
                 <scope>test</scope>
                 <version>${assertj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jsoup</groupId>
+                <artifactId>jsoup</artifactId>
+                <scope>test</scope>
+                <version>${jsoup.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/properties/pom.xml
+++ b/properties/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>quarkus-config-consul</artifactId>
             <version>${quarkiverse.config.version}</version>
         </dependency>
+        <!-- https://github.com/quarkiverse/quarkus-config-extensions/issues/70 -->
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-consul</artifactId>


### PR DESCRIPTION
### Summary

Jsoup is not a Quarkus-junit5  transitive dependency any longer (Quarkus Upstream). This PR adds Jsoup dependency to all scenarios where is need it. 

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)