### PR TITLE
Re-enable `MySQLDatabaseHibernateReactiveIT` on FIPS

### DIFF
--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/MysqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/MysqlMultitenantHibernateSearchIT.java
@@ -23,7 +23,7 @@ public class MysqlMultitenantHibernateSearchIT extends AbstractMultitenantHibern
     static MySqlService company1 = new MySqlService().withDatabase("company1");
 
     @Container(image = "${mysql.upstream.80.image}", port = MYSQL_PORT, expectedLog = "ready for connections")
-    static MySqlService company2 = new MySqlService().withDatabase("company2");;
+    static MySqlService company2 = new MySqlService().withDatabase("company2");
 
     @Container(image = "${elastic.71.image}", port = ELASTIC_PORT, expectedLog = "started")
     static DefaultService elastic = new DefaultService().withProperty("discovery.type", "single-node");

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/MysqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/MysqlMultitenantHibernateSearchIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.hibernate.search;
 
-import org.junit.jupiter.api.Tag;
-
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
@@ -9,8 +7,6 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class MysqlMultitenantHibernateSearchIT extends AbstractMultitenantHibernateSearchIT {
     static final int ELASTIC_PORT = 9200;

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftMysqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftMysqlMultitenantHibernateSearchIT.java
@@ -24,7 +24,7 @@ public class OpenShiftMysqlMultitenantHibernateSearchIT extends AbstractMultiten
     static MySqlService company1 = new MySqlService().withDatabase("company1");
 
     @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point", command = " --max-allowed-packet=5526600")
-    static MySqlService company2 = new MySqlService().withDatabase("company2");;
+    static MySqlService company2 = new MySqlService().withDatabase("company2");
 
     @Container(image = "${elastic.71.image}", port = ELASTIC_PORT, expectedLog = "started")
     static DefaultService elastic = new DefaultService().withProperty("discovery.type", "single-node");

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MySQLDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MySQLDatabaseHibernateReactiveIT.java
@@ -1,15 +1,11 @@
 package io.quarkus.ts.hibernate.reactive;
 
-import org.junit.jupiter.api.Tag;
-
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class MySQLDatabaseHibernateReactiveIT extends AbstractDatabaseHibernateReactiveIT {
 

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/CRUDAllInPanacheWithFlywayIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/CRUDAllInPanacheWithFlywayIT.java
@@ -7,13 +7,10 @@ import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 class CRUDAllInPanacheWithFlywayIT extends PanacheWithFlywayBaseIT {
 

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/CRUDPanacheWithFlywayIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/CRUDPanacheWithFlywayIT.java
@@ -16,15 +16,12 @@ import javax.ws.rs.core.MediaType;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class CRUDPanacheWithFlywayIT extends PanacheWithFlywayBaseIT {
 

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/DataSourceConfigPanacheWithFlywayIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/DataSourceConfigPanacheWithFlywayIT.java
@@ -4,14 +4,11 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.restassured.specification.RequestSpecification;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") //native-mode
 @QuarkusScenario
 public class DataSourceConfigPanacheWithFlywayIT extends PanacheWithFlywayBaseIT {
 

--- a/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MySqlPanacheResourceIT.java
+++ b/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MySqlPanacheResourceIT.java
@@ -1,15 +1,11 @@
 package io.quarkus.ts.reactive.rest.data.panache;
 
-import org.junit.jupiter.api.Tag;
-
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class MySqlPanacheResourceIT extends AbstractPanacheResourceIT {
 

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MySqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MySqlDatabaseIT.java
@@ -1,15 +1,11 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
-import org.junit.jupiter.api.Tag;
-
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {
 

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MysqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MysqlHandlerIT.java
@@ -1,15 +1,11 @@
 package io.quarkus.ts.vertx.sql.handlers;
 
-import org.junit.jupiter.api.Tag;
-
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class MysqlHandlerIT extends CommonTestCases {
     private static final String DATABASE = "amadeus";

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/PostgresqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/PostgresqlHandlerIT.java
@@ -15,7 +15,7 @@ public class PostgresqlHandlerIT extends CommonTestCases {
             .with("test", "test", POSTGRESQL_DATABASE)
             .withProperty("POSTGRES_USER", "test") //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
             .withProperty("POSTGRES_PASSWORD", "test")
-            .withProperty("POSTGRES_DB", POSTGRESQL_DATABASE);;
+            .withProperty("POSTGRES_DB", POSTGRESQL_DATABASE);
 
     @QuarkusApplication
     static final RestService app = new RestService()


### PR DESCRIPTION
### Summary

Based on some local verification on RHEL8 + FIPS there are some MYSQL scenarios that are working on JVM and native mode.

Also, this PR fixes some typos that I found in the code. 

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)