### PR TITLE
Disable LargeFilesIT: multiplart form data request body is always null

### DIFF
--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/LargeFileHandlingIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/LargeFileHandlingIT.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.http.restclient.reactive.files.OsUtils;
 import io.restassured.http.ContentType;
@@ -98,6 +99,8 @@ public class LargeFileHandlingIT {
 
     @Test
     @DisabledOnOs(value = OS.WINDOWS, disabledReason = "https://github.com/quarkus-qe/quarkus-test-framework/issues/584")
+    //TODO: https://github.com/quarkusio/quarkus/issues/28782
+    @DisabledOnQuarkusSnapshot(reason = "multiplart form data request body is always null")
     public void downloadMultipart() {
         Response hashSum = app.given().get("/file/hash");
         assertEquals(HttpStatus.SC_OK, hashSum.statusCode());
@@ -154,6 +157,8 @@ public class LargeFileHandlingIT {
 
     @Test
     @DisabledOnOs(value = OS.WINDOWS, disabledReason = "https://github.com/quarkus-qe/quarkus-test-framework/issues/584")
+    //TODO: https://github.com/quarkusio/quarkus/issues/28782
+    @DisabledOnQuarkusSnapshot(reason = "multiplart form data request body is always null")
     public void uploadMultipart() {
         Response hashSum = app.given().get("/file-client/client-hash");
         assertEquals(HttpStatus.SC_OK, hashSum.statusCode());


### PR DESCRIPTION
### Summary

Related to: https://github.com/quarkus-qe/quarkus-test-suite/pull/884

You were right @michalvavrik :) also, we need to disable these two scenarios due an upstream issue