### PR TITLE
Bump Test Framework from 1.2.0.Beta11 to 1.2.0.Beta12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <quarkus.qe.framework.version>1.2.0.Beta11</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.2.0.Beta12</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.37.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.12.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>


### PR DESCRIPTION
### Summary

Bumps Test Framework from 1.2.0.Beta11 to 1.2.0.Beta12, so we could put issues with `OpenShiftClient` behind us.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)