### PR TITLE
[2.7] Bump Quarkus Test Framework from 1.1.0.Final to 1.1.1.Final

### DIFF
--- a/http/http-advanced-reactive/pom.xml
+++ b/http/http-advanced-reactive/pom.xml
@@ -49,6 +49,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-grpc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-keycloak</artifactId>
             <scope>test</scope>
         </dependency>

--- a/http/http-advanced/pom.xml
+++ b/http/http-advanced/pom.xml
@@ -67,6 +67,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-grpc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-keycloak</artifactId>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.7.6.Final</quarkus.platform.version>
-        <quarkus.qe.framework.version>1.1.0.Final</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.1.1.Final</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.32.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.6.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>


### PR DESCRIPTION
### Summary

Bumps Quarkus Test Framework from 1.1.0.Final to 1.1.1.Final and adds `quarkus-test-service-grpc` to modules `http/http-advanced` and `http/http-advanced-reactive` as gRPC [has recently been decoupled](https://github.com/quarkus-qe/quarkus-test-framework/pull/515) from `quarkus-test-core`.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)