### PR TITLE
Hibernate 6 migration - use dedicated sequence for each table

### DIFF
--- a/sql-db/multiple-pus/src/main/resources/import-fruits.sql
+++ b/sql-db/multiple-pus/src/main/resources/import-fruits.sql
@@ -1,8 +1,7 @@
-INSERT INTO fruit (id, name) VALUES (1, 'Apple');
-INSERT INTO fruit (id, name) VALUES (2, 'Pear');
-INSERT INTO fruit (id, name) VALUES (3, 'Strawberry');
-INSERT INTO fruit (id, name) VALUES (4, 'Plum');
-INSERT INTO fruit (id, name) VALUES (5, 'Cherry');
-INSERT INTO fruit (id, name) VALUES (6, 'Berry');
-INSERT INTO fruit (id, name) VALUES (7, 'Cranberry');
-UPDATE hibernate_sequence SET next_val = 8;
+INSERT INTO fruit (id, name) VALUES (NEXT VALUE FOR fruit_SEQ, 'Apple');
+INSERT INTO fruit (id, name) VALUES (NEXT VALUE FOR fruit_SEQ, 'Pear');
+INSERT INTO fruit (id, name) VALUES (NEXT VALUE FOR fruit_SEQ, 'Strawberry');
+INSERT INTO fruit (id, name) VALUES (NEXT VALUE FOR fruit_SEQ, 'Plum');
+INSERT INTO fruit (id, name) VALUES (NEXT VALUE FOR fruit_SEQ, 'Cherry');
+INSERT INTO fruit (id, name) VALUES (NEXT VALUE FOR fruit_SEQ, 'Berry');
+INSERT INTO fruit (id, name) VALUES (NEXT VALUE FOR fruit_SEQ, 'Cranberry');

--- a/sql-db/multiple-pus/src/main/resources/import-vegetables.sql
+++ b/sql-db/multiple-pus/src/main/resources/import-vegetables.sql
@@ -1,7 +1,7 @@
-INSERT INTO vegetable (id, name) VALUES (nextval('hibernate_sequence'), 'Potato');
-INSERT INTO vegetable (id, name) VALUES (nextval('hibernate_sequence'), 'Carrot');
-INSERT INTO vegetable (id, name) VALUES (nextval('hibernate_sequence'), 'Parsley');
-INSERT INTO vegetable (id, name) VALUES (nextval('hibernate_sequence'), 'Kohlrabi');
-INSERT INTO vegetable (id, name) VALUES (nextval('hibernate_sequence'), 'Leek');
-INSERT INTO vegetable (id, name) VALUES (nextval('hibernate_sequence'), 'Onion');
-INSERT INTO vegetable (id, name) VALUES (nextval('hibernate_sequence'), 'Garlic');
+INSERT INTO vegetable (id, name) VALUES (nextval('vegetable_SEQ'), 'Potato');
+INSERT INTO vegetable (id, name) VALUES (nextval('vegetable_SEQ'), 'Carrot');
+INSERT INTO vegetable (id, name) VALUES (nextval('vegetable_SEQ'), 'Parsley');
+INSERT INTO vegetable (id, name) VALUES (nextval('vegetable_SEQ'), 'Kohlrabi');
+INSERT INTO vegetable (id, name) VALUES (nextval('vegetable_SEQ'), 'Leek');
+INSERT INTO vegetable (id, name) VALUES (nextval('vegetable_SEQ'), 'Onion');
+INSERT INTO vegetable (id, name) VALUES (nextval('vegetable_SEQ'), 'Garlic');

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/AbstractMultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/AbstractMultiplePersistenceIT.java
@@ -50,7 +50,7 @@ public abstract class AbstractMultiplePersistenceIT {
     @Test
     public void getFruitById() {
         getApp().given()
-                .get("/fruit/7")
+                .get("/fruit/301")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("name", equalTo("Cranberry"));
@@ -229,7 +229,7 @@ public abstract class AbstractMultiplePersistenceIT {
     @Test
     public void getVegetableById() {
         getApp().given()
-                .get("/vegetable/7")
+                .get("/vegetable/301")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("name", equalTo("Garlic"));

--- a/sql-db/narayana-transactions/src/main/resources/import.sql
+++ b/sql-db/narayana-transactions/src/main/resources/import.sql
@@ -1,6 +1,6 @@
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('hibernate_sequence'), 'Garcilaso', 'de la Vega', 'CZ9250512252717368964232', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('hibernate_sequence'), 'Miguel', 'de Cervantes', 'SK0389852379529966291984', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('hibernate_sequence'), 'Luis', 'de Góngora', 'ES8521006742088984966816', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('hibernate_sequence'), 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('hibernate_sequence'), 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('Account_SEQ'), 'Garcilaso', 'de la Vega', 'CZ9250512252717368964232', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('Account_SEQ'), 'Miguel', 'de Cervantes', 'SK0389852379529966291984', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('Account_SEQ'), 'Luis', 'de Góngora', 'ES8521006742088984966816', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('Account_SEQ'), 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('Account_SEQ'), 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
 

--- a/sql-db/narayana-transactions/src/test/resources/mariadb_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/mariadb_import.sql
@@ -1,7 +1,5 @@
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (0, 'Garcilaso', 'de la Vega', 'CZ9250512252717368964232', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (1, 'Miguel', 'de Cervantes', 'SK0389852379529966291984', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (2, 'Luis', 'de Góngora', 'ES8521006742088984966816', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (3, 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (5, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
-
-UPDATE hibernate_sequence SET next_val = 5;
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Garcilaso', 'de la Vega', 'CZ9250512252717368964232', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Miguel', 'de Cervantes', 'SK0389852379529966291984', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Luis', 'de Góngora', 'ES8521006742088984966816', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);

--- a/sql-db/narayana-transactions/src/test/resources/mssql_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/mssql_import.sql
@@ -1,6 +1,6 @@
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR hibernate_sequence, 'Garcilaso', 'de la Vega', 'CZ9250512252717368964232', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR hibernate_sequence, 'Miguel', 'de Cervantes', 'SK0389852379529966291984', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR hibernate_sequence, 'Luis', 'de Góngora', 'ES8521006742088984966816', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR hibernate_sequence, 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR hibernate_sequence, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR Account_SEQ, 'Garcilaso', 'de la Vega', 'CZ9250512252717368964232', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR Account_SEQ, 'Miguel', 'de Cervantes', 'SK0389852379529966291984', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR Account_SEQ, 'Luis', 'de Góngora', 'ES8521006742088984966816', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR Account_SEQ, 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR Account_SEQ, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
 

--- a/sql-db/narayana-transactions/src/test/resources/mysql.properties
+++ b/sql-db/narayana-transactions/src/test/resources/mysql.properties
@@ -1,6 +1,5 @@
 quarkus.datasource.db-kind=mysql
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB102Dialect
-quarkus.hibernate-orm.sql-load-script=mariadb_import.sql
+quarkus.hibernate-orm.sql-load-script=mysql_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.opentelemetry.enabled=true
 quarkus.application.name=narayanaTransactions

--- a/sql-db/narayana-transactions/src/test/resources/mysql_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/mysql_import.sql
@@ -1,0 +1,6 @@
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) SELECT IFNULL(MAX(id) + 1, 1), 'Garcilaso', 'de la Vega', 'CZ9250512252717368964232', 100, null, CURRENT_TIMESTAMP FROM account;
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) SELECT MAX(id) + 1, 'Miguel', 'de Cervantes', 'SK0389852379529966291984', 100, null, CURRENT_TIMESTAMP FROM account;
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) SELECT MAX(id) + 1, 'Luis', 'de Góngora', 'ES8521006742088984966816', 100, null, CURRENT_TIMESTAMP FROM account;
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) SELECT MAX(id) + 1, 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP FROM account;
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) SELECT MAX(id) + 1, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP FROM account;
+UPDATE account_SEQ SET next_val=(SELECT MAX(id) + 1 FROM account);

--- a/sql-db/narayana-transactions/src/test/resources/oracle_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/oracle_import.sql
@@ -1,5 +1,5 @@
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (hibernate_sequence.NEXTVAL, 'Garcilaso', 'de la Vega', 'CZ9250512252717368964232', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (hibernate_sequence.NEXTVAL, 'Miguel', 'de Cervantes', 'SK0389852379529966291984', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (hibernate_sequence.NEXTVAL, 'Luis', 'de Góngora', 'ES8521006742088984966816', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (hibernate_sequence.NEXTVAL, 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP);
-INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (hibernate_sequence.NEXTVAL, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (Account_SEQ.NEXTVAL, 'Garcilaso', 'de la Vega', 'CZ9250512252717368964232', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (Account_SEQ.NEXTVAL, 'Miguel', 'de Cervantes', 'SK0389852379529966291984', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (Account_SEQ.NEXTVAL, 'Luis', 'de Góngora', 'ES8521006742088984966816', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (Account_SEQ.NEXTVAL, 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (Account_SEQ.NEXTVAL, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);

--- a/sql-db/sql-app/src/main/java/io/quarkus/ts/sqldb/sqlapp/Book.java
+++ b/sql-db/sql-app/src/main/java/io/quarkus/ts/sqldb/sqlapp/Book.java
@@ -1,14 +1,24 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 
-import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 @Entity
 @Table(name = "book")
-public class Book extends PanacheEntity {
+public class Book extends PanacheEntityBase {
+
+    @Id
+    @SequenceGenerator(name = "bookSequence", sequenceName = "SEQ_Book", allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "bookSequence")
+    public Long id;
+
     @NotBlank(message = "book title must be set")
     public String title;
 

--- a/sql-db/sql-app/src/main/resources/import.sql
+++ b/sql-db/sql-app/src/main/resources/import.sql
@@ -1,7 +1,7 @@
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Foundation', 'Isaac Asimov');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), '2001: A Space Odyssey', 'Arthur C. Clarke');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Stranger in a Strange Land', 'Robert A. Heinlein');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Ender''s Game', 'Orson Scott Card');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Hyperion', 'Dan Simmons');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Anathem', 'Neal Stephenson');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Perdido Street Station', 'China Miéville');
+INSERT INTO book (id, title, author) VALUES (nextval('SEQ_Book'), 'Foundation', 'Isaac Asimov');
+INSERT INTO book (id, title, author) VALUES (nextval('SEQ_Book'), '2001: A Space Odyssey', 'Arthur C. Clarke');
+INSERT INTO book (id, title, author) VALUES (nextval('SEQ_Book'), 'Stranger in a Strange Land', 'Robert A. Heinlein');
+INSERT INTO book (id, title, author) VALUES (nextval('SEQ_Book'), 'Ender''s Game', 'Orson Scott Card');
+INSERT INTO book (id, title, author) VALUES (nextval('SEQ_Book'), 'Hyperion', 'Dan Simmons');
+INSERT INTO book (id, title, author) VALUES (nextval('SEQ_Book'), 'Anathem', 'Neal Stephenson');
+INSERT INTO book (id, title, author) VALUES (nextval('SEQ_Book'), 'Perdido Street Station', 'China Miéville');

--- a/sql-db/sql-app/src/test/resources/db2_app.properties
+++ b/sql-db/sql-app/src/test/resources/db2_app.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=db2
 #quarkus.hibernate-orm.dialect=org.hibernate.dialect.DB2Dialect
 quarkus.hibernate-orm.sql-load-script=db2_import.sql
-quarkus.hibernate-orm.database.generation=drop-and-create

--- a/sql-db/sql-app/src/test/resources/db2_import.sql
+++ b/sql-db/sql-app/src/test/resources/db2_import.sql
@@ -1,7 +1,7 @@
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Foundation', 'Isaac Asimov');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, '2001: A Space Odyssey', 'Arthur C. Clarke');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Stranger in a Strange Land', 'Robert A. Heinlein');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Ender''s Game', 'Orson Scott Card');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Hyperion', 'Dan Simmons');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Anathem', 'Neal Stephenson');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Perdido Street Station', 'China Miéville');
+INSERT INTO book (id, title, author) VALUES (SEQ_Book.NEXTVAL, 'Foundation', 'Isaac Asimov');
+INSERT INTO book (id, title, author) VALUES (SEQ_Book.NEXTVAL, '2001: A Space Odyssey', 'Arthur C. Clarke');
+INSERT INTO book (id, title, author) VALUES (SEQ_Book.NEXTVAL, 'Stranger in a Strange Land', 'Robert A. Heinlein');
+INSERT INTO book (id, title, author) VALUES (SEQ_Book.NEXTVAL, 'Ender''s Game', 'Orson Scott Card');
+INSERT INTO book (id, title, author) VALUES (SEQ_Book.NEXTVAL, 'Hyperion', 'Dan Simmons');
+INSERT INTO book (id, title, author) VALUES (SEQ_Book.NEXTVAL, 'Anathem', 'Neal Stephenson');
+INSERT INTO book (id, title, author) VALUES (SEQ_Book.NEXTVAL, 'Perdido Street Station', 'China Miéville');

--- a/sql-db/sql-app/src/test/resources/mariadb_import.sql
+++ b/sql-db/sql-app/src/test/resources/mariadb_import.sql
@@ -1,8 +1,7 @@
-INSERT INTO book (id, title, author) VALUES (1, 'Foundation', 'Isaac Asimov');
-INSERT INTO book (id, title, author) VALUES (2, '2001: A Space Odyssey', 'Arthur C. Clarke');
-INSERT INTO book (id, title, author) VALUES (3, 'Stranger in a Strange Land', 'Robert A. Heinlein');
-INSERT INTO book (id, title, author) VALUES (4, 'Ender''s Game', 'Orson Scott Card');
-INSERT INTO book (id, title, author) VALUES (5, 'Hyperion', 'Dan Simmons');
-INSERT INTO book (id, title, author) VALUES (6, 'Anathem', 'Neal Stephenson');
-INSERT INTO book (id, title, author) VALUES (7, 'Perdido Street Station', 'China Miéville');
-UPDATE hibernate_sequence SET next_val = 8;
+INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR SEQ_Book, 'Foundation', 'Isaac Asimov');
+INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR SEQ_Book, '2001: A Space Odyssey', 'Arthur C. Clarke');
+INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR SEQ_Book, 'Stranger in a Strange Land', 'Robert A. Heinlein');
+INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR SEQ_Book, 'Ender''s Game', 'Orson Scott Card');
+INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR SEQ_Book, 'Hyperion', 'Dan Simmons');
+INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR SEQ_Book, 'Anathem', 'Neal Stephenson');
+INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR SEQ_Book, 'Perdido Street Station', 'China Miéville');

--- a/sql-db/sql-app/src/test/resources/mssql_import.sql
+++ b/sql-db/sql-app/src/test/resources/mssql_import.sql
@@ -1,7 +1,7 @@
-INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR hibernate_sequence, 'Foundation', 'Isaac Asimov');
-INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR hibernate_sequence, '2001: A Space Odyssey', 'Arthur C. Clarke');
-INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR hibernate_sequence, 'Stranger in a Strange Land', 'Robert A. Heinlein');
-INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR hibernate_sequence, 'Ender''s Game', 'Orson Scott Card');
-INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR hibernate_sequence, 'Hyperion', 'Dan Simmons');
-INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR hibernate_sequence, 'Anathem', 'Neal Stephenson');
-INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR hibernate_sequence, 'Perdido Street Station', 'China Miéville');
+INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR SEQ_Book, 'Foundation', 'Isaac Asimov');
+INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR SEQ_Book, '2001: A Space Odyssey', 'Arthur C. Clarke');
+INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR SEQ_Book, 'Stranger in a Strange Land', 'Robert A. Heinlein');
+INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR SEQ_Book, 'Ender''s Game', 'Orson Scott Card');
+INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR SEQ_Book, 'Hyperion', 'Dan Simmons');
+INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR SEQ_Book, 'Anathem', 'Neal Stephenson');
+INSERT INTO book (id, title, author) VALUES (NEXT VALUE FOR SEQ_Book, 'Perdido Street Station', 'China Miéville');

--- a/sql-db/sql-app/src/test/resources/mysql.properties
+++ b/sql-db/sql-app/src/test/resources/mysql.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=mysql
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB102Dialect
-quarkus.hibernate-orm.sql-load-script=mariadb_import.sql
+quarkus.hibernate-orm.sql-load-script=mysql_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create

--- a/sql-db/sql-app/src/test/resources/mysql_import.sql
+++ b/sql-db/sql-app/src/test/resources/mysql_import.sql
@@ -1,0 +1,8 @@
+INSERT INTO book (id, title, author) SELECT IFNULL(MAX(id) + 1, 1), 'Foundation', 'Isaac Asimov' FROM book;
+INSERT INTO book (id, title, author) SELECT MAX(id) + 1, '2001: A Space Odyssey', 'Arthur C. Clarke' FROM book;
+INSERT INTO book (id, title, author) SELECT MAX(id) + 1, 'Stranger in a Strange Land', 'Robert A. Heinlein' FROM book;
+INSERT INTO book (id, title, author) SELECT MAX(id) + 1, 'Ender''s Game', 'Orson Scott Card' FROM book;
+INSERT INTO book (id, title, author) SELECT MAX(id) + 1, 'Hyperion', 'Dan Simmons' FROM book;
+INSERT INTO book (id, title, author) SELECT MAX(id) + 1, 'Anathem', 'Neal Stephenson' FROM book;
+INSERT INTO book (id, title, author) SELECT MAX(id) + 1, 'Perdido Street Station', 'China Miéville' FROM book;
+UPDATE SEQ_Book SET next_val=(SELECT max(id) + 1 FROM book);

--- a/sql-db/sql-app/src/test/resources/oracle_import.sql
+++ b/sql-db/sql-app/src/test/resources/oracle_import.sql
@@ -1,7 +1,7 @@
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Foundation', 'Isaac Asimov');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, '2001: A Space Odyssey', 'Arthur C. Clarke');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Stranger in a Strange Land', 'Robert A. Heinlein');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Ender''s Game', 'Orson Scott Card');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Hyperion', 'Dan Simmons');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Anathem', 'Neal Stephenson');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Perdido Street Station', 'China Miéville');
+INSERT INTO book (id, title, author) VALUES (SEQ_Book.NEXTVAL, 'Foundation', 'Isaac Asimov');
+INSERT INTO book (id, title, author) VALUES (SEQ_Book.NEXTVAL, '2001: A Space Odyssey', 'Arthur C. Clarke');
+INSERT INTO book (id, title, author) VALUES (SEQ_Book.NEXTVAL, 'Stranger in a Strange Land', 'Robert A. Heinlein');
+INSERT INTO book (id, title, author) VALUES (SEQ_Book.NEXTVAL, 'Ender''s Game', 'Orson Scott Card');
+INSERT INTO book (id, title, author) VALUES (SEQ_Book.NEXTVAL, 'Hyperion', 'Dan Simmons');
+INSERT INTO book (id, title, author) VALUES (SEQ_Book.NEXTVAL, 'Anathem', 'Neal Stephenson');
+INSERT INTO book (id, title, author) VALUES (SEQ_Book.NEXTVAL, 'Perdido Street Station', 'China Miéville');


### PR DESCRIPTION
### Summary

Quarkus main branch is using Hibernate 6 now (please see https://github.com/quarkusio/quarkus/pull/31235 ). Unless we use legacy behavior, Hibernate entities are supposed to use dedicated sequence, instead of Hibernate ones. Test failure dailys are currently failing because of this. Further details in https://github.com/quarkusio/quarkus/issues/31256.

Changes:

- MySQL can't use `org.hibernate.dialect.MariaDB102Dialect` as commands handling next sequel value differ
- Default Hibernate increment by 50 is fine with `multiple-plus` and `naryana-transactions` modules due to how tests are written (don't expected certain id for entities not inserted via sql init script), however SQL app need increment by 1 therefore I skipped there to PanacheEntityBase and set sequence allocation and increment and initial value. This way, at least we have covered both cases

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)