### PR TITLE
Github CI: disable Snapshot download

### DIFF
--- a/.github/mvn-settings.xml
+++ b/.github/mvn-settings.xml
@@ -9,16 +9,25 @@
                     <id>google-maven-central</id>
                     <name>GCS Maven Central mirror EU</name>
                     <url>https://maven-central-eu.storage-download.googleapis.com/repos/central/data/</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
                 </repository>
                 <repository>
                     <id>jboss-maven-central-proxy</id>
                     <name>JBoss Maven Central proxy</name>
                     <url>https://repository.jboss.org/nexus/content/repositories/central/</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
                 </repository>
                 <repository>
                     <id>gradle-official-repository</id>
                     <name>Gradle Official Repository</name>
                     <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
                 </repository>
             </repositories>
             <pluginRepositories>


### PR DESCRIPTION
### Summary

Motivation: we have a daily issue that we can't reproduce locally pointing to the latest Quarkus bits

Currently, we are compiling Quarkus latest code on Github CI and reusing these bits in the sub-sequence steps of the build. 
This PR disables download snapshots from Maven repositories

### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)