### PR TITLE
Replace OpenTelemetry Jaeger exporter with gRPC OTPL exporter

### DIFF
--- a/http/graphql-telemetry/pom.xml
+++ b/http/graphql-telemetry/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry-exporter-jaeger</artifactId>
+            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>

--- a/http/graphql-telemetry/src/test/java/io/quarkus/ts/http/graphql/telemetry/GraphQLTelemetryIT.java
+++ b/http/graphql-telemetry/src/test/java/io/quarkus/ts/http/graphql/telemetry/GraphQLTelemetryIT.java
@@ -21,14 +21,13 @@ import io.restassured.response.Response;
 
 @QuarkusScenario
 public class GraphQLTelemetryIT {
-    private static final int GRPC_COLLECTOR_PORT = 14250;
 
-    @JaegerContainer(restPort = GRPC_COLLECTOR_PORT)
+    @JaegerContainer(useOtlpCollector = true)
     static JaegerService jaeger = new JaegerService();
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.opentelemetry.tracer.exporter.jaeger.endpoint", jaeger::getRestUrl);
+            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl);
 
     @Test
     void verifyTelemetry() {

--- a/http/graphql/src/test/java/io/quarkus/ts/http/graphql/GraphQLTracingIT.java
+++ b/http/graphql/src/test/java/io/quarkus/ts/http/graphql/GraphQLTracingIT.java
@@ -29,7 +29,7 @@ public class GraphQLTracingIT {
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.jaeger.service-name", SERVICE_NAME)
-            .withProperty("quarkus.jaeger.endpoint", jaeger::getRestUrl);
+            .withProperty("quarkus.jaeger.endpoint", jaeger::getCollectorUrl);
 
     @Test
     void verifyTracesInJaegerTest() {

--- a/http/vertx-web-client/pom.xml
+++ b/http/vertx-web-client/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry-exporter-jaeger</artifactId>
+            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/http/vertx-web-client/src/main/resources/application.properties
+++ b/http/vertx-web-client/src/main/resources/application.properties
@@ -3,8 +3,5 @@ chucknorris.api.domain=https://api.chucknorris.io
 vertx.webclient.timeout-sec=2
 vertx.webclient.retries=3
 
-# Jaeger
-quarkus.opentelemetry.tracer.exporter.jaeger.endpoint=http://localhost:14250/api/traces
-
 # debug symbols enabled
 quarkus.native.debug.enabled=true

--- a/http/vertx-web-client/src/test/resources/application.properties
+++ b/http/vertx-web-client/src/test/resources/application.properties
@@ -4,6 +4,3 @@ quarkus.test.native-image-profile=test
 chucknorris.api.domain=https://api.chucknorris.io/
 vertx.webclient.timeout-sec=1
 vertx.webclient.retries=1
-
-# Jaeger
-quarkus.opentelemetry.tracer.exporter.jaeger.endpoint=http://localhost:14250/api/traces

--- a/monitoring/microprofile-opentracing/src/test/java/io/quarkus/ts/microprofile/opentracing/MicroProfileIT.java
+++ b/monitoring/microprofile-opentracing/src/test/java/io/quarkus/ts/microprofile/opentracing/MicroProfileIT.java
@@ -43,7 +43,7 @@ public class MicroProfileIT {
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.jaeger.service-name", SERVICE_NAME)
-            .withProperty("quarkus.jaeger.endpoint", jaeger::getRestUrl);
+            .withProperty("quarkus.jaeger.endpoint", jaeger::getCollectorUrl);
 
     @Order(1)
     @Test

--- a/monitoring/opentelemetry-reactive/pom.xml
+++ b/monitoring/opentelemetry-reactive/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry-exporter-jaeger</artifactId>
+            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>

--- a/monitoring/opentelemetry/pom.xml
+++ b/monitoring/opentelemetry/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry-exporter-jaeger</artifactId>
+            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpentelemetryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpentelemetryIT.java
@@ -29,20 +29,20 @@ public class OpentelemetryIT {
 
     private Response resp;
 
-    @JaegerContainer(restPort = GRPC_COLLECTOR_PORT, expectedLog = "\"Health Check state change\",\"status\":\"ready\"")
+    @JaegerContainer(useOtlpCollector = true, expectedLog = "\"Health Check state change\",\"status\":\"ready\"")
     static final JaegerService jaeger = new JaegerService();
 
     @QuarkusApplication(classes = PongResource.class, properties = "pong.properties")
     static final RestService pongservice = new RestService()
             .withProperty("quarkus.application.name", "pongservice")
-            .withProperty("quarkus.opentelemetry.tracer.exporter.jaeger.endpoint", jaeger::getRestUrl);
+            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl);
 
     @QuarkusApplication(classes = { PingResource.class, PingPongService.class })
     static final RestService pingservice = new RestService()
             .withProperty("quarkus.application.name", "pingservice")
             .withProperty("pongservice_url", pongservice::getHost)
             .withProperty("pongservice_port", () -> String.valueOf(pongservice.getPort()))
-            .withProperty("quarkus.opentelemetry.tracer.exporter.jaeger.endpoint", jaeger::getRestUrl);
+            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl);
 
     @Test
     public void testContextPropagation() {

--- a/monitoring/opentracing-reactive-grpc/src/test/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/AbstractTraceIT.java
+++ b/monitoring/opentracing-reactive-grpc/src/test/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/AbstractTraceIT.java
@@ -29,7 +29,7 @@ public abstract class AbstractTraceIT {
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.jaeger.endpoint", jaeger::getRestUrl);
+            .withProperty("quarkus.jaeger.endpoint", jaeger::getCollectorUrl);
 
     @Test
     public void testServerClientTrace() {

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <quarkus.qe.framework.version>1.2.0.Beta5</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.2.0.Beta6</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.37.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.6.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>


### PR DESCRIPTION
### Summary

Replaces OpenTelemetry Jaeger exporter with a gRPC OTPL exporter. The Quarkus Test Framework version is updated as the changes as this change is only enabled by the latest release.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)