### PR TITLE
Bump Quarkus Test Framework from 1.2.0.Beta1 to 1.2.0.Beta2

### DIFF
--- a/http/http-advanced-reactive/pom.xml
+++ b/http/http-advanced-reactive/pom.xml
@@ -57,6 +57,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-grpc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-keycloak</artifactId>
             <scope>test</scope>
         </dependency>

--- a/http/http-advanced/pom.xml
+++ b/http/http-advanced/pom.xml
@@ -71,6 +71,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-grpc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-keycloak</artifactId>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <quarkus.qe.framework.version>1.2.0.Beta1</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.2.0.Beta2</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.35.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.6.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>
@@ -642,7 +642,7 @@
                             <systemPropertyVariables>
                                 <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                 <!-- Product Services -->
-                                <rhsso.image>registry.redhat.io/rh-sso-7/sso75-openshift-rhel8</rhsso.image>
+                                <rhsso.image>registry.redhat.io/rh-sso-7/sso76-openshift-rhel8</rhsso.image>
                                 <postgresql.10.image>registry.redhat.io/rhscl/postgresql-10-rhel7</postgresql.10.image>
                                 <postgresql.13.image>registry.redhat.io/rhscl/postgresql-13-rhel7</postgresql.13.image>
                                 <mariadb.103.image>registry.redhat.io/rhscl/mariadb-103-rhel7</mariadb.103.image>


### PR DESCRIPTION
### Summary

Bumps Quarkus Test Framework from 1.2.0.Beta1 to 1.2.0.Beta2 and adds `quarkus-test-service-grpc` to modules `http/http-advanced` and `http/http-advanced-reactive` as gRPC [has recently been decoupled](https://github.com/quarkus-qe/quarkus-test-framework/pull/515) from `quarkus-test-core`.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)