### PR TITLE
Add maven.repository.redhat.com into parent POM

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ These requirements are necessary to verify the tests using Operators.
 
 ## Running against Red Hat build of Quarkus
 
-When running against released Red Hat build of Quarkus make sure https://maven.repository.redhat.com/ga/ repository is defined in settings.xml.
+When running against released Red Hat build of Quarkus, https://maven.repository.redhat.com/ga/ repository
+is already defined in parent POM and there should be no need to provide it in settings.xml.
 
 Example command for released Red Hat build of Quarkus:
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,29 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>red-hat-enterprise-maven-repository</id>
+            <url>https://maven.repository.redhat.com/ga/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
     </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>red-hat-enterprise-maven-repository</id>
+            <url>https://maven.repository.redhat.com/ga/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
     <profiles>
         <profile>
             <id>env-info</id>


### PR DESCRIPTION
### Summary

Motivated by failing tests in PIT environment ([1]), where Maven invoked from within test scenarios does not have access to custom settings.xml.

[1] https://gitlab.cee.redhat.com/quarkus-qe/quarkus-ocp-pit

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)