### PR TITLE
Bump Quarkus Test Framework to 1.3.0.Beta6 and disable OpenShift tests and Hibernate Reactive

### DIFF
--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftBaseConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftBaseConfigIT.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 import jakarta.inject.Inject;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -19,6 +20,7 @@ import io.quarkus.test.bootstrap.inject.OpenShiftClient;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public abstract class OpenShiftBaseConfigIT {
 

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftConfigSourcePriorityIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftConfigSourcePriorityIT.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import jakarta.inject.Inject;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -20,6 +21,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.response.Response;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftConfigSourcePriorityIT {
 

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftFailOnMissingConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftFailOnMissingConfigIT.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.configmap.api.server;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -9,6 +10,7 @@ import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftFailOnMissingConfigIT {
 

--- a/funqy/knative-events/src/test/java/io/quarkus/ts/funqy/knativeevents/ServerlessExtensionOpenShiftFunqyKnEventsIT.java
+++ b/funqy/knative-events/src/test/java/io/quarkus/ts/funqy/knativeevents/ServerlessExtensionOpenShiftFunqyKnEventsIT.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +36,7 @@ import io.quarkus.test.services.knative.eventing.OpenShiftExtensionFunqyKnativeE
 import io.quarkus.test.services.knative.eventing.spi.ForwardResponseDTO;
 import io.restassured.common.mapper.TypeRef;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumReactiveIT.java
@@ -1,10 +1,12 @@
 package io.quarkus.ts.http.minimum.reactive;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumReactiveIT extends HttpMinimumReactiveIT {

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionHttpMinimumReactiveIT.java
@@ -1,10 +1,12 @@
 package io.quarkus.ts.http.minimum.reactive;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionHttpMinimumReactiveIT extends HttpMinimumReactiveIT {

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumReactiveIT.java
@@ -2,12 +2,14 @@ package io.quarkus.ts.http.minimum.reactive;
 
 import static io.restassured.RestAssured.given;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionOpenShiftHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionOpenShiftHttpMinimumReactiveIT.java
@@ -2,12 +2,14 @@ package io.quarkus.ts.http.minimum.reactive;
 
 import static io.restassured.RestAssured.given;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumIT.java
@@ -1,10 +1,12 @@
 package io.quarkus.ts.http.minimum;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumIT extends HttpMinimumIT {

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionHttpMinimumIT.java
@@ -1,10 +1,12 @@
 package io.quarkus.ts.http.minimum;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionHttpMinimumIT extends HttpMinimumIT {

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumIT.java
@@ -2,12 +2,14 @@ package io.quarkus.ts.http.minimum;
 
 import static io.restassured.RestAssured.given;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionOpenShiftHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionOpenShiftHttpMinimumIT.java
@@ -2,12 +2,14 @@ package io.quarkus.ts.http.minimum;
 
 import static io.restassured.RestAssured.given;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)

--- a/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/OpenShiftCompressionHandlerIT.java
+++ b/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/OpenShiftCompressionHandlerIT.java
@@ -1,11 +1,13 @@
 package io.quarkus.ts.http.jaxrs.reactive;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 // OCP Native coverage is not required (Test plan QUARKUS-2487), due to a lack of resources and the ROI.

--- a/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/OpenShiftHttpCachingIT.java
+++ b/http/jaxrs-reactive/src/test/java/io/quarkus/ts/http/jaxrs/reactive/OpenShiftHttpCachingIT.java
@@ -1,10 +1,12 @@
 package io.quarkus.ts.http.jaxrs.reactive;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftHttpCachingIT extends HttpCachingIT {

--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/OpenShiftUsingExtensionDockerBuildStrategyVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/OpenShiftUsingExtensionDockerBuildStrategyVertxIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.vertx;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -8,6 +9,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingExtensionDockerBuildStrategyVertxIT extends AbstractVertxIT {

--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/OpenShiftUsingExtensionVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/OpenShiftUsingExtensionVertxIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.vertx;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -8,6 +9,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionVertxIT extends AbstractVertxIT {

--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionDockerBuildStrategyOpenShiftVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionDockerBuildStrategyOpenShiftVertxIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.vertx;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -8,6 +9,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)

--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionOpenShiftVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionOpenShiftVertxIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.vertx;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -8,6 +9,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)

--- a/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanCountersIT.java
+++ b/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanCountersIT.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.utils.Command;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class OperatorOpenShiftInfinispanCountersIT extends BaseOpenShiftInfinispanIT {

--- a/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanObjectsIT.java
+++ b/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanObjectsIT.java
@@ -26,6 +26,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.infinispan.client.serialized.ShopItem;
 import io.restassured.response.Response;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class OperatorOpenShiftInfinispanObjectsIT extends BaseOpenShiftInfinispanIT {

--- a/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/OpenShiftLifecycleApplicationIT.java
+++ b/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/OpenShiftLifecycleApplicationIT.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/29451")
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftLifecycleApplicationIT extends LifecycleApplicationIT {
 

--- a/monitoring/micrometer-prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/OpenShiftCustomMetricsIT.java
+++ b/monitoring/micrometer-prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/OpenShiftCustomMetricsIT.java
@@ -12,6 +12,7 @@ import jakarta.inject.Inject;
 import org.apache.http.HttpStatus;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -26,6 +27,7 @@ import io.quarkus.test.services.QuarkusApplication;
  * - `prime_number_max_{uniqueId}`: max prime number that is found.
  * - `prime_number_test_{uniqueId}`: with information about the calculation of the prime number.
  */
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftCustomMetricsIT {
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <quarkus.qe.framework.version>1.3.0.Beta5</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.3.0.Beta6</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.42.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.12.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.14</apache-httpclient-fluent.version>
@@ -553,7 +553,8 @@
                 <module>sql-db/panache-flyway</module>
                 <module>sql-db/reactive-rest-data-panache</module>
                 <module>sql-db/vertx-sql</module>
-                <module>sql-db/hibernate-reactive</module>
+                <!-- TODO: enable when https://github.com/quarkusio/quarkus/pull/31217 us reverted -->
+                <!-- <module>sql-db/hibernate-reactive</module> -->
                 <module>sql-db/reactive-vanilla</module>
                 <module>sql-db/hibernate-fulltext-search</module>
                 <module>sql-db/narayana-transactions</module>
@@ -585,7 +586,8 @@
             <modules>
                 <module>env-info</module>
                 <module>service-binding/postgresql-crunchy-classic</module>
-                <module>service-binding/postgresql-crunchy-reactive</module>
+                <!-- TODO: enable when https://github.com/quarkusio/quarkus/pull/31217 us reverted -->
+                <!-- <module>service-binding/postgresql-crunchy-reactive</module> -->
             </modules>
         </profile>
         <profile>
@@ -600,7 +602,8 @@
                 <module>env-info</module>
                 <module>spring/spring-data</module>
                 <module>spring/spring-web</module>
-                <module>spring/spring-web-reactive</module>
+                <!-- TODO: enable when https://github.com/quarkusio/quarkus/pull/31217 us reverted -->
+                <!-- <module>spring/spring-web-reactive</module> -->
                 <module>spring/spring-properties</module>
                 <module>spring/spring-cloud-config</module>
                 <module>cache/spring</module>

--- a/service-discovery/stork/pom.xml
+++ b/service-discovery/stork/pom.xml
@@ -27,7 +27,7 @@
         <!-- bouncycastle is required by stork-service-discovery-kubernetes in native mode-->
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
         <!-- https://github.com/quarkusio/quarkus/issues/27886 -->
         <!-- quarkus-kubernetes-client is required by stork-service-discovery-kubernetes in native mode-->

--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/OpenShiftUsingExtensionDockerBuildStrategyManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/OpenShiftUsingExtensionDockerBuildStrategyManyExtensionsIT.java
@@ -1,10 +1,12 @@
 package io.quarkus.ts.many.extensions;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingExtensionDockerBuildStrategyManyExtensionsIT extends ManyExtensionsIT {

--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/OpenShiftUsingExtensionManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/OpenShiftUsingExtensionManyExtensionsIT.java
@@ -1,10 +1,12 @@
 package io.quarkus.ts.many.extensions;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionManyExtensionsIT extends ManyExtensionsIT {

--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionDockerBuildStrategyOpenShiftManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionDockerBuildStrategyOpenShiftManyExtensionsIT.java
@@ -2,12 +2,14 @@ package io.quarkus.ts.many.extensions;
 
 import static io.restassured.RestAssured.given;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)

--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionOpenShiftManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionOpenShiftManyExtensionsIT.java
@@ -2,12 +2,14 @@ package io.quarkus.ts.many.extensions;
 
 import static io.restassured.RestAssured.given;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)


### PR DESCRIPTION
### Summary

- Disable tests that use Quarkus Openshift extension due to https://github.com/quarkusio/quarkus/issues/31228
- Bump Quarkus Test Framework version to 1.3.0.Beta6, which fixes NPE for tests that enrich OpenShift template
- Dependency `org.bouncycastle:bcpkix-jdk15on` is no longer managed by Quarkus, therefore I went with `jdk18on`
- Disable Hibernate Reactive, PostgreSQL Service binding reactive and Spring Web Reactive modules due to https://github.com/quarkusio/quarkus/pull/31217

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)