### PR TITLE
Enable tests with Quarkus OpenShift extension as upstream issue is fixed

### DIFF
--- a/funqy/knative-events/src/test/java/io/quarkus/ts/funqy/knativeevents/ServerlessExtensionOpenShiftFunqyKnEventsIT.java
+++ b/funqy/knative-events/src/test/java/io/quarkus/ts/funqy/knativeevents/ServerlessExtensionOpenShiftFunqyKnEventsIT.java
@@ -36,7 +36,7 @@ import io.quarkus.test.services.knative.eventing.OpenShiftExtensionFunqyKnativeE
 import io.quarkus.test.services.knative.eventing.spi.ForwardResponseDTO;
 import io.restassured.common.mapper.TypeRef;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
+@Disabled("Disabled as flaky") // TODO mvavrik: investigate why the test is flaky
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumReactiveIT.java
@@ -1,12 +1,10 @@
 package io.quarkus.ts.http.minimum.reactive;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumReactiveIT extends HttpMinimumReactiveIT {

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionHttpMinimumReactiveIT.java
@@ -1,12 +1,10 @@
 package io.quarkus.ts.http.minimum.reactive;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionHttpMinimumReactiveIT extends HttpMinimumReactiveIT {

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumReactiveIT.java
@@ -2,14 +2,12 @@ package io.quarkus.ts.http.minimum.reactive;
 
 import static io.restassured.RestAssured.given;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionOpenShiftHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionOpenShiftHttpMinimumReactiveIT.java
@@ -2,14 +2,12 @@ package io.quarkus.ts.http.minimum.reactive;
 
 import static io.restassured.RestAssured.given;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumIT.java
@@ -1,12 +1,10 @@
 package io.quarkus.ts.http.minimum;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumIT extends HttpMinimumIT {

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionHttpMinimumIT.java
@@ -1,12 +1,10 @@
 package io.quarkus.ts.http.minimum;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionHttpMinimumIT extends HttpMinimumIT {

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumIT.java
@@ -2,14 +2,12 @@ package io.quarkus.ts.http.minimum;
 
 import static io.restassured.RestAssured.given;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionOpenShiftHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionOpenShiftHttpMinimumIT.java
@@ -2,14 +2,12 @@ package io.quarkus.ts.http.minimum;
 
 import static io.restassured.RestAssured.given;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)

--- a/http/jakarta-rest-reactive/src/test/java/io/quarkus/ts/http/jakartarest/reactive/OpenShiftCompressionHandlerIT.java
+++ b/http/jakarta-rest-reactive/src/test/java/io/quarkus/ts/http/jakartarest/reactive/OpenShiftCompressionHandlerIT.java
@@ -1,13 +1,11 @@
 package io.quarkus.ts.http.jakartarest.reactive;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 // OCP Native coverage is not required (Test plan QUARKUS-2487), due to a lack of resources and the ROI.

--- a/http/jakarta-rest-reactive/src/test/java/io/quarkus/ts/http/jakartarest/reactive/OpenShiftHttpCachingIT.java
+++ b/http/jakarta-rest-reactive/src/test/java/io/quarkus/ts/http/jakartarest/reactive/OpenShiftHttpCachingIT.java
@@ -1,12 +1,10 @@
 package io.quarkus.ts.http.jakartarest.reactive;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftHttpCachingIT extends HttpCachingIT {

--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/OpenShiftUsingExtensionVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/OpenShiftUsingExtensionVertxIT.java
@@ -1,6 +1,5 @@
 package io.quarkus.ts.vertx;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -9,7 +8,6 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionVertxIT extends AbstractVertxIT {

--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionDockerBuildStrategyOpenShiftVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionDockerBuildStrategyOpenShiftVertxIT.java
@@ -1,6 +1,5 @@
 package io.quarkus.ts.vertx;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -9,7 +8,6 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)

--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionOpenShiftVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionOpenShiftVertxIT.java
@@ -1,6 +1,5 @@
 package io.quarkus.ts.vertx;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -9,7 +8,6 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)

--- a/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanCountersIT.java
+++ b/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanCountersIT.java
@@ -21,7 +21,8 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.utils.Command;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
+// TODO mvavrik: investigate and enable test!
+@Disabled("fails over incorrect response status, mvavrik will investigate in week 14")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class OperatorOpenShiftInfinispanCountersIT extends BaseOpenShiftInfinispanIT {

--- a/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanObjectsIT.java
+++ b/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanObjectsIT.java
@@ -26,7 +26,6 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.infinispan.client.serialized.ShopItem;
 import io.restassured.response.Response;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class OperatorOpenShiftInfinispanObjectsIT extends BaseOpenShiftInfinispanIT {

--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -20,11 +20,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
-        <!-- TODO "https://github.com/quarkusio/quarkus/issues/31228"
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-openshift</artifactId>
-        </dependency>-->
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-di</artifactId>
@@ -51,6 +50,36 @@
                     <url>https://maven.repository.redhat.com/ga/</url>
                 </repository>
             </repositories>
+        </profile>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <!-- disable Dev Services for Kubernetes on Windows due to Docker limitations -->
+                                <quarkus.kubernetes-client.devservices.enabled>false</quarkus.kubernetes-client.devservices.enabled>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <!-- disable Dev Services for Kubernetes on Windows due to Docker limitations -->
+                                <quarkus.kubernetes-client.devservices.enabled>false</quarkus.kubernetes-client.devservices.enabled>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/OpenShiftLifecycleApplicationIT.java
+++ b/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/OpenShiftLifecycleApplicationIT.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
+@Disabled("https://github.com/quarkusio/quarkus/issues/29451")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftLifecycleApplicationIT extends LifecycleApplicationIT {
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <profile.id>jvm</profile.id>
         <!-- S2i configuration -->
         <ts.global.s2i.quarkus.jvm.builder.image>registry.access.redhat.com/ubi8/openjdk-11:latest</ts.global.s2i.quarkus.jvm.builder.image>
-        <ts.global.s2i.quarkus.native.builder.image>quay.io/quarkus/ubi-quarkus-native-s2i:22.2-java17</ts.global.s2i.quarkus.native.builder.image>
+        <ts.global.s2i.quarkus.native.builder.image>quay.io/quarkus/ubi-quarkus-graalvmce-s2i:22.3-java17</ts.global.s2i.quarkus.native.builder.image>
         <!-- Default values for format -->
         <src.format.goal>format</src.format.goal>
         <src.sort.goal>sort</src.sort.goal>

--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/OpenShiftUsingExtensionDockerBuildStrategyManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/OpenShiftUsingExtensionDockerBuildStrategyManyExtensionsIT.java
@@ -1,12 +1,10 @@
 package io.quarkus.ts.many.extensions;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingExtensionDockerBuildStrategyManyExtensionsIT extends ManyExtensionsIT {

--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/OpenShiftUsingExtensionManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/OpenShiftUsingExtensionManyExtensionsIT.java
@@ -1,12 +1,10 @@
 package io.quarkus.ts.many.extensions;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionManyExtensionsIT extends ManyExtensionsIT {

--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionDockerBuildStrategyOpenShiftManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionDockerBuildStrategyOpenShiftManyExtensionsIT.java
@@ -2,14 +2,12 @@ package io.quarkus.ts.many.extensions;
 
 import static io.restassured.RestAssured.given;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)

--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionOpenShiftManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionOpenShiftManyExtensionsIT.java
@@ -2,14 +2,12 @@ package io.quarkus.ts.many.extensions;
 
 import static io.restassured.RestAssured.given;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)


### PR DESCRIPTION
### Summary

- Enable tests using Quarkus OpenShift extension as https://github.com/quarkusio/quarkus/issues/31228 is resolved.
- Funqy Knative test is disabled in native as it is flaky and I need more time to understand it
- Websockets producer test is adjusted as message is sent asynchronously and sometimes it takes a little longer before we can assert it. I saw it several times in OC failures, however I also saw it last week in dailys https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/4537518462 - flaky
- Disabled `OperatorOpenShiftInfinispanCountersIT` as it sometimes expects 200 status and receives 503, flaky method changes, so I disabled whole class
- tests in config module using OC extensions are enabled in a separate PR https://github.com/quarkus-qe/quarkus-test-suite/pull/1140 in order to avoid conflicts
- `quay.io/quarkus/ubi-quarkus-native-s2i` is obsolete and we need to use `ubi-quarkus-graalvmce-s2i` - https://github.com/quarkusio/quarkus/issues/30829#issuecomment-1422548366 I think I changed it as part of debugging, not sure if everything works correctly without this change, but we need to change it anyway

I'll investigate disabled tests next week, but this PR is already WIP for quite long time, let's get it in.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)