### PR TITLE
Remove Quarkus-helm dependency from main pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,8 @@
         <jjwt.version>0.11.5</jjwt.version>
         <jsoup.version>1.15.3</jsoup.version>
         <camel-quarkus-bom.version>2.13.0</camel-quarkus-bom.version>
-        <quarkus-helm.version>0.1.1</quarkus-helm.version>
+        <!-- TODO: https://github.com/quarkiverse/quarkus-helm/issues/114-->
+        <!-- <quarkus-helm.version>0.1.1</quarkus-helm.version> -->
         <quarkiverse.config.version>1.1.0</quarkiverse.config.version>
         <smallrye-stork.version>1.2.0</smallrye-stork.version>
         <assertj.version>3.23.1</assertj.version>
@@ -109,11 +110,12 @@
                 <artifactId>jsoup</artifactId>
                 <version>${jsoup.version}</version>
             </dependency>
-            <dependency>
-                <groupId>io.quarkiverse.helm</groupId>
-                <artifactId>quarkus-helm</artifactId>
-                <version>${quarkus-helm.version}</version>
-            </dependency>
+            <!-- TODO: https://github.com/quarkiverse/quarkus-helm/issues/114-->
+            <!--            <dependency>-->
+            <!--                <groupId>io.quarkiverse.helm</groupId>-->
+            <!--                <artifactId>quarkus-helm</artifactId>-->
+            <!--                <version>${quarkus-helm.version}</version>-->
+            <!--            </dependency>-->
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>


### PR DESCRIPTION
### Summary

Currently, we are not supporting Quarkus/helm due to upstream extension instability. 

Please select the relevant options.
- [X] Dependency update
