### PR TITLE
Use OidcClientFilter which is available for reactive since 2.13.2.Final

### DIFF
--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/clients/AutoAcquireTokenPongClient.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/clients/AutoAcquireTokenPongClient.java
@@ -10,14 +10,13 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter;
+import io.quarkus.oidc.client.filter.OidcClientFilter;
 import io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.model.Score;
 
 @RegisterRestClient
-@RegisterProvider(OidcClientRequestReactiveFilter.class)
+@OidcClientFilter
 @Path("/rest-pong")
 public interface AutoAcquireTokenPongClient {
     @GET


### PR DESCRIPTION
Use OidcClientFilter which is available for reactive since 2.13.2.Final

`RequestHeadersClient` from keycloak-oidc-client-reactive-basic module keeps using `@RegisterProvider(OidcClientRequestReactiveFilter.class)`

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)