### PR TITLE
Update expected Quarkus CLI text for command 'version' and disable failing CLI tests

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -12,6 +13,7 @@ import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliDefaultService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/32219")
 @QuarkusScenario
 @DisabledIfSystemProperty(named = "profile.id", matches = "native", disabledReason = "Only for JVM mode")
 public class QuarkusCliCreateExtensionIT {

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -44,6 +44,7 @@ import io.quarkus.test.bootstrap.QuarkusCliRestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/32219")
 @Tag("QUARKUS-960")
 @Tag("quarkus-cli")
 @QuarkusScenario

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateNativeApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateNativeApplicationIT.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -13,6 +14,7 @@ import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/32219")
 @Tag("QUARKUS-960")
 @Tag("quarkus-cli")
 @QuarkusScenario

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import jakarta.inject.Inject;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -25,6 +26,7 @@ import io.quarkus.test.services.quarkus.model.QuarkusProperties;
  * Note that the extensions list enhancements have been already reported as part
  * of https://github.com/quarkusio/quarkus/issues/18062 and https://github.com/quarkusio/quarkus/issues/18064.
  */
+@Disabled("https://github.com/quarkusio/quarkus/issues/32219")
 @Tag("QUARKUS-960")
 @Tag("quarkus-cli")
 @QuarkusScenario

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliHelpIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliHelpIT.java
@@ -40,7 +40,7 @@ public class QuarkusCliHelpIT {
         DEV("dev", "Run the current project in dev (live coding) mode."),
         EXTENSION("extension", "List platforms and extensions."),
         COMPLETION("completion", "bash/zsh completion:  source <(quarkus completion)"),
-        VERSION("version", "Print CLI version information and exit.");
+        VERSION("version", "Display CLI version information.");
 
         private final String command;
         private final String expectedHelp;

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
@@ -21,6 +21,7 @@ import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.utils.FileUtils;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/32219")
 @Tag("QUARKUS-960")
 @Tag("quarkus-cli")
 @QuarkusScenario


### PR DESCRIPTION
### Summary

Expected text for version help has changed due to https://github.com/quarkusio/quarkus/commit/4af1c06e173316ed3bcb4629a1b72ddb67b8ed75#diff-28dd2b5fee9f9be1f967d404cde0b820f215e2fe6d9ead6579ecdcc8912efb60L194, now it shows `io.quarkus.cli.Version` _header_. Couple of CLI tests are disabled due to the https://github.com/quarkusio/quarkus/issues/32219.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)