### PR TITLE
New Scenario: RequestScope custom context was removed after `javax.enterprise` event propagation

### DIFF
--- a/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/HelloResource.java
+++ b/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/HelloResource.java
@@ -1,8 +1,17 @@
 package io.quarkus.ts.http.advanced;
 
+import java.time.Duration;
+import java.util.Objects;
+
+import javax.enterprise.event.Event;
+import javax.enterprise.event.ObservesAsync;
+import javax.inject.Inject;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
@@ -10,10 +19,48 @@ import javax.ws.rs.core.MediaType;
 @Path("/hello")
 public class HelloResource {
     private static final String TEMPLATE = "Hello, %s!";
+    public static final int EVENT_PROPAGATION_WAIT_MS = 250;
+    private String contextValueAfterEventPropagation;
+
+    @Inject
+    Event<String> event;
+
+    @Inject
+    LocalCustomContext localCustomContext;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Hello get(@QueryParam("name") @DefaultValue("World") String name) {
         return new Hello(String.format(TEMPLATE, name));
+    }
+
+    @PUT()
+    @Path("/local-context/{value}")
+    public void updateContext(@PathParam("value") String value) {
+        event.fireAsync(value);
+    }
+
+    @GET()
+    @Path("/local-context/{value}")
+    public String retrieveContextValue(@PathParam("value") String value) {
+        if (Objects.isNull(contextValueAfterEventPropagation)) {
+            throw new NotFoundException(String.format("Resource %s not found!", value));
+        }
+
+        return contextValueAfterEventPropagation;
+    }
+
+    void dequeueProcessingRequests(@ObservesAsync String value) {
+        localCustomContext.set(value);
+        // 'wait' is required in order to reproduce the issue https://github.com/quarkusio/quarkus/issues/29017
+        wait(Duration.ofMillis(EVENT_PROPAGATION_WAIT_MS));
+        contextValueAfterEventPropagation = localCustomContext.get();
+    }
+
+    private void wait(Duration timeout) {
+        try {
+            Thread.sleep(timeout.toMillis());
+        } catch (Exception e) {
+        }
     }
 }

--- a/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/LocalCustomContext.java
+++ b/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/LocalCustomContext.java
@@ -1,0 +1,18 @@
+package io.quarkus.ts.http.advanced;
+
+import javax.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class LocalCustomContext {
+
+    String value;
+
+    public void set(String value) {
+        this.value = value;
+    }
+
+    public String get() {
+        return value;
+    }
+
+}


### PR DESCRIPTION
### Summary


When firing an async CDI Event, the requestScope context from the emitter briefly exists for the observer and is then terminated. This commit is a reproducer of this scenario that happens on `Quarkus 2.13.0.Final`

**How to reproduce**

```mvn clean verify -Dit.test=HttpAdvancedIT#keepRequestScopeValuesAfterEventPropagation -Dquarkus.platform.version=2.13.0.Final -Dquarkus.platform.group-id=io.quarkus.platform```

Please select the relevant options.

- [X] New scenario (non-breaking change which adds functionality)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)