### PR TITLE
[2.13] Verify that Transfer-Encoding and Content-Length doesn´t goes together in the same http response

### DIFF
--- a/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/HelloResource.java
+++ b/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/HelloResource.java
@@ -36,4 +36,9 @@ public class HelloResource {
         return Response.noContent().build();
     }
 
+    @GET
+    @Path("/no-content-length")
+    public Response hello() {
+        return Response.ok("hello").header("Transfer-Encoding", "chunked").build();
+    }
 }

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpMinimumReactiveIT.java
@@ -2,6 +2,8 @@ package io.quarkus.ts.http.minimum.reactive;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.http.HttpStatus;
@@ -42,6 +44,20 @@ public class HttpMinimumReactiveIT {
                 .get("team_id");
 
         assertEquals("qe", teamId);
+    }
+
+    @Test
+    @Tag("QUARKUS-2754")
+    public void transferEncodingAndContentLengthHeadersAreNotAllowedTogether() {
+        givenSpec().get("/api/hello/no-content-length").then()
+                .statusCode(HttpStatus.SC_OK)
+                .headers("Transfer-Encoding", "chunked")
+                .headers("Content-Length", is(nullValue()));
+
+        givenSpec().get("/api/hello/json").then()
+                .statusCode(HttpStatus.SC_OK)
+                .headers("Transfer-Encoding", is(nullValue()))
+                .headers("Content-Length", is(notNullValue()));
     }
 
     protected RequestSpecification givenSpec() {

--- a/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/HelloResource.java
+++ b/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/HelloResource.java
@@ -33,4 +33,10 @@ public class HelloResource {
     public Response doSomething(@PathParam("something-with-dash") String param) {
         return Response.noContent().build();
     }
+
+    @GET
+    @Path("/no-content-length")
+    public Response hello() {
+        return Response.ok("hello").header("Transfer-Encoding", "chunked").build();
+    }
 }

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/HttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/HttpMinimumIT.java
@@ -2,6 +2,8 @@ package io.quarkus.ts.http.minimum;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Tag;
@@ -27,6 +29,20 @@ public class HttpMinimumIT {
         givenSpec().get("/api/hello/foo/AXY9").then().statusCode(HttpStatus.SC_NO_CONTENT);
         givenSpec().get("/api/hello/foo/ABCDFG").then().statusCode(HttpStatus.SC_NOT_FOUND);
         givenSpec().get("/api/hello/foo/abcd").then().statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    @Tag("QUARKUS-2754")
+    public void transferEncodingAndContentLengthHeadersAreNotAllowedTogether() {
+        givenSpec().get("/api/hello/no-content-length").then()
+                .statusCode(HttpStatus.SC_OK)
+                .headers("Transfer-Encoding", "chunked")
+                .headers("Content-Length", is(nullValue()));
+
+        givenSpec().get("/api/hello/json").then()
+                .statusCode(HttpStatus.SC_OK)
+                .headers("Transfer-Encoding", is(nullValue()))
+                .headers("Content-Length", is(notNullValue()));
     }
 
     protected RequestSpecification givenSpec() {


### PR DESCRIPTION
backport:

[Verify that Transfer-Encoding and Content-Length doesn´t goes together in the same http response](https://github.com/quarkus-qe/quarkus-test-suite/pull/1046)

Please select the relevant options.
- [X] Backport
