### PR TITLE
Fix Spring Web test as ex. thrown for constraint violation is wrapped

### DIFF
--- a/spring/spring-web/src/main/java/io/quarkus/ts/spring/web/reactive/boostrap/web/RestExceptionHandler.java
+++ b/spring/spring-web/src/main/java/io/quarkus/ts/spring/web/reactive/boostrap/web/RestExceptionHandler.java
@@ -1,13 +1,11 @@
 package io.quarkus.ts.spring.web.reactive.boostrap.web;
 
-import jakarta.persistence.PersistenceException;
-
-import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import io.quarkus.arc.ArcUndeclaredThrowableException;
 import io.quarkus.ts.spring.web.reactive.boostrap.web.exception.BookIdMismatchException;
 import io.quarkus.ts.spring.web.reactive.boostrap.web.exception.BookNotFoundException;
 
@@ -21,8 +19,7 @@ public class RestExceptionHandler {
 
     @ExceptionHandler({
             BookIdMismatchException.class,
-            ConstraintViolationException.class,
-            PersistenceException.class
+            ArcUndeclaredThrowableException.class
     })
     public ResponseEntity<Object> handleBadRequest(Exception ex) {
         return new ResponseEntity<>(ex.getLocalizedMessage(), HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
### Summary

Persistence exception is now wrapped with `ArcUndeclaredThrowableException`, so exception is never caught by exception handler and 500 is thrown instead of 400. Previously (tried 2.13), the top-most cost was `PersistenceException`.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)