### PR TITLE
Upgrade Quarkus test framework to 1.2.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <quarkus.qe.framework.version>1.2.0.Beta1</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.2.0.Beta2</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.35.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.6.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>


### PR DESCRIPTION
### Summary

Upgrade Quarkus test framework to 1.2.0.Beta2

Please select the relevant options.
- [X] Dependency update


### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)