### PR TITLE
Replace `quarkus-opentelemetry-exporter-otlp` dependency with `quarkus-opentelemetry`

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,8 +751,7 @@ Jaeger is deployed in an "all-in-one" configuration, and the OpenShift test veri
 ### `monitoring/opentelemetry`
 
 Testing OpenTelemetry with Jaeger components
- - Extension `quarkus-opentelemetry` - responsible for traces generation in OpenTelemetry format
- - Extension `quarkus-opentelemetry-exporter-otlp` -responsible for traces export into OpenTelemetry components (opentelemetry-agent, opentelemetry-collector)
+ - Extension `quarkus-opentelemetry` - responsible for traces generation in OpenTelemetry format and export into OpenTelemetry components (opentelemetry-agent, opentelemetry-collector)
  
 Scenarios that test proper traces export to Jaeger components and context propagation.  
 See also `monitoring/opentelemetry/README.md`

--- a/http/graphql-telemetry/pom.xml
+++ b/http/graphql-telemetry/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
+            <artifactId>quarkus-opentelemetry</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>

--- a/http/vertx-web-client/pom.xml
+++ b/http/vertx-web-client/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
+            <artifactId>quarkus-opentelemetry</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/monitoring/opentelemetry-reactive/README.md
+++ b/monitoring/opentelemetry-reactive/README.md
@@ -5,8 +5,7 @@
 
 ## Scope of the test
 1. Testing OpenTelemetry with Jaeger components and RESTEasy Reactive
- - Extension `quarkus-opentelemetry` - responsible for traces generation in OpenTelemetry format
- - Extension `quarkus-opentelemetry-exporter-otlp` -responsible for traces export into OpenTelemetry components (opentelemetry-agent, opentelemetry-collector)
+ - Extension `quarkus-opentelemetry` - responsible for traces generation in OpenTelemetry format and export into OpenTelemetry components (opentelemetry-agent, opentelemetry-collector)
  
 Scenarios that test proper traces export to Jaeger components and context propagation. 
 Implementation: two REST services, one Jaeger all-in-one pod (creating jaeger-rest & jaeger-query services).  

--- a/monitoring/opentelemetry-reactive/pom.xml
+++ b/monitoring/opentelemetry-reactive/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
+            <artifactId>quarkus-opentelemetry</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>

--- a/monitoring/opentelemetry/README.md
+++ b/monitoring/opentelemetry/README.md
@@ -5,8 +5,7 @@
 
 ## Scope of the test
 1. Testing OpenTelemetry with Jaeger components
- - Extension `quarkus-opentelemetry` - responsible for traces generation in OpenTelemetry format
- - Extension `quarkus-opentelemetry-exporter-otlp` -responsible for traces export into OpenTelemetry components (opentelemetry-agent, opentelemetry-collector)
+ - Extension `quarkus-opentelemetry` - responsible for traces generation in OpenTelemetry format and export into OpenTelemetry components (opentelemetry-agent, opentelemetry-collector)
  
 Scenarios that test proper traces export to Jaeger components and context propagation. 
 Implementation: two REST services, one Jaeger all-in-one pod (creating jaeger-rest & jaeger-query services).  

--- a/monitoring/opentelemetry/pom.xml
+++ b/monitoring/opentelemetry/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
+            <artifactId>quarkus-opentelemetry</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>


### PR DESCRIPTION
### Summary

https://github.com/quarkusio/quarkus/pull/28487 moved `quarkus-opentelemetry-exporter-otlp` dependency to the `quarkus-opentelemetry`. This PR fixes build and reflect the move in our TS.

https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.14#opentelemetry-exporters-moved

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)