### PR TITLE
Disable OpenAPI security scheme check in classic OIDC client

### DIFF
--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenApiStoreSchemaIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenApiStoreSchemaIT.java
@@ -83,13 +83,15 @@ public class OpenApiStoreSchemaIT extends BaseOidcIT {
         assertTrue(content.getJsonObject("paths").containsKey("/rest-pong"), "Missing expected path: /rest-pong");
 
         // verify that path /secured/admin is only accessible by user with role 'admin'
-        var expectedRole = getRequiredRoleForPath(content, "/secured/admin");
-        assertEquals("admin", expectedRole);
+        // TODO: enable when https://github.com/quarkusio/quarkus/issues/32112 is fixed
+        // var expectedRole = getRequiredRoleForPath(content, "/secured/admin");
+        // assertEquals("admin", expectedRole);
 
         // verify that path /secured/getClaimsFromBeans is accessible by any authenticated user
-        expectedRole = getRequiredRoleForPath(content, "/secured/getClaimsFromBeans");
+        // TODO: enable when https://github.com/quarkusio/quarkus/issues/32112 is fixed
+        // expectedRole = getRequiredRoleForPath(content, "/secured/getClaimsFromBeans");
         // note: '**' is equivalent of @Authenticated and @RolesAllowed("**")
-        assertEquals("**", expectedRole);
+        // assertEquals("**", expectedRole);
 
         // verify 'oidc' security schema
         var securitySchema = content


### PR DESCRIPTION
### Summary

Disable flaky assertion till upstream issue is fixed - https://github.com/quarkusio/quarkus/issues/32112

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)