### PR TITLE
Adding rest-client-reactive-jackson

### DIFF
--- a/http/jaxrs-reactive/pom.xml
+++ b/http/jaxrs-reactive/pom.xml
@@ -17,6 +17,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-reactive</artifactId>
         </dependency>
         <dependency>

--- a/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/client/MultipartClientIT.java
+++ b/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/client/MultipartClientIT.java
@@ -3,7 +3,6 @@ package io.quarkus.ts.http.jaxrs.reactive.client;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsStringIgnoringCase;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -11,7 +10,6 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 
 @Tag("QUARKUS-1225")
 @QuarkusScenario
-@Disabled("https://github.com/quarkusio/quarkus/issues/30814")
 public class MultipartClientIT {
 
     @Test

--- a/security/keycloak-oidc-client-reactive-basic/pom.xml
+++ b/security/keycloak-oidc-client-reactive-basic/pom.xml
@@ -17,6 +17,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc</artifactId>
         </dependency>
         <dependency>

--- a/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/KeycloakOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/KeycloakOidcClientSecurityIT.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -41,7 +40,6 @@ public class KeycloakOidcClientSecurityIT extends BaseOidcClientSecurityIT {
     }
 
     @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/30814")
     public void authorizationHeaderDoesNotRepeat() {
         final Response response = given()
                 .when()


### PR DESCRIPTION
* Adding rest-client-reactive-jackson extensions to modules using reactive rest client. This change is needed as the server and client extension has been split in https://github.com/quarkusio/quarkus/pull/30529

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)