### PR TITLE
Drop duplicated definition of quarkus-opentelemetry

### DIFF
--- a/http/vertx-web-client/pom.xml
+++ b/http/vertx-web-client/pom.xml
@@ -17,10 +17,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-routes</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Drop duplicated definition of quarkus-opentelemetry

ATM one gets following warning in console:
```
 Warning:  Some problems were encountered while building the effective model for io.quarkus.ts.qe:vertx-web-client:jar:1.0.0-SNAPSHOT
Warning:  'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.quarkus:quarkus-opentelemetry:jar -> duplicate declaration of version (?) @ line 18, column 21
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)