### PR TITLE
Improve Strimzi Kafka group ID stability (flaky patch)

### DIFF
--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/StrimziKafkaAvroGroupIdIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/StrimziKafkaAvroGroupIdIT.java
@@ -19,16 +19,20 @@ public class StrimziKafkaAvroGroupIdIT extends BaseKafkaAvroGroupIdIT {
     @QuarkusApplication
     static RestService appGroupIdA = new RestService()
             .withProperties("strimzi-application.properties")
-            .withProperty("cron.expr", "0 0 0 ? * * *")
+            .withProperty("cron.expr", "*/1 * * * * ?")
+            .withProperty("cron.expr.skip", "true")
             .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
-            .withProperty("kafka.registry.url", kafka::getRegistryUrl);
+            .withProperty("kafka.registry.url", kafka::getRegistryUrl)
+            .withProperty("mp.messaging.incoming.channel-stock-price.group.id", "groupA");
 
     @QuarkusApplication
     static RestService appGroupIdB = new RestService()
             .withProperties("strimzi-application.properties")
-            .withProperty("cron.expr", "0 0 0 ? * * *")
+            .withProperty("cron.expr", "*/1 * * * * ?")
+            .withProperty("cron.expr.skip", "true")
             .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
-            .withProperty("kafka.registry.url", kafka::getRegistryUrl);
+            .withProperty("kafka.registry.url", kafka::getRegistryUrl)
+            .withProperty("mp.messaging.incoming.channel-stock-price.group.id", "groupB");
 
     @Override
     public RestService getAppA() {


### PR DESCRIPTION
### Summary

Sometimes we are getting errors from CI because a Kafka consumer is reading more events than should be read.
This scenario shares some code with other cases where events are generated by a cronjob. This commit will make
more reliable the group ID scenario.

Please select the relevant options.

- [X] Refactoring

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)