### PR TITLE
Update native image builders - use version 22.2

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        image: [ "ubi-quarkus-native-image:22.1-java11", "ubi-quarkus-mandrel:22.1-java11", "ubi-quarkus-mandrel:22.1-java17" ]
+        image: [ "ubi-quarkus-native-image:22.2-java11", "ubi-quarkus-mandrel:22.2-java11", "ubi-quarkus-mandrel:22.2-java17" ]
         profiles: [ "root-modules,monitoring-modules,spring-modules,test-tooling-modules",
                    "http-modules",
                    "security-modules",
@@ -181,7 +181,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: [ "22.1.0.java11"]
+        graalvm-version: [ "22.2.0.java11"]
     steps:
       - uses: actions/checkout@v2
       - name: Install JDK {{ matrix.java }}

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ More info about how to generate native images could be found in Quarkus [buildin
 User: `Deploy in OpenShift the module http-minimum compiled with a custom GraalVM Docker image and 5GB of memory`
 
 ```shell
-mvn clean verify -Dall-modules -Dnative -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:22.1-java11 -Dquarkus.native.native-image-xmx=5g -Dopenshift -pl http/http-minimum 
+mvn clean verify -Dall-modules -Dnative -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:22.2-java11 -Dquarkus.native.native-image-xmx=5g -Dopenshift -pl http/http-minimum 
 ```
 
 #### OpenShift & Native via local GraalVM

--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -39,7 +39,9 @@
                 </property>
             </activation>
             <properties>
-                <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
+                <!-- please keep Mandrel and RHBQ version compatible -->
+                <quarkus.platform.version>2.7.6.Final</quarkus.platform.version>
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:22.1-java11</quarkus.native.builder-image>
             </properties>
             <repositories>
                 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <profile.id>jvm</profile.id>
         <!-- S2i configuration -->
         <ts.global.s2i.quarkus.jvm.builder.image>registry.access.redhat.com/ubi8/openjdk-11:latest</ts.global.s2i.quarkus.jvm.builder.image>
-        <ts.global.s2i.quarkus.native.builder.image>quay.io/quarkus/ubi-quarkus-native-s2i:22.1-java11</ts.global.s2i.quarkus.native.builder.image>
+        <ts.global.s2i.quarkus.native.builder.image>quay.io/quarkus/ubi-quarkus-native-s2i:22.2-java11</ts.global.s2i.quarkus.native.builder.image>
         <!-- Default values for format -->
         <src.format.goal>format</src.format.goal>
         <src.sort.goal>sort</src.sort.goal>
@@ -609,7 +609,8 @@
                 <quarkus.package.type>native</quarkus.package.type>
                 <quarkus.native.container-build>true</quarkus.native.container-build>
                 <quarkus.native.native-image-xmx>4g</quarkus.native.native-image-xmx>
-                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:22.1-java11</quarkus.native.builder-image>
+                <!-- please keep in mind that lifecycle-application module also defines quarkus.native.builder-image property -->
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:22.2-java11</quarkus.native.builder-image>
                 <exclude.quarkus.devmode.tests>**/*DevMode*IT.java</exclude.quarkus.devmode.tests>
             </properties>
         </profile>


### PR DESCRIPTION
### Summary

Updates GraalVM/Mandrel version to 22.2.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)