### PR TITLE
[2.13] Disable some Multipart scenarios: missing backport from upstream

### DIFF
--- a/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/RESTEasyReactiveMultipartIT.java
+++ b/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/RESTEasyReactiveMultipartIT.java
@@ -13,11 +13,11 @@ import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.restassured.RestAssured;
 import io.restassured.builder.MultiPartSpecBuilder;
 import io.restassured.http.ContentType;
@@ -86,7 +86,7 @@ public class RESTEasyReactiveMultipartIT {
     @Tag("QUARKUS-2744")
     @Test
     //TODO https://github.com/quarkusio/quarkus/issues/30502
-    @DisabledOnQuarkusVersion(version = "2.13.7.Final", reason = "missing backport from upstream")
+    @Disabled("missing backport from upstream")
     public void testPlainTextFilePartFromMultipart() {
         // verifies that every multipart form data field regardless of media type can be used as file
         // as long as Java data type of DTO field is java.io.File
@@ -110,7 +110,7 @@ public class RESTEasyReactiveMultipartIT {
     @Tag("QUARKUS-2744")
     @Test
     //TODO https://github.com/quarkusio/quarkus/issues/30502
-    @DisabledOnQuarkusVersion(version = "2.13.7.Final", reason = "missing backport from upstream")
+    @Disabled("missing backport from upstream")
     public void testAllFilesPartFromMultipart() {
         // test all file uploads from a multipart form are accessible
         String otherImage = "otherImage";


### PR DESCRIPTION
### Summary

Multipart with several content types is partially fixed but is still failing on quarkus 2.13.7.Final
This PR disable those test that is failing for this 2.13 branch

### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)