### PR TITLE
Test Kubernetes Config sources prioritization

### DIFF
--- a/config/src/main/java/io/quarkus/ts/configmap/api/server/HelloConfigProperties.java
+++ b/config/src/main/java/io/quarkus/ts/configmap/api/server/HelloConfigProperties.java
@@ -1,0 +1,38 @@
+package io.quarkus.ts.configmap.api.server;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.inject.ConfigProperties;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ConfigProperties(prefix = "hello")
+public class HelloConfigProperties {
+
+    @ConfigProperty(name = "message")
+    Optional<String> message;
+
+    @ConfigProperty(name = "preamble")
+    String preamble;
+
+    @ConfigProperty(name = "epilogue")
+    String epilogue;
+
+    @ConfigProperty(name = "side-note")
+    String sideNote;
+
+    public Optional<String> getMessage() {
+        return message;
+    }
+
+    public String getPreamble() {
+        return preamble;
+    }
+
+    public String getEpilogue() {
+        return epilogue;
+    }
+
+    public String getSideNote() {
+        return sideNote;
+    }
+}

--- a/config/src/main/java/io/quarkus/ts/configmap/api/server/HelloResource.java
+++ b/config/src/main/java/io/quarkus/ts/configmap/api/server/HelloResource.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.configmap.api.server;
 
-import java.util.Optional;
-
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -10,20 +8,30 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.inject.ConfigProperties;
 
 @Path("/hello")
 public class HelloResource {
-    @ConfigProperty(name = "hello.message")
-    Optional<String> message;
 
+    @ConfigProperties
+    HelloConfigProperties configProperties;
+
+    @Path("/message")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response get(@QueryParam("name") @DefaultValue("World") String name) {
-        if (message.isPresent()) {
-            return Response.ok().entity(new Hello(String.format(message.get(), name))).build();
+    public Response getMessage(@QueryParam("name") @DefaultValue("World") String name) {
+        if (configProperties.message.isPresent()) {
+            return Response.ok().entity(new Hello(String.format(configProperties.message.get(), name))).build();
         }
 
         return Response.serverError().entity("ConfigMap not present").build();
     }
+
+    @Path("/properties")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public HelloConfigProperties getProperties() {
+        return configProperties;
+    }
+
 }

--- a/config/src/main/resources/application.properties
+++ b/config/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+hello.preamble=preamble-never-used-value
+hello.epilogue=epilogue-never-used-value
+side-note=side-note-never-used-value
+hello.side-note=${side-note}

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftBaseConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftBaseConfigIT.java
@@ -32,13 +32,13 @@ public abstract class OpenShiftBaseConfigIT {
     @Test
     public void configMapEndToEnd() {
         // Simple invocation
-        getApp().given().get("/hello")
+        getApp().given().get("/hello/message")
                 .then().statusCode(HttpStatus.SC_OK)
                 .body("content", is("Hello World from " + getConfigType()));
 
         // Parameterized invocation
         getApp().given().queryParam("name", "Albert Einstein")
-                .when().get("/hello").then().statusCode(HttpStatus.SC_OK)
+                .when().get("/hello/message").then().statusCode(HttpStatus.SC_OK)
                 .body("content", is("Hello Albert Einstein from " + getConfigType()));
 
         // Update config map
@@ -46,7 +46,7 @@ public abstract class OpenShiftBaseConfigIT {
         getApp().restart();
 
         await().atMost(ASSERT_TIMEOUT_MINUTES, TimeUnit.MINUTES).untilAsserted(() -> {
-            getApp().given().get("/hello").then().statusCode(HttpStatus.SC_OK)
+            getApp().given().get("/hello/message").then().statusCode(HttpStatus.SC_OK)
                     .body(containsString("Good morning World from an updated " + getConfigType()));
         });
 
@@ -55,7 +55,7 @@ public abstract class OpenShiftBaseConfigIT {
         getApp().restart();
 
         await().atMost(ASSERT_TIMEOUT_MINUTES, TimeUnit.MINUTES).untilAsserted(() -> {
-            getApp().given().get("/hello").then().statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            getApp().given().get("/hello/message").then().statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
         });
     }
 
@@ -72,6 +72,10 @@ public abstract class OpenShiftBaseConfigIT {
     }
 
     private static void applyConfig(String name) {
+        applyConfig(name, openshift);
+    }
+
+    static void applyConfig(String name, OpenShiftClient openshift) {
         openshift.apply(Paths.get(new File("target/test-classes/" + name + ".yaml").toURI()));
     }
 }

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftConfigSourcePriorityIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftConfigSourcePriorityIT.java
@@ -1,0 +1,67 @@
+package io.quarkus.ts.configmap.api.server;
+
+import static io.quarkus.ts.configmap.api.server.OpenShiftBaseConfigIT.CONFIGMAP;
+import static io.quarkus.ts.configmap.api.server.OpenShiftBaseConfigIT.SECRET;
+import static io.quarkus.ts.configmap.api.server.OpenShiftBaseConfigIT.applyConfig;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import javax.inject.Inject;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.bootstrap.Service;
+import io.quarkus.test.bootstrap.inject.OpenShiftClient;
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.response.Response;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
+public class OpenShiftConfigSourcePriorityIT {
+
+    private static final String CONFIGMAP_YAML = CONFIGMAP + "-yaml";
+    private static final String CONFIGMAP_YML = CONFIGMAP + "-yml";
+    private static final String SECRET_YML = SECRET + "-yml";
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperties("config-source-priority.properties")
+            .onPreStart(OpenShiftConfigSourcePriorityIT::loadConfigSource);
+
+    @Inject
+    static OpenShiftClient openShiftClient;
+
+    @Test
+    public void testConfigSourcePriorities() {
+        final Response response = app.given()
+                .get("/hello/properties");
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+        final HelloConfigProperties configProperties = response.as(HelloConfigProperties.class);
+        assertNotNull(configProperties);
+
+        // ConfigMap has higher priority than application properties, and it's possible to create ConfigMap from application.yml.
+        assertEquals(format("epilogue %s", CONFIGMAP_YML), configProperties.epilogue);
+
+        // Last ConfigMap has higher priority than ConfigMaps defined earlier, and it's possible to create ConfigMap from application.yaml.
+        assertEquals(format("preamble %s", CONFIGMAP_YAML), configProperties.preamble);
+
+        // Last Secret has higher priority than Secrets/ConfigMaps defined earlier.
+        assertEquals(format("message %s", SECRET_YML), configProperties.message.orElse(null));
+
+        // Environment variable has the highest priority.
+        assertEquals("side note environment variable", configProperties.sideNote);
+    }
+
+    private static void loadConfigSource(Service service) {
+        // create Secrets and ConfigMaps
+        applyConfig(CONFIGMAP_YAML, openShiftClient);
+        applyConfig(CONFIGMAP_YML, openShiftClient);
+        applyConfig(CONFIGMAP, openShiftClient);
+        applyConfig(SECRET, openShiftClient);
+        applyConfig(SECRET_YML, openShiftClient);
+    }
+}

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftFailOnMissingConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftFailOnMissingConfigIT.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.configmap.api.server;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
+public class OpenShiftFailOnMissingConfigIT {
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .setAutoStart(false)
+            .withProperty("quarkus.kubernetes-config.enabled", "true")
+            .withProperty("quarkus.kubernetes-config.config-maps", "absent-config-map");
+
+    @Test
+    public void shouldFailOnStart() {
+        assertThrows(AssertionError.class, () -> app.start(),
+                "Should fail because property 'quarkus.kubernetes-config.fail-on-missing-config' is true and ConfigMap 'absent-config-map' is missing.");
+    }
+
+}

--- a/config/src/test/resources/config-source-priority.properties
+++ b/config/src/test/resources/config-source-priority.properties
@@ -1,0 +1,5 @@
+quarkus.kubernetes-config.enabled=true
+quarkus.kubernetes-config.config-maps=app-config-yml,app-config-yaml,app-config
+quarkus.kubernetes-config.secrets=app-config,app-config-yml
+quarkus.kubernetes-config.secrets.enabled=true
+quarkus.openshift.env.vars.side-note=side note environment variable

--- a/config/src/test/resources/configmap-yaml.yaml
+++ b/config/src/test/resources/configmap-yaml.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config-yaml
+data:
+  application.yaml: |
+    hello:
+      message: message configmap-yaml
+      preamble: preamble configmap-yaml

--- a/config/src/test/resources/configmap-yml.yaml
+++ b/config/src/test/resources/configmap-yml.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config-yml
+data:
+  application.yml: |
+    hello:
+      message: message configmap-yml
+      epilogue: epilogue configmap-yml
+      preamble: preamble configmap-yml

--- a/config/src/test/resources/secret-yml.yaml
+++ b/config/src/test/resources/secret-yml.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-config-yml
+stringData:
+  application.properties: |
+    hello.message=message secret-yml


### PR DESCRIPTION
### Summary

In addition to existing test coverage of the Quarkus Kubernetes Config, we newly test that:

1. Properties retrieved from ConfigMaps and Secrets created from an `application.yml` file.
2. Priority of obtained properties:
   1. Properties defined in Secrets have higher priority than same properties defined in Config Maps.
   2. When multiple ConfigMaps (or Secrets) are used, ConfigMaps (or Secrets) defined later in the list have a higher priority that ConfigMaps defined earlier in the list.
   3. The properties obtained from the ConfigMaps and Secrets have a higher priority than (i.e. they override) any properties of the same name that are found in application.properties (or the YAML equivalents), but they have lower priority than properties set via Environment Variables or Java System Properties.
3. If property `quarkus.kubernetes-config.fail-on-missing-config` set to true, the application will not start if any of the configured config sources cannot be located.

I left out testing of the ConfigMaps/Secrets placed in another namespace than the app is running in as our OC user can't grant `ClusterRole`s.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)