### PR TITLE
[2.13] coverage of Architecture (XA) connection, Http Restclient path and subpath params and Request Scope event Propagation

### DIFF
--- a/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/HelloResource.java
+++ b/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/HelloResource.java
@@ -1,8 +1,17 @@
 package io.quarkus.ts.http.advanced;
 
+import java.time.Duration;
+import java.util.Objects;
+
+import javax.enterprise.event.Event;
+import javax.enterprise.event.ObservesAsync;
+import javax.inject.Inject;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
@@ -10,10 +19,48 @@ import javax.ws.rs.core.MediaType;
 @Path("/hello")
 public class HelloResource {
     private static final String TEMPLATE = "Hello, %s!";
+    public static final int EVENT_PROPAGATION_WAIT_MS = 250;
+    private String contextValueAfterEventPropagation;
+
+    @Inject
+    Event<String> event;
+
+    @Inject
+    LocalCustomContext localCustomContext;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Hello get(@QueryParam("name") @DefaultValue("World") String name) {
         return new Hello(String.format(TEMPLATE, name));
+    }
+
+    @PUT()
+    @Path("/local-context/{value}")
+    public void updateContext(@PathParam("value") String value) {
+        event.fireAsync(value);
+    }
+
+    @GET()
+    @Path("/local-context/{value}")
+    public String retrieveContextValue(@PathParam("value") String value) {
+        if (Objects.isNull(contextValueAfterEventPropagation)) {
+            throw new NotFoundException(String.format("Resource %s not found!", value));
+        }
+
+        return contextValueAfterEventPropagation;
+    }
+
+    void dequeueProcessingRequests(@ObservesAsync String value) {
+        localCustomContext.set(value);
+        // 'wait' is required in order to reproduce the issue https://github.com/quarkusio/quarkus/issues/29017
+        wait(Duration.ofMillis(EVENT_PROPAGATION_WAIT_MS));
+        contextValueAfterEventPropagation = localCustomContext.get();
+    }
+
+    private void wait(Duration timeout) {
+        try {
+            Thread.sleep(timeout.toMillis());
+        } catch (Exception e) {
+        }
     }
 }

--- a/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/LocalCustomContext.java
+++ b/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/LocalCustomContext.java
@@ -1,0 +1,18 @@
+package io.quarkus.ts.http.advanced;
+
+import javax.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class LocalCustomContext {
+
+    String value;
+
+    public void set(String value) {
+        this.value = value;
+    }
+
+    public String get() {
+        return value;
+    }
+
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/ResourceAndSubResourcesClient.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/ResourceAndSubResourcesClient.java
@@ -1,0 +1,40 @@
+package io.quarkus.ts.http.restclient.reactive;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+@RegisterClientHeaders
+@Consumes(MediaType.TEXT_PLAIN)
+@Produces(MediaType.TEXT_PLAIN)
+public interface ResourceAndSubResourcesClient {
+    @Path("clients")
+    ClientsResource clients();
+
+    interface ClientsResource {
+        @Path("{id}")
+        ClientResource get(@PathParam("id") String id);
+    }
+
+    interface ClientResource {
+        @Path("/resource-server")
+        SubResource sub();
+    }
+
+    interface LeafResource {
+        @GET
+        String retrieve();
+    }
+
+    interface SubResource {
+        @Path("{id}")
+        LeafResource findById(@PathParam("id") String id);
+    }
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/PlainBookResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/PlainBookResource.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.http.restclient.reactive;
+package io.quarkus.ts.http.restclient.reactive.resources;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/PlainComplexClientResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/PlainComplexClientResource.java
@@ -1,0 +1,44 @@
+package io.quarkus.ts.http.restclient.reactive.resources;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.quarkus.ts.http.restclient.reactive.ResourceAndSubResourcesClient;
+
+@Path("clients/{clientId}/clientResource")
+@Consumes("text/plain")
+@Produces("text/plain")
+public class PlainComplexClientResource {
+    @Inject
+    @RestClient
+    ResourceAndSubResourcesClient resourceAndSubResourcesClient;
+
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getClientResource(@PathParam("clientId") String rootParam,
+            @PathParam("id") String id,
+            @QueryParam("baseUri") String baseUri) throws URISyntaxException {
+
+        ResourceAndSubResourcesClient restClient = resourceAndSubResourcesClient;
+        if (!StringUtils.isEmpty(baseUri)) {
+            restClient = RestClientBuilder.newBuilder().baseUri(new URI(baseUri))
+                    .build(ResourceAndSubResourcesClient.class);
+        }
+
+        return restClient.clients().get(rootParam).sub().findById(id).retrieve();
+    }
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/ReactiveClientBookResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/ReactiveClientBookResource.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.http.restclient.reactive;
+package io.quarkus.ts.http.restclient.reactive.resources;
 
 import java.util.List;
 import java.util.Map;
@@ -14,6 +14,7 @@ import javax.ws.rs.core.MultivaluedHashMap;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
+import io.quarkus.ts.http.restclient.reactive.BookClient;
 import io.quarkus.ts.http.restclient.reactive.json.Book;
 import io.quarkus.ts.http.restclient.reactive.json.BookIdWrapper;
 import io.quarkus.ts.http.restclient.reactive.json.IdBeanParam;

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/ReactivecomplexClientResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/ReactivecomplexClientResource.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.http.restclient.reactive.resources;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+@Path("/clients/{rootPath}/resource-server")
+public class ReactivecomplexClientResource {
+    @Path("/{id}")
+    @GET
+    public String retrieveById(@PathParam("rootPath") String rootPath, @PathParam("id") String id) {
+        return "/clients/" + rootPath + "/resource-server/" + id;
+    }
+}

--- a/http/rest-client-reactive/src/main/resources/modern.properties
+++ b/http/rest-client-reactive/src/main/resources/modern.properties
@@ -3,6 +3,8 @@ quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.json.JsonRestInterfa
 quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.files.FileClient".url=http://localhost:${quarkus.http.port}
 quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.BookClient".url=http://localhost:${quarkus.http.port}
 quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.BookClient.AuthorClient".url=http://localhost:${quarkus.http.port}
+quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.ResourceAndSubResourcesClient".url=http://localhost:${quarkus.http.port}
+
 quarkus.rest-client.logging.scope=request-response
 quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG
 quarkus.http.limits.max-body-size=3G

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
@@ -1,8 +1,10 @@
 package io.quarkus.ts.http.restclient.reactive;
 
-import static io.quarkus.ts.http.restclient.reactive.PlainBookResource.SEARCH_TERM_VAL;
+import static io.quarkus.ts.http.restclient.reactive.resources.PlainBookResource.SEARCH_TERM_VAL;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.UUID;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Tag;
@@ -10,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
@@ -197,4 +200,29 @@ public class ReactiveRestClientIT {
         assertEquals(HttpStatus.SC_OK, suffix.statusCode());
         assertEquals("Heller_text", suffix.getBody().asString());
     }
+
+    @Tag("QUARKUS-2741")
+    @Test
+    public void checkProcessPathBeforeSubResources() {
+        final String randomId = UUID.randomUUID().toString();
+        String result = app.given().get("clients/myRealm/clientResource/" + randomId).then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().asString();
+
+        assertEquals("/clients/myRealm/resource-server/" + randomId, result);
+    }
+
+    @Tag("QUARKUS-2741")
+    @Test
+    public void checkProcessPathBeforeSubResourcesManualRestClientBuild() {
+        final String randomId = UUID.randomUUID().toString();
+        String result = app.given()
+                .get("clients/myRealm/clientResource/" + randomId + "/?baseUri=" + app.getURI(Protocol.HTTP).toString())
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().asString();
+
+        assertEquals("/clients/myRealm/resource-server/" + randomId, result);
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,8 @@
         <exclude.operator.openshift.tests>**/Operator*OpenShift*IT.java</exclude.operator.openshift.tests>
         <exclude.quarkus.cli.tests>**/QuarkusCli*IT.java</exclude.quarkus.cli.tests>
         <exclude.quarkus.devmode.tests>no</exclude.quarkus.devmode.tests>
+        <!-- Docker images used by both surefire and failsafe plugin -->
+        <postgresql.latest.image>docker.io/library/postgres:15</postgresql.latest.image>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -213,7 +215,9 @@
                                 <ts.global.s2i.quarkus.jvm.builder.image>${ts.global.s2i.quarkus.jvm.builder.image}</ts.global.s2i.quarkus.jvm.builder.image>
                                 <ts.global.s2i.quarkus.native.builder.image>${ts.global.s2i.quarkus.native.builder.image}</ts.global.s2i.quarkus.native.builder.image>
                                 <!-- Services used in test suite -->
-                                <postgresql.13.image>docker.io/library/postgres:13.8</postgresql.13.image>
+                                <postgresql.latest.image>${postgresql.latest.image}</postgresql.latest.image>
+                                <!-- FIXME: if the same image name is used in two test classes, the second one fails -->
+                                <postgresql.also.latest.image>docker.io/library/postgres:15.1</postgresql.also.latest.image>
                                 <!-- TODO: investigate further in https://github.com/quarkus-qe/quarkus-test-suite/issues/627 -->
                                 <elastic.71.image>docker.io/bitnami/elasticsearch:7.17.6</elastic.71.image>
                                 <!--TODO change into 5.7 when this fixed https://github.com/docker-library/mysql/issues/844 -->

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
                                 <ts.global.s2i.quarkus.jvm.builder.image>${ts.global.s2i.quarkus.jvm.builder.image}</ts.global.s2i.quarkus.jvm.builder.image>
                                 <ts.global.s2i.quarkus.native.builder.image>${ts.global.s2i.quarkus.native.builder.image}</ts.global.s2i.quarkus.native.builder.image>
                                 <!-- Services used in test suite -->
-                                <postgresql.latest.image>${postgresql.latest.image}</postgresql.latest.image>
+                                <postgresql.13.image>docker.io/library/postgres:13.8</postgresql.13.image>
                                 <!-- FIXME: if the same image name is used in two test classes, the second one fails -->
                                 <postgresql.also.latest.image>docker.io/library/postgres:15.1</postgresql.also.latest.image>
                                 <!-- TODO: investigate further in https://github.com/quarkus-qe/quarkus-test-suite/issues/627 -->

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/XAPostgresIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/XAPostgresIT.java
@@ -1,0 +1,26 @@
+package io.quarkus.ts.sqldb.sqlapp;
+
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class XAPostgresIT extends AbstractSqlDatabaseIT {
+
+    static final int POSTGRESQL_PORT = 5432;
+
+    @Container(image = "${postgresql.also.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    static PostgresqlService database = new PostgresqlService()
+            .withUser("user")
+            .withPassword("user")
+            .withDatabase("mydb");
+
+    @QuarkusApplication
+    static RestService app = new RestService().withProperties("postgresql.properties")
+            .withProperty("quarkus.datasource.username", database.getUser())
+            .withProperty("quarkus.datasource.password", database.getPassword())
+            .withProperty("quarkus.datasource.jdbc.transactions", "xa")
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+}


### PR DESCRIPTION
### Summary

Backport of

[Test Extended Architecture (XA) connection](https://github.com/quarkus-qe/quarkus-test-suite/pull/971)
[Improve "process paths before sub resources" scenario](https://github.com/quarkus-qe/quarkus-test-suite/pull/995)
[New Scenario: RequestScope custom context was removed after `javax.enterprise` event propagation](https://github.com/quarkus-qe/quarkus-test-suite/pull/996)

Please select the relevant options.

- [X] Backport

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)