### PR TITLE
Fix OpenTelemetry traces operation names as they changed when OpenTelemetry was bumped to 1.23.1

### DIFF
--- a/http/graphql-telemetry/src/test/java/io/quarkus/ts/http/graphql/telemetry/GraphQLTelemetryIT.java
+++ b/http/graphql-telemetry/src/test/java/io/quarkus/ts/http/graphql/telemetry/GraphQLTelemetryIT.java
@@ -38,7 +38,7 @@ public class GraphQLTelemetryIT {
         Assertions.assertEquals("Plato", reactive.jsonPath().getString("data.friend_r.name"));
 
         await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(10)).untilAsserted(() -> {
-            String operation = "/graphql";
+            String operation = "POST /graphql";
             Response traces = given().when()
                     .queryParam("operation", operation)
                     .queryParam("lookback", "1h")

--- a/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
+++ b/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
@@ -49,6 +49,7 @@ public class VertxWebClientIT {
     static final String EXPECTED_VALUE = "Chuck Norris has already been to mars; that why there's no signs of life";
     static final int DELAY = 3500; // must be greater than vertx.webclient.timeout-sec
     private static final String TRACE_PING_PATH = "/trace/ping";
+    private static final String TRACE_PING_OPERATION_NAME = "GET " + TRACE_PING_PATH;
 
     private Response resp;
 
@@ -106,13 +107,13 @@ public class VertxWebClientIT {
         final int pageLimit = 50;
         await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
             whenIMakePingRequest();
-            thenRetrieveTraces(pageLimit, "1h", getServiceName(), TRACE_PING_PATH);
+            thenRetrieveTraces(pageLimit, "1h", getServiceName(), TRACE_PING_OPERATION_NAME);
             thenStatusCodeMustBe(HttpStatus.SC_OK);
             thenTraceDataSizeMustBe(greaterThan(0));
             thenTraceSpanSizeMustBe(greaterThan(0));
             thenTraceSpanTagsSizeMustBe(greaterThan(0));
             thenTraceSpansOperationNameMustBe(not(empty()));
-            thenCheckOperationNamesIsEqualTo(TRACE_PING_PATH);
+            thenCheckOperationNamesIsEqualTo(TRACE_PING_OPERATION_NAME);
         });
     }
 
@@ -121,13 +122,13 @@ public class VertxWebClientIT {
         final int pageLimit = 50;
         await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
             whenIMakePingRequest();
-            thenRetrieveTraces(pageLimit, "1h", getServiceName(), TRACE_PING_PATH);
+            thenRetrieveTraces(pageLimit, "1h", getServiceName(), TRACE_PING_OPERATION_NAME);
             thenStatusCodeMustBe(HttpStatus.SC_OK);
             thenTraceDataSizeMustBe(greaterThan(0));
             thenTraceSpanSizeMustBe(greaterThan(1));
             thenTraceSpanTagsSizeMustBe(greaterThan(0));
             thenTraceSpansOperationNameMustBe(not(empty()));
-            thenCheckOperationNamesIsEqualTo(TRACE_PING_PATH);
+            thenCheckOperationNamesIsEqualTo(TRACE_PING_OPERATION_NAME);
         });
     }
 

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpentelemetryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpentelemetryIT.java
@@ -47,8 +47,8 @@ public class OpentelemetryIT {
     @Test
     public void testContextPropagation() {
         int pageLimit = 10;
-        String operationName = "/ping/pong";
-        String[] operations = new String[] { "/ping/pong", "HTTP GET", "/hello" };
+        String operationName = "GET /ping/pong";
+        String[] operations = new String[] { "GET /ping/pong", "GET", "GET /hello" };
 
         await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
             whenDoPingPongRequest();

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/TransactionCommons.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/TransactionCommons.java
@@ -122,7 +122,7 @@ public abstract class TransactionCommons {
     @Tag("QUARKUS-2492")
     @Test
     public void smokeTestNarayanaProgrammaticTransactionTrace() {
-        String operationName = "/transfer/accounts/{account_id}";
+        String operationName = "GET /transfer/accounts/{account_id}";
         given().get("/transfer/accounts/" + ACCOUNT_NUMBER_LUIS).then().statusCode(HttpStatus.SC_OK);
         verifyRestRequestTraces(operationName);
     }


### PR DESCRIPTION
### Summary

https://github.com/quarkusio/quarkus/pull/31356 bumped OpenTelemetry to 1.23.1 and we need to update traces operation names.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)