### PR TITLE
Do not support any Origin by default if CORS is enabled

### DIFF
--- a/security/keycloak-oidc-client-extended/src/test/resources/logout.properties
+++ b/security/keycloak-oidc-client-extended/src/test/resources/logout.properties
@@ -19,6 +19,7 @@ quarkus.http.auth.permission.unsecured.policy=permit
 quarkus.http.auth.permission.unsecured.methods=GET
 
 quarkus.http.cors=true
+quarkus.http.cors.origins=*
 quarkus.http.auth.permission.logout.paths=/code-flow/logout
 quarkus.http.auth.permission.logout.policy=authenticated
 

--- a/security/keycloak-oidc-client-reactive-extended/src/test/resources/logout.properties
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/resources/logout.properties
@@ -14,6 +14,7 @@ quarkus.http.auth.permission.unsecured.policy=permit
 quarkus.http.auth.permission.unsecured.methods=GET
 
 quarkus.http.cors=true
+quarkus.http.cors.origins=*
 quarkus.http.auth.permission.logout.paths=/code-flow/logout
 quarkus.http.auth.permission.logout.policy=authenticated
 


### PR DESCRIPTION
### Summary

As part of https://github.com/quarkusio/quarkus/pull/29692, since no "origin" is longer supported out of the box by quarkus, we need to specifically mentioned this in our TS, by using `quarkus.http.cors.origins` property

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)