### PR TITLE
[2.13] Reduce generated bute[] on compression scenario due to an out of memory exception on native / OCP

### DIFF
--- a/http/jaxrs-reactive/src/main/resources/application.properties
+++ b/http/jaxrs-reactive/src/main/resources/application.properties
@@ -3,3 +3,5 @@
 quarkus.openshift.route.annotations."haproxy.router.openshift.io/disable_cookies"=true
 io.quarkus.ts.http.jaxrs.reactive.client.MultipartService/mp-rest/url=http://localhost:${quarkus.http.port}
 quarkus.http.enable-compression=true
+//TODO https://github.com/quarkusio/quarkus/issues/29642
+quarkus.openshift.env.vars.quarkus-opts="-Xmx2024M -Xms80M -Xmn120M"

--- a/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/OpenShiftExecutionModelIT.java
+++ b/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/OpenShiftExecutionModelIT.java
@@ -9,8 +9,10 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
 public class OpenShiftExecutionModelIT extends ExecutionModelIT {
-
-    private static final int FILE_SIZE = 99999999;
+    //TODO https://github.com/quarkusio/quarkus/issues/29642
+    // investigate: when FILE_SIZE is set to 99999999, we are getting a
+    // "java.lang.OutOfMemoryError: Array allocation too large." on OCP-native
+    private static final int FILE_SIZE = 9999999;
 
     @Test
     public void bigCompression() {


### PR DESCRIPTION
Backport of https://github.com/quarkus-qe/quarkus-test-suite/pull/933

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)