### PR TITLE
[2.13] Bump quarkus.qe.framework.version from 1.2.0.Beta13 to 1.2.0.Final

### DIFF
--- a/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/OpenShiftLifecycleApplicationIT.java
+++ b/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/OpenShiftLifecycleApplicationIT.java
@@ -7,11 +7,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/29451")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftLifecycleApplicationIT extends LifecycleApplicationIT {
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.13.6.Final</quarkus.platform.version>
-        <quarkus.qe.framework.version>1.2.0.Beta13</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.2.0.Final</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.38.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.12.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>


### PR DESCRIPTION
### Summary

Motivation:
- https://github.com/quarkus-qe/quarkus-test-framework/pull/625 - merged in FW `1.2.0.Beta16`, fixes interop OCP failures.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)