### PR TITLE
Update lifecycle application Quarkus version to 2.11.2.Final

### DIFF
--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -40,8 +40,7 @@
             </activation>
             <properties>
                 <!-- please keep Mandrel and RHBQ version compatible -->
-                <quarkus.platform.version>2.7.6.Final</quarkus.platform.version>
-                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:22.1-java11</quarkus.native.builder-image>
+                <quarkus.platform.version>2.11.2.Final</quarkus.platform.version>
             </properties>
             <repositories>
                 <repository>


### PR DESCRIPTION
### Summary

Related Conversatrion: https://github.com/quarkusio/quarkus/issues/26640

This PR upgrade lifecycle Quarkus app to the latest released version that is compatible with mandrel 22.2

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)