### PR TITLE
Mssql trustservercertificate required property must be in lower case

### DIFF
--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMssqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMssqlDatabaseIT.java
@@ -1,10 +1,7 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
-//TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/793
-@DisabledOnQuarkusSnapshot(reason = "Required property is ignored on OCP")
 @OpenShiftScenario
 public class OpenShiftMssqlDatabaseIT extends MssqlDatabaseIT {
 

--- a/sql-db/sql-app/src/test/resources/mssql.properties
+++ b/sql-db/sql-app/src/test/resources/mssql.properties
@@ -2,4 +2,4 @@ quarkus.datasource.db-kind=mssql
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServer2012Dialect
 quarkus.hibernate-orm.sql-load-script=mssql_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
-quarkus.datasource.jdbc.additional-jdbc-properties.trustServerCertificate=true
+quarkus.datasource.jdbc.additional-jdbc-properties.trustservercertificate=true


### PR DESCRIPTION
### Summary

Mssql trustservercertificate required property must be in lower case otherwise doesn't work in OpenShift / K8s

Related to: https://github.com/quarkusio/quarkus/issues/27330

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)