### PR TITLE
Remove more unused docker images to free up space

### DIFF
--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -10,11 +10,15 @@ sudo rm -rf /usr/share/swift
 sudo rm -rf /usr/share/gradle-7.5.1
 
 
-du -cskh /usr/bin/*
+du -cskh /opt/az/*
+du -cskh /opt/google/*
+du -cskh /opt/hhvm/*
+du -cskh /opt/hostedtoolcache/*
+du -cskh /opt/microsoft/*
 
-du -cskh /usr/local/*
+du -cskh /usr/local/graalvm/*
+du -cskh /usr/local/julia1.8.2/*
 
-du -cskh /opt/*
 
 
 

--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -4,10 +4,10 @@ df -h /
 docker images
 time docker rmi node:12 node:14 node:16 buildpack-deps:stretch buildpack-deps:buster buildpack-deps:bullseye ubuntu:18.04 ubuntu:16.04 debian:10 debian:11 debian:9 moby/buildkit node:16-alpine node:14-alpine node:12-alpine alpine:3.14 alpine:3.15 alpine:3.16
 
-du -cskh /usr/share/dotnet /usr/share/swift /usr/share/gradle-7.5.1
+du -cskh /usr/share/dotnet /usr/share/swift /usr/share/gradle-*
 sudo rm -rf /usr/share/dotnet
 sudo rm -rf /usr/share/swift
-sudo rm -rf /usr/share/gradle-7.5.1
+sudo rm -rf /usr/share/gradle-*
 
 du -cskh /opt/az /opt/google /opt/hhvm /opt/hostedtoolcache/CodeQL /opt/microsoft /usr/local/graalvm /usr/local/julia*
 sudo rm -rf /opt/az

--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -1,6 +1,6 @@
 # Reclaim disk space, otherwise we only have 13 GB free at the start of a job
 echo "Reclaim disk space."
-df -h
+df -h /
 docker images
 time docker rmi node:12 node:14 node:16 buildpack-deps:stretch buildpack-deps:buster buildpack-deps:bullseye ubuntu:18.04 ubuntu:16.04 debian:10 debian:11 debian:9 moby/buildkit node:16-alpine node:14-alpine node:12-alpine alpine:3.14 alpine:3.15 alpine:3.16
 
@@ -19,5 +19,5 @@ du -cskh /opt/*
 
 
 echo "Reclaim disk space end."
-df -h
+df -h /
 docker images

--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -1,10 +1,10 @@
 # Reclaim disk space, otherwise we only have 13 GB free at the start of a job
 echo "Reclaim disk space."
 df -h
-time docker rmi node:10 node:12 mcr.microsoft.com/azure-pipelines/node8-typescript:latest
-# That is 18 GB
+docker images
+time docker rmi node:10 node:12 node:14 node:16 buildpack-deps:stretch buildpack-deps:buster buildpack-deps:bullseye mcr.microsoft.com/azure-pipelines/node8-typescript:latest
 time sudo rm -rf /usr/share/dotnet
-# That is 1.2 GB
 time sudo rm -rf /usr/share/swift
 echo "Reclaim disk space end."
 df -h
+docker images

--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -9,18 +9,14 @@ sudo rm -rf /usr/share/dotnet
 sudo rm -rf /usr/share/swift
 sudo rm -rf /usr/share/gradle-7.5.1
 
-
-du -cskh /opt/az/*
-du -cskh /opt/google/*
-du -cskh /opt/hhvm/*
-du -cskh /opt/hostedtoolcache/*
-du -cskh /opt/microsoft/*
-
-du -cskh /usr/local/graalvm/*
-du -cskh /usr/local/julia1.8.2/*
-
-
-
+du -cskh /opt/az /opt/google /opt/hhvm /opt/hostedtoolcache/CodeQL /opt/microsoft /usr/local/graalvm /usr/local/julia*
+sudo rm -rf /opt/az
+sudo rm -rf /opt/google
+sudo rm -rf /opt/hhvm
+sudo rm -rf /opt/hostedtoolcache/CodeQL
+sudo rm -rf /opt/microsoft
+sudo rm -rf /usr/local/graalvm
+sudo rm -rf /usr/local/julia*
 
 echo "Reclaim disk space end."
 df -h /

--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -4,15 +4,19 @@ df -h
 docker images
 time docker rmi node:12 node:14 node:16 buildpack-deps:stretch buildpack-deps:buster buildpack-deps:bullseye ubuntu:18.04 ubuntu:16.04 debian:10 debian:11 debian:9 moby/buildkit node:16-alpine node:14-alpine node:12-alpine alpine:3.14 alpine:3.15 alpine:3.16
 
-du -cskh /usr/share/dotnet /usr/share/swift
-time sudo rm -rf /usr/share/dotnet
-time sudo rm -rf /usr/share/swift
+du -cskh /usr/share/dotnet /usr/share/swift /usr/share/gradle-7.5.1
+sudo rm -rf /usr/share/dotnet
+sudo rm -rf /usr/share/swift
+sudo rm -rf /usr/share/gradle-7.5.1
 
 
-du -cskh /usr/share/*
-du -cskh /usr/*
+du -cskh /usr/bin/*
 
-du -cskh /*
+du -cskh /usr/local/*
+
+du -cskh /opt*
+
+
 
 echo "Reclaim disk space end."
 df -h

--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -1,4 +1,4 @@
-# Reclaim disk space, otherwise we only have 13 GB free at the start of a job
+# Reclaim ~14 GB disk space, otherwise we do not have enough disk space for TS execution
 echo "Reclaim disk space."
 df -h /
 docker images

--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -2,9 +2,12 @@
 echo "Reclaim disk space."
 df -h
 docker images
-time docker rmi node:10 node:12 node:14 node:16 buildpack-deps:stretch buildpack-deps:buster buildpack-deps:bullseye mcr.microsoft.com/azure-pipelines/node8-typescript:latest
+time docker rmi node:12 node:14 node:16 buildpack-deps:stretch buildpack-deps:buster buildpack-deps:bullseye ubuntu:18.04 ubuntu:16.04 debian:10 debian:11 debian:9 moby/buildkit node:16-alpine node:14-alpine node:12-alpine alpine:3.14 alpine:3.15 alpine:3.16
+
+du -cskh /usr/share/dotnet /usr/share/swift
 time sudo rm -rf /usr/share/dotnet
 time sudo rm -rf /usr/share/swift
+
 echo "Reclaim disk space end."
 df -h
 docker images

--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -14,7 +14,7 @@ du -cskh /usr/bin/*
 
 du -cskh /usr/local/*
 
-du -cskh /opt*
+du -cskh /opt/*
 
 
 

--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -8,6 +8,12 @@ du -cskh /usr/share/dotnet /usr/share/swift
 time sudo rm -rf /usr/share/dotnet
 time sudo rm -rf /usr/share/swift
 
+
+du -cskh /usr/share/*
+du -cskh /usr/*
+
+du -cskh /*
+
 echo "Reclaim disk space end."
 df -h
 docker images


### PR DESCRIPTION
Remove more unused docker images to free up space (14GB)

Getting from
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   54G   30G  65% /
```
to
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root**        84G   40G   44G  48% /
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)