### PR TITLE
Migrate from legacy (and missing) MariaDB dialect to `MariaDBDialect`

### DIFF
--- a/sql-db/multiple-pus/src/main/resources/application.properties
+++ b/sql-db/multiple-pus/src/main/resources/application.properties
@@ -8,7 +8,6 @@ quarkus.hibernate-orm."fruits".database.generation=drop-and-create
 quarkus.hibernate-orm."fruits".sql-load-script=import-fruits.sql
 quarkus.hibernate-orm."fruits".datasource=fruits
 quarkus.hibernate-orm."fruits".packages=io.quarkus.ts.sqldb.multiplepus.model.fruit
-quarkus.hibernate-orm."fruits".dialect=org.hibernate.dialect.MariaDB102Dialect
 # Vegetables using PostgresSQL
 quarkus.datasource."vegetables".db-kind=postgresql
 quarkus.datasource."vegetables".jdbc.url=${POSTGRESQL_JDBC_URL}

--- a/sql-db/narayana-transactions/src/test/resources/mariadb_app.properties
+++ b/sql-db/narayana-transactions/src/test/resources/mariadb_app.properties
@@ -1,5 +1,5 @@
 quarkus.datasource.db-kind=mariadb
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB102Dialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDBDialect
 quarkus.hibernate-orm.sql-load-script=mariadb_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.opentelemetry.enabled=true

--- a/sql-db/reactive-rest-data-panache/src/test/resources/mariadb_app.properties
+++ b/sql-db/reactive-rest-data-panache/src/test/resources/mariadb_app.properties
@@ -1,4 +1,4 @@
 quarkus.datasource.db-kind=mariadb
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB102Dialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDBDialect
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql

--- a/sql-db/reactive-rest-data-panache/src/test/resources/mysql.properties
+++ b/sql-db/reactive-rest-data-panache/src/test/resources/mysql.properties
@@ -1,4 +1,3 @@
 quarkus.datasource.db-kind=mysql
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB102Dialect
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql


### PR DESCRIPTION
### Summary

Fixes DB-related daily failures. Migration guide https://docs.jboss.org/hibernate/orm/6.2/migration-guide/migration-guide.html suggest we should use `MariaDBDialect` unless we need to support legacy databases (which we don't). Quarkus guide suggest we don't need to specify dialect as Quarkus identifies the right dialect based on database kind (autoresolution). So I kinda combined it to have tested both.

Tests started to fail after https://github.com/quarkusio/quarkus/pull/31947 identified by @rsvoboda .

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)