### PR TITLE
Add missing Mssql required property to 'application.properties' file

### DIFF
--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMssqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMssqlDatabaseIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
+//TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/793
+@DisabledOnQuarkusSnapshot(reason = "Required property is ignored on OCP")
 @OpenShiftScenario
 public class OpenShiftMssqlDatabaseIT extends MssqlDatabaseIT {
 

--- a/sql-db/sql-app/src/test/resources/mssql.properties
+++ b/sql-db/sql-app/src/test/resources/mssql.properties
@@ -2,3 +2,4 @@ quarkus.datasource.db-kind=mssql
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServer2012Dialect
 quarkus.hibernate-orm.sql-load-script=mssql_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.datasource.jdbc.additional-jdbc-properties.trustServerCertificate=true

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MssqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MssqlHandlerIT.java
@@ -19,6 +19,7 @@ public class MssqlHandlerIT extends CommonTestCases {
             .withProperty("quarkus.datasource.mssql.password", database.getPassword())
             .withProperty("quarkus.datasource.mssql.jdbc.url", database::getJdbcUrl)
             .withProperty("quarkus.datasource.mssql.reactive.url", database::getReactiveUrl)
+            .withProperty("quarkus.datasource.mssql.jdbc.additional-jdbc-properties.trustServerCertificate", "true")
             .withProperty("app.selected.db", "mssql")
             // Enable Flyway for MySQL
             .withProperty("quarkus.flyway.mssql.migrate-at-start", "true");


### PR DESCRIPTION
### Summary

Mssql driver has been updated: https://github.com/quarkusio/quarkus/commit/bccd9a1b3e125649cd0b91fb5e4d3af34bed92fc#diff-f1a3b4e6df9f63193be9632bac4425e522e28a3445149dfde5510c213f4a4493R8

This PR add a required property by the new driver version: `quarkus.datasource.jdbc.additional-jdbc-properties.trustServerCertificate`

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)