### PR TITLE
Remove 'jakarta.activation' exclusion from Keycloak OIDC Client extended

### DIFF
--- a/security/keycloak-oidc-client-extended/pom.xml
+++ b/security/keycloak-oidc-client-extended/pom.xml
@@ -42,13 +42,6 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-authz-client</artifactId>
-            <!-- TODO: remove exclusion when https://github.com/quarkusio/quarkus/pull/31188 is merged -->
-            <exclusions>
-                <exclusion>
-                    <groupId>com.sun.activation</groupId>
-                    <artifactId>jakarta.activation</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>


### PR DESCRIPTION
### Summary

https://github.com/quarkusio/quarkus/pull/31188 is merged and Jakarta activation exclusion is no longer needed for native build.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)