### PR TITLE
Transaction API migration

### DIFF
--- a/sql-db/narayana-transactions/src/main/java/io.quarkus.ts.transactions/LegacyTransferTopUpService.java
+++ b/sql-db/narayana-transactions/src/main/java/io.quarkus.ts.transactions/LegacyTransferTopUpService.java
@@ -7,32 +7,32 @@ import org.jboss.logging.Logger;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.narayana.jta.QuarkusTransaction;
-import io.quarkus.narayana.jta.TransactionExceptionResult;
+import io.quarkus.narayana.jta.RunOptions;
 
 @ApplicationScoped
-@Named("TransferTopUpService")
-public class TransferTopUpService extends TransferProcessor {
-    private static final Logger LOG = Logger.getLogger(TransferTopUpService.class);
+@Named("LegacyTransferTopUpService")
+public class LegacyTransferTopUpService extends TransferProcessor {
+    private static final Logger LOG = Logger.getLogger(LegacyTransferTopUpService.class);
     private final static String ANNOTATION_TOP_UP = "user top up";
     private final static int TRANSACTION_TIMEOUT_SEC = 10;
     private final MeterRegistry registry;
     private long transactionsAmount;
 
-    public TransferTopUpService(MeterRegistry registry) {
+    public LegacyTransferTopUpService(MeterRegistry registry) {
         this.registry = registry;
-        registry.gauge("transaction.topup.amount", this, TransferTopUpService::getTransactionsAmount);
+        registry.gauge("transaction.topup.amount", this, LegacyTransferTopUpService::getTransactionsAmount);
     }
 
     public JournalEntity makeTransaction(String from, String to, int amount) {
         LOG.infof("TopUp account %s amount %s", from, amount);
         verifyAccounts(to);
-        JournalEntity journal = QuarkusTransaction.requiringNew()
+        JournalEntity journal = QuarkusTransaction.call(QuarkusTransaction.runOptions()
                 .timeout(TRANSACTION_TIMEOUT_SEC)
                 .exceptionHandler(t -> {
                     transactionsAmount--;
-                    return TransactionExceptionResult.ROLLBACK;
+                    return RunOptions.ExceptionResult.ROLLBACK;
                 })
-                .call(() -> {
+                .semantic(RunOptions.Semantic.REQUIRE_NEW), () -> {
                     transactionsAmount++;
                     JournalEntity journalentity = journalService.addToJournal(from, to, ANNOTATION_TOP_UP, amount);
                     accountService.increaseBalance(from, amount);

--- a/sql-db/narayana-transactions/src/main/java/io.quarkus.ts.transactions/TransferResource.java
+++ b/sql-db/narayana-transactions/src/main/java/io.quarkus.ts.transactions/TransferResource.java
@@ -25,6 +25,10 @@ public class TransferResource {
     TransferProcessor regularTransaction;
 
     @Inject
+    @Named("LegacyTransferTopUpService")
+    TransferProcessor legacyTopUp;
+
+    @Inject
     @Named("TransferTopUpService")
     TransferProcessor topUp;
 
@@ -55,6 +59,15 @@ public class TransferResource {
      * TopUp represent a transfer funds transaction to your account, but the money doesn't come from another account.
      * On the journal will look like a transaction with the same from / to account and the annotation top-up.
      */
+    @Path("/legacy/top-up")
+    @POST
+    public Response legacyTopup(TransferDTO transferDTO) {
+        Long ID = legacyTopUp.makeTransaction(transferDTO.getAccountFrom(), transferDTO.getAccountTo(),
+                transferDTO.getAmount()).getId();
+
+        return Response.ok(ID).status(CREATED.getStatusCode()).build();
+    }
+
     @Path("/top-up")
     @POST
     public Response topup(TransferDTO transferDTO) {

--- a/sql-db/narayana-transactions/src/main/resources/import.sql
+++ b/sql-db/narayana-transactions/src/main/resources/import.sql
@@ -3,4 +3,5 @@ INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, creat
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('Account_SEQ'), 'Luis', 'de Góngora', 'ES8521006742088984966816', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('Account_SEQ'), 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('Account_SEQ'), 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('Account_SEQ'), 'Eduardo', 'Mendoza', 'ES8521006742088984966899', 100, null, CURRENT_TIMESTAMP);
 

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/TransactionCommons.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/TransactionCommons.java
@@ -25,6 +25,8 @@ public abstract class TransactionCommons {
     static final String ACCOUNT_NUMBER_LUIS = "ES8521006742088984966816";
     static final String ACCOUNT_NUMBER_LOPE = "CZ9250512252717368964232";
     static final String ACCOUNT_NUMBER_FRANCISCO = "ES8521006742088984966817";
+
+    static final String ACCOUNT_NUMBER_EDUARDO = "ES8521006742088984966899";
     static final int ASSERT_SERVICE_TIMEOUT_MINUTES = 1;
     private Response jaegerResponse;
 
@@ -56,7 +58,7 @@ public abstract class TransactionCommons {
 
     @Tag("QUARKUS-2492")
     @Test
-    public void verifyNarayanaLambdaApproachTransaction() {
+    public void verifyLegacyNarayanaLambdaApproachTransaction() {
         TransferDTO transferDTO = new TransferDTO();
         transferDTO.setAccountFrom(ACCOUNT_NUMBER_GARCILASO);
         transferDTO.setAccountTo(ACCOUNT_NUMBER_GARCILASO);
@@ -64,7 +66,7 @@ public abstract class TransactionCommons {
 
         given()
                 .contentType(ContentType.JSON)
-                .body(transferDTO).post("/transfer/top-up")
+                .body(transferDTO).post("/transfer/legacy/top-up")
                 .then().statusCode(HttpStatus.SC_CREATED);
 
         AccountEntity garcilasoAccount = getAccount(ACCOUNT_NUMBER_GARCILASO);
@@ -72,6 +74,27 @@ public abstract class TransactionCommons {
                 "Unexpected account amount. Expected 200 found " + garcilasoAccount.getAmount());
 
         JournalEntity garcilasoJournal = getLatestJournalRecord(ACCOUNT_NUMBER_GARCILASO);
+        Assertions.assertEquals(100, garcilasoJournal.getAmount(), "Unexpected journal amount.");
+    }
+
+    @Tag("QUARKUS-2492")
+    @Test
+    public void verifyNarayanaLambdaApproachTransaction() {
+        TransferDTO transferDTO = new TransferDTO();
+        transferDTO.setAccountFrom(ACCOUNT_NUMBER_EDUARDO);
+        transferDTO.setAccountTo(ACCOUNT_NUMBER_EDUARDO);
+        transferDTO.setAmount(100);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(transferDTO).post("/transfer/top-up")
+                .then().statusCode(HttpStatus.SC_CREATED);
+
+        AccountEntity garcilasoAccount = getAccount(ACCOUNT_NUMBER_EDUARDO);
+        Assertions.assertEquals(200, garcilasoAccount.getAmount(),
+                "Unexpected account amount. Expected 200 found " + garcilasoAccount.getAmount());
+
+        JournalEntity garcilasoJournal = getLatestJournalRecord(ACCOUNT_NUMBER_EDUARDO);
         Assertions.assertEquals(100, garcilasoJournal.getAmount(), "Unexpected journal amount.");
     }
 

--- a/sql-db/narayana-transactions/src/test/resources/mariadb_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/mariadb_import.sql
@@ -3,3 +3,4 @@ INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, creat
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Luis', 'de Góngora', 'ES8521006742088984966816', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Eduardo', 'Mendoza', 'ES8521006742088984966899', 100, null, CURRENT_TIMESTAMP);

--- a/sql-db/narayana-transactions/src/test/resources/mssql_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/mssql_import.sql
@@ -3,4 +3,4 @@ INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, creat
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR Account_SEQ, 'Luis', 'de Góngora', 'ES8521006742088984966816', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR Account_SEQ, 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR Account_SEQ, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
-
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Eduardo', 'Mendoza', 'ES8521006742088984966899', 100, null, CURRENT_TIMESTAMP);

--- a/sql-db/narayana-transactions/src/test/resources/mysql_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/mysql_import.sql
@@ -3,4 +3,5 @@ INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, creat
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) SELECT MAX(id) + 1, 'Luis', 'de Góngora', 'ES8521006742088984966816', 100, null, CURRENT_TIMESTAMP FROM account;
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) SELECT MAX(id) + 1, 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP FROM account;
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) SELECT MAX(id) + 1, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP FROM account;
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) SELECT MAX(id) + 1, 'Eduardo', 'Mendoza', 'ES8521006742088984966899', 100, null, CURRENT_TIMESTAMP FROM account;
 UPDATE account_SEQ SET next_val=(SELECT MAX(id) + 1 FROM account);

--- a/sql-db/narayana-transactions/src/test/resources/oracle_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/oracle_import.sql
@@ -3,3 +3,4 @@ INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, creat
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (Account_SEQ.NEXTVAL, 'Luis', 'de Góngora', 'ES8521006742088984966816', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (Account_SEQ.NEXTVAL, 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (Account_SEQ.NEXTVAL, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
+INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (Account_SEQ.NEXTVAL, 'Eduardo', 'Mendoza', 'ES8521006742088984966899', 100, null, CURRENT_TIMESTAMP);


### PR DESCRIPTION
### Summary

Migrate old transaction API references to the new API

Motivation: https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.16#quarkustransactionrunquarkustransactioncall-are-deprecated

Please select the relevant options.

- [X] Refactoring


### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)