### PR TITLE
Add debug logging to Kafka Avro Reactive Messaging tests

### DIFF
--- a/messaging/kafka-confluent-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/BaseKafkaAvroGroupIdIT.java
+++ b/messaging/kafka-confluent-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/BaseKafkaAvroGroupIdIT.java
@@ -71,8 +71,12 @@ abstract class BaseKafkaAvroGroupIdIT {
             CountDownLatch latch = new CountDownLatch(expectedAmount);
             SseEventSource source = SseEventSource.target(target).build();
             source.register(inboundSseEvent -> {
-                receive.add(inboundSseEvent.readData(String.class, MediaType.APPLICATION_JSON_TYPE));
+                // FIXME: remove logging once flaky tests are fixed
+                final var data = inboundSseEvent.readData(String.class, MediaType.APPLICATION_JSON_TYPE);
+                receive.add(data);
                 totalAmountReceived.incrementAndGet();
+                System.out.printf("Received inboundSseEvent '%s' %n total amount is '%d' %n 'receive' is %s.%n%n%n", data,
+                        totalAmountReceived.get(), receive);
             });
 
             source.open();

--- a/messaging/kafka-confluent-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/BaseKafkaAvroIT.java
+++ b/messaging/kafka-confluent-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/BaseKafkaAvroIT.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.messaging.kafka;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -51,6 +52,8 @@ public abstract class BaseKafkaAvroIT {
 
         SseEventSource source = SseEventSource.target(target).build();
         source.register(inboundSseEvent -> {
+            // FIXME: remove logging once flaky tests are fixed
+            System.out.printf("Received 'inboundSseEvent' '%s'.%n%n%n", inboundSseEvent);
             if (expectedItemsPerEvent == SINGLE) {
                 latch.countDown();
             } else {
@@ -58,7 +61,10 @@ public abstract class BaseKafkaAvroIT {
                 if (items.length >= expectedItemsPerEvent) {
                     latch.countDown();
                 }
+                System.out.printf("Received items '%s' %n countDown is '%b' %n%n%n", Arrays.toString(items),
+                        items.length >= expectedItemsPerEvent);
             }
+            System.out.printf("Latch count is '%d'.%n%n%n", latch.getCount());
         });
 
         source.open();

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/BaseKafkaAvroGroupIdIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/BaseKafkaAvroGroupIdIT.java
@@ -71,8 +71,12 @@ abstract class BaseKafkaAvroGroupIdIT {
             CountDownLatch latch = new CountDownLatch(expectedAmount);
             SseEventSource source = SseEventSource.target(target).build();
             source.register(inboundSseEvent -> {
-                receive.add(inboundSseEvent.readData(String.class, MediaType.APPLICATION_JSON_TYPE));
+                // FIXME: remove logging once flaky tests are fixed
+                final var data = inboundSseEvent.readData(String.class, MediaType.APPLICATION_JSON_TYPE);
+                receive.add(data);
                 totalAmountReceived.incrementAndGet();
+                System.out.printf("Received inboundSseEvent '%s' %n total amount is '%d' %n 'receive' is %s.%n%n%n", data,
+                        totalAmountReceived.get(), receive);
             });
 
             source.open();

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/BaseKafkaAvroIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/BaseKafkaAvroIT.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.messaging.strimzi.kafka.reactive;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -51,6 +52,8 @@ public abstract class BaseKafkaAvroIT {
 
         SseEventSource source = SseEventSource.target(target).build();
         source.register(inboundSseEvent -> {
+            // FIXME: remove logging once flaky tests are fixed
+            System.out.printf("Received 'inboundSseEvent' '%s'.%n%n%n", inboundSseEvent);
             if (expectedItemsPerEvent == SINGLE) {
                 latch.countDown();
             } else {
@@ -58,7 +61,10 @@ public abstract class BaseKafkaAvroIT {
                 if (items.length >= expectedItemsPerEvent) {
                     latch.countDown();
                 }
+                System.out.printf("Received items '%s' %n countDown is '%b' %n%n%n", Arrays.toString(items),
+                        items.length >= expectedItemsPerEvent);
             }
+            System.out.printf("Latch count is '%d'.%n%n%n", latch.getCount());
         });
 
         source.open();


### PR DESCRIPTION
### Summary

In daily runs, `ConfluentKafkaAvroGroupIdIT`, `ConfluentKafkaAvroIT`, `StrimziKafkaAvroIT` and `StrimziKafkaAvroGroupIdIT`, `DevModeApicurioIT` and others  are sometimes failing. I can't reproduce issues locally (over 50 successful runs in row), neither I can be sure what's the root cause without more information. Now we log state of relevant variables. I'll revert the PR in a week time (provided tests are going to fail).

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] Debug

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)