### PR TITLE
Disable FIPS native failures - part II

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HttpAdvancedReactiveIT.java
@@ -1,11 +1,14 @@
 package io.quarkus.ts.http.advanced.reactive;
 
+import org.junit.jupiter.api.Tag;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
+@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class HttpAdvancedReactiveIT extends BaseHttpAdvancedReactiveIT {
 

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
@@ -1,11 +1,14 @@
 package io.quarkus.ts.http.advanced;
 
+import org.junit.jupiter.api.Tag;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
+@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class HttpAdvancedIT extends BaseHttpAdvancedIT {
 

--- a/security/bouncycastle-fips/bcFipsJsse/src/test/java/io/quarkus/ts/security/bouncycastle/fips/jsse/BouncyCastleFipsJsseIT.java
+++ b/security/bouncycastle-fips/bcFipsJsse/src/test/java/io/quarkus/ts/security/bouncycastle/fips/jsse/BouncyCastleFipsJsseIT.java
@@ -14,6 +14,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.runtime.util.ClassPathUtils;
@@ -24,6 +25,7 @@ import io.vertx.core.net.KeyStoreOptions;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.mutiny.ext.web.client.WebClient;
 
+@Tag("fips-incompatible") // native-mode
 @QuarkusTest
 public class BouncyCastleFipsJsseIT {
 

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/di/SpringDiTest.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/di/SpringDiTest.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 
 import javax.enterprise.inject.spi.CDI;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -18,6 +19,7 @@ import io.quarkus.test.junit.QuarkusTest;
 
 // Not converted into @QuarkusScenario, because invoking javax.enterprise.inject.spi.CDI / io.quarkus.arc.Arc is not supported.
 // TODO: Workaround by implementing REST endpoints which expose all necessary information.
+@Tag("fips-incompatible") // native-mode
 @QuarkusTest
 public class SpringDiTest {
 

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalPoolTest.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalPoolTest.java
@@ -21,6 +21,7 @@ import org.apache.http.HttpStatus;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.agroal.api.AgroalDataSource;
@@ -35,6 +36,7 @@ import io.smallrye.mutiny.tuples.Tuple2;
  * The aim of these tests is verified agroal and entityManager pool management
  * Some of these tests required some extra load, in order to reproduce concurrency issues.
  */
+@Tag("fips-incompatible") // native-mode
 @QuarkusTest
 @TestProfile(AgroalTestProfile.class)
 public class AgroalPoolTest {

--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ManyExtensionsIT.java
@@ -4,11 +4,13 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.restassured.specification.RequestSpecification;
 
+@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class ManyExtensionsIT {
 


### PR DESCRIPTION
### Summary

Some scenarios are failing on FIPS native mode. This PR will disable those scenarios until some valuable improvement from development / QE team 

Please select the relevant options.

- [X] Refactoring


### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)