### PR TITLE
[2.13] Reactive graphQL + httpHeaderFilters + API deprecation updates + OIDC client filters

### DIFF
--- a/http/graphql/src/main/java/io/quarkus/ts/http/graphql/Person.java
+++ b/http/graphql/src/main/java/io/quarkus/ts/http/graphql/Person.java
@@ -1,8 +1,15 @@
 package io.quarkus.ts.http.graphql;
 
+import io.smallrye.graphql.api.AdaptToScalar;
+import io.smallrye.graphql.api.Scalar;
+
 public class Person {
     private final String name;
+
     private Person friend;
+
+    @AdaptToScalar(Scalar.String.class)
+    private Person idol;
 
     public Person(String name) {
         this.name = name;
@@ -18,5 +25,18 @@ public class Person {
 
     public Person getFriend() {
         return friend;
+    }
+
+    public Person getIdol() {
+        return idol;
+    }
+
+    public void setIdol(Person idol) {
+        this.idol = idol;
+    }
+
+    @Override
+    public String toString() {
+        return name;
     }
 }

--- a/http/graphql/src/main/java/io/quarkus/ts/http/graphql/PersonsEndpoint.java
+++ b/http/graphql/src/main/java/io/quarkus/ts/http/graphql/PersonsEndpoint.java
@@ -1,8 +1,7 @@
 package io.quarkus.ts.http.graphql;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.eclipse.microprofile.graphql.Description;
@@ -11,20 +10,8 @@ import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Query;
 
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.Uni;
-
 @GraphQLApi
-public class PersonsEndpoint {
-    private final List<Person> philosophers = new ArrayList<>();
-
-    public PersonsEndpoint() {
-        final Person plato = new Person("Plato");
-        final Person aristotle = new Person("Aristotle");
-        plato.setFriend(aristotle);
-        aristotle.setFriend(plato);
-        philosophers.addAll(Arrays.asList(plato, aristotle));
-    }
+public class PersonsEndpoint extends PersonsEndpointBase {
 
     @Query("philosophers")
     @Description("Get a couple of Greek philosophers")
@@ -42,18 +29,20 @@ public class PersonsEndpoint {
         throw new NoSuchElementException(name);
     }
 
-    @Query("friend_r")
-    public Uni<Person> getPhilosopherReactively(@Name("name") String name) {
-        return Multi.createFrom().iterable(philosophers)
-                .filter(person -> person.getName().equals(name))
-                .map(Person::getFriend)
-                .toUni();
-    }
-
     @Mutation("create")
     public Person createPhilosopher(@Name("name") String name) {
         Person philosopher = new Person(name);
         philosophers.add(philosopher);
         return philosopher;
+    }
+
+    @Query("map")
+    public Map<PhilosophyEra, Person> getPhilosophersMap() {
+        return philosophersMap;
+    }
+
+    @Query("error")
+    public String throwError() throws PhilosophyException {
+        throw new PhilosophyException();
     }
 }

--- a/http/graphql/src/main/java/io/quarkus/ts/http/graphql/PersonsEndpointBase.java
+++ b/http/graphql/src/main/java/io/quarkus/ts/http/graphql/PersonsEndpointBase.java
@@ -1,0 +1,26 @@
+package io.quarkus.ts.http.graphql;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class PersonsEndpointBase {
+    protected final List<Person> philosophers = new ArrayList<>();
+
+    protected final Map<PhilosophyEra, Person> philosophersMap = new HashMap<>();
+
+    public PersonsEndpointBase() {
+        final Person plato = new Person("Plato");
+        final Person aristotle = new Person("Aristotle");
+        final Person anaxagoras = new Person("Anaxagoras");
+        plato.setFriend(aristotle);
+        plato.setIdol(anaxagoras);
+        aristotle.setFriend(plato);
+        aristotle.setIdol(anaxagoras);
+        philosophers.addAll(Arrays.asList(plato, aristotle, anaxagoras));
+        philosophersMap.put(PhilosophyEra.PRE_SOCRATIC, anaxagoras);
+        philosophersMap.put(PhilosophyEra.POST_SOCRATIC, plato);
+    }
+}

--- a/http/graphql/src/main/java/io/quarkus/ts/http/graphql/PersonsReactiveEndpoint.java
+++ b/http/graphql/src/main/java/io/quarkus/ts/http/graphql/PersonsReactiveEndpoint.java
@@ -1,0 +1,44 @@
+package io.quarkus.ts.http.graphql;
+
+import org.eclipse.microprofile.graphql.DefaultValue;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Name;
+import org.eclipse.microprofile.graphql.Query;
+
+import io.smallrye.graphql.api.Context;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+@GraphQLApi
+public class PersonsReactiveEndpoint extends PersonsEndpointBase {
+
+    @Query("friend_reactive")
+    public Uni<Person> getPhilosopherReactively(@Name("name") String name) {
+        return getPhilosopherUni(name);
+    }
+
+    @Query("friend_reactive_default")
+    public Uni<Person> getPhilosopherWithDefaultName(@Name("name") @DefaultValue("Plato") String name) {
+        return getPhilosopherUni(name);
+    }
+
+    private Uni<Person> getPhilosopherUni(String name) {
+        return Multi.createFrom().iterable(philosophers)
+                .filter(person -> person.getName().equals(name))
+                .map(Person::getFriend)
+                .toUni();
+    }
+
+    @Query("echo_context_path_reactive")
+    public Uni<String> echoContextPath(Context context) {
+        return Uni.createFrom().item(context.getPath());
+    }
+
+    @Mutation("create_reactive")
+    public Uni<Person> createPhilosopherReactively(@Name("name") String name) {
+        Person philosopher = new Person(name);
+        philosophers.add(philosopher);
+        return Uni.createFrom().item(philosopher);
+    }
+}

--- a/http/graphql/src/main/java/io/quarkus/ts/http/graphql/PhilosophyEra.java
+++ b/http/graphql/src/main/java/io/quarkus/ts/http/graphql/PhilosophyEra.java
@@ -1,0 +1,6 @@
+package io.quarkus.ts.http.graphql;
+
+public enum PhilosophyEra {
+    PRE_SOCRATIC,
+    POST_SOCRATIC
+}

--- a/http/graphql/src/main/java/io/quarkus/ts/http/graphql/PhilosophyException.java
+++ b/http/graphql/src/main/java/io/quarkus/ts/http/graphql/PhilosophyException.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.http.graphql;
+
+import io.smallrye.graphql.api.ErrorCode;
+
+@ErrorCode("42")
+public class PhilosophyException extends RuntimeException {
+}

--- a/http/graphql/src/main/resources/application.properties
+++ b/http/graphql/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-smallrye.graphql.allowGet=true
+quarkus.smallrye-graphql.http.get.enabled=true
 
 quarkus.application.name=graphql
 

--- a/http/graphql/src/main/resources/application.properties
+++ b/http/graphql/src/main/resources/application.properties
@@ -2,7 +2,8 @@ quarkus.smallrye-graphql.http.get.enabled=true
 
 quarkus.application.name=graphql
 
-quarkus.jaeger.service-name=graphql-service
-quarkus.jaeger.sampler-type=const
-quarkus.jaeger.sampler-param=1
-quarkus.jaeger.endpoint=http://localhost:14268/api/traces
+# Jaeger tracing configuration - uncomment when running standalone app + Jaeger or specify in a test scenario
+#quarkus.jaeger.service-name=graphql-service
+#quarkus.jaeger.sampler-type=const
+#quarkus.jaeger.sampler-param=1
+#quarkus.jaeger.endpoint=http://localhost:14268/api/traces

--- a/http/graphql/src/main/resources/application.properties
+++ b/http/graphql/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.smallrye-graphql.http.get.enabled=true
+quarkus.smallrye-graphql.error-extension-fields=code
 
 quarkus.application.name=graphql
 

--- a/http/graphql/src/test/java/io/quarkus/ts/http/graphql/GraphQLDisabledGetIT.java
+++ b/http/graphql/src/test/java/io/quarkus/ts/http/graphql/GraphQLDisabledGetIT.java
@@ -1,0 +1,54 @@
+package io.quarkus.ts.http.graphql;
+
+import static io.quarkus.ts.http.graphql.Utils.createQuery;
+import static io.quarkus.ts.http.graphql.Utils.sendGetQuery;
+import static io.quarkus.ts.http.graphql.Utils.sendQuery;
+import static io.restassured.RestAssured.given;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
+
+@QuarkusScenario
+@Tag("QUARKUS-2485")
+public class GraphQLDisabledGetIT {
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.smallrye-graphql.http.get.enabled", "false");
+
+    @Test
+    public void singlePost() {
+        final String query = createQuery("friend(name:\"Aristotle\"){name}");
+        final Response response = sendQuery(query);
+        final JsonPath json = response.jsonPath();
+        Assertions.assertEquals("Plato", json.getString("data.friend.name"));
+    }
+
+    @Test
+    public void emptyGet() {
+        Response response = given().basePath("graphql")
+                .contentType("application/json")
+                .get();
+        Assertions.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.statusCode());
+    }
+
+    @Test
+    public void singleGet() {
+        final Response response = sendGetQuery("friend(name:\"Aristotle\"){name}");
+        Assertions.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.statusCode());
+    }
+
+    @Test
+    public void singleGetReactive() {
+        final Response response = sendGetQuery("friend_reactive(name:\"Aristotle\"){name}");
+        Assertions.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.statusCode());
+    }
+}

--- a/http/graphql/src/test/java/io/quarkus/ts/http/graphql/GraphQLIT.java
+++ b/http/graphql/src/test/java/io/quarkus/ts/http/graphql/GraphQLIT.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.http.graphql;
 
 import static io.quarkus.ts.http.graphql.Utils.createMutation;
 import static io.quarkus.ts.http.graphql.Utils.createQuery;
+import static io.quarkus.ts.http.graphql.Utils.sendGetQuery;
 import static io.quarkus.ts.http.graphql.Utils.sendQuery;
 import static io.restassured.RestAssured.given;
 
@@ -36,11 +37,12 @@ public class GraphQLIT {
     }
 
     @Test
+    @Tag("QUARKUS-2485")
     public void reactive() {
-        final String query = createQuery("friend_r(name:\"Aristotle\"){name}");
+        final String query = createQuery("friend_reactive(name:\"Aristotle\"){name}");
         final Response response = sendQuery(query);
         final JsonPath json = response.jsonPath();
-        Assertions.assertEquals("Plato", json.getString("data.friend_r.name"));
+        Assertions.assertEquals("Plato", json.getString("data.friend_reactive.name"));
     }
 
     @Test
@@ -52,14 +54,38 @@ public class GraphQLIT {
     }
 
     @Test
+    @Tag("QUARKUS-2485")
+    public void createReactive() {
+        final String query = createMutation("create_reactive(name:\"Parmenides\"){name}");
+        final Response response = sendQuery(query);
+        final JsonPath json = response.jsonPath();
+        Assertions.assertEquals("Parmenides", json.getString("data.create_reactive.name"));
+    }
+
+    @Test
     public void emptyGet() {
         Response response = given().basePath("graphql")
                 .contentType("application/json")
-                .post();
+                .get();
         Assertions.assertNotEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.statusCode());
         Assertions.assertNotEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.statusCode());
         Assertions.assertNotEquals(HttpStatus.SC_NO_CONTENT, response.statusCode());
         Assertions.assertEquals(HttpStatus.SC_BAD_REQUEST, response.statusCode());
+    }
+
+    @Test
+    public void singleGet() {
+        final Response response = sendGetQuery("friend(name:\"Aristotle\"){name}");
+        final JsonPath json = response.jsonPath();
+        Assertions.assertEquals("Plato", json.getString("data.friend.name"));
+    }
+
+    @Test
+    @Tag("QUARKUS-2485")
+    public void singleGetReactive() {
+        final Response response = sendGetQuery("friend_reactive(name:\"Aristotle\"){name}");
+        final JsonPath json = response.jsonPath();
+        Assertions.assertEquals("Plato", json.getString("data.friend_reactive.name"));
     }
 
     @Test
@@ -70,5 +96,50 @@ public class GraphQLIT {
                 .post();
         Assertions.assertNotEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.statusCode());
         Assertions.assertEquals(HttpStatus.SC_BAD_REQUEST, response.statusCode());
+    }
+
+    @Test
+    @Tag("QUARKUS-2485")
+    public void singleGetReactiveWithDefault() {
+        final String query = createQuery("friend_reactive_default{name}");
+        final Response response = sendQuery(query);
+        final JsonPath json = response.jsonPath();
+        Assertions.assertEquals("Aristotle", json.getString("data.friend_reactive_default.name"));
+    }
+
+    @Test
+    @Tag("QUARKUS-2485")
+    public void contextPathReactive() {
+        final String query = createQuery("echo_context_path_reactive");
+        final Response response = sendQuery(query);
+        final JsonPath json = response.jsonPath();
+        Assertions.assertEquals("/echo_context_path_reactive", json.getString("data.echo_context_path_reactive"));
+    }
+
+    @Test
+    @Tag("QUARKUS-2485")
+    public void singleScalar() {
+        final String query = createQuery("friend(name:\"Aristotle\"){idol}");
+        final Response response = sendQuery(query);
+        final JsonPath json = response.jsonPath();
+        Assertions.assertEquals("Anaxagoras", json.getString("data.friend.idol"));
+    }
+
+    @Test
+    @Tag("QUARKUS-2485")
+    public void map() {
+        final String query = createQuery("map(key:PRE_SOCRATIC){value{name}}");
+        final Response response = sendQuery(query);
+        final JsonPath json = response.jsonPath();
+        Assertions.assertEquals("Anaxagoras", json.getString("data.map[0].value.name"));
+    }
+
+    @Test
+    @Tag("QUARKUS-2485")
+    public void error() {
+        final String query = createQuery("error");
+        final Response response = sendQuery(query);
+        final JsonPath json = response.jsonPath();
+        Assertions.assertEquals("42", json.getString("errors[0].extensions.code"));
     }
 }

--- a/http/graphql/src/test/java/io/quarkus/ts/http/graphql/GraphQLTracingIT.java
+++ b/http/graphql/src/test/java/io/quarkus/ts/http/graphql/GraphQLTracingIT.java
@@ -29,7 +29,9 @@ public class GraphQLTracingIT {
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.jaeger.service-name", SERVICE_NAME)
-            .withProperty("quarkus.jaeger.endpoint", jaeger::getCollectorUrl);
+            .withProperty("quarkus.jaeger.endpoint", jaeger::getCollectorUrl)
+            .withProperty("quarkus.jaeger.sampler-type", "const")
+            .withProperty("quarkus.jaeger.sampler-param", "1");
 
     @Test
     void verifyTracesInJaegerTest() {

--- a/http/graphql/src/test/java/io/quarkus/ts/http/graphql/GraphQLTracingIT.java
+++ b/http/graphql/src/test/java/io/quarkus/ts/http/graphql/GraphQLTracingIT.java
@@ -36,10 +36,10 @@ public class GraphQLTracingIT {
     @Test
     void verifyTracesInJaegerTest() {
         Response classic = sendQuery(createQuery("friend(name:\"Aristotle\"){name}"));
-        Response reactive = sendQuery(createQuery("friend_r(name:\"Aristotle\"){name}"));
+        Response reactive = sendQuery(createQuery("friend_reactive(name:\"Aristotle\"){name}"));
 
         Assertions.assertEquals("Plato", classic.jsonPath().getString("data.friend.name"));
-        Assertions.assertEquals("Plato", reactive.jsonPath().getString("data.friend_r.name"));
+        Assertions.assertEquals("Plato", reactive.jsonPath().getString("data.friend_reactive.name"));
 
         // the tracer inside the application doesn't send traces to the Jaeger server immediately,
         // they are batched, so we need to wait a bit
@@ -52,7 +52,7 @@ public class GraphQLTracingIT {
             Assertions.assertEquals(2, jsonPath.getList("data[0].spans").size());
             Assertions.assertEquals(2, jsonPath.getList("data[1].spans").size());
             Assertions.assertTrue(jsonPath.getList("data[0].spans.operationName").contains("GraphQL:Query.friend"));
-            Assertions.assertTrue(jsonPath.getList("data[1].spans.operationName").contains("GraphQL:Query.friend_r"));
+            Assertions.assertTrue(jsonPath.getList("data[1].spans.operationName").contains("GraphQL:Query.friend_reactive"));
         });
     }
 }

--- a/http/graphql/src/test/java/io/quarkus/ts/http/graphql/OpenShiftGraphQLDisabledGetIT.java
+++ b/http/graphql/src/test/java/io/quarkus/ts/http/graphql/OpenShiftGraphQLDisabledGetIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.http.graphql;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftGraphQLDisabledGetIT extends GraphQLDisabledGetIT {
+}

--- a/http/graphql/src/test/java/io/quarkus/ts/http/graphql/Utils.java
+++ b/http/graphql/src/test/java/io/quarkus/ts/http/graphql/Utils.java
@@ -2,6 +2,9 @@ package io.quarkus.ts.http.graphql;
 
 import static io.restassured.RestAssured.given;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import javax.json.Json;
 
 import io.restassured.response.Response;
@@ -12,6 +15,12 @@ public class Utils {
                 .contentType("application/json")
                 .body(query)
                 .post();
+    }
+
+    public static Response sendGetQuery(String query) {
+        return given()
+                .contentType("application/json")
+                .get("/graphql?query=" + URLEncoder.encode("{" + query + "}", StandardCharsets.UTF_8));
     }
 
     public static String createQuery(String query) {

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/HeadersResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/HeadersResource.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/headers")
+public class HeadersResource {
+
+    @GET
+    @Path("/any")
+    public Uni<String> headers() {
+        return Uni.createFrom().item("ok");
+    }
+
+    @GET
+    @Path("/pragma")
+    public Uni<String> pragmaHeaderMustBeSet() {
+        return Uni.createFrom().item("ok");
+    }
+
+    @GET
+    @Path("/override")
+    public Uni<Response> headersOverride() {
+        final Response response = Response.ok("ok").header("foo", "abc").build();
+        return Uni.createFrom().item(response);
+    }
+
+}

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/PathSpecificHeadersResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/PathSpecificHeadersResource.java
@@ -1,0 +1,43 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/filter")
+public class PathSpecificHeadersResource {
+
+    @GET
+    @Path("/any")
+    public Uni<String> headers() {
+        return Uni.createFrom().item("ok");
+    }
+
+    @GET
+    @Path("/another")
+    public Uni<String> another() {
+        return Uni.createFrom().item("ok");
+    }
+
+    @GET
+    @Path("/override")
+    public Uni<Response> headersOverride() {
+        final Response response = Response.ok("ok").header("Cache-Control", "max-age=0").build();
+        return Uni.createFrom().item(response);
+    }
+
+    @GET
+    @Path("/no-cache")
+    public Uni<String> noCache() {
+        return Uni.createFrom().item("ok");
+    }
+
+    @GET
+    @Path("/order")
+    public Uni<String> order() {
+        return Uni.createFrom().item("ok");
+    }
+
+}

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HeadersIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HeadersIT.java
@@ -1,0 +1,121 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.response.ValidatableResponse;
+
+@QuarkusScenario
+public class HeadersIT {
+
+    @QuarkusApplication(classes = { PathSpecificHeadersResource.class,
+            HeadersResource.class }, properties = "headers.properties")
+    static RestService app = new RestService();
+
+    @Test
+    void testAdditionalHeaders() {
+        whenGet("/headers/any")
+                .header("Pragma", emptyOrNullString());
+    }
+
+    @Test
+    void testAdditionalHeadersOverride() {
+        whenGet("/headers/override")
+                .header("foo", is("abc"))
+                .header("Pragma", emptyOrNullString());
+    }
+
+    @Test
+    void testAdditionalHeadersPragmaIsSent() {
+        whenGet("/headers/pragma")
+                .header("foo", is("bar"))
+                .header("Pragma", is("no-cache"));
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeadersHead() {
+        // HEAD requests should not include the header
+        final ValidatableResponse response = given()
+                .head("/filter/any")
+                .then()
+                .statusCode(200);
+        final List<String> headerValues = response.extract().headers().getValues("Cache-Control");
+        assertThat(headerValues, not(hasItem(containsString("max-age=31536000"))));
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeadersGet() {
+        final ValidatableResponse response = whenGet("/filter/any");
+        cacheControlMatches(response, "max-age=31536000");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificAnotherPathHeadersGet() {
+        final ValidatableResponse response = whenGet("/filter/another");
+        cacheControlMatches(response, "max-age=31536000");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeadersOverride() {
+        final ValidatableResponse response = whenGet("/filter/override");
+        cacheControlMatches(response, "max-age=0");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificCacheControlIsSent() {
+        final ValidatableResponse response = whenGet("/filter/no-cache");
+        cacheControlMatches(response, "none");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeaderRulesOrder() {
+        final ValidatableResponse response = whenGet("/filter/order");
+        cacheControlMatches(response, "max-age=1");
+    }
+
+    private ValidatableResponse whenGet(String path) {
+        return given()
+                .get(path)
+                .then()
+                .statusCode(200)
+                .body(is("ok"));
+    }
+
+    /**
+     * Cache-Control header may be present multiple times in the response, e.g. in an OpenShift deployment. That is why we need
+     * to look for a specific value among all headers of the same name, and not just match the last one of them, which is what
+     * would be done by a test like this:
+     *
+     * <pre>
+     * ...
+     * given()
+     *     .get(path)
+     *     .then()
+     *     .header("Cache-Control", is(expectedValue));
+     * ...
+     * </pre>
+     */
+    private void cacheControlMatches(ValidatableResponse response, String expectedValue) {
+        final List<String> headerValues = response.extract().headers().getValues("Cache-Control");
+        assertThat(headerValues, hasItem(containsString(expectedValue)));
+    }
+}

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHeadersIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHeadersIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftHeadersIT extends HeadersIT {
+}

--- a/http/http-advanced-reactive/src/test/resources/headers.properties
+++ b/http/http-advanced-reactive/src/test/resources/headers.properties
@@ -1,0 +1,23 @@
+quarkus.oidc.enabled=false
+
+quarkus.http.header.foo.value=bar
+quarkus.http.header.Pragma.value=no-cache
+quarkus.http.header.Pragma.path=/headers/pragma
+quarkus.http.header.Pragma.methods=GET,HEAD
+
+# See io.quarkus.it.vertx.FilterTestCase.testAdditionalHeaders
+quarkus.http.filter.uncached.header."Cache-Control"=none
+quarkus.http.filter.uncached.matches=/filter/no-cache
+
+quarkus.http.filter.cached.header."Cache-Control"=max-age=31536000
+quarkus.http.filter.cached.matches=/filter/(an.*|override)
+quarkus.http.filter.cached.methods=GET
+
+# See io.quarkus.it.vertx.FilterTestCase.testPathOrder
+quarkus.http.filter.just-order.order=10
+quarkus.http.filter.just-order.header."Cache-Control"=max-age=5000
+quarkus.http.filter.just-order.matches=/filter/order
+
+quarkus.http.filter.any-order.order=11
+quarkus.http.filter.any-order.header."Cache-Control"=max-age=1
+quarkus.http.filter.any-order.matches=/filter/order.*

--- a/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/HeadersResource.java
+++ b/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/HeadersResource.java
@@ -1,0 +1,28 @@
+package io.quarkus.ts.http.advanced;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Path("/headers")
+public class HeadersResource {
+
+    @GET
+    @Path("/any")
+    public String headers() {
+        return "ok";
+    }
+
+    @GET
+    @Path("/pragma")
+    public String pragmaHeaderMustBeSet() {
+        return "ok";
+    }
+
+    @GET
+    @Path("/override")
+    public Response headersOverride() {
+        return Response.ok("ok").header("foo", "abc").build();
+    }
+
+}

--- a/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/PathSpecificHeadersResource.java
+++ b/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/PathSpecificHeadersResource.java
@@ -1,0 +1,40 @@
+package io.quarkus.ts.http.advanced;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Path("/filter")
+public class PathSpecificHeadersResource {
+
+    @GET
+    @Path("/any")
+    public String headers() {
+        return "ok";
+    }
+
+    @GET
+    @Path("/another")
+    public String another() {
+        return "ok";
+    }
+
+    @GET
+    @Path("/override")
+    public Response headersOverride() {
+        return Response.ok("ok").header("Cache-Control", "max-age=0").build();
+    }
+
+    @GET
+    @Path("/no-cache")
+    public String noCache() {
+        return "ok";
+    }
+
+    @GET
+    @Path("/order")
+    public String order() {
+        return "ok";
+    }
+
+}

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HeadersIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HeadersIT.java
@@ -1,0 +1,122 @@
+package io.quarkus.ts.http.advanced;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.response.ValidatableResponse;
+
+@QuarkusScenario
+public class HeadersIT {
+
+    @QuarkusApplication(classes = { PathSpecificHeadersResource.class,
+            HeadersResource.class }, properties = "headers.properties")
+    static RestService app = new RestService();
+
+    @Test
+    void testAdditionalHeaders() {
+        whenGet("/headers/any")
+                .header("Pragma", emptyOrNullString());
+    }
+
+    @Test
+    void testAdditionalHeadersOverride() {
+        whenGet("/headers/override")
+                .header("foo", is("abc"))
+                .header("Pragma", emptyOrNullString());
+    }
+
+    @Test
+    void testAdditionalHeadersPragmaIsSent() {
+        whenGet("/headers/pragma")
+                .header("foo", is("bar"))
+                .header("Pragma", is("no-cache"));
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeadersHead() {
+        // HEAD requests should not include the header
+        final ValidatableResponse response = given()
+                .head("/filter/any")
+                .then()
+                .statusCode(200);
+        final List<String> headerValues = response.extract().headers().getValues("Cache-Control");
+        assertThat(headerValues, not(hasItem(containsString("max-age=31536000"))));
+
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeadersGet() {
+        final ValidatableResponse response = whenGet("/filter/any");
+        cacheControlMatches(response, "max-age=31536000");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificAnotherPathHeadersGet() {
+        final ValidatableResponse response = whenGet("/filter/another");
+        cacheControlMatches(response, "max-age=31536000");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeadersOverride() {
+        final ValidatableResponse response = whenGet("/filter/override");
+        cacheControlMatches(response, "max-age=0");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificCacheControlIsSent() {
+        final ValidatableResponse response = whenGet("/filter/no-cache");
+        cacheControlMatches(response, "none");
+    }
+
+    @Test
+    @Tag("QUARKUS-2490")
+    void testPathSpecificHeaderRulesOrder() {
+        final ValidatableResponse response = whenGet("/filter/order");
+        cacheControlMatches(response, "max-age=1");
+    }
+
+    private ValidatableResponse whenGet(String path) {
+        return given()
+                .get(path)
+                .then()
+                .statusCode(200)
+                .body(is("ok"));
+    }
+
+    /**
+     * Cache-Control header may be present multiple times in the response, e.g. in an OpenShift deployment. That is why we need
+     * to look for a specific value among all headers of the same name, and not just match the last one of them, which is what
+     * would be done by a test like this:
+     *
+     * <pre>
+     * ...
+     * given()
+     *     .get(path)
+     *     .then()
+     *     .header("Cache-Control", is(expectedValue));
+     * ...
+     * </pre>
+     */
+    private void cacheControlMatches(ValidatableResponse response, String expectedValue) {
+        final List<String> headerValues = response.extract().headers().getValues("Cache-Control");
+        assertThat(headerValues, hasItem(containsString(expectedValue)));
+    }
+}

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHeadersIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHeadersIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.http.advanced;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftHeadersIT extends HeadersIT {
+}

--- a/http/http-advanced/src/test/resources/headers.properties
+++ b/http/http-advanced/src/test/resources/headers.properties
@@ -1,0 +1,23 @@
+quarkus.oidc.enabled=false
+
+quarkus.http.header.foo.value=bar
+quarkus.http.header.Pragma.value=no-cache
+quarkus.http.header.Pragma.path=/headers/pragma
+quarkus.http.header.Pragma.methods=GET,HEAD
+
+# See io.quarkus.it.vertx.FilterTestCase.testAdditionalHeaders
+quarkus.http.filter.uncached.header."Cache-Control"=none
+quarkus.http.filter.uncached.matches=/filter/no-cache
+
+quarkus.http.filter.cached.header."Cache-Control"=max-age=31536000
+quarkus.http.filter.cached.matches=/filter/(an.*|override)
+quarkus.http.filter.cached.methods=GET
+
+# See io.quarkus.it.vertx.FilterTestCase.testPathOrder
+quarkus.http.filter.just-order.order=10
+quarkus.http.filter.just-order.header."Cache-Control"=max-age=5000
+quarkus.http.filter.just-order.matches=/filter/order
+
+quarkus.http.filter.any-order.order=11
+quarkus.http.filter.any-order.header."Cache-Control"=max-age=1
+quarkus.http.filter.any-order.matches=/filter/order.*

--- a/messaging/infinispan-grpc-kafka/pom.xml
+++ b/messaging/infinispan-grpc-kafka/pom.xml
@@ -20,11 +20,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny</artifactId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/messaging/kafkaSSL/pom.xml
+++ b/messaging/kafkaSSL/pom.xml
@@ -20,11 +20,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny</artifactId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/monitoring/micrometer-prometheus-kafka/pom.xml
+++ b/monitoring/micrometer-prometheus-kafka/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny</artifactId>
+            <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/monitoring/opentracing-reactive-grpc/pom.xml
+++ b/monitoring/opentracing-reactive-grpc/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client</artifactId>
+            <artifactId>quarkus-rest-client-reactive</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/monitoring/opentracing-reactive-grpc/src/main/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/ping/ServerSentEventsPingResource.java
+++ b/monitoring/opentracing-reactive-grpc/src/main/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/ping/ServerSentEventsPingResource.java
@@ -23,6 +23,6 @@ public class ServerSentEventsPingResource extends TraceableResource {
     @Produces(MediaType.SERVER_SENT_EVENTS)
     public Multi<String> getPing() {
         recordTraceId();
-        return Multi.createFrom().publisher(pongClient.getPong()).map(response -> "ping " + response);
+        return pongClient.getPong().map(response -> "ping " + response);
     }
 }

--- a/monitoring/opentracing-reactive-grpc/src/main/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/ping/clients/ServerSentEventsPongClient.java
+++ b/monitoring/opentracing-reactive-grpc/src/main/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/ping/clients/ServerSentEventsPongClient.java
@@ -6,13 +6,14 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import org.reactivestreams.Publisher;
+
+import io.smallrye.mutiny.Multi;
 
 @RegisterRestClient
 public interface ServerSentEventsPongClient {
     @GET
     @Path("/server-sent-events-pong")
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    Publisher<String> getPong();
+    Multi<String> getPong();
 
 }

--- a/monitoring/opentracing-reactive-grpc/src/test/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/AbstractTraceIT.java
+++ b/monitoring/opentracing-reactive-grpc/src/test/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/AbstractTraceIT.java
@@ -21,9 +21,6 @@ public abstract class AbstractTraceIT {
     private static final String PING_ENDPOINT = "/%s-ping";
     private static final String PONG_ENDPOINT = "/%s-pong";
 
-    private static final String PING_RESOURCE = "PingResource";
-    private static final String PONG_RESOURCE = "PongResource";
-
     @JaegerContainer
     static final JaegerService jaeger = new JaegerService();
 
@@ -50,7 +47,7 @@ public abstract class AbstractTraceIT {
         await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> given()
                 .when().get(jaeger.getTraceUrl() + "?traceID=" + pingTraceId)
                 .then().statusCode(HttpStatus.SC_OK)
-                .and().body(allOf(containsString(PING_RESOURCE), containsString(PONG_RESOURCE))));
+                .and().body(allOf(containsString(pingEndpoint()), containsString(pongEndpoint()))));
     }
 
     protected abstract String endpointPrefix();

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/clients/AutoAcquireTokenPongClient.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/clients/AutoAcquireTokenPongClient.java
@@ -10,14 +10,13 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter;
+import io.quarkus.oidc.client.filter.OidcClientFilter;
 import io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.model.Score;
 
 @RegisterRestClient
-@RegisterProvider(OidcClientRequestReactiveFilter.class)
+@OidcClientFilter
 @Path("/rest-pong")
 public interface AutoAcquireTokenPongClient {
     @GET

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalTestProfile.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalTestProfile.java
@@ -24,7 +24,7 @@ public class AgroalTestProfile implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
         Map<String, String> config = new HashMap<>();
-        config.put("quarkus.datasource.devservices", "false");
+        config.put("quarkus.datasource.devservices.enabled", "false");
         config.put("quarkus.datasource.with-xa.devservices", "false");
         return config;
     }


### PR DESCRIPTION
### Summary
The following main commits have been backported with this PR

[Use OidcClientFilter which is available for reactive since 2.13.2.Final](https://github.com/quarkus-qe/quarkus-test-suite/pull/924) | b9ea65172155e91c6ce0b92814354f3a3eb75bc2
[SmallRye GraphQL non-blocking support](https://github.com/quarkus-qe/quarkus-test-suite/pull/919) 

- a39a45be08fe5eca4e0d53763f1aaa5b650f5e69
- 9f0f83b7d505e8c3a0b8beaa1e60ae344d2fc18e
- 5413a003f5425ca08d5340d2b65d4115eee41711

[Add additional HTTP headers coverage](https://github.com/quarkus-qe/quarkus-test-suite/pull/926) | 241cccb3c21a62ad2649545c11f572d301452184
[Property quarkus.datasource.devservices was deprecated in favor of quarkus.datasource.devservices.enabled](https://github.com/quarkus-qe/quarkus-test-suite/pull/929) | f6ff411c000499a7fd901e8fffea6f608e65a24e
[quarkus-resteasy-mutiny is deprecated, replace by quarkus-resteasy-reactive](https://github.com/quarkus-qe/quarkus-test-suite/pull/928) | eb19d2408eb10c91d88fa9e5570dc9f8c122359f

Please select the relevant options.
- [X] Backport
