### PR TITLE
Disable OpenAPI definition check for allowed roles in security scheme

### DIFF
--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenApiStoreSchemaIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenApiStoreSchemaIT.java
@@ -83,13 +83,15 @@ public class OpenApiStoreSchemaIT extends BaseOidcIT {
         assertTrue(content.getJsonObject("paths").containsKey("/rest-pong"), "Missing expected path: /rest-pong");
 
         // verify that path /secured/admin is only accessible by user with role 'admin'
-        var expectedRole = getRequiredRoleForPath(content, "/secured/admin");
-        assertEquals("admin", expectedRole);
+        // TODO: enable when https://github.com/quarkusio/quarkus/issues/32112 get fixed
+        // var expectedRole = getRequiredRoleForPath(content, "/secured/admin");
+        // assertEquals("admin", expectedRole);
 
         // verify that path /secured/getClaimsFromBeans is accessible by any authenticated user
-        expectedRole = getRequiredRoleForPath(content, "/secured/getClaimsFromBeans");
+        // TODO: enable when https://github.com/quarkusio/quarkus/issues/32112 get fixed
+        // expectedRole = getRequiredRoleForPath(content, "/secured/getClaimsFromBeans");
         // note: '**' is equivalent of @Authenticated and @RolesAllowed("**")
-        assertEquals("**", expectedRole);
+        // assertEquals("**", expectedRole);
 
         // verify 'oidc' security schema
         var securitySchema = content


### PR DESCRIPTION
### Summary

Disables assertion of roles allowed to access path in generated OpenAPI definition. We already had to [disable same check for OIDC classic](https://github.com/quarkus-qe/quarkus-test-suite/pull/1129) and now that [daily build # 779 failed](https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/4585690826/jobs/8098110705), we know it is also affected by https://github.com/quarkusio/quarkus/issues/32112

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)