### PR TITLE
Improve Strimzi Kafka AVRO stability (flaky patch)

### DIFF
--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/BaseKafkaAvroIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/BaseKafkaAvroIT.java
@@ -35,7 +35,7 @@ public abstract class BaseKafkaAvroIT {
     @Test
     public void batchMustBeGreaterThanSingleEvent() throws InterruptedException {
         givenAnApplicationEndpoint(getEndpoint() + "/stock-price/stream-batch");
-        whenRequestSomeEvents(EVENTS_AMOUNT, 2);
+        whenRequestSomeEvents(SINGLE, 2); // we expected that a single batch retrieve all events
         thenVerifyAllEventsArrived();
     }
 


### PR DESCRIPTION
### Summary

Batch processing sometimes fails because it consumes all events in a single request and then
there are no more events for the following request. This commit tries to make more reliable
this scenario by expecting just one request with more than one event.

Please select the relevant options.
- [X] Refactoring


### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)