### PR TITLE
Remove `quarkus.container-image.build=false` from GH CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
         run: |
           if [[ -n ${MODULES_ARG} ]]; then
             echo "Running modules: ${MODULES_ARG}"
-            mvn -fae -V -B -s .github/mvn-settings.xml -fae -Dall-modules -Dquarkus.container-image.build=false \
+            mvn -fae -V -B -s .github/mvn-settings.xml -fae -Dall-modules \
                         -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" \
                         -pl $MODULES_ARG clean verify -Dnative -am
           fi
@@ -224,7 +224,7 @@ jobs:
             MODULES_MAVEN_PARAM="-pl ${MODULES_ARG}"
           fi
 
-          mvn -B -fae -s .github/mvn-settings.xml clean verify -Dall-modules -Dquarkus.container-image.build=false $MODULES_MAVEN_PARAM -am
+          mvn -B -fae -s .github/mvn-settings.xml clean verify -Dall-modules $MODULES_MAVEN_PARAM -am
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -161,7 +161,7 @@ jobs:
       - name: Build in JVM mode
         shell: bash
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean verify -Dquarkus.container-image.build=false
+          mvn -B -fae -s .github/mvn-settings.xml clean verify
       - name: Zip Artifacts
         shell: bash
         if: failure()
@@ -218,7 +218,7 @@ jobs:
         shell: bash
         run: |
           # Running only http/http-minimum as after some time, it gives disk full in Windows when running on Native.
-          mvn -B -fae -s .github/mvn-settings.xml clean verify -Dall-modules -Dnative -Dquarkus.container-image.build=false -Dquarkus.native.container-build=false -pl http/http-minimum
+          mvn -B -fae -s .github/mvn-settings.xml clean verify -Dall-modules -Dnative -Dquarkus.native.container-build=false -pl http/http-minimum
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/docker-build/pom.xml
+++ b/docker-build/pom.xml
@@ -10,6 +10,9 @@
     <artifactId>docker-build</artifactId>
     <packaging>jar</packaging>
     <name>Quarkus QE TS: Docker-build</name>
+    <properties>
+        <quarkus.container-image.build>true</quarkus.container-image.build>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -29,6 +32,9 @@
                     <family>windows</family>
                 </os>
             </activation>
+            <properties>
+                <quarkus.container-image.build>false</quarkus.container-image.build>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/docker-build/src/main/resources/application.properties
+++ b/docker-build/src/main/resources/application.properties
@@ -1,4 +1,3 @@
-quarkus.container-image.build=true
 quarkus.container-image.group=qe
 # DON'T remove the spaces that are at the end of quarkus app name
 quarkus.application.name=hello-world-app      

--- a/docker-build/src/test/java/io/quarkus/ts/docker/DockerBuildIT.java
+++ b/docker-build/src/test/java/io/quarkus/ts/docker/DockerBuildIT.java
@@ -26,7 +26,7 @@ public class DockerBuildIT {
     }
 
     @Test
-    public void buildDockerImage() {
+    public void verifyContainerImageDockerExtensionBuildImageNameWithEmptySpace() {
         Image dockerImg = DockerUtils.getImage(DOCKER_IMG_NAME, DOCKER_IMG_VERSION);
         assertTrue(Objects.nonNull(dockerImg.getId()) && !dockerImg.getId().isEmpty(), "Docker image was not created");
     }

--- a/docker-build/src/test/java/io/quarkus/ts/docker/DockerBuildIT.java
+++ b/docker-build/src/test/java/io/quarkus/ts/docker/DockerBuildIT.java
@@ -10,11 +10,9 @@ import org.junit.jupiter.api.Test;
 import com.github.dockerjava.api.model.Image;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.utils.DockerUtils;
 
 @QuarkusScenario
-@DisabledOnNative(reason = "To reduce execution time")
 public class DockerBuildIT {
 
     private static final String DOCKER_IMG_NAME = "hello-world-app";
@@ -26,7 +24,7 @@ public class DockerBuildIT {
     }
 
     @Test
-    public void verifyContainerImageDockerExtensionBuildImageNameWithEmptySpace() {
+    public void verifyContainerImageDockerExtensionBuildImageWithEmptySpaceInImageName() {
         Image dockerImg = DockerUtils.getImage(DOCKER_IMG_NAME, DOCKER_IMG_VERSION);
         assertTrue(Objects.nonNull(dockerImg.getId()) && !dockerImg.getId().isEmpty(), "Docker image was not created");
     }


### PR DESCRIPTION
### Summary

This PR introduces some amendments based on these comments: https://github.com/quarkus-qe/quarkus-test-suite/pull/438

  - Enable `DockerBuildIT` on native mode
  - Rename scenario to something more meaningful
  - Remove `quarkus.container-image.build=false` from GH CI

Please select the relevant options.
- [X] Refactoring


### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)