### PR TITLE
Fix Test Suite compilation by removing Kamelet module and fix native build and adjust Pact comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,8 @@ jobs:
 
           for module in $MODULES
           do
-            if [[ "$module" != "messaging/qpid/" && "$module" != "helm/helm-minimum/" && "$module" != "kamelet/" ]] ; then
-              if [[ "${{ steps.files.outputs.all_changed_and_modified_files }}" =~ ("$module") ]] ; then
-                  CHANGED=$(echo $CHANGED" "$module)
-              fi
+            if [[ "${{ steps.files.outputs.all_changed_and_modified_files }}" =~ ("$module") ]] ; then
+                CHANGED=$(echo $CHANGED" "$module)
             fi
           done
 

--- a/http/hibernate-validator/pom.xml
+++ b/http/hibernate-validator/pom.xml
@@ -22,28 +22,4 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- TODO: enable native profile when https://github.com/quarkusio/quarkus/issues/31105 is fixed -->
-        <profile>
-            <id>native</id>
-            <activation>
-                <property>
-                    <name>native</name>
-                </property>
-            </activation>
-            <properties>
-                <quarkus.build.skip>true</quarkus.build.skip>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/http/rest-client-reactive/pom.xml
+++ b/http/rest-client-reactive/pom.xml
@@ -58,27 +58,5 @@
                 </plugins>
             </build>
         </profile>
-        <!-- TODO: enable native profile when https://github.com/quarkusio/quarkus/issues/31105 is fixed -->
-        <profile>
-            <id>native</id>
-            <activation>
-                <property>
-                    <name>native</name>
-                </property>
-            </activation>
-            <properties>
-                <quarkus.build.skip>true</quarkus.build.skip>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/http/rest-client/pom.xml
+++ b/http/rest-client/pom.xml
@@ -28,28 +28,4 @@
             <artifactId>quarkus-micrometer</artifactId>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- TODO: enable native profile when https://github.com/quarkusio/quarkus/issues/31105 is fixed -->
-        <profile>
-            <id>native</id>
-            <activation>
-                <property>
-                    <name>native</name>
-                </property>
-            </activation>
-            <properties>
-                <quarkus.build.skip>true</quarkus.build.skip>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,8 @@
         <checkstyle.version>10.6.0</checkstyle.version>
         <jjwt.version>0.11.5</jjwt.version>
         <jsoup.version>1.15.3</jsoup.version>
-        <camel-quarkus-bom.version>2.16.0</camel-quarkus-bom.version>
+        <!-- TODO: uncomment Camel Quarkus BOM when Camel Quarkus 3 is released -->
+        <!-- <camel-quarkus-bom.version>2.16.0</camel-quarkus-bom.version> -->
         <!-- TODO: https://github.com/quarkiverse/quarkus-helm/issues/114-->
         <!-- <quarkus-helm.version>0.1.1</quarkus-helm.version> -->
         <quarkiverse.config.version>1.1.0</quarkiverse.config.version>
@@ -70,13 +71,15 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus-bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
+            <!-- TODO: uncomment Camel Quarkus BOM when 3.0 is released -->
+            <!-- Disabled due to https://github.com/quarkusio/quarkus/issues/31105#issuecomment-1431441875 -->
+            <!-- <dependency> -->
+            <!-- <groupId>org.apache.camel.quarkus</groupId> -->
+            <!-- <artifactId>camel-quarkus-bom</artifactId> -->
+            <!-- <version>${camel-quarkus-bom.version}</version> -->
+            <!-- <type>pom</type> -->
+            <!-- <scope>import</scope> -->
+            <!-- </dependency> -->
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-avro-serializer</artifactId>
@@ -389,7 +392,9 @@
                 <module>infinispan-client</module>
                 <module>super-size/many-extensions</module>
                 <module>quarkus-cli</module>
-                <module>kamelet</module>
+                <!-- TODO: uncomment Kamelet module when 3.0 is released -->
+                <!-- module does not compile and Camel Quarkus BOM breaks native build of other modules -->
+                <!-- <module>kamelet</module> -->
                 <module>logging/jboss</module>
                 <module>cache/caffeine</module>
                 <module>qute/multimodule</module>
@@ -415,7 +420,9 @@
                 <module>infinispan-client</module>
                 <module>super-size/many-extensions</module>
                 <module>quarkus-cli</module>
-                <module>kamelet</module>
+                <!-- TODO: uncomment Kamelet module when 3.0 is released -->
+                <!-- module does not compile and Camel Quarkus BOM breaks native build of other modules -->
+                <!-- <module>kamelet</module> -->
                 <module>logging/jboss</module>
                 <module>cache/caffeine</module>
             </modules>

--- a/security/keycloak-oidc-client-extended/pom.xml
+++ b/security/keycloak-oidc-client-extended/pom.xml
@@ -42,6 +42,13 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-authz-client</artifactId>
+            <!-- TODO: remove exclusion when https://github.com/quarkusio/quarkus/pull/31188 is merged -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.activation</groupId>
+                    <artifactId>jakarta.activation</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>
@@ -77,28 +84,6 @@
                             <skip>true</skip>
                         </configuration>
                     </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <!-- TODO: enable native profile when https://github.com/quarkusio/quarkus/issues/31105 is fixed -->
-        <profile>
-            <id>native</id>
-            <activation>
-                <property>
-                    <name>native</name>
-                </property>
-            </activation>
-            <properties>
-                <quarkus.build.skip>true</quarkus.build.skip>
-            </properties>
-            <build>
-                <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>

--- a/super-size/many-extensions/pom.xml
+++ b/super-size/many-extensions/pom.xml
@@ -226,27 +226,5 @@
                 </dependency>
             </dependencies>
         </profile>
-        <!-- TODO: enable native profile when https://github.com/quarkusio/quarkus/issues/31105 is fixed -->
-        <profile>
-            <id>native</id>
-            <activation>
-                <property>
-                    <name>native</name>
-                </property>
-            </activation>
-            <properties>
-                <quarkus.build.skip>true</quarkus.build.skip>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/test-tooling/pact/src/test/java/io/quarkus/ts/http/pact/ProviderPactTest.java
+++ b/test-tooling/pact/src/test/java/io/quarkus/ts/http/pact/ProviderPactTest.java
@@ -15,8 +15,10 @@ import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvide
 import au.com.dius.pact.provider.junitsupport.Provider;
 import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
 
-// TODO: mvavrik investigate ASAP!
-@Disabled("Disabled as failing, mvavrik will investigate ASAP")
+// TODO: enable test once we migrate to Quarkus Pact extension, which will be possible after Quarkus 3 is released
+// I believe nature of the failure is identical to https://github.com/quarkiverse/quarkus-pact/issues/73
+// and failure goes down to class loading changes in Quarkus 3
+@Disabled("Disabled until Quarkus Pact 3 is released and we migrate pact module to that extension")
 @QuarkusTest
 @Tag("QUARKUS-1024")
 @Provider("TheProvider")


### PR DESCRIPTION
### Summary

- Right now our test suite does not compile at all thanks to https://github.com/quarkus-qe/quarkus-test-suite/pull/1025 that was never rebased on current main - that is fixed by commenting out kamelet module.
- Native build of multiple modules is fixed by commenting out Camel BOM - https://github.com/quarkusio/quarkus/issues/31105.
- Pact failure goes down to class loading changes in Quarkus 3, IMO we should migrate to Quarkus Pact once it's adapted to Quarkus 3. Comment has been added.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)