### PR TITLE
Remove hardcoded smallrye-stork.version on main pom in favor of stork BOM version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,6 @@
         <jsoup.version>1.15.3</jsoup.version>
         <camel-quarkus-bom.version>2.12.0</camel-quarkus-bom.version>
         <quarkiverse.config.version>1.1.0</quarkiverse.config.version>
-        <smallrye-stork.version>1.1.2</smallrye-stork.version>
         <assertj.version>3.23.1</assertj.version>
         <profile.id>jvm</profile.id>
         <!-- S2i configuration -->

--- a/service-discovery/stork-custom/pom.xml
+++ b/service-discovery/stork-custom/pom.xml
@@ -45,7 +45,6 @@
                         <path>
                             <groupId>io.smallrye.stork</groupId>
                             <artifactId>stork-configuration-generator</artifactId>
-                            <version>${smallrye-stork.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>


### PR DESCRIPTION
### Summary

Remove hardcoded smallrye-stork.version on main pom in favor of stork BOM version

Please select the relevant options.
- [X] Dependency update


### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)