### PR TITLE
Bump quarkus-qpid-jms from 0.38.0 to 0.39.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <quarkus.qe.framework.version>1.2.0.Beta15</quarkus.qe.framework.version>
-        <quarkus-qpid-jms.version>0.38.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.39.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.12.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>
         <confluent.kafka-avro-serializer.version>7.3.0</confluent.kafka-avro-serializer.version>


### PR DESCRIPTION
Bump quarkus-qpid-jms from 0.38.0 to 0.39.0

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)