### PR TITLE
quarkus-resteasy-mutiny is deprecated, replace by quarkus-resteasy-reactive

### DIFF
--- a/messaging/infinispan-grpc-kafka/pom.xml
+++ b/messaging/infinispan-grpc-kafka/pom.xml
@@ -20,11 +20,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny</artifactId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/messaging/kafkaSSL/pom.xml
+++ b/messaging/kafkaSSL/pom.xml
@@ -20,11 +20,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny</artifactId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/monitoring/micrometer-prometheus-kafka/pom.xml
+++ b/monitoring/micrometer-prometheus-kafka/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny</artifactId>
+            <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/monitoring/opentracing-reactive-grpc/pom.xml
+++ b/monitoring/opentracing-reactive-grpc/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client</artifactId>
+            <artifactId>quarkus-rest-client-reactive</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/monitoring/opentracing-reactive-grpc/src/main/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/ping/ServerSentEventsPingResource.java
+++ b/monitoring/opentracing-reactive-grpc/src/main/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/ping/ServerSentEventsPingResource.java
@@ -23,6 +23,6 @@ public class ServerSentEventsPingResource extends TraceableResource {
     @Produces(MediaType.SERVER_SENT_EVENTS)
     public Multi<String> getPing() {
         recordTraceId();
-        return Multi.createFrom().publisher(pongClient.getPong()).map(response -> "ping " + response);
+        return pongClient.getPong().map(response -> "ping " + response);
     }
 }

--- a/monitoring/opentracing-reactive-grpc/src/main/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/ping/clients/ServerSentEventsPongClient.java
+++ b/monitoring/opentracing-reactive-grpc/src/main/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/ping/clients/ServerSentEventsPongClient.java
@@ -6,13 +6,14 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import org.reactivestreams.Publisher;
+
+import io.smallrye.mutiny.Multi;
 
 @RegisterRestClient
 public interface ServerSentEventsPongClient {
     @GET
     @Path("/server-sent-events-pong")
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    Publisher<String> getPong();
+    Multi<String> getPong();
 
 }

--- a/monitoring/opentracing-reactive-grpc/src/test/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/AbstractTraceIT.java
+++ b/monitoring/opentracing-reactive-grpc/src/test/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/AbstractTraceIT.java
@@ -21,9 +21,6 @@ public abstract class AbstractTraceIT {
     private static final String PING_ENDPOINT = "/%s-ping";
     private static final String PONG_ENDPOINT = "/%s-pong";
 
-    private static final String PING_RESOURCE = "PingResource";
-    private static final String PONG_RESOURCE = "PongResource";
-
     @JaegerContainer
     static final JaegerService jaeger = new JaegerService();
 
@@ -50,7 +47,7 @@ public abstract class AbstractTraceIT {
         await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> given()
                 .when().get(jaeger.getTraceUrl() + "?traceID=" + pingTraceId)
                 .then().statusCode(HttpStatus.SC_OK)
-                .and().body(allOf(containsString(PING_RESOURCE), containsString(PONG_RESOURCE))));
+                .and().body(allOf(containsString(pingEndpoint()), containsString(pongEndpoint()))));
     }
 
     protected abstract String endpointPrefix();


### PR DESCRIPTION
### Summary

`quarkus-resteasy-mutiny` was deprecated on Quarkus 2.13.x
Replace `quarkus-resteasy-mutiny` by `quarkus-resteasy-reactive`

Please select the relevant options.
- [X] Refactoring


### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)