### PR TITLE
Update Pact to supported 4.1

### DIFF
--- a/test-tooling/pact/pom.xml
+++ b/test-tooling/pact/pom.xml
@@ -11,22 +11,22 @@
     <packaging>jar</packaging>
     <name>Quarkus QE TS: Test Tooling: Pact</name>
     <properties>
-        <pact.version>4.0.10</pact.version>
+        <pact.version>4.1.39</pact.version>
     </properties>
     <dependencies>
         <dependency>
-            <groupId>au.com.dius</groupId>
-            <artifactId>pact-jvm-consumer-junit5</artifactId>
+            <groupId>au.com.dius.pact.consumer</groupId>
+            <artifactId>junit5</artifactId>
             <version>${pact.version}</version>
         </dependency>
         <dependency>
-            <groupId>au.com.dius</groupId>
-            <artifactId>pact-jvm-consumer-java8</artifactId>
+            <groupId>au.com.dius.pact.consumer</groupId>
+            <artifactId>java8</artifactId>
             <version>${pact.version}</version>
         </dependency>
         <dependency>
-            <groupId>au.com.dius</groupId>
-            <artifactId>pact-jvm-provider-junit5</artifactId>
+            <groupId>au.com.dius.pact.provider</groupId>
+            <artifactId>junit5</artifactId>
             <version>${pact.version}</version>
         </dependency>
         <!-- Required for native compilation -->

--- a/test-tooling/pact/src/test/java/io/quarkus/ts/http/pact/ProviderPactTest.java
+++ b/test-tooling/pact/src/test/java/io/quarkus/ts/http/pact/ProviderPactTest.java
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import io.quarkus.test.junit.QuarkusTest;
 
 import au.com.dius.pact.provider.PactVerifyProvider;
-import au.com.dius.pact.provider.junit.Provider;
-import au.com.dius.pact.provider.junit.loader.PactFolder;
 import au.com.dius.pact.provider.junit5.AmpqTestTarget;
 import au.com.dius.pact.provider.junit5.PactVerificationContext;
 import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
 
 @QuarkusTest
 @Tag("QUARKUS-1024")


### PR DESCRIPTION
Update Pact to supported 4.1 version which uses V3 specification

Details in https://github.com/pact-foundation/pact-jvm#supported-jdk-and-specification-versions

Also fixes some issues reported by Snyk.io

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)