### PR TITLE
Update dependencies and images to latest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ Container images used in the tests are:
   - version 10.6: `mariadb:10.6`
 - MSSQL: `mcr.microsoft.com/mssql/rhel/server`
 - Oracle
-  - version 21 XE: `gvenzl/oracle-xe:21-slim`
+  - version 21 XE: `gvenzl/oracle-xe:21-slim-faststart`
 
 ### `sql-db/sql-app-oracle`
 Functionally identical to `sql-db/sql-app`, but using only `quarkus-jdbc-oracle` driver. This is a workaround for the missing native Oracle coverage in `sql-db/sql-app`.

--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-di</artifactId>
-            <version>1.3.2.Final-redhat-00001</version>
+            <version>2.7.6.Final-redhat-00006</version>
         </dependency>
     </dependencies>
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <quarkus.qe.framework.version>1.2.0.Beta9</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.37.0</quarkus-qpid-jms.version>
-        <quarkus-ide-config.version>2.6.1.Final</quarkus-ide-config.version>
+        <quarkus-ide-config.version>2.12.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>
         <confluent.kafka-avro-serializer.version>7.2.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.20.0</formatter-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
                                 <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7</mysql.80.image>
                                 <mariadb.10.image>docker.io/library/mariadb:10.6</mariadb.10.image>
                                 <mssql.image>mcr.microsoft.com/mssql/rhel/server:2019-latest</mssql.image>
-                                <oracle.image>docker.io/gvenzl/oracle-xe:21-slim</oracle.image>
+                                <oracle.image>docker.io/gvenzl/oracle-xe:21-slim-faststart</oracle.image>
                                 <db2.image>quay.io/quarkusqeteam/db2:11.5.7.0</db2.image>
                                 <mongodb.image>docker.io/bitnami/mongodb:5.0</mongodb.image>
                                 <redis.image>docker.io/library/redis:6.0</redis.image>

--- a/pom.xml
+++ b/pom.xml
@@ -213,9 +213,9 @@
                                 <ts.global.s2i.quarkus.jvm.builder.image>${ts.global.s2i.quarkus.jvm.builder.image}</ts.global.s2i.quarkus.jvm.builder.image>
                                 <ts.global.s2i.quarkus.native.builder.image>${ts.global.s2i.quarkus.native.builder.image}</ts.global.s2i.quarkus.native.builder.image>
                                 <!-- Services used in test suite -->
-                                <postgresql.13.image>docker.io/library/postgres:13.6</postgresql.13.image>
+                                <postgresql.13.image>docker.io/library/postgres:13.8</postgresql.13.image>
                                 <!-- TODO: investigate further in https://github.com/quarkus-qe/quarkus-test-suite/issues/627 -->
-                                <elastic.71.image>docker.io/bitnami/elasticsearch:7.17.2</elastic.71.image>
+                                <elastic.71.image>docker.io/bitnami/elasticsearch:7.17.6</elastic.71.image>
                                 <!--TODO change into 5.7 when this fixed https://github.com/docker-library/mysql/issues/844 -->
                                 <mysql.57.image>docker.io/library/mysql:5.7.36</mysql.57.image>
                                 <!-- TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/609 -->
@@ -229,8 +229,8 @@
                                 <redis.image>docker.io/library/redis:6.0</redis.image>
                                 <wiremock.image>quay.io/ocpmetal/wiremock</wiremock.image>
                                 <!-- TODO use official image when/if this fixed https://github.com/hashicorp/docker-consul/issues/184 -->
-                                <consul.image>docker.io/bitnami/consul:1.12.0</consul.image>
-                                <infinispan.image>quay.io/infinispan/server:12.1</infinispan.image>
+                                <consul.image>docker.io/bitnami/consul:1.13.1</consul.image>
+                                <infinispan.image>quay.io/infinispan/server:13.0</infinispan.image>
                                 <infinispan.expected-log>Infinispan Server.*started in</infinispan.expected-log>
                                 <spring.cloud.server.image>quay.io/quarkusqeteam/spring-cloud-config-server:3.0</spring.cloud.server.image>
                                 <bouncycastle.bctls-fips.version>1.0.12.2</bouncycastle.bctls-fips.version>


### PR DESCRIPTION
### Summary

### Update docker images to latest versions

Wherever possible.
Red Hat registry images unchanged.
Other images synchronized with Quarkus upstream or updated to the latest
applicable version.
Note to `docker.io/infinispan/server:13.0`: there is a newer tag `14.0`,
but `quarkus-infinispan-client` uses Infinispan `13.0.10` which does not
work with server version `14.0`.

### Update maven dependencies to latest versions

New versions inspected using `mvn versions:display-dependency-updates`.
Maven plugins updated to latest available version.

### Switch to gvenzl/oracle-xe:21-slim-faststart

Faststart image has faster startup in exchange for bigger image size.
See
https://github.com/gvenzl/oci-oracle-xe/pkgs/container/oracle-xe#image-flavors.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)