### PR TITLE
OutboundSseEvent is not correctly serialized

### DIFF
--- a/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/sse/ServerSentEventsPingResource.java
+++ b/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/sse/ServerSentEventsPingResource.java
@@ -1,10 +1,17 @@
 package io.quarkus.ts.opentelemetry.reactive.sse;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.sse.OutboundSseEvent;
+import javax.ws.rs.sse.Sse;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -23,5 +30,17 @@ public class ServerSentEventsPingResource extends TraceableResource {
     public Multi<String> getPing() {
         recordTraceId();
         return pongClient.getPong().map(response -> "ping " + response);
+    }
+
+    @Path("/raw")
+    @GET
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    public Multi<OutboundSseEvent> sseRaw(@Context Sse sse, @QueryParam("amount") int amount) {
+        List<OutboundSseEvent> events = new ArrayList<>(amount);
+        for (int i = 0; i < amount; i++) {
+            events.add(sse.newEventBuilder().id("id_" + i).data("data_" + i).name("name_" + i).build());
+        }
+
+        return Multi.createFrom().items(events.toArray(OutboundSseEvent[]::new));
     }
 }

--- a/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpenTelemetrySseIT.java
+++ b/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpenTelemetrySseIT.java
@@ -8,7 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.TimeUnit;
 
+import javax.ws.rs.core.MediaType;
+
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.JaegerService;
@@ -53,6 +56,19 @@ public class OpenTelemetrySseIT {
                 .and().body(allOf(containsString(PING_ENDPOINT), containsString(PONG_ENDPOINT))));
     }
 
+    @Tag("QUARKUS-2745")
+    @Test
+    public void verifySeeRawSerialization() {
+        final int amount = 3;
+        given()
+                .when().get(PING_ENDPOINT + "/raw?amount=" + amount)
+                .then().statusCode(HttpStatus.SC_OK)
+                .contentType(MediaType.SERVER_SENT_EVENTS)
+                .body(containsString("data:data_0"))
+                .body(containsString("id:id_1"))
+                .body(containsString("event:name_2"));
+    }
+
     protected void assertTraceIdWithPongService(String expected) {
         String pongTraceId = given()
                 .when().get(PONG_ENDPOINT + "/lastTraceId")
@@ -60,5 +76,4 @@ public class OpenTelemetrySseIT {
 
         assertEquals(expected, pongTraceId);
     }
-
 }


### PR DESCRIPTION
### Summary

Jira: https://issues.redhat.com/browse/QUARKUS-2745

OutboundSseEvent is throwing a serialization error on Quarkus 2.13.5.Final 

This PR covers the upstream patch.
Reproducer:

 `mvn clean verify -Dit.test=OpenTelemetrySseIT#verifySeeRawSerialization -Dquarkus.platform.version=2.13.5.Final -Dquarkus.platform.group-id=io.quarkus.platform`

Please select the relevant options.
- [X] New scenario (non-breaking change which adds functionality)


### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)