### PR TITLE
Test handling a multipart request part as a file based on the content-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ Additional coverage:
 - Gzip compression
 - REST Client reactive - support for POJO JSON serialization in multipart forms.
 - Request matching - selecting from multiple media types
+- Handling Multipart Form data
 
 ### `http/rest-client`
 Verifies Rest Client configuration using `quarkus-rest-client-jaxb` (XML support) and `quarkus-rest-client-jsonb` (JSON support).

--- a/http/jaxrs-reactive/src/main/java/io/quarkus/ts/http/jaxrs/reactive/MultipartBody.java
+++ b/http/jaxrs-reactive/src/main/java/io/quarkus/ts/http/jaxrs/reactive/MultipartBody.java
@@ -1,11 +1,13 @@
 package io.quarkus.ts.http.jaxrs.reactive;
 
 import java.io.File;
+import java.util.List;
 
 import javax.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.reactive.PartType;
 import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
 
 public class MultipartBody {
 
@@ -20,4 +22,11 @@ public class MultipartBody {
     @RestForm("data")
     @PartType(MediaType.APPLICATION_OCTET_STREAM)
     public File data;
+
+    @RestForm
+    public File plainTextFile;
+
+    @RestForm(FileUpload.ALL)
+    public List<FileUpload> allFiles;
+
 }

--- a/http/jaxrs-reactive/src/main/java/io/quarkus/ts/http/jaxrs/reactive/MultipartResource.java
+++ b/http/jaxrs-reactive/src/main/java/io/quarkus/ts/http/jaxrs/reactive/MultipartResource.java
@@ -9,7 +9,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.io.IOUtils;
-import org.jboss.resteasy.reactive.MultipartForm;
 
 @Path("/multipart")
 public class MultipartResource {
@@ -17,7 +16,7 @@ public class MultipartResource {
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.MULTIPART_FORM_DATA)
-    public MultipartBody postForm(@MultipartForm MultipartBody multipartBody) {
+    public MultipartBody postForm(MultipartBody multipartBody) {
         return multipartBody;
     }
 
@@ -25,7 +24,7 @@ public class MultipartResource {
     @Path("/text")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.TEXT_PLAIN)
-    public String postFormReturnText(@MultipartForm MultipartBody multipartBody) {
+    public String postFormReturnText(MultipartBody multipartBody) {
         return multipartBody.text;
     }
 
@@ -33,7 +32,7 @@ public class MultipartResource {
     @Path("/image")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    public byte[] postFormReturnFile(@MultipartForm MultipartBody multipartBody) throws IOException {
+    public byte[] postFormReturnFile(MultipartBody multipartBody) throws IOException {
         return IOUtils.toByteArray(multipartBody.image.toURI());
     }
 
@@ -41,7 +40,7 @@ public class MultipartResource {
     @Path("/data")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    public byte[] postFormReturnData(@MultipartForm MultipartBody multipartBody) throws IOException {
+    public byte[] postFormReturnData(MultipartBody multipartBody) throws IOException {
         return IOUtils.toByteArray(multipartBody.data.toURI());
     }
 

--- a/http/jaxrs-reactive/src/main/java/io/quarkus/ts/http/jaxrs/reactive/MultipartResource.java
+++ b/http/jaxrs-reactive/src/main/java/io/quarkus/ts/http/jaxrs/reactive/MultipartResource.java
@@ -1,6 +1,9 @@
 package io.quarkus.ts.http.jaxrs.reactive;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collection;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
@@ -9,6 +12,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.io.IOUtils;
+import org.jboss.resteasy.reactive.multipart.FilePart;
 
 @Path("/multipart")
 public class MultipartResource {
@@ -42,6 +46,22 @@ public class MultipartResource {
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     public byte[] postFormReturnData(MultipartBody multipartBody) throws IOException {
         return IOUtils.toByteArray(multipartBody.data.toURI());
+    }
+
+    @POST
+    @Path("/plain-text-file")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String postFormReturnPlainTextFile(MultipartBody multipartBody) throws IOException {
+        return Files.readString(multipartBody.plainTextFile.toPath());
+    }
+
+    @POST
+    @Path("/all-file-control-names")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Collection<String> postFormReturnAllFileControlNames(MultipartBody multipartBody) {
+        return multipartBody.allFiles.stream().map(FilePart::name).collect(Collectors.toList());
     }
 
     @POST

--- a/http/jaxrs-reactive/src/main/java/io/quarkus/ts/http/jaxrs/reactive/client/MultipartService.java
+++ b/http/jaxrs-reactive/src/main/java/io/quarkus/ts/http/jaxrs/reactive/client/MultipartService.java
@@ -7,7 +7,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import org.jboss.resteasy.reactive.MultipartForm;
 
 @Path("/multipart/echo")
 @RegisterRestClient
@@ -16,5 +15,5 @@ public interface MultipartService {
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.TEXT_PLAIN)
-    String sendMultipartData(@MultipartForm ClientMultipartBody data);
+    String sendMultipartData(ClientMultipartBody data);
 }

--- a/http/jaxrs-reactive/src/main/resources/application.properties
+++ b/http/jaxrs-reactive/src/main/resources/application.properties
@@ -5,3 +5,4 @@ io.quarkus.ts.http.jaxrs.reactive.client.MultipartService/mp-rest/url=http://loc
 quarkus.http.enable-compression=true
 //TODO https://github.com/quarkusio/quarkus/issues/29642
 quarkus.openshift.env.vars.quarkus-opts=-Xmx2024M -Xms80M -Xmn120M
+quarkus.http.body.multipart.file-content-types=text/xml,custom/content-type

--- a/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/MediaTypeSelectionIT.java
+++ b/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/MediaTypeSelectionIT.java
@@ -21,11 +21,13 @@ import static javax.ws.rs.core.MediaType.TEXT_XML;
 import static javax.ws.rs.core.MediaType.WILDCARD;
 
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.restassured.RestAssured;
 
+@Tag("QUARKUS-2743")
 @QuarkusScenario
 public class MediaTypeSelectionIT {
 

--- a/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/RESTEasyReactiveMultipartIT.java
+++ b/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/RESTEasyReactiveMultipartIT.java
@@ -30,6 +30,8 @@ public class RESTEasyReactiveMultipartIT {
     private static final String IMAGE_FILE_NAME = "/quarkus.png";
     private static final String TEXT_WITH_DIACRITICS = "Přikrášlený žloťoučký kůň úpěl ďábelské ódy.";
     private static byte[] randomBytes = new byte[120];
+    private static final String DATA = "data";
+    private static final String IMAGE = "image";
     private static File imageFile;
     private static byte[] imageBytes;
 
@@ -80,25 +82,78 @@ public class RESTEasyReactiveMultipartIT {
         assertThat(receivedBytes, equalTo(randomBytes));
     }
 
-    private ValidatableResponse whenSendMultipartData(String path) {
+    @Tag("QUARKUS-2744")
+    @Test
+    public void testPlainTextFilePartFromMultipart() {
+        // verifies that every multipart form data field regardless of media type can be used as file
+        // as long as Java data type of DTO field is java.io.File
+        String text = "Old Time Rock & Roll";
+        MultiPartSpecification textSpec = new MultiPartSpecBuilder(text)
+                .controlName("plainTextFile")
+                .fileName("plainTextFile")
+                .header("Content-Type", MediaType.TEXT_PLAIN)
+                .build();
+        String receivedString = RestAssured.given()
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .multiPart(textSpec)
+                .post("/multipart/plain-text-file")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+        assertThat(receivedString, equalTo(text));
+    }
+
+    @Tag("QUARKUS-2744")
+    @Test
+    public void testAllFilesPartFromMultipart() {
+        // test all file uploads from a multipart form are accessible
+        String otherImage = "otherImage";
+        String xmlFileName = "xmlFile";
+        String customContentTypeFileName = "customContentTypeFile";
+        String[] controlNames = RestAssured.given()
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .multiPart(createXmlSpec(xmlFileName))
+                .multiPart(createCustomContentTypeSpec(customContentTypeFileName))
+                .multiPart(createDataSpec())
+                .multiPart(createImageSpec())
+                .multiPart(createOtherImage(otherImage))
+                .post("/multipart/all-file-control-names")
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(String[].class);
+        // verify files with content types specified via 'quarkus.http.body.multipart.file-content-types' property
+        assertThat(controlNames.length, equalTo(5));
+        assertThat(controlNames[0], equalTo(xmlFileName));
+        assertThat(controlNames[1], equalTo(customContentTypeFileName));
+        // verify files that are also MultipartBody fields
+        assertThat(controlNames[2], equalTo(DATA));
+        assertThat(controlNames[3], equalTo(IMAGE));
+        // verify file that is neither MultipartBody field nor file content type specified via config property
+        // file is present as image/png is known file type
+        assertThat(controlNames[4], equalTo(otherImage));
+    }
+
+    private static MultiPartSpecification createOtherImage(String otherImage) {
+        return new MultiPartSpecBuilder(imageFile)
+                .controlName(otherImage)
+                .fileName("other.png")
+                .mimeType("image/png")
+                .build();
+    }
+
+    private static ValidatableResponse whenSendMultipartData(String path) {
         MultiPartSpecification textSpec = new MultiPartSpecBuilder(TEXT_WITH_DIACRITICS)
                 .controlName("text")
                 .mimeType("text/plain")
                 .charset(StandardCharsets.UTF_8)
                 .build();
-        MultiPartSpecification dataSpec = new MultiPartSpecBuilder(randomBytes)
-                .controlName("data")
-                .fileName("random.dat")
-                .header("Content-Type", "application/octet-stream")
-                .build();
-        MultiPartSpecification imageSpec = new MultiPartSpecBuilder(imageFile)
-                .controlName("image")
-                .fileName("quarkus.png")
-                .mimeType("image/png")
-                .build();
+        MultiPartSpecification dataSpec = createDataSpec();
+        MultiPartSpecification imageSpec = createImageSpec();
 
         return RestAssured.given()
-                .contentType("multipart/form-data")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
                 .multiPart(textSpec)
                 .multiPart(imageSpec)
                 .multiPart(dataSpec)
@@ -106,4 +161,37 @@ public class RESTEasyReactiveMultipartIT {
                 .then()
                 .statusCode(200);
     }
+
+    private static MultiPartSpecification createImageSpec() {
+        return new MultiPartSpecBuilder(imageFile)
+                .controlName(IMAGE)
+                .fileName("quarkus.png")
+                .mimeType("image/png")
+                .build();
+    }
+
+    private static MultiPartSpecification createDataSpec() {
+        return new MultiPartSpecBuilder(randomBytes)
+                .controlName(DATA)
+                .fileName("random.dat")
+                .header("Content-Type", "application/octet-stream")
+                .build();
+    }
+
+    private static MultiPartSpecification createXmlSpec(String xmlFileName) {
+        return new MultiPartSpecBuilder("<song>Born To Be Wild</song>")
+                .controlName(xmlFileName)
+                .fileName("my.xml")
+                .header("Content-Type", MediaType.TEXT_XML)
+                .build();
+    }
+
+    private static MultiPartSpecification createCustomContentTypeSpec(String customContentTypeFileName) {
+        return new MultiPartSpecBuilder("The Rocky Road to Dublin")
+                .controlName(customContentTypeFileName)
+                .fileName("your.custom")
+                .header("Content-Type", "custom/content-type")
+                .build();
+    }
+
 }

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/files/FileClient.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/files/FileClient.java
@@ -11,7 +11,6 @@ import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import org.jboss.resteasy.reactive.MultipartForm;
 
 import io.smallrye.mutiny.Uni;
 
@@ -50,6 +49,6 @@ public interface FileClient {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/upload-multipart")
-    String sendMultipart(@MultipartForm FileWrapper data);
+    String sendMultipart(FileWrapper data);
 
 }

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/files/FileResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/files/FileResource.java
@@ -16,7 +16,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.resteasy.reactive.MultipartForm;
 import org.jboss.resteasy.reactive.RestResponse;
 
 import io.quarkus.logging.Log;
@@ -61,7 +60,7 @@ public class FileResource {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/upload-multipart")
     @Blocking
-    public String uploadMultipart(@MultipartForm FileWrapper body) {
+    public String uploadMultipart(FileWrapper body) {
         deathRow.add(body.file);
         return utils.getSum(body.file.getAbsoluteFile().toPath());
     }


### PR DESCRIPTION
### Summary

Verifies: https://github.com/quarkusio/quarkus/issues/29725
Test plan PR: https://github.com/quarkus-qe/quarkus-test-plans/pull/120

Minor commits:
- [Tag MediaTypeSelectionIT with QUARKUS-2743](https://github.com/quarkus-qe/quarkus-test-suite/commit/4bcee563563f9a1d9deb009d5eb4069c441f268e) - adds a tag over tests created by https://github.com/quarkus-qe/quarkus-test-suite/pull/960 as [ticket QUARKUS-2743](https://issues.redhat.com/browse/QUARKUS-2743) didn't exist when I was writing the test
- [Drop deprecated @MultipartForm annotation, it is surplus to requirements](https://github.com/quarkus-qe/quarkus-test-suite/commit/a3d897abdc9ccb0be07d1161c4136d7d6f209b75) - the annotation has been deprecated and will be removed in the future version

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)