### PR TITLE
Re-enable some Kafka strimzi scenarios

### DIFF
--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/StrimziKafkaAvroGroupIdIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/StrimziKafkaAvroGroupIdIT.java
@@ -5,15 +5,12 @@ import org.junit.jupiter.api.Tag;
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @Tag("QUARKUS-1089")
 @QuarkusScenario
-// TODO https://github.com/quarkusio/quarkus/issues/25814
-@DisabledOnQuarkusSnapshot(reason = "Quarkus upstream is using Apicurio 2.2.3.Final that is not backward compatible with Apicurio 2.1.5 used previously")
 public class StrimziKafkaAvroGroupIdIT extends BaseKafkaAvroGroupIdIT {
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI, withRegistry = true, registryPath = "/apis/registry/v2")

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/StrimziKafkaAvroIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/StrimziKafkaAvroIT.java
@@ -3,14 +3,11 @@ package io.quarkus.ts.messaging.strimzi.kafka.reactive;
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @QuarkusScenario
-// TODO https://github.com/quarkusio/quarkus/issues/25814
-@DisabledOnQuarkusSnapshot(reason = "Quarkus upstream is using Apicurio 2.2.3.Final that is not backward compatible with Apicurio 2.1.5 used previously")
 public class StrimziKafkaAvroIT extends BaseKafkaAvroIT {
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI, withRegistry = true, registryPath = "/apis/registry/v2")


### PR DESCRIPTION
### Summary

Quarkus test framework already supports apicurio 2.2.3.Final
CodeRef: https://github.com/quarkus-qe/quarkus-test-framework/commit/6fa41715e2f498ca0681caddc3ceb4f52845410b#diff-97cd2066f40b4ab3ffc4cb3d0060d3da6a0c7f869b2f01757e9942760d704415L5

Please select the relevant options.
- [X] Refactoring


### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)