### PR TITLE
Remove hardcode keycloak 19 docker image references

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,6 @@
                                 <ts.global.s2i.quarkus.jvm.builder.image>${ts.global.s2i.quarkus.jvm.builder.image}</ts.global.s2i.quarkus.jvm.builder.image>
                                 <ts.global.s2i.quarkus.native.builder.image>${ts.global.s2i.quarkus.native.builder.image}</ts.global.s2i.quarkus.native.builder.image>
                                 <!-- Services used in test suite -->
-                                <keycloak.image>quay.io/keycloak/keycloak:19.0.1</keycloak.image>
                                 <postgresql.13.image>docker.io/library/postgres:13.6</postgresql.13.image>
                                 <!-- TODO: investigate further in https://github.com/quarkus-qe/quarkus-test-suite/issues/627 -->
                                 <elastic.71.image>docker.io/bitnami/elasticsearch:7.17.2</elastic.71.image>

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/KeycloakMultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/KeycloakMultiTenantSecurityIT.java
@@ -14,7 +14,7 @@ public class KeycloakMultiTenantSecurityIT extends BaseMultiTenantSecurityIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @KeycloakContainer(command = {
-            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" }, image = "quay.io/keycloak/keycloak:19.0.1")
+            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" })
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 

--- a/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/KeycloakOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/KeycloakOidcClientSecurityIT.java
@@ -11,7 +11,7 @@ public class KeycloakOidcClientSecurityIT extends BaseOidcClientSecurityIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @KeycloakContainer(command = {
-            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" }, image = "quay.io/keycloak/keycloak:19.0.1")
+            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" })
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseOidcIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseOidcIT.java
@@ -17,7 +17,7 @@ public abstract class BaseOidcIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @KeycloakContainer(command = {
-            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" }, image = "quay.io/keycloak/keycloak:19.0.1")
+            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" })
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 

--- a/security/keycloak-oidc-client-reactive/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/RequestHeadersIT.java
+++ b/security/keycloak-oidc-client-reactive/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/RequestHeadersIT.java
@@ -23,7 +23,7 @@ public class RequestHeadersIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
     @KeycloakContainer(command = {
-            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" }, image = "quay.io/keycloak/keycloak:19.0.1")
+            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" })
     static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/IncorrectKsFileTypeOidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/IncorrectKsFileTypeOidcMtlsIT.java
@@ -25,7 +25,7 @@ public class IncorrectKsFileTypeOidcMtlsIT extends BaseOidcMtlsIT {
     static final String KEYSTORE_FILE_EXTENSION = "jks";
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = KC_DEV_MODE_JKS_CMD, image = "quay.io/keycloak/keycloak:19.0.1", port = KEYCLOAK_PORT)
+    @KeycloakContainer(command = KC_DEV_MODE_JKS_CMD, port = KEYCLOAK_PORT)
     static KeycloakService keycloak = newKeycloakInstance(REALM_FILE_PATH, REALM_DEFAULT, "realms")
             .withRedHatFipsDisabled()
             .withProperty("HTTPS_KEYSTORE", "resource_with_destination::/etc/|server-keystore." + KEYSTORE_FILE_EXTENSION)

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/JksOidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/JksOidcMtlsIT.java
@@ -16,7 +16,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class JksOidcMtlsIT extends KeycloakMtlsAuthN {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = KC_DEV_MODE_JKS_CMD, image = "quay.io/keycloak/keycloak:19.0.1", port = KEYCLOAK_PORT)
+    @KeycloakContainer(command = KC_DEV_MODE_JKS_CMD, port = KEYCLOAK_PORT)
     static KeycloakService keycloak = newKeycloakInstance(REALM_FILE_PATH, REALM_DEFAULT, "realms")
             .withRedHatFipsDisabled()
             .withProperty("HTTPS_KEYSTORE", "resource_with_destination::/etc/|server-keystore." + JKS_KEYSTORE_FILE_EXTENSION)

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/Pkcs12OidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/Pkcs12OidcMtlsIT.java
@@ -20,7 +20,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class Pkcs12OidcMtlsIT extends KeycloakMtlsAuthN {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = KC_DEV_MODE_P12_CMD, image = "quay.io/keycloak/keycloak:19.0.1", port = KEYCLOAK_PORT)
+    @KeycloakContainer(command = KC_DEV_MODE_P12_CMD, port = KEYCLOAK_PORT)
     static KeycloakService keycloak = newKeycloakInstance(REALM_FILE_PATH, REALM_DEFAULT, "realms")
             .withRedHatFipsDisabled()
             .withProperty("HTTPS_KEYSTORE", "resource_with_destination::/etc/|server-keystore." + P12_KEYSTORE_FILE_EXTENSION)


### PR DESCRIPTION
### Summary

Keycloak 19 is used by default on Quarkus test framework `1.2.0.Beta5`. This PR remove all hardcode references to Keycloak 19 docker image

Please select the relevant options.
- [X] Refactoring


### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)