### PR TITLE
Remove PostgreSQL image workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,8 +229,6 @@
                                 <ts.global.s2i.quarkus.native.builder.image>${ts.global.s2i.quarkus.native.builder.image}</ts.global.s2i.quarkus.native.builder.image>
                                 <!-- Services used in test suite -->
                                 <postgresql.latest.image>${postgresql.latest.image}</postgresql.latest.image>
-                                <!-- FIXME: if the same image name is used in two test classes, the second one fails -->
-                                <postgresql.also.latest.image>docker.io/library/postgres:15.1</postgresql.also.latest.image>
                                 <!-- TODO: investigate further in https://github.com/quarkus-qe/quarkus-test-suite/issues/627 -->
                                 <elastic.71.image>docker.io/bitnami/elasticsearch:7.17.6</elastic.71.image>
                                 <!--TODO change into 5.7 when this fixed https://github.com/docker-library/mysql/issues/844 -->

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/PostgresqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/PostgresqlDatabaseIT.java
@@ -11,8 +11,10 @@ public class PostgresqlDatabaseIT extends AbstractSqlDatabaseIT {
 
     static final int POSTGRESQL_PORT = 5432;
 
+    // TODO rename "postgresql" database to "database" once this issue is fixed
+    // quarkus-qe/quarkus-test-framework#641
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static PostgresqlService database = new PostgresqlService()
+    static PostgresqlService postgresql = new PostgresqlService()
             //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
             .withProperty("POSTGRES_USER", "user")
             .withProperty("POSTGRES_PASSWORD", "user")
@@ -20,7 +22,7 @@ public class PostgresqlDatabaseIT extends AbstractSqlDatabaseIT {
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("postgresql.properties")
-            .withProperty("quarkus.datasource.username", database.getUser())
-            .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+            .withProperty("quarkus.datasource.username", postgresql.getUser())
+            .withProperty("quarkus.datasource.password", postgresql.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", postgresql::getJdbcUrl);
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/XAPostgresIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/XAPostgresIT.java
@@ -11,7 +11,7 @@ public class XAPostgresIT extends AbstractSqlDatabaseIT {
 
     static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "${postgresql.also.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static PostgresqlService database = new PostgresqlService()
             .withUser("user")
             .withPassword("user")

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/XAPostgresIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/XAPostgresIT.java
@@ -11,16 +11,18 @@ public class XAPostgresIT extends AbstractSqlDatabaseIT {
 
     static final int POSTGRESQL_PORT = 5432;
 
+    // TODO rename "postgresql" database to "database" once this issue is fixed
+    // quarkus-qe/quarkus-test-framework#641
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static PostgresqlService database = new PostgresqlService()
+    static PostgresqlService postgresql = new PostgresqlService()
             .withUser("user")
             .withPassword("user")
             .withDatabase("mydb");
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("postgresql.properties")
-            .withProperty("quarkus.datasource.username", database.getUser())
-            .withProperty("quarkus.datasource.password", database.getPassword())
+            .withProperty("quarkus.datasource.username", postgresql.getUser())
+            .withProperty("quarkus.datasource.password", postgresql.getPassword())
             .withProperty("quarkus.datasource.jdbc.transactions", "xa")
-            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+            .withProperty("quarkus.datasource.jdbc.url", postgresql::getJdbcUrl);
 }

--- a/sql-db/sql-app/src/test/resources/test.properties
+++ b/sql-db/sql-app/src/test/resources/test.properties
@@ -1,6 +1,8 @@
 ts.app.log.enable=true
 ts.database.log.enable=true
+ts.postgresql.log.enable=true
 ts.database.container.delete.image.on.stop=true
 ts.database.openshift.use-internal-service-as-url=true
+ts.postgresql.openshift.use-internal-service-as-url=true
 ts.db2.container.privileged-mode=true
 ts.db2.startup.timeout=10m


### PR DESCRIPTION
### Summary

Removes workaround for a failure reported in
https://github.com/quarkus-qe/quarkus-test-framework/issues/641 and observed in https://github.com/quarkus-qe/quarkus-test-suite/pull/971.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)