### PR TITLE
Add minimal coverage for local Infinispan and for working with DevMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,6 +1066,10 @@ a collection using a filter and a projection. All tests are performed using:
 
 Reactive equivalent of `nosql-db/mongodb`. Uses reactive ReactiveMongoClient (without codecs)
 
+### `nosql-db/infinispan`
+
+Provides some coverage similar to `infinispan-client` module, but with focus on connecting to local cluster and Dev mode and not on working with OpenShift
+
 ### `websockets/quarkus-websockets`
 Coverage for sending messages over websockets
 

--- a/nosql-db/infinispan/pom.xml
+++ b/nosql-db/infinispan/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>infinispan</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: NoSQL Database: Infinispan</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-infinispan-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-infinispan</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
+        <profile>
+            <id>skip-tests-on-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- Disable native build on this module -->
+            <!-- https://github.com/quarkusio/quarkus/issues/30304 -->
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- To not build the module on Native -->
+                <quarkus.package.type>fast-jar</quarkus.package.type>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/FirstCounterResource.java
+++ b/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/FirstCounterResource.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.infinispan.client;
+
+import javax.ws.rs.Path;
+
+@Path("/first-counter")
+public class FirstCounterResource extends InfinispanCounterResource {
+}

--- a/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/InfinispanClientApp.java
+++ b/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/InfinispanClientApp.java
@@ -1,0 +1,63 @@
+package io.quarkus.ts.infinispan.client;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryModified;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryRemoved;
+import org.infinispan.client.hotrod.annotation.ClientListener;
+import org.infinispan.client.hotrod.event.ClientCacheEntryCreatedEvent;
+import org.infinispan.client.hotrod.event.ClientCacheEntryModifiedEvent;
+import org.infinispan.client.hotrod.event.ClientCacheEntryRemovedEvent;
+import org.infinispan.commons.configuration.XMLStringConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkus.runtime.StartupEvent;
+
+@ApplicationScoped
+public class InfinispanClientApp {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("InfinispanClientApp");
+
+    @Inject
+    RemoteCacheManager cacheManager;
+
+    private static final String MYCACHE_CACHE_CONFIG = "<infinispan><cache-container>" +
+            "<distributed-cache name=\"%s\"></distributed-cache>" +
+            "</cache-container></infinispan>";
+
+    void onStart(@Observes StartupEvent ev) {
+        LOGGER.info("Create or get cache named mycache with the default configuration");
+        RemoteCache<Object, Object> cache = cacheManager.administration().getOrCreateCache("mycache",
+                new XMLStringConfiguration(String.format(MYCACHE_CACHE_CONFIG, "mycache")));
+        cache.addClientListener(new EventPrintListener());
+        if (cache.isEmpty()) {
+            cache.put("counter", 0);
+        }
+    }
+
+    @ClientListener
+    static class EventPrintListener {
+
+        @ClientCacheEntryCreated
+        public void handleCreatedEvent(ClientCacheEntryCreatedEvent e) {
+            LOGGER.info("Listener: cache entry was CREATED: " + e);
+        }
+
+        @ClientCacheEntryModified
+        public void handleModifiedEvent(ClientCacheEntryModifiedEvent e) {
+            LOGGER.info("Listener: cache entry was MODIFIED: " + e);
+        }
+
+        @ClientCacheEntryRemoved
+        public void handleRemovedEvent(ClientCacheEntryRemovedEvent e) {
+            LOGGER.info("Listener: cache entry was REMOVED: " + e);
+        }
+
+    }
+}

--- a/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/InfinispanCounterResource.java
+++ b/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/InfinispanCounterResource.java
@@ -1,0 +1,62 @@
+package io.quarkus.ts.infinispan.client;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.infinispan.client.hotrod.RemoteCache;
+
+import io.quarkus.infinispan.client.Remote;
+
+public class InfinispanCounterResource {
+    protected AtomicInteger counter = new AtomicInteger(0);
+
+    @Inject
+    @Remote("mycache")
+    RemoteCache<String, Integer> cache;
+
+    @Path("/get-cache")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Integer getCacheCounter() {
+        return cache.get("counter");
+    }
+
+    @Path("/get-client")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Integer getClientCounter() {
+        return counter.get();
+    }
+
+    @Path("/increment-counters")
+    @PUT
+    @Produces(MediaType.TEXT_PLAIN)
+    public String incCounters() {
+        int invocationClientNumber = counter.incrementAndGet();
+        int invocationCacheNumber = cache.get("counter") + 1;
+        cache.put("counter", invocationCacheNumber);
+        return "Cache=" + invocationCacheNumber + " Client=" + invocationClientNumber;
+    }
+
+    @Path("/reset-cache")
+    @PUT
+    @Produces(MediaType.TEXT_PLAIN)
+    public String resetCacheCounter() {
+        cache.put("counter", 0);
+        return "Cache=" + cache.get("counter");
+    }
+
+    @Path("/reset-client")
+    @PUT
+    @Produces(MediaType.TEXT_PLAIN)
+    public String resetClientCounter() {
+        counter.set(0);
+        return "Client=" + counter.get();
+    }
+}

--- a/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/SecondCounterResource.java
+++ b/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/SecondCounterResource.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.infinispan.client;
+
+import javax.ws.rs.Path;
+
+@Path("/second-counter")
+public class SecondCounterResource extends InfinispanCounterResource {
+}

--- a/nosql-db/infinispan/src/main/resources/application.properties
+++ b/nosql-db/infinispan/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+quarkus.infinispan-client.auth-username=admin
+quarkus.infinispan-client.auth-password=password
+quarkus.infinispan-client.client-intelligence=BASIC
+
+quarkus.infinispan-client.cache."cache".configuration-uri=cache-configuration.xml
+quarkus.infinispan-client.cache."cache".near-cache-mode: disabled
+quarkus.infinispan-client.cache."cache".near-cache-max-entries: -1

--- a/nosql-db/infinispan/src/main/resources/cache-configuration.xml
+++ b/nosql-db/infinispan/src/main/resources/cache-configuration.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan>
+    <!-->Very basic cache configuration</-->
+    <cache-container name="clustered">
+        <distributed-cache name="cache" mode="SYNC">
+            <locking isolation="REPEATABLE_READ"/>
+            <transaction locking="PESSIMISTIC" mode="NON_DURABLE_XA"/>
+            <encoding media-type="application/x-protostream"/>
+        </distributed-cache>
+    </cache-container>
+</infinispan>

--- a/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/DevModeInfinispanIT.java
+++ b/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/DevModeInfinispanIT.java
@@ -1,0 +1,39 @@
+package io.quarkus.ts.infinispan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.InfinispanService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+
+@QuarkusScenario
+public class DevModeInfinispanIT {
+    @Container(image = "${infinispan.image}", port = 11222)
+    static InfinispanService infinispan = new InfinispanService()
+            .withUsername("admin")
+            .withPassword("password");
+
+    @DevModeQuarkusApplication()
+    static RestService service = new RestService()
+            .withProperty("quarkus.infinispan-client.server-list",
+                    () -> infinispan.getURI().toString());
+
+    @Test
+    void smoke() {
+        String firstCache = service.given()
+                .get("/first-counter/get-cache")
+                .then().statusCode(HttpStatus.SC_OK)
+                .extract().asString();
+        String secondCache = service.given()
+                .get("/second-counter/get-cache")
+                .then().statusCode(HttpStatus.SC_OK)
+                .extract().asString();
+
+        assertEquals(firstCache, secondCache);
+    }
+}

--- a/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/InfinispanIT.java
+++ b/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/InfinispanIT.java
@@ -1,0 +1,41 @@
+package io.quarkus.ts.infinispan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.InfinispanService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+@DisabledOnNative(reason = "https://github.com/quarkusio/quarkus/issues/30304")
+public class InfinispanIT {
+    @Container(image = "${infinispan.image}", port = 11222)
+    static InfinispanService infinispan = new InfinispanService()
+            .withUsername("admin")
+            .withPassword("password");
+
+    @QuarkusApplication()
+    static RestService service = new RestService()
+            .withProperty("quarkus.infinispan-client.server-list",
+                    () -> infinispan.getURI().toString());
+
+    @Test
+    void smoke() {
+        String firstCache = service.given()
+                .get("/first-counter/get-cache")
+                .then().statusCode(HttpStatus.SC_OK)
+                .extract().asString();
+        String secondCache = service.given()
+                .get("/second-counter/get-cache")
+                .then().statusCode(HttpStatus.SC_OK)
+                .extract().asString();
+
+        assertEquals(firstCache, secondCache);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -571,6 +571,7 @@
                 <module>env-info</module>
                 <module>nosql-db/mongodb</module>
                 <module>nosql-db/mongodb-reactive</module>
+                <module>nosql-db/infinispan</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
### Summary

Adds coverage for a bug, encountered in https://issues.redhat.com/browse/QUARKUS-2747.

The separate module was created, since `application.properties ` files for this scenario and for scenarios in `infinispan` module are not compatible and we cannot customise them with per-app granularity, because of https://github.com/quarkus-qe/quarkus-test-framework/issues/174.
The module has as little coverage as possible to minimise running time and consumed resources.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)