### PR TITLE
[2.13] jbang + HQL queries backports

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -145,7 +145,14 @@ public class QuarkusCliCreateJvmApplicationIT {
         QuarkusCliRestService app = cliClient.createApplication("app", defaultWithFixedStream().withExtraArgs("--jbang"));
 
         // Should build on Jvm
-        Result result = app.buildOnJvm("--verbose");
+        final String repository = System.getProperty("maven.repo.local");
+        final Result result;
+        if (repository == null) {
+            result = app.buildOnJvm("--verbose");
+        } else {
+            result = app.buildOnJvm("--verbose", "--", "--repos", "local=file://" + repository);
+        }
+
         assertTrue(result.isSuccessful(), "The application didn't build on JVM. Output: " + result.getOutput());
 
         // Start using DEV mode

--- a/sql-db/hibernate-reactive/src/main/java/io/quarkus/ts/hibernate/reactive/http/PanacheEndpoint.java
+++ b/sql-db/hibernate-reactive/src/main/java/io/quarkus/ts/hibernate/reactive/http/PanacheEndpoint.java
@@ -141,4 +141,20 @@ public class PanacheEndpoint {
                 })
                 .map(Response.ResponseBuilder::build);
     }
+
+    @GET
+    @Path("by-author/{name}")
+    public Uni<Response> searchByAuthor(String name) {
+        return Book
+                .find("SELECT book.title \nFROM Book book \n JOIN Author author on author.id=book.author\n WHERE author.name=?1",
+                        name)
+                .project(BookDescription.class).list()
+                .map(books -> books.isEmpty()
+                        ? Response.status(Response.Status.NOT_FOUND)
+                        : Response.ok(books))
+                .onFailure().recoverWithItem(error -> {
+                    return Response.status(Response.Status.BAD_REQUEST).entity(error.getMessage());
+                })
+                .map(Response.ResponseBuilder::build);
+    }
 }

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/AbstractDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/AbstractDatabaseHibernateReactiveIT.java
@@ -1,11 +1,14 @@
 package io.quarkus.ts.hibernate.reactive;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -285,6 +288,15 @@ public abstract class AbstractDatabaseHibernateReactiveIT {
                 .contentType(ContentType.JSON)
                 .post("hibernate/books/pablo/suntzu")
                 .then().statusCode(HttpStatus.SC_CREATED);
+    }
+
+    @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/31117")
+    public void newLineInQuery() {
+        Response author = getApp().given()
+                .get("/library/by-author/Dlugi");
+        assertEquals(HttpStatus.SC_OK, author.statusCode());
+        assertThat(author.body().asString(), containsString("Slovník"));
     }
 
     protected abstract RestService getApp();


### PR DESCRIPTION
### Summary

[Add coverage for new lines in HQL queries](https://github.com/quarkus-qe/quarkus-test-suite/pull/1056) fedinskiy
[Make jbang use the same repository as maven](https://github.com/quarkus-qe/quarkus-test-suite/pull/1058) fedinskiy

Please select the relevant options.
- [X] Backport

