### PR TITLE
Make DEV mode Infinispan test use Dev Services for Infinispan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1030,7 +1030,7 @@ This namespace must be created by "qe" user or this user must have access to it 
 
 Tests create an Infinispan cluster in the `datagrid-cluster` namespace. Cluster is created before tests by `infinispan_cluster_config.yaml`. 
 To allow parallel runs of tests this cluster is renamed for every test run - along with configmap `infinispan-config`. The configmap contains 
-configuration property `quarkus.infinispan-client.server-list`. Value of this property is a path to the infinispan cluster from test namespace, 
+configuration property `quarkus.infinispan-client.hosts`. Value of this property is a path to the infinispan cluster from test namespace, 
 its structure is `infinispan-cluster-name.datagrid-cluster-namespace.svc.cluster.local:11222`. It is because the testsuite uses dynamically generated 
 namespaces for tests. So this path is needed for the tests to find Infinispan cluster in another namespace.
 

--- a/infinispan-client/src/main/resources/application.properties
+++ b/infinispan-client/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 
 # Auth info
 quarkus.infinispan-client.auth-realm=default
-quarkus.infinispan-client.auth-username=qe
-quarkus.infinispan-client.auth-password=qe
+quarkus.infinispan-client.username=qe
+quarkus.infinispan-client.password=qe
 quarkus.infinispan-client.sasl-mechanism=PLAIN
 quarkus.infinispan-client.client-intelligence=BASIC
 

--- a/infinispan-client/src/test/resources/infinispan_cluster_configmap.yaml
+++ b/infinispan-client/src/test/resources/infinispan_cluster_configmap.yaml
@@ -4,4 +4,4 @@ metadata:
   name: infinispan-config
 data:
   application.properties: |
-    quarkus.infinispan-client.server-list=totally-random-infinispan-cluster-name.datagrid-cluster.svc.cluster.local:11222
+    quarkus.infinispan-client.hosts=totally-random-infinispan-cluster-name.datagrid-cluster.svc.cluster.local:11222

--- a/messaging/infinispan-grpc-kafka/src/main/resources/application.properties
+++ b/messaging/infinispan-grpc-kafka/src/main/resources/application.properties
@@ -4,7 +4,7 @@ quarkus.infinispan-client.trust-store=src/main/resources/truststore.jks
 quarkus.infinispan-client.trust-store-password=password
 quarkus.infinispan-client.trust-store-type=jks
 
-quarkus.infinispan-client.server-list=localhost:11222
+quarkus.infinispan-client.hosts=localhost:11222
 quarkus.infinispan-client.use-auth=true
 
 # gRPC

--- a/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/ts/messaging/infinispan/grpc/kafka/InfinispanKafkaIT.java
+++ b/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/ts/messaging/infinispan/grpc/kafka/InfinispanKafkaIT.java
@@ -42,9 +42,9 @@ public class InfinispanKafkaIT {
 
     @QuarkusApplication
     static final RestService app = new RestService()
-            .withProperty("quarkus.infinispan-client.server-list", infinispan::getInfinispanServerAddress)
-            .withProperty("quarkus.infinispan-client.auth-username", infinispan.getUsername())
-            .withProperty("quarkus.infinispan-client.auth-password", infinispan.getPassword())
+            .withProperty("quarkus.infinispan-client.hosts", infinispan::getInfinispanServerAddress)
+            .withProperty("quarkus.infinispan-client.username", infinispan.getUsername())
+            .withProperty("quarkus.infinispan-client.password", infinispan.getPassword())
             .withProperty("quarkus.infinispan-client.trust-store", "secret::/truststore.jks")
             .withProperty("quarkus.infinispan-client.trust-store-password", "password")
             .withProperty("quarkus.infinispan-client.trust-store-type", "jks")

--- a/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/ts/messaging/infinispan/grpc/kafka/InfinispanKafkaSaslIT.java
+++ b/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/ts/messaging/infinispan/grpc/kafka/InfinispanKafkaSaslIT.java
@@ -37,9 +37,9 @@ public class InfinispanKafkaSaslIT {
 
     @QuarkusApplication
     static final RestService app = new RestService()
-            .withProperty("quarkus.infinispan-client.server-list", infinispan::getInfinispanServerAddress)
-            .withProperty("quarkus.infinispan-client.auth-username", infinispan.getUsername())
-            .withProperty("quarkus.infinispan-client.auth-password", infinispan.getPassword())
+            .withProperty("quarkus.infinispan-client.hosts", infinispan::getInfinispanServerAddress)
+            .withProperty("quarkus.infinispan-client.username", infinispan.getUsername())
+            .withProperty("quarkus.infinispan-client.password", infinispan.getPassword())
             .withProperty("quarkus.infinispan-client.trust-store", "secret::/truststore.jks")
             .withProperty("quarkus.infinispan-client.trust-store-password", "password")
             .withProperty("quarkus.infinispan-client.trust-store-type", "jks")

--- a/nosql-db/infinispan/src/main/resources/application.properties
+++ b/nosql-db/infinispan/src/main/resources/application.properties
@@ -1,7 +1,1 @@
-quarkus.infinispan-client.auth-username=admin
-quarkus.infinispan-client.auth-password=password
-quarkus.infinispan-client.client-intelligence=BASIC
-
 quarkus.infinispan-client.cache."cache".configuration-uri=cache-configuration.xml
-quarkus.infinispan-client.cache."cache".near-cache-mode: disabled
-quarkus.infinispan-client.cache."cache".near-cache-max-entries: -1

--- a/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/DevModeInfinispanIT.java
+++ b/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/DevModeInfinispanIT.java
@@ -5,23 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.bootstrap.InfinispanService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @QuarkusScenario
 public class DevModeInfinispanIT {
-    @Container(image = "${infinispan.image}", port = 11222)
-    static InfinispanService infinispan = new InfinispanService()
-            .withUsername("admin")
-            .withPassword("password");
 
     @DevModeQuarkusApplication()
-    static RestService service = new RestService()
-            .withProperty("quarkus.infinispan-client.server-list",
-                    () -> infinispan.getURI().toString());
+    static RestService service = new RestService();
 
     @Test
     void smoke() {

--- a/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/InfinispanIT.java
+++ b/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/InfinispanIT.java
@@ -22,8 +22,9 @@ public class InfinispanIT {
 
     @QuarkusApplication()
     static RestService service = new RestService()
-            .withProperty("quarkus.infinispan-client.server-list",
-                    () -> infinispan.getURI().toString());
+            .withProperty("quarkus.infinispan-client.hosts",
+                    () -> infinispan.getURI().toString())
+            .withProperties("infinispan-it.properties");
 
     @Test
     void smoke() {

--- a/nosql-db/infinispan/src/test/resources/infinispan-it.properties
+++ b/nosql-db/infinispan/src/test/resources/infinispan-it.properties
@@ -1,0 +1,3 @@
+quarkus.infinispan-client.username=admin
+quarkus.infinispan-client.password=password
+quarkus.infinispan-client.client-intelligence=BASIC


### PR DESCRIPTION
### Summary

Currently we don't have any DEV mode test for Infinispan using Dev Services for Infinispan. There was a test at DEV mode that actually didn't start Dev Services as it set `server-list`. Now we use Dev Services to have this covered. Also some deprecated properties are migrated.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)