### PR TITLE
Add Kafka Strimzi DevService coverage

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeStrimziKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeStrimziKafkaStreamIT.java
@@ -1,0 +1,34 @@
+package io.quarkus.ts.messaging.kafka.reactive.streams;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+
+@Tag("QUARKUS-1026")
+@Tag("QUARKUS-959")
+@QuarkusScenario
+public class DevModeStrimziKafkaStreamIT extends BaseKafkaStreamTest {
+
+    static final String DEV_SERVICE_KAFKA_IMG = "quay.io/strimzi-test-container/test-container:0.100.0-kafka-3.1.0";
+
+    /**
+     * Kafka must be started using DEV services when running in DEV mode
+     */
+    @DevModeQuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.kafka.devservices.image-name", DEV_SERVICE_KAFKA_IMG)
+            .withProperty("quarkus.kafka.devservices.enabled", Boolean.TRUE.toString());
+
+    @Override
+    protected String getAppUrl() {
+        return app.getHost() + ":" + app.getPort();
+    }
+
+    @Test
+    public void kafkaContainerShouldBeStarted() {
+        app.logs().assertContains("Creating container for image: quay.io/strimzi-test-container/test-container");
+    }
+}


### PR DESCRIPTION
### Summary

Kafka strimzi is also supported as DevService provider. This PR adds the coverage for this scenario
Doc: https://quarkus.io/guides/kafka#configuring-the-image

Please select the relevant options.
- [X] New scenario (non-breaking change which adds functionality)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)