### PR TITLE
Use US GCS Maven Central mirror

### DIFF
--- a/.github/mvn-settings.xml
+++ b/.github/mvn-settings.xml
@@ -7,8 +7,8 @@
             <repositories>
                 <repository>
                     <id>google-maven-central</id>
-                    <name>GCS Maven Central mirror EU</name>
-                    <url>https://maven-central-eu.storage-download.googleapis.com/repos/central/data/</url>
+                    <name>GCS Maven Central mirror</name>
+                    <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
                     <snapshots>
                         <enabled>false</enabled>
                     </snapshots>
@@ -33,8 +33,8 @@
             <pluginRepositories>
                 <pluginRepository>
                     <id>google-maven-central</id>
-                    <name>GCS Maven Central mirror EU</name>
-                    <url>https://maven-central-eu.storage-download.googleapis.com/repos/central/data/</url>
+                    <name>GCS Maven Central mirror</name>
+                    <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
                 </pluginRepository>
                 <pluginRepository>
                     <id>jboss-maven-central-proxy</id>


### PR DESCRIPTION
Use US GCS Maven Central mirror

Downloads on https://github.com/quarkus-qe/quarkus-test-suite/pull/1097 are slow

Also trying if the slowness is just temporary through https://github.com/quarkus-qe/quarkus-test-suite/pull/1098

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)