### PR TITLE
Fix CI failures - correct Vert.X Web handler order

### DIFF
--- a/messaging/kafka-producer/src/main/java/io/quarkus/ts/messaging/kafka/producer/Application.java
+++ b/messaging/kafka-producer/src/main/java/io/quarkus/ts/messaging/kafka/producer/Application.java
@@ -50,8 +50,8 @@ public class Application {
 
     private void addRoute(HttpMethod method, String path, Handler<RoutingContext> handler) {
         Route route = this.router.route(method, path)
-                .handler(CorsHandler.create("*"))
-                .handler(LoggerHandler.create());
+                .handler(LoggerHandler.create())
+                .handler(CorsHandler.create("*"));
 
         if (method.equals(HttpMethod.POST) || method.equals(HttpMethod.PUT))
             route.handler(BodyHandler.create());

--- a/security/vertx-jwt/src/main/java/io/quarkus/ts/security/vertx/Application.java
+++ b/security/vertx-jwt/src/main/java/io/quarkus/ts/security/vertx/Application.java
@@ -87,8 +87,8 @@ public class Application {
 
     private void addRoute(HttpMethod method, String path, AUTH authEnabled, Handler<RoutingContext> handler) {
         Route route = this.router.route(method, path)
-                .handler(CorsHandler.create("*"))
-                .handler(LoggerHandler.create());
+                .handler(LoggerHandler.create())
+                .handler(CorsHandler.create("*"));
 
         if (method.equals(HttpMethod.POST) || method.equals(HttpMethod.PUT))
             route.handler(BodyHandler.create());


### PR DESCRIPTION
### Summary

Two days ago Vert.X were [bumped to 4.3.1](https://github.com/quarkusio/quarkus/pull/26294) that caused errors in CI daily runs. According to the [4.3 release notes](https://vertx.io/blog/whats-new-in-vert-x-4-3/#vertx-web) the handler order matters, I also found similar issue [reported here](https://github.com/vert-x3/vertx-web/issues/2182). Security policy handler `CorsHandler` should be registered after the logging handler.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)