### PR TITLE
Fix Quartz job tests by adjusting Hibernate entity id, job scope and job start-up

### DIFF
--- a/scheduling/quartz/src/main/java/io/quarkus/ts/scheduling/quartz/basic/ManuallyScheduledCounter.java
+++ b/scheduling/quartz/src/main/java/io/quarkus/ts/scheduling/quartz/basic/ManuallyScheduledCounter.java
@@ -4,7 +4,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
-import jakarta.transaction.Transactional;
+import jakarta.inject.Singleton;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.quartz.Job;
@@ -25,8 +25,8 @@ import io.quarkus.ts.scheduling.quartz.basic.services.CounterService;
 @ApplicationScoped
 public class ManuallyScheduledCounter {
 
-    @ConfigProperty(name = "quarkus.scheduler.enabled")
-    boolean schedulerEnabled;
+    @ConfigProperty(name = "quarkus-qe.enable-manually-scheduled-counter")
+    boolean manualSchedulerEnabled;
 
     @Inject
     Provider<Scheduler> quartz;
@@ -38,10 +38,9 @@ public class ManuallyScheduledCounter {
         return service.get(caller());
     }
 
-    @Transactional
     @PostConstruct
     void init() throws SchedulerException {
-        if (schedulerEnabled) {
+        if (manualSchedulerEnabled) {
             JobDetail job = JobBuilder.newJob(CountingJob.class).build();
             Trigger trigger = TriggerBuilder
                     .newTrigger()
@@ -55,8 +54,10 @@ public class ManuallyScheduledCounter {
         }
     }
 
+    @Singleton
     @RegisterForReflection
     public static class CountingJob implements Job {
+
         @Inject
         CounterService service;
 
@@ -71,7 +72,7 @@ public class ManuallyScheduledCounter {
         }
     }
 
-    private static final String caller() {
+    private static String caller() {
         return ManuallyScheduledCounter.class.getName();
     }
 }

--- a/scheduling/quartz/src/main/java/io/quarkus/ts/scheduling/quartz/basic/services/CounterService.java
+++ b/scheduling/quartz/src/main/java/io/quarkus/ts/scheduling/quartz/basic/services/CounterService.java
@@ -16,7 +16,8 @@ public class CounterService {
     }
 
     public int get(String caller) {
-        return counters.get(caller).get();
+        var count = counters.get(caller);
+        return count == null ? -1 : count.get();
     }
 
     public void invoke(String caller) {

--- a/scheduling/quartz/src/main/java/io/quarkus/ts/scheduling/quartz/failover/AnnotationScheduledJob.java
+++ b/scheduling/quartz/src/main/java/io/quarkus/ts/scheduling/quartz/failover/AnnotationScheduledJob.java
@@ -2,11 +2,13 @@ package io.quarkus.ts.scheduling.quartz.failover;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import jakarta.transaction.Transactional;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.Scheduled.ApplicationNotRunning;
 
 @ApplicationScoped
 public class AnnotationScheduledJob {
@@ -17,10 +19,22 @@ public class AnnotationScheduledJob {
     @Inject
     ExecutionService service;
 
+    @Inject
+    InternalApplicationNotRunning appNotRunning;
+
     @Transactional
     @Scheduled(cron = "0/1 * * * * ?", identity = "my-unique-task")
     void increment() {
-        service.addExecution(ownerName);
+        boolean appIsRunning = !appNotRunning.test(null);
+        if (appIsRunning) {
+            service.addExecution(ownerName);
+        }
+    }
+
+    // necessary as 'ApplicationNotRunning' is not registered with Quartz extension
+    @Singleton
+    public static class InternalApplicationNotRunning extends ApplicationNotRunning {
+
     }
 
 }

--- a/scheduling/quartz/src/main/java/io/quarkus/ts/scheduling/quartz/failover/ExecutionEntity.java
+++ b/scheduling/quartz/src/main/java/io/quarkus/ts/scheduling/quartz/failover/ExecutionEntity.java
@@ -1,11 +1,19 @@
 package io.quarkus.ts.scheduling.quartz.failover;
 
-import jakarta.persistence.Entity;
+import static jakarta.persistence.GenerationType.IDENTITY;
 
-import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 @Entity
-public class ExecutionEntity extends PanacheEntity {
+public class ExecutionEntity extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    public Long id;
     public Long seconds;
     public String owner;
 

--- a/scheduling/quartz/src/main/resources/application.properties
+++ b/scheduling/quartz/src/main/resources/application.properties
@@ -2,7 +2,6 @@
 quarkus.datasource.db-kind=mysql
 quarkus.datasource.jdbc.max-size=8
 quarkus.datasource.jdbc.min-size=2
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB102Dialect
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 # custom configuration
@@ -19,3 +18,5 @@ quarkus.flyway.migrate-at-start=true
 quarkus.flyway.baseline-on-migrate=true
 quarkus.flyway.baseline-version=1.0
 quarkus.flyway.baseline-description=Quartz
+
+quarkus-qe.enable-manually-scheduled-counter=false


### PR DESCRIPTION
### Summary

Fix Quartz jobs:

- with Hibernate 6, identity wasn't used as strategy for PK, so there was sometimes duplicate keys exception (and sometimes I experienced table not found :-/)
- I mentioned that `init` method of the `io.quarkus.ts.scheduling.quartz.basic.ManuallyScheduledCounter.CountingJob` was called every single time job was executed. Also job is started way before job result is tested. It doesn't really make sense to have there 2 second waiting and test sequence (greater than 0 and greater than 1), I rewrote that test
- manually scheduled job was running even when it wasn't tested (when other `@QuarkusScenario` test classes where running), I adjusted the condition
- `AnnotationScheduledJob` tried to save results to database before application started (depending on a moment when job was started), I experienced problem with it, but also think it doesn't cause regular failure
- when manually scheduled job wasn't triggered, test was failing over NPE and test failed with HTTP STATUS 500. That's less intuitive then assertion failed, so I return -1 and now, assertion fails.

I hit all of above-mentioned issues when debugging daily run failures, but I honestly think only setting `IDENTITY` was required. The rest just makes for flaky tests (sometimes green, sometimes red).

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)