### PR TITLE
Moves oidc Keycloak scenarios to Keycloak 19

### DIFF
--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/KeycloakMultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/KeycloakMultiTenantSecurityIT.java
@@ -13,7 +13,8 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakMultiTenantSecurityIT extends BaseMultiTenantSecurityIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
+    @KeycloakContainer(command = {
+            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" }, image = "quay.io/keycloak/keycloak:19.0.1")
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseOidcIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseOidcIT.java
@@ -16,7 +16,8 @@ public abstract class BaseOidcIT {
     static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
+    @KeycloakContainer(command = {
+            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" }, image = "quay.io/keycloak/keycloak:19.0.1")
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 

--- a/security/keycloak-oidc-client-reactive/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/RequestHeadersIT.java
+++ b/security/keycloak-oidc-client-reactive/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/RequestHeadersIT.java
@@ -22,7 +22,8 @@ public class RequestHeadersIT {
     static final String REALM_DEFAULT = "test-realm";
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
+    @KeycloakContainer(command = {
+            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" }, image = "quay.io/keycloak/keycloak:19.0.1")
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 


### PR DESCRIPTION
### Summary

We have some flaky test on Keycloak 18 that looks like they are not happening on Keycloak 19. 
This PR moves all oidc scenarios to Keycloak 19

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)