### PR TITLE
Add HelmClient to Github CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           check-latest: true
+      - name: Install Helm client
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.9.0
       - name: Build Quarkus main
         run: |
           git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Prelocations

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -20,6 +20,10 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           check-latest: true
+      - name: Install Helm client
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.9.0
       - name: Build Quarkus main
         run: |
           git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Prelocations


### PR DESCRIPTION
### Summary

Quarkus Helm extension is coming on the following releases. This PR install Helm client on Github CI jobs

Please select the relevant options.

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)