### PR TITLE
Add support for marking configs as secret

### DIFF
--- a/config/src/main/java/io/quarkus/ts/configmap/api/server/secrets/BuiltConfigResource.java
+++ b/config/src/main/java/io/quarkus/ts/configmap/api/server/secrets/BuiltConfigResource.java
@@ -1,0 +1,25 @@
+package io.quarkus.ts.configmap.api.server.secrets;
+
+import javax.ws.rs.Path;
+
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+@Path("/built")
+public class BuiltConfigResource extends SecretResource {
+
+    private final SmallRyeConfig config;
+
+    public BuiltConfigResource() {
+        config = new SmallRyeConfigBuilder()
+                .addDefaultSources()
+                .addDefaultInterceptors()
+                .withSecretKeys("secret.ip")
+                .build();
+    }
+
+    @Override
+    public String getProperty(String key) {
+        return config.getRawValue(key);
+    }
+}

--- a/config/src/main/java/io/quarkus/ts/configmap/api/server/secrets/ConfigInterceptorFactory.java
+++ b/config/src/main/java/io/quarkus/ts/configmap/api/server/secrets/ConfigInterceptorFactory.java
@@ -1,0 +1,15 @@
+package io.quarkus.ts.configmap.api.server.secrets;
+
+import java.util.Set;
+
+import io.smallrye.config.ConfigSourceInterceptor;
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigSourceInterceptorFactory;
+import io.smallrye.config.SecretKeysConfigSourceInterceptor;
+
+public class ConfigInterceptorFactory implements ConfigSourceInterceptorFactory {
+    @Override
+    public ConfigSourceInterceptor getInterceptor(ConfigSourceInterceptorContext context) {
+        return new SecretKeysConfigSourceInterceptor(Set.of("secret.password"));
+    }
+}

--- a/config/src/main/java/io/quarkus/ts/configmap/api/server/secrets/InjectedConfigResource.java
+++ b/config/src/main/java/io/quarkus/ts/configmap/api/server/secrets/InjectedConfigResource.java
@@ -1,0 +1,18 @@
+package io.quarkus.ts.configmap.api.server.secrets;
+
+import javax.inject.Inject;
+import javax.ws.rs.Path;
+
+import io.smallrye.config.SmallRyeConfig;
+
+@Path("/injected")
+public class InjectedConfigResource extends SecretResource {
+
+    @Inject
+    SmallRyeConfig config;
+
+    @Override
+    public String getProperty(String key) {
+        return config.getRawValue(key);
+    }
+}

--- a/config/src/main/java/io/quarkus/ts/configmap/api/server/secrets/InjectedProperitesResource.java
+++ b/config/src/main/java/io/quarkus/ts/configmap/api/server/secrets/InjectedProperitesResource.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.configmap.api.server.secrets;
+
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/properties")
+public class InjectedProperitesResource extends SecretResource {
+    @ConfigProperty(name = "secret.password")
+    String password;
+
+    @ConfigProperty(name = "the.answer")
+    String answer;
+
+    @ConfigProperty(name = "secret.ip")
+    String ip;
+
+    @Override
+    public String getProperty(String key) {
+        switch (key) {
+            case "secret.password":
+                return password;
+            case "the.answer":
+                return answer;
+            case "secret.ip":
+                return ip;
+            default:
+                throw new IllegalStateException("Unexpected value: " + key);
+        }
+    }
+}

--- a/config/src/main/java/io/quarkus/ts/configmap/api/server/secrets/SecretResource.java
+++ b/config/src/main/java/io/quarkus/ts/configmap/api/server/secrets/SecretResource.java
@@ -1,0 +1,34 @@
+package io.quarkus.ts.configmap.api.server.secrets;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import io.smallrye.config.SecretKeys;
+
+public abstract class SecretResource {
+    public abstract String getProperty(String key);
+
+    @GET
+    @Path("/locked/{key}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response getSecret(@PathParam("key") String key) {
+        Response.ResponseBuilder result;
+        try {
+            result = Response.ok(getProperty(key));
+        } catch (SecurityException ex) {
+            result = Response.serverError().entity(ex.getMessage());
+        }
+        return result.build();
+    }
+
+    @Path("/unlocked/{key}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getUnlocked(@PathParam("key") String key) {
+        return SecretKeys.doUnlocked(() -> getProperty(key));
+    }
+}

--- a/config/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptorFactory
+++ b/config/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptorFactory
@@ -1,0 +1,1 @@
+io.quarkus.ts.configmap.api.server.secrets.ConfigInterceptorFactory

--- a/config/src/main/resources/application.properties
+++ b/config/src/main/resources/application.properties
@@ -2,3 +2,7 @@ hello.preamble=preamble-never-used-value
 hello.epilogue=epilogue-never-used-value
 side-note=side-note-never-used-value
 hello.side-note=${side-note}
+
+# todo secret keys in quarkus configs are not supported yet
+#the.answer=42
+#secret.password=T0tallySafePa$$word

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/ConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/ConfigIT.java
@@ -1,0 +1,91 @@
+package io.quarkus.ts.configmap.api.server;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.response.Response;
+
+@QuarkusScenario
+public class ConfigIT {
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("the.answer", "42")
+            .withProperty("secret.password", "T0tallySafePa\\$\\$word")
+            .withProperty("secret.ip", "127.0.0.1");
+
+    @Test
+    void properties() {
+        // when we inject properties directly, they are not marked as secret
+        Response answer = app.given().get("/properties/locked/the.answer");
+        Assertions.assertEquals(200, answer.statusCode());
+        Assertions.assertEquals("42", answer.body().asString());
+
+        Response password = app.given().get("/properties/locked/secret.password");
+        Assertions.assertEquals(200, password.statusCode());
+        Assertions.assertEquals("T0tallySafePa$$word", password.body().asString());
+
+        Response ip = app.given().get("/properties/locked/secret.ip");
+        Assertions.assertEquals(200, ip.statusCode());
+        Assertions.assertEquals("127.0.0.1", ip.body().asString());
+    }
+
+    @Test
+    void injectedConfig() {
+        // when we inject config, properties are marked as secret by interceptor
+        Response answer = app.given().get("/injected/locked/the.answer");
+        Assertions.assertEquals(200, answer.statusCode());
+        Assertions.assertEquals("42", answer.body().asString());
+
+        Response password = app.given().get("/injected/locked/secret.password");
+        Assertions.assertEquals(500, password.statusCode());
+        Assertions.assertEquals("SRCFG00024: Not allowed to access secret key secret.password", password.body().asString());
+
+        Response unlocked = app.given().get("/injected/unlocked/secret.password");
+        Assertions.assertEquals(200, unlocked.statusCode());
+        Assertions.assertEquals("T0tallySafePa$$word", unlocked.body().asString());
+
+        Response ip = app.given().get("/injected/locked/secret.ip");
+        Assertions.assertEquals(200, ip.statusCode());
+        Assertions.assertEquals("127.0.0.1", ip.body().asString());
+    }
+
+    @Test
+    void builtConfig() {
+        // when we build properties, we choose, which ones we mark as secret
+        Response answer = app.given().get("/built/locked/the.answer");
+        Assertions.assertEquals(200, answer.statusCode());
+        Assertions.assertEquals("42", answer.body().asString());
+
+        Response unlocked = app.given().get("/built/locked/secret.password");
+        Assertions.assertEquals(200, unlocked.statusCode());
+        Assertions.assertEquals("T0tallySafePa$$word", unlocked.body().asString());
+
+        Response password = app.given().get("/built/locked/secret.ip");
+        Assertions.assertEquals(500, password.statusCode());
+        Assertions.assertEquals("SRCFG00024: Not allowed to access secret key secret.ip", password.body().asString());
+
+        Response ip = app.given().get("/built/unlocked/secret.ip");
+        Assertions.assertEquals(200, ip.statusCode());
+        Assertions.assertEquals("127.0.0.1", ip.body().asString());
+    }
+
+    @Test
+    void unlocked() {
+        // verify, what doUnlock doesn't mess with public values
+        Response properties = app.given().get("/properties/unlocked/the.answer");
+        Assertions.assertEquals(200, properties.statusCode());
+        Assertions.assertEquals("42", properties.body().asString());
+
+        Response answer = app.given().get("/injected/unlocked/the.answer");
+        Assertions.assertEquals(200, answer.statusCode());
+        Assertions.assertEquals("42", answer.body().asString());
+
+        Response built = app.given().get("/built/unlocked/the.answer");
+        Assertions.assertEquals(200, built.statusCode());
+        Assertions.assertEquals("42", built.body().asString());
+    }
+}


### PR DESCRIPTION
### Summary

Issue: https://issues.redhat.com/browse/QUARKUS-2479
Test plans: https://github.com/quarkus-qe/quarkus-test-plans/pull/105

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)