### PR TITLE
Add debug logging to flaky `OpenApiStoreSchemaIT` tests

### DIFF
--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenApiStoreSchemaIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenApiStoreSchemaIT.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.Yaml;
 
@@ -26,7 +27,8 @@ import io.vertx.core.json.JsonObject;
 @QuarkusScenario
 public class OpenApiStoreSchemaIT extends BaseOidcIT {
 
-    private static String directory = "target/generated/jax-rs/";
+    private static final Logger LOGGER = Logger.getLogger(OpenApiStoreSchemaIT.class.getName());
+    private static final String directory = "target/generated/jax-rs/";
     private static final String OPEN_API_DOT = "openapi.";
 
     private static final String YAML = Format.YAML.toString().toLowerCase();
@@ -104,13 +106,19 @@ public class OpenApiStoreSchemaIT extends BaseOidcIT {
     }
 
     private static String getRequiredRoleForPath(JsonObject content, String path) {
-        return content
+        var securityScheme = content
                 .getJsonObject("paths")
                 .getJsonObject(path)
                 .getJsonObject("get")
                 .getJsonArray("security")
                 .getJsonObject(0)
-                .getJsonArray("SecurityScheme")
-                .getString(0);
+                .getJsonArray("SecurityScheme");
+
+        if (securityScheme.size() == 0) {
+            LOGGER.infof("There are no roles for path '%s': %s", path, content);
+            return null;
+        }
+
+        return securityScheme.getString(0);
     }
 }

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenApiStoreSchemaIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenApiStoreSchemaIT.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.Yaml;
 
@@ -26,7 +27,8 @@ import io.vertx.core.json.JsonObject;
 @QuarkusScenario
 public class OpenApiStoreSchemaIT extends BaseOidcIT {
 
-    private static String directory = "target/generated/jax-rs/";
+    private static final Logger LOGGER = Logger.getLogger(OpenApiStoreSchemaIT.class.getName());
+    private static final String directory = "target/generated/jax-rs/";
     private static final String OPEN_API_DOT = "openapi.";
 
     private static final String YAML = Format.YAML.toString().toLowerCase();
@@ -104,13 +106,19 @@ public class OpenApiStoreSchemaIT extends BaseOidcIT {
     }
 
     private static String getRequiredRoleForPath(JsonObject content, String path) {
-        return content
+        var securityScheme = content
                 .getJsonObject("paths")
                 .getJsonObject(path)
                 .getJsonObject("get")
                 .getJsonArray("security")
                 .getJsonObject(0)
-                .getJsonArray("SecurityScheme")
-                .getString(0);
+                .getJsonArray("SecurityScheme");
+
+        if (securityScheme.size() == 0) {
+            LOGGER.infof("There are no roles for path '%s': %s", path, content);
+            return null;
+        }
+
+        return securityScheme.getString(0);
     }
 }


### PR DESCRIPTION
### Summary

Sometimes security scheme is empty (contains no roles). It only happens in CI, or in circumstances I'm not aware of. I run it locally about 100 times without single failure. I need to add extra logging that will show me generated OpenAPI definition in situation when test is failing. Now we also return for required role `null` instead of NPE, which means assertion will still fail.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)