### PR TITLE
Use RESTEasy CDI to inject beans with `@Inject` instead of `@Context`

### DIFF
--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MultipleResponseSerializersResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MultipleResponseSerializersResource.java
@@ -15,11 +15,11 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
@@ -80,7 +80,7 @@ public class MultipleResponseSerializersResource {
 
     private static abstract class StringResponseSerializer implements MessageBodyWriter<String> {
 
-        @Context
+        @Inject
         HttpServerRequest httpRequest;
 
         private final MediaType acceptedMediaType;

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/PremierLeagueContainerRequestFilter.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/PremierLeagueContainerRequestFilter.java
@@ -3,6 +3,7 @@ package io.quarkus.ts.http.advanced.reactive;
 import java.util.Objects;
 
 import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.core.Context;
@@ -26,7 +27,7 @@ public class PremierLeagueContainerRequestFilter implements ContainerRequestFilt
     @Context
     HttpServerRequest httpRequest;
 
-    @Context
+    @Inject
     UriInfo uriInfo;
 
     @Override

--- a/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/PremierLeagueContainerRequestFilter.java
+++ b/http/http-advanced/src/main/java/io/quarkus/ts/http/advanced/PremierLeagueContainerRequestFilter.java
@@ -3,6 +3,7 @@ package io.quarkus.ts.http.advanced;
 import java.util.Objects;
 
 import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.core.Context;
@@ -25,7 +26,7 @@ public class PremierLeagueContainerRequestFilter implements ContainerRequestFilt
     @Context
     HttpRequest httpRequest;
 
-    @Context
+    @Inject
     UriInfo uriInfo;
 
     @Override

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/json/JsonParamConverterProvider.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/json/JsonParamConverterProvider.java
@@ -5,12 +5,10 @@ import java.lang.reflect.Type;
 import java.util.Arrays;
 
 import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.ParamConverter;
 import jakarta.ws.rs.ext.ParamConverterProvider;
 import jakarta.ws.rs.ext.Provider;
-import jakarta.ws.rs.ext.Providers;
 
 import org.apache.commons.lang3.ClassUtils;
 
@@ -23,8 +21,6 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 // This code is taken from https://github.com/pravussum/quarkus-query-param-repro
 public class JsonParamConverterProvider implements ParamConverterProvider {
 
-    @Context
-    private Providers providers;
     final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override

--- a/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/sse/ServerSentEventsPingResource.java
+++ b/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/sse/ServerSentEventsPingResource.java
@@ -8,7 +8,6 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.Sse;
@@ -35,7 +34,7 @@ public class ServerSentEventsPingResource extends TraceableResource {
     @Path("/raw")
     @GET
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    public Multi<OutboundSseEvent> sseRaw(@Context Sse sse, @QueryParam("amount") int amount) {
+    public Multi<OutboundSseEvent> sseRaw(Sse sse, @QueryParam("amount") int amount) {
         List<OutboundSseEvent> events = new ArrayList<>(amount);
         for (int i = 0; i < amount; i++) {
             events.add(sse.newEventBuilder().id("id_" + i).data("data_" + i).name("name_" + i).build());

--- a/security/basic/src/main/java/io/quarkus/ts/openshift/security/basic/AdminResource.java
+++ b/security/basic/src/main/java/io/quarkus/ts/openshift/security/basic/AdminResource.java
@@ -1,16 +1,31 @@
 package io.quarkus.ts.openshift.security.basic;
 
+import java.util.Objects;
+
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.SecurityContext;
 
 @Path("/admin")
 @RolesAllowed("admin")
 public class AdminResource {
+
+    private volatile SecurityContext securityContext = null;
+
+    @Inject
+    public void setSecurityContext(SecurityContext securityContext) {
+        this.securityContext = securityContext;
+    }
+
     @GET
-    public String get(@Context SecurityContext security) {
-        return "Hello, admin " + security.getUserPrincipal().getName();
+    public String get() {
+        Objects.requireNonNull(securityContext, "'SecurityContext' is supposed to be injected");
+        var response = "Hello, admin " + securityContext.getUserPrincipal().getName();
+        // this verifies that security context injection has request scope as this endpoint
+        // is called multiple times
+        securityContext = null;
+        return response;
     }
 }


### PR DESCRIPTION
### Summary

[It is now possible](https://github.com/gsmet/quarkus/commit/2d4332267a81ec49b9d950c44790a44327c8c6f0) to use `@Inject` on field injection points in RESTEasy Classic providers instead of `@Context`. RESTEasy Reactive has already supported this approach. [There is a plan to drop support](https://github.com/quarkusio/quarkus/issues/29240) of `@Context` on method parameters too, however this is not supported by RESTEasy (classic) yet. RESTEasy Reactive already supports this method parameter injection.

Changes done by this PR:

- module HTTP advanced:
  - `UriInfo` is newly injected with `@Inject`, however legacy `@Context` is stll used for `HttpRequest` injection
- module HTTP advanced reactive:
  - in `PremierLeagueContainerRequestFilter`, `UriInfo` is newly injected with `@Inject`, however legacy `@Context` is stll used for `HttpRequest` injection 
  - in `StringResponseSerializer`, `HttpServerRequest` is newly using `@Inject`
- module HTTP Rest Client Reactive:
  - I dropped the only `@Conext` that was there as the provider member wasn't used at all
- module OpenTelemetry Reactive (uses RESTEasy Mutiny):
  - dropped `@Context` from resource method param as we have several tests where resources are using `@Context` and I consider it interesting that `@Context` is in fact not needed there at all (we can see similar behavior on multiple RESTEasy Reactive upstream tests, e.g. in `io.quarkus.resteasy.reactive.jsonb.deployment.test.sse.SseResource`, `io.quarkus.resteasy.reactive.jackson.deployment.test.streams.StreamResource` and plenty others (same goes for `@Context` usage, it's frequently used in upstream)
- module Security - Basic
  - dropped `@Context SecurityContext security` from resource method parameters and instead, I used `@Inject` on setter. IMO we should test this pattern as it's legit and in this module, `@Context SecurityContext security` is used in 5 other cases (`UserResource`, `DenyAllResource`, `EveryoneResource`, `PermitAllResource` and `UnannotatedResource`). Note: `@Inject` can't be used on fields.

This change is done according to the [QUARKUS-2736 test plan](https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-2736.md).

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)