### PR TITLE
Disable OpenShift config module tests due to upstream issue

### DIFF
--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftApiServerConfigMapConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftApiServerConfigMapConfigIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.ts.configmap.api.server;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.services.QuarkusApplication;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 public class OpenShiftApiServerConfigMapConfigIT extends OpenShiftBaseConfigIT {
 
     @QuarkusApplication

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftApiServerConfigSecretConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftApiServerConfigSecretConfigIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.ts.configmap.api.server;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.services.QuarkusApplication;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 public class OpenShiftApiServerConfigSecretConfigIT extends OpenShiftBaseConfigIT {
 
     @QuarkusApplication

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftFileSystemConfigMapConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftFileSystemConfigMapConfigIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.ts.configmap.api.server;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.services.QuarkusApplication;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 public class OpenShiftFileSystemConfigMapConfigIT extends OpenShiftBaseConfigIT {
 
     @QuarkusApplication

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftFileSystemConfigSecretConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftFileSystemConfigSecretConfigIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.ts.configmap.api.server;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.services.QuarkusApplication;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 public class OpenShiftFileSystemConfigSecretConfigIT extends OpenShiftBaseConfigIT {
 
     @QuarkusApplication


### PR DESCRIPTION
### Summary

Disables test in config module due to https://github.com/quarkusio/quarkus/issues/31228. I intentionally do not run OC CI (`run tests`) as 

1. disabling can't break anything 
2. loads of OC tests are failing over `NoClassDefFoundError`, which is unrelated and debugging is WIP.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)