### PR TITLE
Fix Keycloak 19 OCP scenarios

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHttpAdvancedReactiveIT.java
@@ -4,18 +4,17 @@ import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
 public class OpenShiftHttpAdvancedReactiveIT extends BaseHttpAdvancedReactiveIT {
 
     private static final String REALM_DEFAULT = "test-realm";
-    private static final int KEYCLOAK_PORT = 8080;
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @Container(image = "${keycloak.image}", expectedLog = "Admin console listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
+    @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication(ssl = true)

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHttpAdvancedIT.java
@@ -4,17 +4,15 @@ import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
 public class OpenShiftHttpAdvancedIT extends BaseHttpAdvancedIT {
 
-    private static final int KEYCLOAK_PORT = 8080;
-
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @Container(image = "${keycloak.image}", expectedLog = "Admin console listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT)
+    @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication(ssl = true)


### PR DESCRIPTION
### Summary

Keycloak was updated to 19 version but some OCP scenarios were still using the old way to start Keycloak. This PR fix these scenarios. 

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)