### PR TITLE
[2.13] backports for uberjar, Dev ui with HTTPS, local infinispan and mixing of tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1065,6 +1065,10 @@ a collection using a filter and a projection. All tests are performed using:
 
 Reactive equivalent of `nosql-db/mongodb`. Uses reactive ReactiveMongoClient (without codecs)
 
+### `nosql-db/infinispan`
+
+Provides some coverage similar to `infinispan-client` module, but with focus on connecting to local cluster and Dev mode and not on working with OpenShift
+
 ### `websockets/quarkus-websockets`
 Coverage for sending messages over websockets
 

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/TodoDemoIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/TodoDemoIT.java
@@ -11,12 +11,28 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 @DisabledOnNative(reason = "This scenario is using uber-jar, so it's incompatible with Native")
 @QuarkusScenario
 public class TodoDemoIT {
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/todo-demo-app.git", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_VERSION} ")
+    private static final String TODO_REPO = "https://github.com/quarkusio/todo-demo-app.git";
+    private static final String VERSIONS = "-Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_VERSION} ";
+    private static final String DEFAULT_OPTIONS = "-DskipTests=true " + VERSIONS;
+
+    @GitRepositoryQuarkusApplication(repo = TODO_REPO, mavenArgs = "-Dquarkus.package.type=uber-jar " + DEFAULT_OPTIONS)
     static final RestService app = new RestService();
 
+    @GitRepositoryQuarkusApplication(repo = TODO_REPO, artifact = "todo-backend-1.0-SNAPSHOT.jar", mavenArgs = "-Dquarkus.package.type=uber-jar -Dquarkus.package.add-runner-suffix=false"
+            + DEFAULT_OPTIONS)
+    static final RestService replaced = new RestService();
+
     @Test
-    public void verify() {
+    public void startsSuccessfully() {
         app.given()
+                .get()
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void replacedStartsSuccessfully() {
+        replaced.given()
                 .get()
                 .then()
                 .statusCode(HttpStatus.SC_OK);

--- a/http/http-advanced-reactive/src/main/resources/application.properties
+++ b/http/http-advanced-reactive/src/main/resources/application.properties
@@ -67,3 +67,5 @@ pl-container-request-filter.enabled=false
 # Register MultipartFormDataReader as provider (used by io.quarkus.ts.http.advanced.reactive.MultipartResource.multipartFormData)
 quarkus.index-dependency.resteasy-multipart.group-id=org.jboss.resteasy
 quarkus.index-dependency.resteasy-multipart.artifact-id=resteasy-multipart-provider
+
+quarkus.qe.test.value=42

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeHttpsIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeHttpsIT.java
@@ -1,0 +1,104 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+import io.quarkus.test.bootstrap.DevModeQuarkusService;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.test.services.URILike;
+import io.quarkus.test.utils.AwaitilityUtils;
+
+@QuarkusScenario
+public class DevModeHttpsIT {
+    private static final String PROPERTY = "quarkus.qe.test.value";
+
+    @DevModeQuarkusApplication(ssl = true)
+    static RestService app = new DevModeQuarkusService()
+            .withProperty("quarkus.oidc.enabled", "false")
+            .withProperty("quarkus.keycloak.policy-enforcer.enable", "false")
+            .withProperty("quarkus.keycloak.devservices.enabled", "false");
+
+    private WebClient webClient;
+
+    @BeforeEach
+    void setUp() {
+        webClient = new WebClient();
+
+        webClient.getOptions().setRedirectEnabled(true); //required for the test case
+        //The execution breaks without the two options below
+        webClient.getOptions().setUseInsecureSSL(true);
+        webClient.getOptions().setWebSocketEnabled(false);
+
+        //make sure, that the cache doesn't affect us
+        webClient.getCookieManager().clearCookies();
+        webClient.getCookieManager().setCookiesEnabled(false);
+        webClient.getCache().clear();
+        webClient.getCache().setMaxSize(0);
+
+        //disable everything, that we don't need
+        webClient.getOptions().setDownloadImages(false);
+        webClient.getOptions().setGeolocationEnabled(false);
+        webClient.getOptions().setAppletEnabled(false);
+        webClient.getOptions().setCssEnabled(false);
+    }
+
+    @AfterEach
+    void tearDown() {
+        webClient.close();
+    }
+
+    @Test
+    public void uiChange() throws IOException {
+        URILike uri = app.getURI(Protocol.HTTPS);
+
+        HtmlPage before = webClient.getPage(uri.withPath("/q/dev/io.quarkus.quarkus-vertx-http/config").toString());
+        QuarkusUIField field = new QuarkusUIField(before.getElementById(PROPERTY));
+        assertEquals("42", field.getValue());
+        assertEquals("42", app.getProperty(PROPERTY, ""));
+
+        field.setValue("23");
+        HtmlPage saved = field.getSaveButton().click();
+        QuarkusUIField updated = new QuarkusUIField(saved.getElementById(PROPERTY));
+        assertEquals("23", updated.getValue());
+
+        AwaitilityUtils.untilIsTrue(() -> app.getLogs().stream().anyMatch(log -> log.contains("File change detected")));
+        assertEquals("23", app.getProperty(PROPERTY, ""));
+    }
+}
+
+class QuarkusUIField {
+    private final DomElement element;
+
+    QuarkusUIField(DomElement element) {
+        this.element = element;
+    }
+
+    public String getValue() {
+        return element.getAttribute("value");
+    }
+
+    public void setValue(String newValue) {
+        element.setAttribute("value", newValue);
+    }
+
+    public DomElement getSaveButton() {
+        for (DomElement sibling : element.getParentNode().getDomElementDescendants()) {
+            if (sibling.getAttribute("class").equals("input-group-text formInputButton")) {
+                return sibling;
+            }
+        }
+        throw new IllegalStateException("Save button was not found!");
+    }
+}

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeHttpsIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeHttpsIT.java
@@ -16,11 +16,13 @@ import io.quarkus.test.bootstrap.DevModeQuarkusService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.services.URILike;
 import io.quarkus.test.utils.AwaitilityUtils;
 
 @QuarkusScenario
+@DisabledOnQuarkusVersion(version = "2\\.13\\.[0-6].*", reason = "Fixed in Quarkus 2.13.7")
 public class DevModeHttpsIT {
     private static final String PROPERTY = "quarkus.qe.test.value";
 

--- a/lifecycle-application/src/main/java/io/quarkus/ts/lifecycle/Main.java
+++ b/lifecycle-application/src/main/java/io/quarkus/ts/lifecycle/Main.java
@@ -16,6 +16,10 @@ public final class Main {
 
     public static void main(String... args) {
         LOG.info(ARGUMENTS_FROM_MAIN + String.join(",", args));
-        Quarkus.run(args);
+        if (args.length > 0 && "cli".equals(args[0])) {
+            return;
+        } else {
+            Quarkus.run(args);
+        }
     }
 }

--- a/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/AlphabeticallyFirstTest.java
+++ b/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/AlphabeticallyFirstTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.lifecycle;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * The name of the test is crucial to make it run before HelloMainTest.
+ * See comments to the issue for the explanation.
+ */
+@QuarkusTest
+@Tag("QUARKUS-2789")
+public class AlphabeticallyFirstTest {
+
+    @Test
+    public void shouldBeOk() {
+        given()
+                .when().get("/args")
+                .then()
+                .statusCode(200)
+                .body(is(""));
+    }
+}

--- a/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/HelloMainTest.java
+++ b/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/HelloMainTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.ts.lifecycle;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+
+@QuarkusMainTest
+public class HelloMainTest {
+
+    @Test
+    @Launch({ "cli", "Hello", "World" })
+    public void annotatedLaunch(LaunchResult result) {
+        List<String> outputStream = result.getOutputStream();
+        String args = null;
+        for (String output : outputStream) {
+            if (output.contains("Received arguments:")) {
+                args = output;
+            }
+        }
+        Assertions.assertNotNull(args);
+        Assertions.assertTrue(args.contains("Hello"), "No 'Hello' in the output!");
+        Assertions.assertTrue(args.contains("World"), "No 'World' in the output!");
+    }
+}

--- a/nosql-db/infinispan/pom.xml
+++ b/nosql-db/infinispan/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>infinispan</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: NoSQL Database: Infinispan</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-infinispan-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-infinispan</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
+        <profile>
+            <id>skip-tests-on-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- Disable native build on this module -->
+            <!-- https://github.com/quarkusio/quarkus/issues/30304 -->
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- To not build the module on Native -->
+                <quarkus.package.type>fast-jar</quarkus.package.type>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/FirstCounterResource.java
+++ b/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/FirstCounterResource.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.infinispan.client;
+
+import javax.ws.rs.Path;
+
+@Path("/first-counter")
+public class FirstCounterResource extends InfinispanCounterResource {
+}

--- a/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/InfinispanClientApp.java
+++ b/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/InfinispanClientApp.java
@@ -1,0 +1,63 @@
+package io.quarkus.ts.infinispan.client;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryModified;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryRemoved;
+import org.infinispan.client.hotrod.annotation.ClientListener;
+import org.infinispan.client.hotrod.event.ClientCacheEntryCreatedEvent;
+import org.infinispan.client.hotrod.event.ClientCacheEntryModifiedEvent;
+import org.infinispan.client.hotrod.event.ClientCacheEntryRemovedEvent;
+import org.infinispan.commons.configuration.XMLStringConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkus.runtime.StartupEvent;
+
+@ApplicationScoped
+public class InfinispanClientApp {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("InfinispanClientApp");
+
+    @Inject
+    RemoteCacheManager cacheManager;
+
+    private static final String MYCACHE_CACHE_CONFIG = "<infinispan><cache-container>" +
+            "<distributed-cache name=\"%s\"></distributed-cache>" +
+            "</cache-container></infinispan>";
+
+    void onStart(@Observes StartupEvent ev) {
+        LOGGER.info("Create or get cache named mycache with the default configuration");
+        RemoteCache<Object, Object> cache = cacheManager.administration().getOrCreateCache("mycache",
+                new XMLStringConfiguration(String.format(MYCACHE_CACHE_CONFIG, "mycache")));
+        cache.addClientListener(new EventPrintListener());
+        if (cache.isEmpty()) {
+            cache.put("counter", 0);
+        }
+    }
+
+    @ClientListener
+    static class EventPrintListener {
+
+        @ClientCacheEntryCreated
+        public void handleCreatedEvent(ClientCacheEntryCreatedEvent e) {
+            LOGGER.info("Listener: cache entry was CREATED: " + e);
+        }
+
+        @ClientCacheEntryModified
+        public void handleModifiedEvent(ClientCacheEntryModifiedEvent e) {
+            LOGGER.info("Listener: cache entry was MODIFIED: " + e);
+        }
+
+        @ClientCacheEntryRemoved
+        public void handleRemovedEvent(ClientCacheEntryRemovedEvent e) {
+            LOGGER.info("Listener: cache entry was REMOVED: " + e);
+        }
+
+    }
+}

--- a/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/InfinispanCounterResource.java
+++ b/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/InfinispanCounterResource.java
@@ -1,0 +1,62 @@
+package io.quarkus.ts.infinispan.client;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.infinispan.client.hotrod.RemoteCache;
+
+import io.quarkus.infinispan.client.Remote;
+
+public class InfinispanCounterResource {
+    protected AtomicInteger counter = new AtomicInteger(0);
+
+    @Inject
+    @Remote("mycache")
+    RemoteCache<String, Integer> cache;
+
+    @Path("/get-cache")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Integer getCacheCounter() {
+        return cache.get("counter");
+    }
+
+    @Path("/get-client")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Integer getClientCounter() {
+        return counter.get();
+    }
+
+    @Path("/increment-counters")
+    @PUT
+    @Produces(MediaType.TEXT_PLAIN)
+    public String incCounters() {
+        int invocationClientNumber = counter.incrementAndGet();
+        int invocationCacheNumber = cache.get("counter") + 1;
+        cache.put("counter", invocationCacheNumber);
+        return "Cache=" + invocationCacheNumber + " Client=" + invocationClientNumber;
+    }
+
+    @Path("/reset-cache")
+    @PUT
+    @Produces(MediaType.TEXT_PLAIN)
+    public String resetCacheCounter() {
+        cache.put("counter", 0);
+        return "Cache=" + cache.get("counter");
+    }
+
+    @Path("/reset-client")
+    @PUT
+    @Produces(MediaType.TEXT_PLAIN)
+    public String resetClientCounter() {
+        counter.set(0);
+        return "Client=" + counter.get();
+    }
+}

--- a/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/SecondCounterResource.java
+++ b/nosql-db/infinispan/src/main/java/io/quarkus/ts/infinispan/client/SecondCounterResource.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.infinispan.client;
+
+import javax.ws.rs.Path;
+
+@Path("/second-counter")
+public class SecondCounterResource extends InfinispanCounterResource {
+}

--- a/nosql-db/infinispan/src/main/resources/application.properties
+++ b/nosql-db/infinispan/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+quarkus.infinispan-client.auth-username=admin
+quarkus.infinispan-client.auth-password=password
+quarkus.infinispan-client.client-intelligence=BASIC
+
+quarkus.infinispan-client.cache."cache".configuration-uri=cache-configuration.xml
+quarkus.infinispan-client.cache."cache".near-cache-mode: disabled
+quarkus.infinispan-client.cache."cache".near-cache-max-entries: -1

--- a/nosql-db/infinispan/src/main/resources/cache-configuration.xml
+++ b/nosql-db/infinispan/src/main/resources/cache-configuration.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan>
+    <!-->Very basic cache configuration</-->
+    <cache-container name="clustered">
+        <distributed-cache name="cache" mode="SYNC">
+            <locking isolation="REPEATABLE_READ"/>
+            <transaction locking="PESSIMISTIC" mode="NON_DURABLE_XA"/>
+            <encoding media-type="application/x-protostream"/>
+        </distributed-cache>
+    </cache-container>
+</infinispan>

--- a/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/DevModeInfinispanIT.java
+++ b/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/DevModeInfinispanIT.java
@@ -1,0 +1,39 @@
+package io.quarkus.ts.infinispan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.InfinispanService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+
+@QuarkusScenario
+public class DevModeInfinispanIT {
+    @Container(image = "${infinispan.image}", port = 11222)
+    static InfinispanService infinispan = new InfinispanService()
+            .withUsername("admin")
+            .withPassword("password");
+
+    @DevModeQuarkusApplication()
+    static RestService service = new RestService()
+            .withProperty("quarkus.infinispan-client.server-list",
+                    () -> infinispan.getURI().toString());
+
+    @Test
+    void smoke() {
+        String firstCache = service.given()
+                .get("/first-counter/get-cache")
+                .then().statusCode(HttpStatus.SC_OK)
+                .extract().asString();
+        String secondCache = service.given()
+                .get("/second-counter/get-cache")
+                .then().statusCode(HttpStatus.SC_OK)
+                .extract().asString();
+
+        assertEquals(firstCache, secondCache);
+    }
+}

--- a/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/InfinispanIT.java
+++ b/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/InfinispanIT.java
@@ -1,0 +1,41 @@
+package io.quarkus.ts.infinispan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.InfinispanService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+@DisabledOnNative(reason = "https://github.com/quarkusio/quarkus/issues/30304")
+public class InfinispanIT {
+    @Container(image = "${infinispan.image}", port = 11222)
+    static InfinispanService infinispan = new InfinispanService()
+            .withUsername("admin")
+            .withPassword("password");
+
+    @QuarkusApplication()
+    static RestService service = new RestService()
+            .withProperty("quarkus.infinispan-client.server-list",
+                    () -> infinispan.getURI().toString());
+
+    @Test
+    void smoke() {
+        String firstCache = service.given()
+                .get("/first-counter/get-cache")
+                .then().statusCode(HttpStatus.SC_OK)
+                .extract().asString();
+        String secondCache = service.given()
+                .get("/second-counter/get-cache")
+                .then().statusCode(HttpStatus.SC_OK)
+                .extract().asString();
+
+        assertEquals(firstCache, secondCache);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -553,6 +553,7 @@
                 <module>env-info</module>
                 <module>nosql-db/mongodb</module>
                 <module>nosql-db/mongodb-reactive</module>
+                <module>nosql-db/infinispan</module>
             </modules>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.13.6.Final</quarkus.platform.version>
-        <quarkus.qe.framework.version>1.2.0.Final</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.2.1.Final</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.38.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.12.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>


### PR DESCRIPTION
### Summary

depends on: https://github.com/quarkus-qe/quarkus-test-suite/pull/997

Backport of these PRs:
https://github.com/quarkus-qe/quarkus-test-suite/pull/987 (Verify, that uberjar can be built even with empty suffix)
https://github.com/quarkus-qe/quarkus-test-suite/pull/986 (Verify, that dev ui page can be updated via "browser" and HTTPS)
https://github.com/quarkus-qe/quarkus-test-suite/pull/984 (Add minimal coverage for local Infinispan and for working with DevMode)
https://github.com/quarkus-qe/quarkus-test-suite/pull/979 (Coverage for mixing @QuarkusMainTest and @QuarkusTest in the same package )

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)