### PR TITLE
Update mandrel image to 22.3-java17

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        image: [ "ubi-quarkus-native-image:22.2-java17", "ubi-quarkus-mandrel:22.2-java17" ]
+        image: [ "ubi-quarkus-native-image:22.3-java17", "ubi-quarkus-mandrel:22.3-java17" ]
         profiles: [ "root-modules,monitoring-modules,spring-modules,test-tooling-modules",
                    "http-modules",
                    "security-modules",
@@ -181,7 +181,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: [ "22.2.0.java11"]
+        graalvm-version: [ "22.3.0.java17"]
     steps:
       - uses: actions/checkout@v2
       - name: Install JDK {{ matrix.java }}

--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -40,7 +40,7 @@
             </activation>
             <properties>
                 <!-- please keep Mandrel and RHBQ version compatible -->
-                <quarkus.platform.version>2.11.2.Final</quarkus.platform.version>
+                <quarkus.platform.version>2.13.4.Final</quarkus.platform.version>
             </properties>
             <repositories>
                 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -659,7 +659,7 @@
                 <quarkus.native.container-build>true</quarkus.native.container-build>
                 <quarkus.native.native-image-xmx>4g</quarkus.native.native-image-xmx>
                 <!-- please keep in mind that lifecycle-application module also defines quarkus.native.builder-image property -->
-                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:22.2-java11</quarkus.native.builder-image>
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17</quarkus.native.builder-image>
                 <exclude.quarkus.devmode.tests>**/*DevMode*IT.java</exclude.quarkus.devmode.tests>
             </properties>
         </profile>


### PR DESCRIPTION
### Summary

`quay.io/quarkus/ubi-quarkus-mandrel:22.2-java11` -> `quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17`

Please select the relevant options.
- [X] Dependency update

### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)