### PR TITLE
CustomStork doesn't require 'quarkus-extension-processor' annotation processor path any longer

### DIFF
--- a/service-discovery/stork-custom/pom.xml
+++ b/service-discovery/stork-custom/pom.xml
@@ -38,11 +38,6 @@
                 <configuration>
                     <annotationProcessorPaths>
                         <path>
-                            <groupId>io.quarkus</groupId>
-                            <artifactId>quarkus-extension-processor</artifactId>
-                            <version>${quarkus.platform.version}</version>
-                        </path>
-                        <path>
                             <groupId>io.smallrye.stork</groupId>
                             <artifactId>stork-configuration-generator</artifactId>
                             <version>${smallrye-stork.version}</version>


### PR DESCRIPTION
### Summary


Looks that `quarkus-extension-processor` is no longer needed.

Maybe was a leftover because I could not find any reference on the original documentation: http://smallrye.io/smallrye-stork/1.2.0/quarkus/

- [X] Dependency update
- [X] Refactoring

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)