### PR TITLE
Upgrade Keycloak 18 -> 19 on oidc client scenarios

### DIFF
--- a/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/KeycloakOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/KeycloakOidcClientSecurityIT.java
@@ -10,7 +10,8 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakOidcClientSecurityIT extends BaseOidcClientSecurityIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
+    @KeycloakContainer(command = {
+            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" }, image = "quay.io/keycloak/keycloak:19.0.1")
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 


### PR DESCRIPTION
### Summary

We have a daily issue on daily build that looks that is related to Keycloak 18. Is a flaky test, but I could not reproduce on Keycloak 19.

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)