### PR TITLE
Fix flaky Kafka tests

### DIFF
--- a/messaging/kafka-confluent-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/ConfluentKafkaAvroGroupIdIT.java
+++ b/messaging/kafka-confluent-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/ConfluentKafkaAvroGroupIdIT.java
@@ -18,13 +18,13 @@ public class ConfluentKafkaAvroGroupIdIT extends BaseKafkaAvroGroupIdIT {
 
     @QuarkusApplication
     static RestService appGroupIdA = new RestService()
-            .withProperty("cron.expr", "0 0 0 ? * * *")
+            .withProperty("cron.expr", "disabled")
             .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
             .withProperty("confluent.registry.url", kafka::getRegistryUrl);
 
     @QuarkusApplication
     static RestService appGroupIdB = new RestService()
-            .withProperty("cron.expr", "0 0 0 ? * * *")
+            .withProperty("cron.expr", "disabled")
             .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
             .withProperty("confluent.registry.url", kafka::getRegistryUrl);
 

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/main/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/KStockPriceProducer.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/main/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/KStockPriceProducer.java
@@ -1,19 +1,22 @@
 package io.quarkus.ts.messaging.strimzi.kafka.reactive;
 
+import static io.quarkus.scheduler.Scheduled.ConcurrentExecution.SKIP;
+
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.stream.IntStream;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.OnOverflow;
 import org.jboss.logging.Logger;
 
 import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.Scheduled.ApplicationNotRunning;
 import io.quarkus.ts.messaging.kafka.StockPrice;
 import io.quarkus.ts.messaging.kafka.status;
 import io.smallrye.common.constraint.NotNull;
@@ -23,20 +26,19 @@ public class KStockPriceProducer {
 
     private static final Logger LOG = Logger.getLogger(KStockPriceProducer.class);
     private static final int BATCH_SIZE = 100;
+    // FIXME: remove EXECUTION_COUNT once https://github.com/quarkusio/quarkus/issues/28567 is resolved
+    private static final AtomicInteger EXECUTION_COUNT = new AtomicInteger(4);
 
     @Inject
     @Channel("source-stock-price")
     @OnOverflow(value = OnOverflow.Strategy.DROP)
     Emitter<StockPrice> emitter;
 
-    @ConfigProperty(name = "cron.expr.skip", defaultValue = "false")
-    String skipCronJob;
-
     private Random random = new Random();
 
-    @Scheduled(cron = "{cron.expr}")
+    @Scheduled(cron = "{cron.expr}", skipExecutionIf = ApplicationNotRunning.class, concurrentExecution = SKIP)
     public void generate() {
-        if (!Boolean.parseBoolean(skipCronJob)) {
+        if (EXECUTION_COUNT.getAndDecrement() > 0) {
             IntStream.range(0, BATCH_SIZE).forEach(next -> {
                 StockPrice event = StockPrice.newBuilder()
                         .setId("IBM")

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/StrimziKafkaAvroGroupIdIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/StrimziKafkaAvroGroupIdIT.java
@@ -19,8 +19,7 @@ public class StrimziKafkaAvroGroupIdIT extends BaseKafkaAvroGroupIdIT {
     @QuarkusApplication
     static RestService appGroupIdA = new RestService()
             .withProperties("strimzi-application.properties")
-            .withProperty("cron.expr", "*/1 * * * * ?")
-            .withProperty("cron.expr.skip", "true")
+            .withProperty("cron.expr", "disabled")
             .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
             .withProperty("kafka.registry.url", kafka::getRegistryUrl)
             .withProperty("mp.messaging.incoming.channel-stock-price.group.id", "groupA");
@@ -28,8 +27,7 @@ public class StrimziKafkaAvroGroupIdIT extends BaseKafkaAvroGroupIdIT {
     @QuarkusApplication
     static RestService appGroupIdB = new RestService()
             .withProperties("strimzi-application.properties")
-            .withProperty("cron.expr", "*/1 * * * * ?")
-            .withProperty("cron.expr.skip", "true")
+            .withProperty("cron.expr", "disabled")
             .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
             .withProperty("kafka.registry.url", kafka::getRegistryUrl)
             .withProperty("mp.messaging.incoming.channel-stock-price.group.id", "groupB");


### PR DESCRIPTION
### Summary

Fixes

- `testAlertMonitorEventStream` in `kafka-confluent-avro-reactive-messaging`. This test scheduled generation of events to the midnight (when also our CI runs) and therefore test results sometimes (depending on when CI started) had 100 more events than expected. I think the intention of scheduling this to midnight was to disable generation of events in certain tests.
- ```ScheduledInvoker_generate_c9e4876862861cd03eb297791b102d51bdc3ba72, cron=* * * * * ?]: java.util.concurrent.CompletionException: java.lang.RuntimeException: Error injecting org.eclipse.microprofile.reactive.messaging.Emitter<io.quarkus.ts.messaging.kafka.StockPrice> io.quarkus.ts.messaging.strimzi.kafka.reactive.KStockPriceProducer.emitter``` We tried to emit events before `source-stock-price` channel was ready, which lead to the injection exception (basically, when emitter is invoked, exception was thrown due to channel state). Now we wait till app is ready, to my observations, this seems to be enough.
- Stability - we don't run scheduled job concurrently from now on (see `concurrentExecution = SKIP` on `@Scheduled`), as although `org.eclipse.microprofile.reactive.messaging.Emitter#send(T)` is thread safe, our tests are expecting batches that have at least _xyz_ size, they expect to consume one batch at time, not one and half. Let's imagine you consume more events one time and on second call, you have less than expected number (because in first run you consumed more, just because execution was a little bit faster). I don't think it was an issue (AFAIK we try to fetch all in one batch, couple months back we didn't), but it's bad practice, tests should be idempotent.

Works around

- https://github.com/quarkusio/quarkus/issues/28567 by stopping generation after 4 iterations (we don't need that much anyway...). The intention is to avoid generation of events when the endpoint is returning response. I added FIXME so we can get rid of this as soon as the issue is fixed.

I'd like to keep in place logging that I added previously (for debugging) as I can't reproduce none of these things, so all above are just my best guesses.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)