### PR TITLE
Server and client address checks

### DIFF
--- a/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/RequestDetailsResource.java
+++ b/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/RequestDetailsResource.java
@@ -1,0 +1,30 @@
+package io.quarkus.ts.http.advanced;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.vertx.core.http.HttpServerRequest;
+
+@Path("/details")
+public class RequestDetailsResource {
+
+    @Inject
+    HttpServerRequest request;
+
+    @GET
+    @Path("/server/address")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String serverAddress() {
+        return request.localAddress().toString();
+    }
+
+    @GET
+    @Path("/client/address")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String clientAddress() {
+        return request.remoteAddress().toString();
+    }
+}

--- a/http/http-advanced/src/main/resources/application.properties
+++ b/http/http-advanced/src/main/resources/application.properties
@@ -44,6 +44,8 @@ quarkus.keycloak.policy-enforcer.paths.version.enforcement-mode=DISABLED
 # Application endpoints
 quarkus.keycloak.policy-enforcer.paths.hello.path=/api/hello/*
 quarkus.keycloak.policy-enforcer.paths.hello.enforcement-mode=DISABLED
+quarkus.keycloak.policy-enforcer.paths.details.path=/api/details/*
+quarkus.keycloak.policy-enforcer.paths.details.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.grpc.path=/api/grpc/*
 quarkus.keycloak.policy-enforcer.paths.grpc.enforcement-mode=DISABLED
 quarkus.oidc.client-id=test-application-client


### PR DESCRIPTION
Server and client address checks

`http-advanced-reactive` doesn't need to be enhanced because the test is working with data from `io.vertx.core.http.HttpServerRequest` which is not JAX-RS specific.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)