### PR TITLE
Revert "Disable Quarkus-cli create extension scenario on Quarkus upstream"

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
@@ -11,12 +11,9 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliDefaultService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
 @QuarkusScenario
 @DisabledIfSystemProperty(named = "profile.id", matches = "native", disabledReason = "Only for JVM mode")
-// TODO https://github.com/quarkusio/quarkus/pull/25880#issuecomment-1149671224
-@DisabledOnQuarkusSnapshot(reason = "quarkus-extension-maven-plugin introduced for Quarkus 2.10, re-enable once 2.10 is out")
 public class QuarkusCliCreateExtensionIT {
 
     @Inject


### PR DESCRIPTION
Revert "Disable Quarkus-cli create extension scenario on Quarkus upstream"

This reverts commit fb912d2af7c6a987ee3626620b8e09d69806df6b.

Fixed in https://github.com/quarkusio/quarkus/pull/26130, we do not need to wait for Quarkus 2.10 release

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)