### PR TITLE
Remove deprecated Jaeger exporter references

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,7 +739,6 @@ Jaeger is deployed in an "all-in-one" configuration, and the OpenShift test veri
 
 Testing OpenTelemetry with Jaeger components
  - Extension `quarkus-opentelemetry` - responsible for traces generation in OpenTelemetry format
- - Extension `quarkus-opentelemetry-exporter-jaeger` - responsible for traces export into Jaeger components (jaeger-agent, jaeger-collector)
  - Extension `quarkus-opentelemetry-exporter-otlp` -responsible for traces export into OpenTelemetry components (opentelemetry-agent, opentelemetry-collector)
  
 Scenarios that test proper traces export to Jaeger components and context propagation.  

--- a/monitoring/opentelemetry-reactive/README.md
+++ b/monitoring/opentelemetry-reactive/README.md
@@ -6,7 +6,6 @@
 ## Scope of the test
 1. Testing OpenTelemetry with Jaeger components and RESTEasy Reactive
  - Extension `quarkus-opentelemetry` - responsible for traces generation in OpenTelemetry format
- - Extension `quarkus-opentelemetry-exporter-jaeger` - responsible for traces export into Jaeger components (jaeger-agent, jaeger-collector)
  - Extension `quarkus-opentelemetry-exporter-otlp` -responsible for traces export into OpenTelemetry components (opentelemetry-agent, opentelemetry-collector)
  
 Scenarios that test proper traces export to Jaeger components and context propagation. 

--- a/monitoring/opentelemetry/README.md
+++ b/monitoring/opentelemetry/README.md
@@ -6,7 +6,6 @@
 ## Scope of the test
 1. Testing OpenTelemetry with Jaeger components
  - Extension `quarkus-opentelemetry` - responsible for traces generation in OpenTelemetry format
- - Extension `quarkus-opentelemetry-exporter-jaeger` - responsible for traces export into Jaeger components (jaeger-agent, jaeger-collector)
  - Extension `quarkus-opentelemetry-exporter-otlp` -responsible for traces export into OpenTelemetry components (opentelemetry-agent, opentelemetry-collector)
  
 Scenarios that test proper traces export to Jaeger components and context propagation. 


### PR DESCRIPTION
### Summary

Jaeger Exporter will be moved to Quarkiverse in favor of OLTP
This PR remove any reference to `quarkus-opentelemetry-exporter-jaeger`

TP: https://github.com/quarkus-qe/quarkus-test-plans/pull/102

Please select the relevant options.
- [X] This change requires a documentation update