### PR TITLE
Disable CLI tests on native build

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateNativeApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateNativeApplicationIT.java
@@ -7,7 +7,7 @@ import javax.inject.Inject;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
@@ -16,7 +16,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 @Tag("QUARKUS-960")
 @Tag("quarkus-cli")
 @QuarkusScenario
-@EnabledIfSystemProperty(named = "profile.id", matches = "native", disabledReason = "Only for Native verification")
+@DisabledIfSystemProperty(named = "profile.id", matches = "native", disabledReason = "Only for Native verification")
 public class QuarkusCliCreateNativeApplicationIT {
 
     @Inject


### PR DESCRIPTION
### Summary
Before that change, a single test was enabled in CLI for Native Since we do not install Quarkus CLI during Native runs in our Jenkins, this lead to failures.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)