### PR TITLE
Fix detection of changes in the PR by correcting step output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,13 +72,13 @@ jobs:
 
           for module in $MODULES
           do
-              if [[ "${{ steps.changed-files.outputs.all_changed_and_modified_files }}" =~ ("$module") ]] ; then
+              if [[ "${{ steps.files.outputs.all_changed_and_modified_files }}" =~ ("$module") ]] ; then
                   CHANGED=$(echo $CHANGED" "$module)
               fi
           done
 
           MODULES_ARG="${CHANGED// /,}"
-          echo "{MODULES_ARG}=${MODULES_ARG}" >> $GITHUB_OUTPUT
+          echo "MODULES_ARG=$MODULES_ARG" >> $GITHUB_OUTPUT
     outputs:
       MODULES_ARG: ${{ steps.detect-changes.outputs.MODULES_ARG }}
   linux-build-jvm-latest:


### PR DESCRIPTION
### Summary

- reverts https://github.com/quarkus-qe/quarkus-test-suite/pull/967 (I made mistake)
- fixes step output according to https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs#overview

Proof that this fixes issue is here https://github.com/michalvavrik/quarkus-test-suite/pull/3.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)