### PR TITLE
Add coverage to eventbus '@ConsumeEvent' annotation

### DIFF
--- a/security/vertx-jwt/src/main/java/io/quarkus/ts/security/vertx/CommonApplication.java
+++ b/security/vertx-jwt/src/main/java/io/quarkus/ts/security/vertx/CommonApplication.java
@@ -1,0 +1,8 @@
+package io.quarkus.ts.security.vertx;
+
+public abstract class CommonApplication<T> {
+
+    public static final String ADDRESS = "greeting";
+
+    public abstract void consumeEventBusEvent(T event);
+}

--- a/security/vertx-jwt/src/main/java/io/quarkus/ts/security/vertx/model/HelloEvent.java
+++ b/security/vertx-jwt/src/main/java/io/quarkus/ts/security/vertx/model/HelloEvent.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.security.vertx.model;
+
+public class HelloEvent {
+
+    final String message;
+
+    public HelloEvent(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/BladeRunnerHandlerIT.java
+++ b/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/BladeRunnerHandlerIT.java
@@ -2,6 +2,11 @@ package io.quarkus.ts.security.vertx;
 
 import static org.hamcrest.Matchers.is;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -46,5 +51,17 @@ public class BladeRunnerHandlerIT extends AbstractCommonIT {
                 .get("/bladeRunner/" + bladeRunner.getId())
                 .then()
                 .statusCode(404);
+    }
+
+    @Tag("QUARKUS-2746 ")
+    @Test
+    public void verifyConsumeEventAnnotation() {
+        List<String> actualLogs = app.getLogs();
+        List<String> helloEvents = actualLogs.stream()
+                .filter(l -> l.contains("Consuming generated HelloEvent at starting point"))
+                .collect(Collectors.toList());
+
+        Assertions.assertTrue(new HashSet<>(helloEvents).size() == helloEvents.size(),
+                "@ConsumeEvent annotation should be invoked once per event");
     }
 }


### PR DESCRIPTION
### Summary

https://issues.redhat.com/browse/QUARKUS-2746

ConsumeEvent annotation should be invoked once when the generic parent class
has an abstract method for it.

How to reproduce:

`mvn clean verify -Dit.test=BladeRunnerHandlerIT#verifyConsumeEventAnnotation -Dquarkus.platform.version=2.14.0.Final -Dquarkus.platform.group-id=io.quarkus.platform`

Please select the relevant options.
- [X] New scenario (non-breaking change which adds functionality)


### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)