### PR TITLE
Fix OpenShiftHttpCachingIT in native mode

### DIFF
--- a/http/jaxrs-reactive/src/main/resources/application.properties
+++ b/http/jaxrs-reactive/src/main/resources/application.properties
@@ -4,4 +4,4 @@ quarkus.openshift.route.annotations."haproxy.router.openshift.io/disable_cookies
 io.quarkus.ts.http.jaxrs.reactive.client.MultipartService/mp-rest/url=http://localhost:${quarkus.http.port}
 quarkus.http.enable-compression=true
 //TODO https://github.com/quarkusio/quarkus/issues/29642
-quarkus.openshift.env.vars.quarkus-opts="-Xmx2024M -Xms80M -Xmn120M"
+quarkus.openshift.env.vars.quarkus-opts=-Xmx2024M -Xms80M -Xmn120M


### PR DESCRIPTION
### Summary

OpenShiftHttpCachingIT is failing in native mode in both RHBQ 2.13 and upstream as `QUARKUS_OPTS` are enclosed as one value in double quotes, I've explained it here https://github.com/quarkusio/quarkus/issues/29642#issuecomment-1341644852. Bug was added to our TS in https://github.com/quarkus-qe/quarkus-test-suite/pull/933.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)