### PR TITLE
Update mandrel docker image to 22.1

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        image: [ "ubi-quarkus-native-image:21.3-java11", "ubi-quarkus-mandrel:21.3-java11", "ubi-quarkus-mandrel:21.3-java17" ]
+        image: [ "ubi-quarkus-native-image:22.1-java11", "ubi-quarkus-mandrel:22.1-java11", "ubi-quarkus-mandrel:22.1-java17" ]
         profiles: [ "root-modules,monitoring-modules,spring-modules,test-tooling-modules",
                    "http-modules",
                    "security-modules",
@@ -181,7 +181,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: [ "21.3.0.java11"]
+        graalvm-version: [ "22.1.0.java11"]
     steps:
       - uses: actions/checkout@v2
       - name: Install JDK {{ matrix.java }}

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ More info about how to generate native images could be found in Quarkus [buildin
 User: `Deploy in OpenShift the module http-minimum compiled with a custom GraalVM Docker image and 5GB of memory`
 
 ```shell
-mvn clean verify -Dall-modules -Dnative -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:21.3-java11 -Dquarkus.native.native-image-xmx=5g -Dopenshift -pl http/http-minimum 
+mvn clean verify -Dall-modules -Dnative -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:22.1-java11 -Dquarkus.native.native-image-xmx=5g -Dopenshift -pl http/http-minimum 
 ```
 
 #### OpenShift & Native via local GraalVM

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <profile.id>jvm</profile.id>
         <!-- S2i configuration -->
         <ts.global.s2i.quarkus.jvm.builder.image>registry.access.redhat.com/ubi8/openjdk-11:latest</ts.global.s2i.quarkus.jvm.builder.image>
-        <ts.global.s2i.quarkus.native.builder.image>quay.io/quarkus/ubi-quarkus-native-s2i:21.3-java11</ts.global.s2i.quarkus.native.builder.image>
+        <ts.global.s2i.quarkus.native.builder.image>quay.io/quarkus/ubi-quarkus-native-s2i:22.1-java11</ts.global.s2i.quarkus.native.builder.image>
         <!-- Default values for format -->
         <src.format.goal>format</src.format.goal>
         <src.sort.goal>sort</src.sort.goal>
@@ -608,7 +608,7 @@
                 <quarkus.package.type>native</quarkus.package.type>
                 <quarkus.native.container-build>true</quarkus.native.container-build>
                 <quarkus.native.native-image-xmx>4g</quarkus.native.native-image-xmx>
-                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11</quarkus.native.builder-image>
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:22.1-java11</quarkus.native.builder-image>
                 <exclude.quarkus.devmode.tests>**/*DevMode*IT.java</exclude.quarkus.devmode.tests>
             </properties>
         </profile>


### PR DESCRIPTION
### Summary

Default Mandrel image has been updated to 22.1
Ref: https://github.com/quarkusio/quarkus/commit/b6c2db24c48db432ce69a3abfae7bc7848daa873

Please select the relevant options.

- [X] Dependency update

### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)