### PR TITLE
Fix changed modules detection in PRs and run only necessary CI modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
 
           for module in $MODULES
           do
-              if [[ "${{ steps.files.outputs.all_changed_and_modified_files }}" =~ ("$module") ]] ; then
+              if [[ "${{ steps.changed-files.outputs.all_changed_and_modified_files }}" =~ ("$module") ]] ; then
                   CHANGED=$(echo $CHANGED" "$module)
               fi
           done


### PR DESCRIPTION
### Summary

Fix based on the example https://github.com/tj-actions/changed-files#usage.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)