### PR TITLE
Remove helm-minimum scenarios from root-modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,8 @@
                 <module>qute/multimodule</module>
                 <module>qute/synchronous</module>
                 <module>qute/reactive</module>
-                <module>helm/helm-minimum</module>
+                <!-- TODO: https://github.com/quarkiverse/quarkus-helm/issues/114-->
+                <!-- <module>helm/helm-minimum</module> -->
                 <module>funqy/knative-events</module>
             </modules>
         </profile>


### PR DESCRIPTION
There is an issue on Upstream related to dekorate that makes this module fails on compile time
Ref: https://github.com/quarkiverse/quarkus-helm/issues/114

### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)