### PR TITLE
Test RESTEasy Reactive  support for a 'NewCookie' 'sameSite' attribute

### DIFF
--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/CookiesResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/CookiesResource.java
@@ -1,0 +1,75 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.common.headers.NewCookieHeaderDelegate;
+import org.jboss.resteasy.reactive.server.jaxrs.RestResponseBuilderImpl;
+
+import io.vertx.core.http.Cookie;
+import io.vertx.ext.web.RoutingContext;
+
+@Path("/cookie")
+public class CookiesResource {
+
+    public static final String TEST_COOKIE = "test-cookie";
+
+    @POST
+    @Path("/same-site/cookie-param")
+    public RestResponse<String> getSameSiteAttributeFromCookieParam(@CookieParam(TEST_COOKIE) String sameSite) {
+        String rawCookie = toRawCookie(sameSite);
+        NewCookie newCookie = (NewCookie) NewCookieHeaderDelegate.INSTANCE.fromString(rawCookie);
+        return new RestResponseBuilderImpl<String>()
+                .cookie(newCookie)
+                .entity(getSameSite(newCookie))
+                .build();
+    }
+
+    @GET
+    @Path("/same-site/vertx")
+    public Response getSameSiteAttributeFromVertx(HttpHeaders httpHeaders, RoutingContext routingContext) {
+        routingContext.response().addCookie(Cookie.cookie("vertx", "ignored"));
+        var sameSite = httpHeaders.getCookies().get(TEST_COOKIE).getValue();
+        return Response.ok().entity(sameSite).build();
+    }
+
+    @POST
+    @Path("/same-site/form-param")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public Response getSameSiteAttributeFromFormParam(@FormParam(TEST_COOKIE) String cookie) {
+        NewCookie newCookie = (NewCookie) NewCookieHeaderDelegate.INSTANCE.fromString(cookie);
+        final Response.ResponseBuilder responseBuilder;
+        if (newCookie.getSameSite() == null) {
+            responseBuilder = Response.noContent();
+        } else {
+            responseBuilder = Response.ok(getSameSite(newCookie));
+        }
+        return responseBuilder.cookie(newCookie).build();
+    }
+
+    public static String toRawCookie(String sameSite) {
+        if (sameSite == null || sameSite.isEmpty()) {
+            return String.format("%s=\"test-cookie-value\";Version=\"1\";", TEST_COOKIE);
+        } else {
+            return String.format("%s=\"test-cookie-value\";SameSite=\"%s\";Version=\"1\";", TEST_COOKIE, sameSite);
+        }
+    }
+
+    private static String getSameSite(NewCookie cookie) {
+        if (cookie.getSameSite() == null) {
+            return null;
+        } else {
+            return cookie.getSameSite().toString();
+        }
+    }
+
+}

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/CookiesIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/CookiesIT.java
@@ -1,0 +1,92 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import static io.quarkus.ts.http.advanced.reactive.CookiesResource.TEST_COOKIE;
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static io.restassured.matcher.RestAssuredMatchers.detailedCookie;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.http.Cookie;
+import io.restassured.response.ValidatableResponse;
+
+@QuarkusScenario
+public class CookiesIT {
+
+    @QuarkusApplication(classes = { CookiesResource.class }, properties = "cookies.properties")
+    static RestService app = new RestService();
+
+    @Test
+    void testLaxSameSiteAttribute() {
+        assertSameSiteAttribute("Lax");
+    }
+
+    @Test
+    void testStrictSameSiteAttribute() {
+        assertSameSiteAttribute("Strict");
+    }
+
+    @Test
+    void testNoneSameSiteAttribute() {
+        assertSameSiteAttribute("None");
+    }
+
+    @Test
+    void testNoSameSiteAttribute() {
+        assertSameSiteAttribute("");
+    }
+
+    @Test
+    void testSameSiteAttributeAddedByVertxHttpExt() {
+        String sameSite = "None";
+        given()
+                .cookie(new Cookie.Builder(TEST_COOKIE, sameSite).setVersion(1).build())
+                .get("/cookie/same-site/vertx")
+                .then()
+                .statusCode(200)
+                .body(is(sameSite))
+                .cookie("vertx", detailedCookie().sameSite(sameSite).secured(true));
+    }
+
+    private static void assertSameSiteAttribute(String sameSite) {
+        ValidatableResponse response;
+
+        response = whenCookieParamSameSiteReq(sameSite);
+        assertSameSiteInResponse(response, sameSite);
+
+        response = whenFormParamSameSiteReq(sameSite);
+        assertSameSiteInResponse(response, sameSite);
+    }
+
+    private static ValidatableResponse whenFormParamSameSiteReq(String sameSite) {
+        return given()
+                .formParam(TEST_COOKIE, CookiesResource.toRawCookie(sameSite))
+                .post("/cookie/same-site/form-param")
+                .then();
+    }
+
+    private static ValidatableResponse whenCookieParamSameSiteReq(String sameSite) {
+        var cookie = new Cookie.Builder(TEST_COOKIE, sameSite).setVersion(1).build();
+        return given()
+                .cookie(cookie)
+                .post("/cookie/same-site/cookie-param")
+                .then();
+    }
+
+    private static void assertSameSiteInResponse(ValidatableResponse response, String sameSite) {
+        if (sameSite.isEmpty()) {
+            response.statusCode(204)
+                    .cookie(TEST_COOKIE, detailedCookie().sameSite((String) null));
+        } else {
+            sameSite = sameSite.toUpperCase();
+            response.statusCode(200)
+                    .body(is(sameSite))
+                    .cookie(TEST_COOKIE, detailedCookie().sameSite(sameSite));
+        }
+    }
+
+}

--- a/http/http-advanced-reactive/src/test/resources/cookies.properties
+++ b/http/http-advanced-reactive/src/test/resources/cookies.properties
@@ -1,0 +1,2 @@
+quarkus.oidc.enabled=false
+quarkus.http.same-site-cookie.vertx.value=None


### PR DESCRIPTION
### Summary

https://github.com/quarkusio/quarkus/issues/31122 added support for a 'sameSite' attribute to 'NewCookie'. This change is possible as Jakarta 3.1 added support for the 'sameSite'. In short, it means that `Response` and `RestResponse` or anything that uses `RuntimeDelegate` for `NewCookie` map `sameSite` attribute when parsing the cookie and transforming `NewCookie` to `String`. In past, cookie would not contain `sameSite` attribute added to the `Response`. I also added test for `same-site-cookie` as we don't test it anywhere and I wanted a smoke test to ensure they can work together. `same-site-cookie` is tested in upstream, but I didn't find integration test with RESTEasy Reactive.

TD is done according to the TP [QUARKUS-2736](https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-2736.md).

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)