### PR TITLE
Test `MessageBodyWriters` resources works in native mode

### DIFF
--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/NinetyNineBottlesOfBeerResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/NinetyNineBottlesOfBeerResource.java
@@ -10,14 +10,12 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 
 import io.quarkus.arc.properties.UnlessBuildProperty;
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Uni;
 
 /**
  * {@link Path#value()} set in this resource contains characters that were causing the build time
  * validation failure. The issue was resolved in 2.8.3 with https://github.com/quarkusio/quarkus/issues/25258.
  */
-@RegisterForReflection
 @UnlessBuildProperty(name = QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3, stringValue = QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3_VAL, enableIfMissing = true)
 @Path(NinetyNineBottlesOfBeerResource.PATH)
 public class NinetyNineBottlesOfBeerResource {


### PR DESCRIPTION
### Summary

verifies: https://github.com/quarkusio/quarkus/pull/25385

When we provide `MessageBodyWriter` that does not extend `ServerMessageBodyWriter`, related resource methods must be registered for the reflection. Previously, we had to do this manually, now it's done by the Quarkus for us.

Issue reproducer
1. go to Quarkus project
2. revert PR `git revert 224ec8c3e8e50930970e9c8b7316622ba898b0b9` and `mvn -Dquickly`
3. checkout this PR
4. `cd quarkus-test-suite/http/http-advanced-reactive`
5. run `mvn clean verify -Dit.test=HttpAdvancedReactiveIT -Dnative`

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [X] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)