### PR TITLE
Move Confluent repository definition into relevant module

### DIFF
--- a/messaging/kafka-confluent-avro-reactive-messaging/pom.xml
+++ b/messaging/kafka-confluent-avro-reactive-messaging/pom.xml
@@ -44,6 +44,15 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
     <profiles>
         <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -356,15 +356,6 @@
             </plugin>
         </plugins>
     </build>
-    <repositories>
-        <repository>
-            <id>confluent</id>
-            <url>https://packages.confluent.io/maven/</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
     <profiles>
         <profile>
             <id>env-info</id>


### PR DESCRIPTION
Move Confluent repository definition into relevant module

Confluent repository definition in root pom.xml causes slow build / run of the TS because https://packages.confluent.io/maven/ gets contacted for every artifact that needs to be downloaded. Confluent repository definition is relevant just for `kafka-confluent-avro-reactive-messaging` module

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)