### PR TITLE
Fix vertx-sql native compilation error

### DIFF
--- a/sql-db/vertx-sql/src/main/resources/application.properties
+++ b/sql-db/vertx-sql/src/main/resources/application.properties
@@ -77,6 +77,3 @@ quarkus.datasource.oracle.reactive.url=oracle:thin:@localhost:1521:amadeus
 ## Flyway
 quarkus.datasource.oracle.jdbc.url=jdbc:oracle:thin:@localhost:1521:amadeus
 quarkus.flyway.oracle.locations=db/migration/oracle,db/migration/common
-
-# https://github.com/quarkusio/quarkus/issues/27101
-quarkus.native.additional-build-args=--initialize-at-run-time=oracle.jdbc.driver.BlockSource$ThreadedCachingBlockSource


### PR DESCRIPTION
### Summary

Native `Vertx-sql` compilation was failing due to unregistered class on Quarkus-oracle extension
Fixed by: https://github.com/quarkusio/quarkus/pull/27124

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)