### PR TITLE
SmallRye GraphQL - test route context in DEV mode is terminated

### DIFF
--- a/security/jwt/pom.xml
+++ b/security/jwt/pom.xml
@@ -23,5 +23,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-jwt-build</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-graphql</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/security/jwt/src/main/java/io/quarkus/ts/security/jwt/GenerateJwtResource.java
+++ b/security/jwt/src/main/java/io/quarkus/ts/security/jwt/GenerateJwtResource.java
@@ -38,7 +38,8 @@ public class GenerateJwtResource {
     @PermitAll
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN)
-    public String login(@QueryParam("invalidity") String invalidity, String body) throws NoSuchAlgorithmException {
+    public String login(@QueryParam("invalidity") String invalidity, String body, @QueryParam("subClaim") String subClaim)
+            throws NoSuchAlgorithmException {
         Date now = new Date();
         Date expiration = new Date(TimeUnit.SECONDS.toMillis(TEN) + now.getTime());
         String issuer = DEFAULT_ISSUER;
@@ -61,7 +62,7 @@ public class GenerateJwtResource {
         JwtClaimsBuilder jwtbuilder = Jwt.issuer(issuer)
                 .expiresAt(expiration.getTime())
                 .issuedAt(now.getTime())
-                .subject("test_subject_at_example_com")
+                .subject(Objects.requireNonNullElse(subClaim, "test_subject_at_example_com"))
                 .groups(Set.of(body))
                 .claim("upn", "test-subject@example.com")
                 .claim("roleMappings", Collections.singletonMap("admin", "superuser"));

--- a/security/jwt/src/main/java/io/quarkus/ts/security/jwt/GraphQLResource.java
+++ b/security/jwt/src/main/java/io/quarkus/ts/security/jwt/GraphQLResource.java
@@ -1,0 +1,22 @@
+package io.quarkus.ts.security.jwt;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import io.smallrye.mutiny.Uni;
+
+@GraphQLApi
+public class GraphQLResource {
+
+    @Inject
+    JsonWebToken jwt;
+
+    @Query("subject")
+    public Uni<String> getSubject() {
+        return Uni.createFrom().item(jwt.getSubject());
+    }
+
+}

--- a/security/jwt/src/test/java/io/quarkus/ts/security/jwt/CookieJwtSecurityIT.java
+++ b/security/jwt/src/test/java/io/quarkus/ts/security/jwt/CookieJwtSecurityIT.java
@@ -15,8 +15,8 @@ public class CookieJwtSecurityIT extends BaseJwtSecurityIT {
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("smallrye.jwt.token.header", "Cookie")
-            .withProperty("smallrye.jwt.token.cookie", COOKIE_NAME);
+            .withProperty("mp.jwt.token.header", "Cookie")
+            .withProperty("mp.jwt.token.cookie", COOKIE_NAME);
 
     @Override
     protected RequestSpecification givenWithToken(String token) {

--- a/security/jwt/src/test/java/io/quarkus/ts/security/jwt/DevModeJwtSecurityIT.java
+++ b/security/jwt/src/test/java/io/quarkus/ts/security/jwt/DevModeJwtSecurityIT.java
@@ -1,0 +1,18 @@
+package io.quarkus.ts.security.jwt;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.restassured.specification.RequestSpecification;
+
+@QuarkusScenario
+public class DevModeJwtSecurityIT extends BaseJwtSecurityIT {
+
+    @DevModeQuarkusApplication
+    static RestService app = new RestService();
+
+    @Override
+    protected RequestSpecification givenWithToken(String token) {
+        return app.given().auth().oauth2(token);
+    }
+}


### PR DESCRIPTION
### Summary

Verifies: https://github.com/quarkusio/quarkus/issues/26748

In the Quarkus Smallrye GraphQL 2.10.2.Final and 2.10.1.Final, a route context had not been properly terminated. If BE received 3+ requests then 3rd (and every other) request were handled with the first request's route context (thus identity, headers etc. were incorrect). I could only reproduce this behavior with `mvn quarkus:dev` and `@QuarkusTest`, my best guess is that's due to [this hack](https://github.com/quarkusio/quarkus/blob/main/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java#L303), but I can be easily wrong!

Issue can be reproduced with `mvn clean verify -Dit.test=DevModeJwtSecurityGraphQLIT -Dquarkus.platform.version=2.10.2.Final`.

The issue verification is done by the `DevModeJwtSecurityLIT`. In addition, this PR also runs `testRouteContextTermination` for `cookie`, `Oauth2` and `OpenShift` scenarios as we don't have a basic JWT scenario with GraphQL yet. `BaseJwtSecurityIT` is newly run in DEV mode which  increase the coverage (+29 tests).

I also refactored `smallrye.jwt.verify.publickey.location` to the `mp.jwt.verify.publickey.location` and `smallrye.jwt.verify.issuer` to the `mp.jwt.verify.issuer` as former is going to be removed in the next version.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)