### PR TITLE
`quarkus.kafka.devservices.provider` property should be now used for Kafka dev services

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeStrimziKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeStrimziKafkaStreamIT.java
@@ -12,14 +12,14 @@ import io.quarkus.test.services.DevModeQuarkusApplication;
 @QuarkusScenario
 public class DevModeStrimziKafkaStreamIT extends BaseKafkaStreamTest {
 
-    static final String DEV_SERVICE_KAFKA_IMG = "quay.io/strimzi-test-container/test-container:0.100.0-kafka-3.1.0";
+    static final String DEV_SERVICE_KAFKA_PROVIDER = "strimzi";
 
     /**
      * Kafka must be started using DEV services when running in DEV mode
      */
     @DevModeQuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.kafka.devservices.image-name", DEV_SERVICE_KAFKA_IMG)
+            .withProperty("quarkus.kafka.devservices.provider", DEV_SERVICE_KAFKA_PROVIDER)
             .withProperty("quarkus.kafka.devservices.enabled", Boolean.TRUE.toString());
 
     @Override


### PR DESCRIPTION

### Summary

Due to https://github.com/quarkusio/quarkus/commit/0f3a9384a0da9ca149b40a4b88f8713fc0a80b46, now `quarkus.kafka.devservices.provider` should be defined, so `quarkus.kafka.devservices.image-name` is not really needed.
Otherwise, there may be an issue, as the default `provider` is set to `redpanda` instead of `strimzi`. See [[1]](https://github.com/quarkusio/quarkus/issues/29954)

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)