### PR TITLE
[2.13] Remove a logout debug log that was leftover

### DIFF
--- a/security/keycloak-oidc-client-reactive-extended/src/test/resources/logout.properties
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/resources/logout.properties
@@ -18,5 +18,3 @@ quarkus.http.auth.permission.logout.paths=/code-flow/logout
 quarkus.http.auth.permission.logout.policy=authenticated
 
 quarkus.oidc.token-cache.max-size=1
-
-quarkus.log.category."io.quarkus.oidc.runtime.BackChannelLogoutHandler".level=DEBUG


### PR DESCRIPTION
Backport:

[Remove a logout debug log that was leftover](https://github.com/quarkus-qe/quarkus-test-suite/pull/921) | 373e4fdd8fd78183cbcf67e8104996d9deb330f2

Please select the relevant options.
- [X] Backport


### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)