### PR TITLE
[2.7]  Add tag 'fips-incompatible' to quarkus JWT sceanrios

### DIFF
--- a/security/jwt/src/test/java/io/quarkus/ts/security/jwt/CookieJwtSecurityIT.java
+++ b/security/jwt/src/test/java/io/quarkus/ts/security/jwt/CookieJwtSecurityIT.java
@@ -1,11 +1,14 @@
 package io.quarkus.ts.security.jwt;
 
+import org.junit.jupiter.api.Tag;
+
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
 @QuarkusScenario
+@Tag("fips-incompatible")
 public class CookieJwtSecurityIT extends BaseJwtSecurityIT {
 
     static final String COOKIE_NAME = "MY_COOKIE_NAME";

--- a/security/jwt/src/test/java/io/quarkus/ts/security/jwt/Oauth2JwtSecurityIT.java
+++ b/security/jwt/src/test/java/io/quarkus/ts/security/jwt/Oauth2JwtSecurityIT.java
@@ -2,10 +2,13 @@ package io.quarkus.ts.security.jwt;
 
 import static io.restassured.RestAssured.given;
 
+import org.junit.jupiter.api.Tag;
+
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.restassured.specification.RequestSpecification;
 
 @QuarkusScenario
+@Tag("fips-incompatible")
 public class Oauth2JwtSecurityIT extends BaseJwtSecurityIT {
 
     @Override


### PR DESCRIPTION

### Summary
backport #749 

Please select the relevant options.
- [X] Backport


### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)