### PR TITLE
Coverage for Path Param group name containing a dash

### DIFF
--- a/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/HelloResource.java
+++ b/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/HelloResource.java
@@ -4,9 +4,11 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import io.smallrye.mutiny.Uni;
 
@@ -26,6 +28,12 @@ public class HelloResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<Hello> getJson() {
         return Uni.createFrom().item(new Hello("hello"));
+    }
+
+    @GET
+    @Path("/foo/{something-with-dash:[A-Z0-9]{4}}")
+    public Response doSomething(@PathParam("something-with-dash") String param) {
+        return Response.noContent().build();
     }
 
 }

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpMinimumReactiveIT.java
@@ -23,6 +23,15 @@ public class HttpMinimumReactiveIT {
     }
 
     @Test
+    @Tag("QUARKUS-2893")
+    public void pathParamNameWithDash() {
+        givenSpec().get("/api/hello/foo/AAAA").then().statusCode(HttpStatus.SC_NO_CONTENT);
+        givenSpec().get("/api/hello/foo/AXY9").then().statusCode(HttpStatus.SC_NO_CONTENT);
+        givenSpec().get("/api/hello/foo/ABCDFG").then().statusCode(HttpStatus.SC_NOT_FOUND);
+        givenSpec().get("/api/hello/foo/abcd").then().statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
     @Tag("QUARKUS-1543")
     public void nativeListSerialization() {
         String teamId = (String) givenSpec().get("/api/cluster/default").then()

--- a/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/HelloResource.java
+++ b/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/HelloResource.java
@@ -4,9 +4,11 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Path("/hello")
 public class HelloResource {
@@ -24,5 +26,11 @@ public class HelloResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Hello getJson() {
         return new Hello("hello");
+    }
+
+    @GET
+    @Path("/foo/{something-with-dash:[A-Z0-9]{4}}")
+    public Response doSomething(@PathParam("something-with-dash") String param) {
+        return Response.noContent().build();
     }
 }

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/HttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/HttpMinimumIT.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -17,6 +18,15 @@ public class HttpMinimumIT {
     @Test
     public void httpServer() {
         givenSpec().get("/api/hello").then().statusCode(HttpStatus.SC_OK).body("content", is("Hello, World!"));
+    }
+
+    @Test
+    @Tag("QUARKUS-2893")
+    public void pathParamNameWithDash() {
+        givenSpec().get("/api/hello/foo/AAAA").then().statusCode(HttpStatus.SC_NO_CONTENT);
+        givenSpec().get("/api/hello/foo/AXY9").then().statusCode(HttpStatus.SC_NO_CONTENT);
+        givenSpec().get("/api/hello/foo/ABCDFG").then().statusCode(HttpStatus.SC_NOT_FOUND);
+        givenSpec().get("/api/hello/foo/abcd").then().statusCode(HttpStatus.SC_NOT_FOUND);
     }
 
     protected RequestSpecification givenSpec() {


### PR DESCRIPTION
Coverage for Path Param group name containing a dash

JIRA: https://issues.redhat.com/browse/QUARKUS-2893
Issue was present in RESTEasy Reactive, covering the scenario also in RESTEasy Classic module to ensure the same behaviour.

PASS: `mvn clean verify -Dit.test=HttpMinimumReactiveIT -f http/http-minimum-reactive -Dquarkus.platform.version=2.16.1.Final`

PASS: `mvn clean verify -Dit.test=HttpMinimumReactiveIT -f http/http-minimum-reactive -Dquarkus.platform.version=2.7.7.Final`

FAIL: `mvn clean verify -Dit.test=HttpMinimumReactiveIT -f http/http-minimum-reactive -Dquarkus.platform.version=2.7.6.Final`

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)