### PR TITLE
[2.13] Fix quarkus platform version when no maven profile is provided

### DIFF
--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -40,7 +40,7 @@
             </activation>
             <properties>
                 <!-- please keep Mandrel and RHBQ version compatible -->
-                <quarkus.platform.version>2.13.6.Final</quarkus.platform.version>
+                <quarkus.platform.version>2.13.7.Final</quarkus.platform.version>
             </properties>
             <repositories>
                 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -652,7 +652,7 @@
                 <quarkus.native.container-build>true</quarkus.native.container-build>
                 <quarkus.native.native-image-xmx>4g</quarkus.native.native-image-xmx>
                 <!-- please keep in mind that lifecycle-application module also defines quarkus.native.builder-image property -->
-                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17</quarkus.native.builder-image>
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17</quarkus.native.builder-image>
                 <exclude.quarkus.devmode.tests>**/*DevMode*IT.java</exclude.quarkus.devmode.tests>
             </properties>
         </profile>


### PR DESCRIPTION
### Summary

- Missing upgrade `quarkus.platform.version` to Quarkus 2.13.7.Final on maven main pom.xml
- Update native builder image reference used on lifecycle-application module

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
