### PR TITLE
[2.13] re-location of Confluent maven repository and coverage of pathParams groupName with slash

### DIFF
--- a/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/HelloResource.java
+++ b/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/HelloResource.java
@@ -4,9 +4,11 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import io.smallrye.mutiny.Uni;
 
@@ -26,6 +28,12 @@ public class HelloResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<Hello> getJson() {
         return Uni.createFrom().item(new Hello("hello"));
+    }
+
+    @GET
+    @Path("/foo/{something-with-dash:[A-Z0-9]{4}}")
+    public Response doSomething(@PathParam("something-with-dash") String param) {
+        return Response.noContent().build();
     }
 
 }

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpMinimumReactiveIT.java
@@ -23,6 +23,15 @@ public class HttpMinimumReactiveIT {
     }
 
     @Test
+    @Tag("QUARKUS-2893")
+    public void pathParamNameWithDash() {
+        givenSpec().get("/api/hello/foo/AAAA").then().statusCode(HttpStatus.SC_NO_CONTENT);
+        givenSpec().get("/api/hello/foo/AXY9").then().statusCode(HttpStatus.SC_NO_CONTENT);
+        givenSpec().get("/api/hello/foo/ABCDFG").then().statusCode(HttpStatus.SC_NOT_FOUND);
+        givenSpec().get("/api/hello/foo/abcd").then().statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
     @Tag("QUARKUS-1543")
     public void nativeListSerialization() {
         String teamId = (String) givenSpec().get("/api/cluster/default").then()

--- a/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/HelloResource.java
+++ b/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/HelloResource.java
@@ -4,9 +4,11 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Path("/hello")
 public class HelloResource {
@@ -24,5 +26,11 @@ public class HelloResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Hello getJson() {
         return new Hello("hello");
+    }
+
+    @GET
+    @Path("/foo/{something-with-dash:[A-Z0-9]{4}}")
+    public Response doSomething(@PathParam("something-with-dash") String param) {
+        return Response.noContent().build();
     }
 }

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/HttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/HttpMinimumIT.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -17,6 +18,15 @@ public class HttpMinimumIT {
     @Test
     public void httpServer() {
         givenSpec().get("/api/hello").then().statusCode(HttpStatus.SC_OK).body("content", is("Hello, World!"));
+    }
+
+    @Test
+    @Tag("QUARKUS-2893")
+    public void pathParamNameWithDash() {
+        givenSpec().get("/api/hello/foo/AAAA").then().statusCode(HttpStatus.SC_NO_CONTENT);
+        givenSpec().get("/api/hello/foo/AXY9").then().statusCode(HttpStatus.SC_NO_CONTENT);
+        givenSpec().get("/api/hello/foo/ABCDFG").then().statusCode(HttpStatus.SC_NOT_FOUND);
+        givenSpec().get("/api/hello/foo/abcd").then().statusCode(HttpStatus.SC_NOT_FOUND);
     }
 
     protected RequestSpecification givenSpec() {

--- a/messaging/kafka-confluent-avro-reactive-messaging/pom.xml
+++ b/messaging/kafka-confluent-avro-reactive-messaging/pom.xml
@@ -44,6 +44,15 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
     <profiles>
         <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -347,15 +347,6 @@
             </plugin>
         </plugins>
     </build>
-    <repositories>
-        <repository>
-            <id>confluent</id>
-            <url>https://packages.confluent.io/maven/</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
     <profiles>
         <profile>
             <id>env-info</id>


### PR DESCRIPTION
### Summary

- [Move Confluent repository definition into relevant module](https://github.com/quarkus-qe/quarkus-test-suite/pull/1032) rsvoboda
- [Coverage for Path Param group name containing a dash](https://github.com/quarkus-qe/quarkus-test-suite/pull/1031) rsvoboda

Please select the relevant options.
- [X] Backport