### PR TITLE
Keycloak 18 requires uma_protection scope on http/http_advanced

### DIFF
--- a/http/http-advanced-reactive/src/test/resources/keycloak-realm.json
+++ b/http/http-advanced-reactive/src/test/resources/keycloak-realm.json
@@ -19,8 +19,14 @@
           "value": "test-normal-user"
         }
       ],
+      "clientRoles": {
+        "test-application-client": [
+          "uma_protection"
+        ]
+      },
       "realmRoles": [
-        "test-user-role"
+        "test-user-role",
+        "uma_protection"
       ]
     }
   ],
@@ -65,7 +71,28 @@
           }
         }
       ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "uma_protection",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "uma_protection",
+        "microprofile-jwt"
+      ],
       "authorizationSettings": {
+        "scopes": [
+          {
+            "id": "uma_authorization",
+            "name": "uma_authorization"
+          }
+        ],
         "resources": [
           {
             "name": "test-user-resource",

--- a/http/http-advanced/src/test/resources/keycloak-realm.json
+++ b/http/http-advanced/src/test/resources/keycloak-realm.json
@@ -19,8 +19,14 @@
           "value": "test-normal-user"
         }
       ],
+      "clientRoles": {
+        "test-application-client": [
+          "uma_protection"
+        ]
+      },
       "realmRoles": [
-        "test-user-role"
+        "test-user-role",
+        "uma_protection"
       ]
     }
   ],
@@ -65,7 +71,28 @@
           }
         }
       ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "uma_protection",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "uma_protection",
+        "microprofile-jwt"
+      ],
       "authorizationSettings": {
+        "scopes": [
+          {
+            "id": "uma_authorization",
+            "name": "uma_authorization"
+          }
+        ],
         "resources": [
           {
             "name": "test-user-resource",


### PR DESCRIPTION
### Summary

From now I didn't see this problem in other scenarios so I am not going to propagate this scope to all the realms/scenarios. Maybe is need it on `http/http-advanced` ( and reactive) because `quarkus-keycloak-authorization` is making some internal query that requires `uma_protection` (this is only an issue with Keycloak 18 +)
 
Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)