### PR TITLE
[2.13] Explicitly use maven local repo for gradle build (#1064)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>
         <confluent.kafka-avro-serializer.version>7.2.2</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.20.0</formatter-maven-plugin.version>
-        <impsort-maven-plugin.version>1.7.0</impsort-maven-plugin.version>
+        <impsort-maven-plugin.version>1.8.0</impsort-maven-plugin.version>
         <xml-format-maven-plugin.version>3.2.1</xml-format-maven-plugin.version>
         <checkstyle.version>10.3.4</checkstyle.version>
         <jjwt.version>0.11.5</jjwt.version>

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -121,7 +121,15 @@ public class QuarkusCliCreateJvmApplicationIT {
         QuarkusCliRestService app = cliClient.createApplication("app", defaultWithFixedStream().withExtraArgs("--gradle"));
 
         // Should build on Jvm
-        Result result = app.buildOnJvm();
+        final String repository = System.getProperty("maven.repo.local");
+        final Result result;
+        if (repository == null) {
+            result = app.buildOnJvm();
+        } else {
+            app.withProperty("maven.repo.local", repository);
+            result = app.buildOnJvm("-Dmaven.repo.local=" + repository);
+        }
+
         assertTrue(result.isSuccessful(), "The application didn't build on JVM. Output: " + result.getOutput());
 
         // Start using DEV mode


### PR DESCRIPTION
### Summary

- backport: https://github.com/quarkus-qe/quarkus-test-suite/commit/1f1eec0267337c3855a5dbdb258bdd8012608fed
- Bump `impsort-maven-plugin` to 1.8.0

Please select the relevant options.

- [X] Backport