### PR TITLE
Fix `NativeStorkServiceDiscoveryIT` and `StorkLoadBalancerIT`

### DIFF
--- a/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PongReplicaResource.java
+++ b/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PongReplicaResource.java
@@ -43,7 +43,7 @@ public class PongReplicaResource {
         }
     }
 
-    @Route(path = "/", methods = Route.HttpMethod.GET)
+    @Route(path = "*", methods = Route.HttpMethod.GET)
     public Uni<String> pong() {
         return Uni.createFrom().item(DEFAULT_PONG_REPLICA_RESPONSE);
     }

--- a/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PongResource.java
+++ b/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PongResource.java
@@ -47,7 +47,7 @@ public class PongResource {
         }
     }
 
-    @Route(path = "/", methods = Route.HttpMethod.GET)
+    @Route(path = "*", methods = Route.HttpMethod.GET)
     public void pong(final RoutingContext context) {
         context.response().putHeader(HEADER_ID, instanceUniqueId).end(DEFAULT_PONG_RESPONSE);
     }

--- a/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PungResource.java
+++ b/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PungResource.java
@@ -39,7 +39,7 @@ public class PungResource {
         }
     }
 
-    @Route(path = "/", methods = Route.HttpMethod.GET)
+    @Route(path = "*", methods = Route.HttpMethod.GET)
     public Uni<String> pung() {
         return Uni.createFrom().item("pung");
     }


### PR DESCRIPTION
### Summary

Tests fails as path called by Rest Client is not found. IMHO that's due to [this PR](https://github.com/quarkusio/quarkus/pull/26101). One way or another, adjusting resource/client paths fixes the issue. Daily run (Linux Native mode) are failing because of this issue. I read PR 26101 in a way that `/pung/` is cut to `/pung` and so is the `/pong/`.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)