### PR TITLE
Partially revert 'Test handling a multipart request part as a file based on the content-type'

### DIFF
--- a/http/jaxrs-reactive/src/main/java/io/quarkus/ts/http/jaxrs/reactive/client/MultipartService.java
+++ b/http/jaxrs-reactive/src/main/java/io/quarkus/ts/http/jaxrs/reactive/client/MultipartService.java
@@ -7,6 +7,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.jboss.resteasy.reactive.MultipartForm;
 
 @Path("/multipart/echo")
 @RegisterRestClient
@@ -15,5 +16,5 @@ public interface MultipartService {
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.TEXT_PLAIN)
-    String sendMultipartData(ClientMultipartBody data);
+    String sendMultipartData(@MultipartForm ClientMultipartBody data);
 }

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/files/FileResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/files/FileResource.java
@@ -16,6 +16,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.resteasy.reactive.MultipartForm;
 import org.jboss.resteasy.reactive.RestResponse;
 
 import io.quarkus.logging.Log;
@@ -60,7 +61,7 @@ public class FileResource {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/upload-multipart")
     @Blocking
-    public String uploadMultipart(FileWrapper body) {
+    public String uploadMultipart(@MultipartForm FileWrapper body) {
         deathRow.add(body.file);
         return utils.getSum(body.file.getAbsoluteFile().toPath());
     }


### PR DESCRIPTION
### Summary

[Here I dropped occurrence in 4 files](https://github.com/quarkus-qe/quarkus-test-suite/pull/961/commits/a3d897abdc9ccb0be07d1161c4136d7d6f209b75) of deprecated `@MultipartForm` in RESTEasy Reactive modules. [I made mistake to think they are not used](https://github.com/quarkus-qe/quarkus-test-suite/pull/961#issuecomment-1363850598) at all as I was searching in compiled source code and code occurence/ text searching didn't work there. Apologies @rsvoboda . Now I put the annotation back to 2 files as user still might use it, even though it should have no affect according to annotation JavaDoc. I can see one function in Quarkus relevant to reverts in `org.jboss.resteasy.reactive.common.processor.EndpointIndexer#extractParameterInfo`. We could use `@BeanParam`, however all relevant DTOs have at least one annotated field, so that annotation is not needed either.


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)