### PR TITLE
Update lifecycle-application 'quarkus.platform.version' to the latest stream

### DIFF
--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -40,7 +40,7 @@
             </activation>
             <properties>
                 <!-- please keep Mandrel and RHBQ version compatible -->
-                <quarkus.platform.version>2.13.6.Final</quarkus.platform.version>
+                <quarkus.platform.version>2.13.7.Final</quarkus.platform.version>
             </properties>
             <repositories>
                 <repository>


### PR DESCRIPTION
### Summary

Main 'lifecycle-application' wasn´t pointing to the latest stream 
This PR update lifecycle-application 'quarkus.platform.version' to 2.13.7.Final

Note that branch 2.13 was already pointing to the latest version, so doesn´t require a backport 

https://github.com/quarkus-qe/quarkus-test-suite/commit/80b2297bb2fde087235596f3c3fb0fb488adceba

Please select the relevant options.

- [X] Dependency update
