### PR TITLE
Temporary fix for failing CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <failsafe-plugin.version>2.22.2</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.16.1.Final</quarkus.platform.version>
         <quarkus.qe.framework.version>1.3.0.Beta3</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.42.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.12.1.Final</quarkus-ide-config.version>


### PR DESCRIPTION
Because of move to jakarta, our CI broke on 999-SNAPSHOT.
While we adapt our TS to jakarta, it makes sense to temporarily switch to 2.16.1.Final

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)