### PR TITLE
Reactive Rest Client: Process paths before sub resources

### DIFF
--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/PlainRootResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/PlainRootResource.java
@@ -1,0 +1,51 @@
+package io.quarkus.ts.http.restclient.reactive;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.reactive.RestPath;
+
+@Path("/plain-root/{rootParam}")
+@Consumes("text/plain")
+@Produces("text/plain")
+public class PlainRootResource {
+
+    @Inject
+    @RestClient
+    SubResourcesClient subResourcesClient;
+
+    @GET
+    @Path("{method}/{param2}/{param3}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getSubResource(
+            @RestPath("rootParam") String rootParam,
+            @RestPath("method") String method,
+            @RestPath("param2") String param2,
+            @RestPath("param3") String param3) {
+        return subResourcesClient.sub(rootParam, method).sub(param2).get(param3);
+    }
+
+    @GET
+    @Path("/manualClient/{method}/{param2}/{param3}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getSubResourceManualClient(
+            @PathParam("rootParam") String rootParam,
+            @PathParam("method") String method,
+            @PathParam("param2") String param2,
+            @PathParam("param3") String param3,
+            @QueryParam("baseUri") String baseUri) throws URISyntaxException {
+        SubResourcesClient rClient = RestClientBuilder.newBuilder().baseUri(new URI(baseUri)).build(SubResourcesClient.class);
+        return rClient.sub(rootParam, method).sub(param2).get(param3);
+    }
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/ReactiveClientRootResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/ReactiveClientRootResource.java
@@ -1,0 +1,25 @@
+package io.quarkus.ts.http.restclient.reactive;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+
+@Path("/root")
+@Consumes("text/plain")
+@Produces("text/plain")
+@ClientHeaderParam(name = "fromRoot", value = "headerValue")
+@ClientHeaderParam(name = "overridable", value = "RootClient")
+public class ReactiveClientRootResource {
+
+    @GET
+    @Path("{part1}/{part2}/{part3}/{part4}/{part5}")
+    public String getUriParts(@PathParam("part1") String part1, @PathParam("part2") String part2,
+            @PathParam("part3") String part3, @PathParam("part4") String part4,
+            @PathParam("part5") String part5) {
+        return String.format("%s/%s/%s/%s/%s", part1, part2, part3, part4, part5);
+    }
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/SubResourcesClient.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/SubResourcesClient.java
@@ -1,0 +1,38 @@
+package io.quarkus.ts.http.restclient.reactive;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+@Path("/root/{rootParam}")
+@RegisterClientHeaders
+@Consumes(MediaType.TEXT_PLAIN)
+@Produces(MediaType.TEXT_PLAIN)
+public interface SubResourcesClient {
+
+    @Path("/{param1}")
+    SubClient sub(@PathParam("rootParam") String rootParam, @PathParam("param1") String param1);
+
+    @Consumes("text/plain")
+    @Produces("text/plain")
+    interface SubClient {
+        @Path("/sub/{param2}")
+        SubSubClient sub(@PathParam("param2") String param2);
+    }
+
+    @Consumes("text/plain")
+    @Produces("text/plain")
+    interface SubSubClient {
+
+        @GET
+        @Path("/{param3}")
+        String get(@PathParam("param3") String param3);
+    }
+}

--- a/http/rest-client-reactive/src/main/resources/modern.properties
+++ b/http/rest-client-reactive/src/main/resources/modern.properties
@@ -3,6 +3,8 @@ quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.json.JsonRestInterfa
 quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.files.FileClient".url=http://localhost:${quarkus.http.port}
 quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.BookClient".url=http://localhost:${quarkus.http.port}
 quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.BookClient.AuthorClient".url=http://localhost:${quarkus.http.port}
+quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.SubResourcesClient".url=http://localhost:${quarkus.http.port}
+
 quarkus.rest-client.logging.scope=request-response
 quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG
 quarkus.http.limits.max-body-size=3G

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
@@ -197,4 +197,27 @@ public class ReactiveRestClientIT {
         assertEquals(HttpStatus.SC_OK, suffix.statusCode());
         assertEquals("Heller_text", suffix.getBody().asString());
     }
+
+    @Tag("QUARKUS-2741")
+    @Test
+    public void checkProcessPathBeforeSubResources() {
+        // should result in sending GET root/method/sub/sub/subsub
+        String result = app.given().get("/plain-root/root/method/sub/subsub").then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().asString();
+
+        assertEquals("root/method/sub/sub/subsub", result);
+    }
+
+    @Tag("QUARKUS-2741")
+    @Test
+    public void checkProcessPathBeforeSubResourcesManualRestClientBuild() {
+        String baseUri = String.format("http://%s:%s", app.getURI().getHost(), "" + app.getURI().getPort());
+        // should result in sending GET root/method/sub/sub/subsub
+        String result = app.given().get("/plain-root/root/manualClient/method/sub/subsub?baseUri=" + baseUri).then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().asString();
+
+        assertEquals("root/method/sub/sub/subsub", result);
+    }
 }


### PR DESCRIPTION
### Summary

Verify that Reactive RestClient `@PathParam` parameters are applied to the web target before passing it to the sub-resource instance.

Please select the relevant options.

- [X] New scenario (non-breaking change which adds functionality)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)