### PR TITLE
Re-enable mssql scenario

### DIFF
--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftHibernateReactiveMsSQLIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftHibernateReactiveMsSQLIT.java
@@ -1,11 +1,8 @@
 package io.quarkus.ts.hibernate.reactive.openshift;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.ts.hibernate.reactive.MsSQLDatabaseHibernateReactiveIT;
 
 @OpenShiftScenario
-@Disabled("https://github.com/microsoft/mssql-docker/issues/769")
 public class OpenShiftHibernateReactiveMsSQLIT extends MsSQLDatabaseHibernateReactiveIT {
 }

--- a/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/OpenShiftMssqlPanacheResourceIT.java
+++ b/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/OpenShiftMssqlPanacheResourceIT.java
@@ -1,10 +1,7 @@
 package io.quarkus.ts.reactive.rest.data.panache;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@Disabled("https://github.com/microsoft/mssql-docker/issues/769")
 public class OpenShiftMssqlPanacheResourceIT extends MssqlPanacheResourceIT {
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMssqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMssqlDatabaseIT.java
@@ -1,11 +1,8 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@Disabled("https://github.com/microsoft/mssql-docker/issues/769")
 public class OpenShiftMssqlDatabaseIT extends MssqlDatabaseIT {
 
 }


### PR DESCRIPTION
### Summary

Mssql database is running as a non-root container but requires a non-preallocated K8s / OCP user, basically, run as `anyuid`. 

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)