### PR TITLE
Fix app startup with Keycloak 18.0.2

### DIFF
--- a/http/http-advanced-reactive/src/test/resources/keycloak-realm.json
+++ b/http/http-advanced-reactive/src/test/resources/keycloak-realm.json
@@ -66,6 +66,12 @@
         }
       ],
       "authorizationSettings": {
+        "scopes": [
+          {
+            "id": "uma_protection",
+            "name": "uma_protection"
+          }
+        ],
         "resources": [
           {
             "name": "test-user-resource",

--- a/http/http-advanced/src/test/resources/keycloak-realm.json
+++ b/http/http-advanced/src/test/resources/keycloak-realm.json
@@ -66,6 +66,12 @@
         }
       ],
       "authorizationSettings": {
+        "scopes": [
+          {
+            "id": "uma_protection",
+            "name": "uma_protection"
+          }
+        ],
         "resources": [
           {
             "name": "test-user-resource",

--- a/security/keycloak-authz-classic/src/test/resources/keycloak-realm.json
+++ b/security/keycloak-authz-classic/src/test/resources/keycloak-realm.json
@@ -83,6 +83,12 @@
         }
       ],
       "authorizationSettings": {
+        "scopes": [
+          {
+            "id": "uma_protection",
+            "name": "uma_protection"
+          }
+        ],
         "resources": [
           {
             "name": "test-user-resource",

--- a/security/keycloak-authz-reactive/src/test/resources/keycloak-realm.json
+++ b/security/keycloak-authz-reactive/src/test/resources/keycloak-realm.json
@@ -83,6 +83,12 @@
         }
       ],
       "authorizationSettings": {
+        "scopes": [
+          {
+            "id": "uma_protection",
+            "name": "uma_protection"
+          }
+        ],
         "resources": [
           {
             "name": "test-user-resource",


### PR DESCRIPTION
### Summary

Our client set up is missing required scope (`uma_protection`), at least that's how I read this https://lists.jboss.org/pipermail/keycloak-user/2018-November/016413.html

This is important as f.e. Keycloak dev services are currently using 18.0.2 and when you run `mvn clean verify` in `http/http-advanced-reactive` than despite logged stuff (default 18.0.0) I think it's in fact running on 18.0.2 as I that's only explanation why I can reproduce daily CI failures with `mvn clean verify -Dnative` in `HttpAdvancedReactiveIT` but not `mvn clean verify -Dnative -Dit.test=HttpAdvancedReactiveIT`.

Steps to reproduce client scope issue:
- set version to 18.0.2
```Java
@KeycloakContainer(command = {
            "start-dev --import-realm --hostname-strict=false" }, image = "quay.io/keycloak/keycloak:18.0.2")
```
- register `TokenIntrospectionResponse` for reflection (that's the actual reason why CI is failing in native, I'm currently working on that, but we should not reflect that in our TS!)
```
//@RegisterForReflection(classNames = "javax.ws.rs.core.MediaType")
@RegisterForReflection(classNames = { "javax.ws.rs.core.MediaType",
        "org.keycloak.authorization.client.representation.TokenIntrospectionResponse" })
public class ReflectionConfiguration {
```
- `mvn clean verify -Dit.test=HttpAdvancedReactiveIT`

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)