### PR TITLE
Enable PKCE for reactive logout SPA flow test

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,6 +654,12 @@ Variants:
 Verifies special cases of using reactive OIDC client:
 - Proper handling of `Authorization` request header by `OidcClientRequestReactiveFilter`: the filter should always add a single`Authorization` header, not duplicate it in multiple request attempts.
 
+### `security/keycloak-oidc-client-reactive-extended`
+
+Reactive twin of the `security/keycloak-oidc-client-extended`, extends `security/keycloak-oidc-client-reactive-basic` and also covers some special cases that are common for both classic and reactive modules:
+
+- Verifies Proof Of Key for Code Exchange support for a Keycloak and Red Hat Single Sign-On together with OIDC Single Page Application logout flow
+
 ### `securty/oidc-client-mutual-tls`
 
 Verifies OIDC client can be authenticated as part of the `Mutual TLS` (`mTLS`) authentication process 

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/LogoutSinglePageAppFlowIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/LogoutSinglePageAppFlowIT.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.Objects;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
@@ -41,6 +42,7 @@ public class LogoutSinglePageAppFlowIT {
             .withProperty("keycloak.url", () -> keycloak.getURI(Protocol.HTTP).toString())
             .withProperties("logout.properties");
 
+    @Tag("QUARKUS-2491")
     @Test
     public void singlePageAppLogoutFlow() throws IOException {
         try (final WebClient webClient = createWebClient()) {

--- a/security/keycloak-oidc-client-reactive-extended/src/test/resources/kc-logout-realm.json
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/resources/kc-logout-realm.json
@@ -550,7 +550,8 @@
       "post.logout.redirect.uris" : "*",
       "display.on.consent.screen" : "false",
       "oauth2.device.authorization.grant.enabled" : "false",
-      "backchannel.logout.revoke.offline.tokens" : "true"
+      "backchannel.logout.revoke.offline.tokens" : "true",
+      "pkce.code.challenge.method" : "S256"
     },
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,

--- a/security/keycloak-oidc-client-reactive-extended/src/test/resources/logout.properties
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/resources/logout.properties
@@ -18,3 +18,7 @@ quarkus.http.auth.permission.logout.paths=/code-flow/logout
 quarkus.http.auth.permission.logout.policy=authenticated
 
 quarkus.oidc.token-cache.max-size=1
+
+# PKCE
+quarkus.oidc.authentication.pkce-required=true
+quarkus.oidc.authentication.pkce-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU


### PR DESCRIPTION
### Summary

Enables PKCE for logout SPA flow test in `LogoutSinglePageAppFlowIT` and `OpenShiftOidcSinglePageAppLogoutFlowIT`. Reasoning explained in depth in https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-2491.md. We know tests verifies PKCE as with changes in `kc-logout-realm.json` and without enabling PKCE in `application.properties`, tests are failing.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)