### PR TITLE
Property quarkus.datasource.devservices was deprecated in favor of quarkus.datasource.devservices.enabled

### DIFF
--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalTestProfile.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalTestProfile.java
@@ -24,7 +24,7 @@ public class AgroalTestProfile implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
         Map<String, String> config = new HashMap<>();
-        config.put("quarkus.datasource.devservices", "false");
+        config.put("quarkus.datasource.devservices.enabled", "false");
         config.put("quarkus.datasource.with-xa.devservices", "false");
         return config;
     }


### PR DESCRIPTION
### Summary

Property quarkus.datasource.devservices was deprecated

`quarkus.datasource.devservices` -> `quarkus.datasource.devservices.enabled`

Please select the relevant options.
- [X] Refactoring


### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)