### PR TITLE
Add additional HTTP headers coverage

### DIFF
--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/HeadersResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/HeadersResource.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/headers")
+public class HeadersResource {
+
+    @GET
+    @Path("/any")
+    public Uni<String> headers() {
+        return Uni.createFrom().item("ok");
+    }
+
+    @GET
+    @Path("/pragma")
+    public Uni<String> pragmaHeaderMustBeSet() {
+        return Uni.createFrom().item("ok");
+    }
+
+    @GET
+    @Path("/override")
+    public Uni<Response> headersOverride() {
+        final Response response = Response.ok("ok").header("foo", "abc").build();
+        return Uni.createFrom().item(response);
+    }
+
+}

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/PathSpecificHeadersResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/PathSpecificHeadersResource.java
@@ -1,0 +1,43 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/filter")
+public class PathSpecificHeadersResource {
+
+    @GET
+    @Path("/any")
+    public Uni<String> headers() {
+        return Uni.createFrom().item("ok");
+    }
+
+    @GET
+    @Path("/another")
+    public Uni<String> another() {
+        return Uni.createFrom().item("ok");
+    }
+
+    @GET
+    @Path("/override")
+    public Uni<Response> headersOverride() {
+        final Response response = Response.ok("ok").header("Cache-Control", "max-age=0").build();
+        return Uni.createFrom().item(response);
+    }
+
+    @GET
+    @Path("/no-cache")
+    public Uni<String> noCache() {
+        return Uni.createFrom().item("ok");
+    }
+
+    @GET
+    @Path("/order")
+    public Uni<String> order() {
+        return Uni.createFrom().item("ok");
+    }
+
+}

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HeadersIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HeadersIT.java
@@ -1,0 +1,121 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.response.ValidatableResponse;
+
+@QuarkusScenario
+public class HeadersIT {
+
+    @QuarkusApplication(classes = { PathSpecificHeadersResource.class,
+            HeadersResource.class }, properties = "headers.properties")
+    static RestService app = new RestService();
+
+    @Test
+    void testAdditionalHeaders() {
+        whenGet("/headers/any")
+                .header("Pragma", emptyOrNullString());
+    }
+
+    @Test
+    void testAdditionalHeadersOverride() {
+        whenGet("/headers/override")
+                .header("foo", is("abc"))
+                .header("Pragma", emptyOrNullString());
+    }
+
+    @Test
+    void testAdditionalHeadersPragmaIsSent() {
+        whenGet("/headers/pragma")
+                .header("foo", is("bar"))
+                .header("Pragma", is("no-cache"));
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeadersHead() {
+        // HEAD requests should not include the header
+        final ValidatableResponse response = given()
+                .head("/filter/any")
+                .then()
+                .statusCode(200);
+        final List<String> headerValues = response.extract().headers().getValues("Cache-Control");
+        assertThat(headerValues, not(hasItem(containsString("max-age=31536000"))));
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeadersGet() {
+        final ValidatableResponse response = whenGet("/filter/any");
+        cacheControlMatches(response, "max-age=31536000");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificAnotherPathHeadersGet() {
+        final ValidatableResponse response = whenGet("/filter/another");
+        cacheControlMatches(response, "max-age=31536000");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeadersOverride() {
+        final ValidatableResponse response = whenGet("/filter/override");
+        cacheControlMatches(response, "max-age=0");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificCacheControlIsSent() {
+        final ValidatableResponse response = whenGet("/filter/no-cache");
+        cacheControlMatches(response, "none");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeaderRulesOrder() {
+        final ValidatableResponse response = whenGet("/filter/order");
+        cacheControlMatches(response, "max-age=1");
+    }
+
+    private ValidatableResponse whenGet(String path) {
+        return given()
+                .get(path)
+                .then()
+                .statusCode(200)
+                .body(is("ok"));
+    }
+
+    /**
+     * Cache-Control header may be present multiple times in the response, e.g. in an OpenShift deployment. That is why we need
+     * to look for a specific value among all headers of the same name, and not just match the last one of them, which is what
+     * would be done by a test like this:
+     *
+     * <pre>
+     * ...
+     * given()
+     *     .get(path)
+     *     .then()
+     *     .header("Cache-Control", is(expectedValue));
+     * ...
+     * </pre>
+     */
+    private void cacheControlMatches(ValidatableResponse response, String expectedValue) {
+        final List<String> headerValues = response.extract().headers().getValues("Cache-Control");
+        assertThat(headerValues, hasItem(containsString(expectedValue)));
+    }
+}

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHeadersIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHeadersIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftHeadersIT extends HeadersIT {
+}

--- a/http/http-advanced-reactive/src/test/resources/headers.properties
+++ b/http/http-advanced-reactive/src/test/resources/headers.properties
@@ -1,0 +1,23 @@
+quarkus.oidc.enabled=false
+
+quarkus.http.header.foo.value=bar
+quarkus.http.header.Pragma.value=no-cache
+quarkus.http.header.Pragma.path=/headers/pragma
+quarkus.http.header.Pragma.methods=GET,HEAD
+
+# See io.quarkus.it.vertx.FilterTestCase.testAdditionalHeaders
+quarkus.http.filter.uncached.header."Cache-Control"=none
+quarkus.http.filter.uncached.matches=/filter/no-cache
+
+quarkus.http.filter.cached.header."Cache-Control"=max-age=31536000
+quarkus.http.filter.cached.matches=/filter/(an.*|override)
+quarkus.http.filter.cached.methods=GET
+
+# See io.quarkus.it.vertx.FilterTestCase.testPathOrder
+quarkus.http.filter.just-order.order=10
+quarkus.http.filter.just-order.header."Cache-Control"=max-age=5000
+quarkus.http.filter.just-order.matches=/filter/order
+
+quarkus.http.filter.any-order.order=11
+quarkus.http.filter.any-order.header."Cache-Control"=max-age=1
+quarkus.http.filter.any-order.matches=/filter/order.*

--- a/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/HeadersResource.java
+++ b/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/HeadersResource.java
@@ -1,0 +1,28 @@
+package io.quarkus.ts.http.advanced;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Path("/headers")
+public class HeadersResource {
+
+    @GET
+    @Path("/any")
+    public String headers() {
+        return "ok";
+    }
+
+    @GET
+    @Path("/pragma")
+    public String pragmaHeaderMustBeSet() {
+        return "ok";
+    }
+
+    @GET
+    @Path("/override")
+    public Response headersOverride() {
+        return Response.ok("ok").header("foo", "abc").build();
+    }
+
+}

--- a/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/PathSpecificHeadersResource.java
+++ b/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/PathSpecificHeadersResource.java
@@ -1,0 +1,40 @@
+package io.quarkus.ts.http.advanced;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Path("/filter")
+public class PathSpecificHeadersResource {
+
+    @GET
+    @Path("/any")
+    public String headers() {
+        return "ok";
+    }
+
+    @GET
+    @Path("/another")
+    public String another() {
+        return "ok";
+    }
+
+    @GET
+    @Path("/override")
+    public Response headersOverride() {
+        return Response.ok("ok").header("Cache-Control", "max-age=0").build();
+    }
+
+    @GET
+    @Path("/no-cache")
+    public String noCache() {
+        return "ok";
+    }
+
+    @GET
+    @Path("/order")
+    public String order() {
+        return "ok";
+    }
+
+}

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HeadersIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HeadersIT.java
@@ -1,0 +1,122 @@
+package io.quarkus.ts.http.advanced;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.response.ValidatableResponse;
+
+@QuarkusScenario
+public class HeadersIT {
+
+    @QuarkusApplication(classes = { PathSpecificHeadersResource.class,
+            HeadersResource.class }, properties = "headers.properties")
+    static RestService app = new RestService();
+
+    @Test
+    void testAdditionalHeaders() {
+        whenGet("/headers/any")
+                .header("Pragma", emptyOrNullString());
+    }
+
+    @Test
+    void testAdditionalHeadersOverride() {
+        whenGet("/headers/override")
+                .header("foo", is("abc"))
+                .header("Pragma", emptyOrNullString());
+    }
+
+    @Test
+    void testAdditionalHeadersPragmaIsSent() {
+        whenGet("/headers/pragma")
+                .header("foo", is("bar"))
+                .header("Pragma", is("no-cache"));
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeadersHead() {
+        // HEAD requests should not include the header
+        final ValidatableResponse response = given()
+                .head("/filter/any")
+                .then()
+                .statusCode(200);
+        final List<String> headerValues = response.extract().headers().getValues("Cache-Control");
+        assertThat(headerValues, not(hasItem(containsString("max-age=31536000"))));
+
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeadersGet() {
+        final ValidatableResponse response = whenGet("/filter/any");
+        cacheControlMatches(response, "max-age=31536000");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificAnotherPathHeadersGet() {
+        final ValidatableResponse response = whenGet("/filter/another");
+        cacheControlMatches(response, "max-age=31536000");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeadersOverride() {
+        final ValidatableResponse response = whenGet("/filter/override");
+        cacheControlMatches(response, "max-age=0");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificCacheControlIsSent() {
+        final ValidatableResponse response = whenGet("/filter/no-cache");
+        cacheControlMatches(response, "none");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeaderRulesOrder() {
+        final ValidatableResponse response = whenGet("/filter/order");
+        cacheControlMatches(response, "max-age=1");
+    }
+
+    private ValidatableResponse whenGet(String path) {
+        return given()
+                .get(path)
+                .then()
+                .statusCode(200)
+                .body(is("ok"));
+    }
+
+    /**
+     * Cache-Control header may be present multiple times in the response, e.g. in an OpenShift deployment. That is why we need
+     * to look for a specific value among all headers of the same name, and not just match the last one of them, which is what
+     * would be done by a test like this:
+     *
+     * <pre>
+     * ...
+     * given()
+     *     .get(path)
+     *     .then()
+     *     .header("Cache-Control", is(expectedValue));
+     * ...
+     * </pre>
+     */
+    private void cacheControlMatches(ValidatableResponse response, String expectedValue) {
+        final List<String> headerValues = response.extract().headers().getValues("Cache-Control");
+        assertThat(headerValues, hasItem(containsString(expectedValue)));
+    }
+}

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHeadersIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHeadersIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.http.advanced;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftHeadersIT extends HeadersIT {
+}

--- a/http/http-advanced/src/test/resources/headers.properties
+++ b/http/http-advanced/src/test/resources/headers.properties
@@ -1,0 +1,23 @@
+quarkus.oidc.enabled=false
+
+quarkus.http.header.foo.value=bar
+quarkus.http.header.Pragma.value=no-cache
+quarkus.http.header.Pragma.path=/headers/pragma
+quarkus.http.header.Pragma.methods=GET,HEAD
+
+# See io.quarkus.it.vertx.FilterTestCase.testAdditionalHeaders
+quarkus.http.filter.uncached.header."Cache-Control"=none
+quarkus.http.filter.uncached.matches=/filter/no-cache
+
+quarkus.http.filter.cached.header."Cache-Control"=max-age=31536000
+quarkus.http.filter.cached.matches=/filter/(an.*|override)
+quarkus.http.filter.cached.methods=GET
+
+# See io.quarkus.it.vertx.FilterTestCase.testPathOrder
+quarkus.http.filter.just-order.order=10
+quarkus.http.filter.just-order.header."Cache-Control"=max-age=5000
+quarkus.http.filter.just-order.matches=/filter/order
+
+quarkus.http.filter.any-order.order=11
+quarkus.http.filter.any-order.header."Cache-Control"=max-age=1
+quarkus.http.filter.any-order.matches=/filter/order.*


### PR DESCRIPTION
### Summary

Tests of additional HTTP headers and additional HTTP headers per path (QUARKUS-2490).
Coverage for both non-reactive and reactive execution + OpenShift.

See also
https://quarkus.io/guides/http-reference#additional-http-headers.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)