### PR TITLE
Use explicit version of kafka operator

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.operator.KafkaInstance;
 @OpenShiftScenario
 public class OperatorOpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTest {
     @Operator(name = "amq-streams", source = "redhat-operators")
-    static KafkaInstance kafka = new KafkaInstance();
+    static KafkaInstance kafka = new KafkaInstance("kafka-instance", "/strimzi-operator-kafka-updated.yaml");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/messaging/kafka-streams-reactive-messaging/src/test/resources/strimzi-operator-kafka-updated.yaml
+++ b/messaging/kafka-streams-reactive-messaging/src/test/resources/strimzi-operator-kafka-updated.yaml
@@ -1,0 +1,38 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: kafka-instance
+spec:
+  kafka:
+    version: 3.3.1
+    replicas: 1
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      log.message.format.version: "3.1-IV0"
+    storage:
+      type: jbod
+      volumes:
+        - id: 0
+          type: persistent-claim
+          size: 100Mi
+          deleteClaim: true
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 100Mi
+      deleteClaim: true
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}


### PR DESCRIPTION
### Summary

Version of kafka operator in the test framework is incompatible with our cluster. Since 2.7 will stop being supported soon, there is not reason to do a release of the framework, so we will do just an ad-hoc fix

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)