### PR TITLE
Remove JDK11 docker native image references

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        image: [ "ubi-quarkus-native-image:22.2-java11", "ubi-quarkus-mandrel:22.2-java11", "ubi-quarkus-mandrel:22.2-java17" ]
+        image: [ "ubi-quarkus-native-image:22.2-java17", "ubi-quarkus-mandrel:22.2-java17" ]
         profiles: [ "root-modules,monitoring-modules,spring-modules,test-tooling-modules",
                    "http-modules",
                    "security-modules",

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ More info about how to generate native images could be found in Quarkus [buildin
 User: `Deploy in OpenShift the module http-minimum compiled with a custom GraalVM Docker image and 5GB of memory`
 
 ```shell
-mvn clean verify -Dall-modules -Dnative -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:22.2-java11 -Dquarkus.native.native-image-xmx=5g -Dopenshift -pl http/http-minimum 
+mvn clean verify -Dall-modules -Dnative -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:22.2-java17 -Dquarkus.native.native-image-xmx=5g -Dopenshift -pl http/http-minimum 
 ```
 
 #### OpenShift & Native via local GraalVM

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <profile.id>jvm</profile.id>
         <!-- S2i configuration -->
         <ts.global.s2i.quarkus.jvm.builder.image>registry.access.redhat.com/ubi8/openjdk-11:latest</ts.global.s2i.quarkus.jvm.builder.image>
-        <ts.global.s2i.quarkus.native.builder.image>quay.io/quarkus/ubi-quarkus-native-s2i:22.2-java11</ts.global.s2i.quarkus.native.builder.image>
+        <ts.global.s2i.quarkus.native.builder.image>quay.io/quarkus/ubi-quarkus-native-s2i:22.2-java17</ts.global.s2i.quarkus.native.builder.image>
         <!-- Default values for format -->
         <src.format.goal>format</src.format.goal>
         <src.sort.goal>sort</src.sort.goal>


### PR DESCRIPTION
### Summary

Replace `ubi-quarkus-native-image:22.2-java11` by `ubi-quarkus-native-image:22.2-java17`
Remove `ubi-quarkus-mandrel:22.2-java11`

Please select the relevant options.

- [X] Dependency update
- [X] This change requires a documentation update

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)