### PR TITLE
Disabling tests due to serialization

### DIFF
--- a/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/client/MultipartClientIT.java
+++ b/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/client/MultipartClientIT.java
@@ -3,6 +3,7 @@ package io.quarkus.ts.http.jaxrs.reactive.client;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsStringIgnoringCase;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +11,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 
 @Tag("QUARKUS-1225")
 @QuarkusScenario
+@Disabled("https://github.com/quarkusio/quarkus/issues/30814")
 public class MultipartClientIT {
 
     @Test

--- a/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/KeycloakOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/KeycloakOidcClientSecurityIT.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -40,6 +41,7 @@ public class KeycloakOidcClientSecurityIT extends BaseOidcClientSecurityIT {
     }
 
     @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/30814")
     public void authorizationHeaderDoesNotRepeat() {
         final Response response = given()
                 .when()


### PR DESCRIPTION
### Summary

* Disabling Resteasy reactive client tests due to issue with serialization/deserialization.

  Issue: https://github.com/quarkusio/quarkus/issues/30814

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)