### PR TITLE
Template hint for OCP run

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ Please select the relevant options.
 - [ ] Backport
 - [ ] New scenario (non-breaking change which adds functionality)
 - [ ] This change requires a documentation update
+- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
 
 ### Checklist:
 - [ ] Methods and classes used in PR scenarios are meaningful


### PR DESCRIPTION
### Summary

Add a hint to the PR template that if you wanna run OCP tests, you must type a comment `run tests`. That's going to be necessary as I adjusted JVM and native Jenkins jobs (please see the PR in the Jenkins project for more info).

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)