### PR TITLE
Fix Spring Web native module build - Hibernate ORM shouldn't use legacy dialect as it fails in native

### DIFF
--- a/spring/spring-web/src/main/resources/application.properties
+++ b/spring/spring-web/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name = Bootstrap Spring Boot
 
 quarkus.datasource.db-kind=mariadb
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB102Dialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDBDialect
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.log.console.format=%d{HH:mm:ss.SSS} [%t] %-5p %c{36} - %m%n


### PR DESCRIPTION
### Summary

Spring Web module succeeds in JVM mode, but native build fails over missing class

```
Caused by: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported type org.hibernate.boot.xsd.ConfigXsdSupport is reachable
To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime. The unsupported element is then reported at run time when it is accessed the first time.
```

It's just demonstration of incorrect dialect (as legacy dialect needs extra dependency - see https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0:-Hibernate-ORM-5-to-6-migration#dialect-configuration-changes).

Spring Web Reactive will need similar change, but it's disabled now. As https://github.com/quarkusio/quarkus/pull/31454 is merged now, I'll enable it in a separate PR.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)