### PR TITLE
Fix Test Suite compilation broken by bump to Hibernate 6.2 in Quarkus

### DIFF
--- a/sql-db/panache-flyway/src/main/java/io/quarkus/ts/sqldb/panacheflyway/ApplicationEntity.java
+++ b/sql-db/panache-flyway/src/main/java/io/quarkus/ts/sqldb/panacheflyway/ApplicationEntity.java
@@ -27,9 +27,9 @@ import com.fasterxml.jackson.annotation.JsonManagedReference;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 @Entity(name = "application")
-@FilterDef(name = "useLikeByName", parameters = { @ParamDef(name = "name", type = "string") })
+@FilterDef(name = "useLikeByName", parameters = { @ParamDef(name = "name", type = String.class) })
 @Filter(name = "useLikeByName", condition = "name like :name")
-@FilterDef(name = "useServiceByName", parameters = { @ParamDef(name = "name", type = "string") })
+@FilterDef(name = "useServiceByName", parameters = { @ParamDef(name = "name", type = String.class) })
 public class ApplicationEntity extends PanacheEntityBase {
 
     @Id

--- a/sql-db/reactive-rest-data-panache/src/main/java/io/quarkus/ts/reactive/rest/data/panache/ApplicationEntity.java
+++ b/sql-db/reactive-rest-data-panache/src/main/java/io/quarkus/ts/reactive/rest/data/panache/ApplicationEntity.java
@@ -27,9 +27,9 @@ import com.fasterxml.jackson.annotation.JsonManagedReference;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 @Entity(name = "application")
-@FilterDef(name = "useLikeByName", parameters = { @ParamDef(name = "name", type = "string") })
+@FilterDef(name = "useLikeByName", parameters = { @ParamDef(name = "name", type = String.class) })
 @Filter(name = "useLikeByName", condition = "name like :name")
-@FilterDef(name = "useServiceByName", parameters = { @ParamDef(name = "name", type = "string") })
+@FilterDef(name = "useServiceByName", parameters = { @ParamDef(name = "name", type = String.class) })
 public class ApplicationEntity extends PanacheEntityBase {
 
     @Id


### PR DESCRIPTION
### Summary

https://github.com/quarkusio/quarkus/pull/31235 upgraded Hibernate to version 6.2. `org.hibernate.annotations.ParamDef#type` now accepts `Class` instead of plain string. Because of that, TS don't compile.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)