### PR TITLE
Profile for OpenShift running on aarch64

### DIFF
--- a/funqy/knative-events/src/test/java/io/quarkus/ts/funqy/knativeevents/ServerlessExtensionOpenShiftFunqyKnEventsIT.java
+++ b/funqy/knative-events/src/test/java/io/quarkus/ts/funqy/knativeevents/ServerlessExtensionOpenShiftFunqyKnEventsIT.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.fabric8.knative.sources.v1.PingSourceBuilder;
 import io.quarkus.test.bootstrap.Action;
@@ -37,6 +38,7 @@ import io.quarkus.test.services.knative.eventing.spi.ForwardResponseDTO;
 import io.restassured.common.mapper.TypeRef;
 
 @Disabled("Disabled as flaky") // TODO mvavrik: investigate why the test is flaky
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1142")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumReactiveIT.java
@@ -3,11 +3,13 @@ package io.quarkus.ts.http.minimum.reactive;
 import static io.restassured.RestAssured.given;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1142")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionOpenShiftHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/ServerlessExtensionOpenShiftHttpMinimumReactiveIT.java
@@ -3,11 +3,13 @@ package io.quarkus.ts.http.minimum.reactive;
 import static io.restassured.RestAssured.given;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1142")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionDockerBuildStrategyOpenShiftHttpMinimumIT.java
@@ -3,11 +3,13 @@ package io.quarkus.ts.http.minimum;
 import static io.restassured.RestAssured.given;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1142")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionOpenShiftHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/ServerlessExtensionOpenShiftHttpMinimumIT.java
@@ -3,11 +3,13 @@ package io.quarkus.ts.http.minimum;
 import static io.restassured.RestAssured.given;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1142")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)

--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionDockerBuildStrategyOpenShiftVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionDockerBuildStrategyOpenShiftVertxIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.vertx;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
@@ -8,6 +9,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1142")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)

--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionOpenShiftVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionOpenShiftVertxIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.vertx;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
@@ -8,6 +9,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1142")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)

--- a/messaging/amqp-reactive/src/test/java/io/quarkus/ts/messaging/amqpreactive/OpenShiftProdAmqpReactiveIT.java
+++ b/messaging/amqp-reactive/src/test/java/io/quarkus/ts/messaging/amqpreactive/OpenShiftProdAmqpReactiveIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.ts.messaging.amqpreactive;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1144")
 public class OpenShiftProdAmqpReactiveIT extends ProdAmqpReactiveIT {
 }

--- a/messaging/cloud-events/amqp-binary/src/test/java/io/quarkus/ts/messaging/cloudevents/amqpbinary/OpenShiftBinaryCloudEventsOverProdAmqpIT.java
+++ b/messaging/cloud-events/amqp-binary/src/test/java/io/quarkus/ts/messaging/cloudevents/amqpbinary/OpenShiftBinaryCloudEventsOverProdAmqpIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.ts.messaging.cloudevents.amqpbinary;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1144")
 public class OpenShiftBinaryCloudEventsOverProdAmqpIT extends BinaryCloudEventsOverProdAmqpIT {
 }

--- a/messaging/cloud-events/amqp-json/src/test/java/io/quarkus/ts/messaging/cloudevents/amqpjson/OpenShiftJSONCloudEventsOverProdAmqpIT.java
+++ b/messaging/cloud-events/amqp-json/src/test/java/io/quarkus/ts/messaging/cloudevents/amqpjson/OpenShiftJSONCloudEventsOverProdAmqpIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.ts.messaging.cloudevents.amqpjson;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1144")
 public class OpenShiftJSONCloudEventsOverProdAmqpIT extends JSONCloudEventsOverProdAmqpIT {
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftAmqStreamsKafkaStreamIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.messaging.kafka.reactive.streams;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KafkaService;
@@ -10,6 +11,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1144")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTest {
 

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.messaging.kafka.reactive.streams;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.Operator;
@@ -7,6 +9,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.operator.KafkaInstance;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1147")
 public class OperatorOpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTest {
     @Operator(name = "amq-streams", source = "redhat-operators")
     static KafkaInstance kafka = new KafkaInstance();

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/OpenShiftAmqStreamsKafkaAvroIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/OpenShiftAmqStreamsKafkaAvroIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.messaging.strimzi.kafka.reactive;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KafkaService;
@@ -10,6 +11,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1144")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsKafkaAvroIT extends BaseKafkaAvroIT {
 

--- a/monitoring/micrometer-prometheus-kafka-reactive/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/OpenShiftAmqStreamsAlertEventsReactiveIT.java
+++ b/monitoring/micrometer-prometheus-kafka-reactive/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/OpenShiftAmqStreamsAlertEventsReactiveIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.micrometer.prometheus.kafka.reactive;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KafkaService;
@@ -9,6 +10,7 @@ import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1144")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsAlertEventsReactiveIT extends BaseOpenShiftAlertEventsReactiveIT {
 

--- a/monitoring/micrometer-prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftAmqStreamsAlertEventsIT.java
+++ b/monitoring/micrometer-prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftAmqStreamsAlertEventsIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.micrometer.prometheus.kafka;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KafkaService;
@@ -9,6 +10,7 @@ import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1144")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsAlertEventsIT extends BaseOpenShiftAlertEventsIT {
 

--- a/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/reactive/OpenShiftMongoClientReactiveIT.java
+++ b/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/reactive/OpenShiftMongoClientReactiveIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.nosqldb.mongodb.reactive;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.MongoDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -7,6 +9,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1146")
 public class OpenShiftMongoClientReactiveIT extends AbstractMongoClientReactiveIT {
 
     @Container(image = "${mongodb.image}", port = 27017, expectedLog = "Waiting for connections")

--- a/nosql-db/mongodb/src/test/java/io/quarkus/ts/nosqldb/mongodb/OpenShiftMongoClientIT.java
+++ b/nosql-db/mongodb/src/test/java/io/quarkus/ts/nosqldb/mongodb/OpenShiftMongoClientIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.ts.nosqldb.mongodb;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1146")
 public class OpenShiftMongoClientIT extends MongoClientIT {
 }

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
                                 <redis.image>docker.io/library/redis:6.0</redis.image>
                                 <wiremock.image>quay.io/ocpmetal/wiremock</wiremock.image>
                                 <!-- TODO use official image when/if this fixed https://github.com/hashicorp/docker-consul/issues/184 -->
-                                <consul.image>docker.io/bitnami/consul:1.13.1</consul.image>
+                                <consul.image>docker.io/bitnami/consul:1.15.2</consul.image>
                                 <infinispan.image>quay.io/infinispan/server:14.0</infinispan.image>
                                 <infinispan.expected-log>Infinispan Server.*started in</infinispan.expected-log>
                                 <spring.cloud.server.image>quay.io/quarkusqeteam/spring-cloud-config-server:3.0</spring.cloud.server.image>

--- a/pom.xml
+++ b/pom.xml
@@ -740,6 +740,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
+                                <ts.arm.missing.services.excludes>true</ts.arm.missing.services.excludes>
                                 <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                 <!-- Product Services -->
                                 <rhsso.image>registry.redhat.io/rh-sso-7/sso76-openshift-rhel8</rhsso.image>

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
                                 <mysql.57.image>docker.io/library/mysql:5.7.36</mysql.57.image>
                                 <!-- TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/609 -->
                                 <mysql.upstream.80.image>docker.io/library/mysql:8.0</mysql.upstream.80.image>
-                                <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7</mysql.80.image>
+                                <mysql.80.image>registry.redhat.io/rhel8/mysql-80</mysql.80.image>
                                 <mariadb.10.image>docker.io/library/mariadb:10.10</mariadb.10.image>
                                 <mssql.image>mcr.microsoft.com/mssql/rhel/server:2022-latest</mssql.image>
                                 <oracle.image>docker.io/gvenzl/oracle-xe:21-slim-faststart</oracle.image>

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
                                 <!-- Services used in test suite -->
                                 <postgresql.latest.image>${postgresql.latest.image}</postgresql.latest.image>
                                 <!-- TODO: investigate further in https://github.com/quarkus-qe/quarkus-test-suite/issues/627 -->
-                                <elastic.71.image>docker.io/bitnami/elasticsearch:7.17.6</elastic.71.image>
+                                <elastic.71.image>docker.io/bitnami/elasticsearch:7.17.9</elastic.71.image>
                                 <!--TODO change into 5.7 when this fixed https://github.com/docker-library/mysql/issues/844 -->
                                 <mysql.57.image>docker.io/library/mysql:5.7.36</mysql.57.image>
                                 <!-- TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/609 -->

--- a/pom.xml
+++ b/pom.xml
@@ -713,6 +713,49 @@
             </build>
         </profile>
         <profile>
+            <!-- You need to be connected to an OpenShift instance to activate this
+                profile! -->
+            <id>openshift-arm</id>
+            <activation>
+                <property>
+                    <name>openshift-arm</name>
+                </property>
+            </activation>
+            <properties>
+                <include.tests>**/*OpenShift*IT.java</include.tests>
+                <exclude.openshift.tests>no</exclude.openshift.tests>
+            </properties>
+        </profile>
+        <profile>
+            <id>openshift-arm-containers</id>
+            <activation>
+                <property>
+                    <name>openshift-arm</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
+                                <!-- Product Services -->
+                                <rhsso.image>registry.redhat.io/rh-sso-7/sso76-openshift-rhel8</rhsso.image>
+                                <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10</postgresql.10.image>
+                                <postgresql.latest.image>registry.redhat.io/rhscl/postgresql-13-rhel7</postgresql.latest.image>
+                                <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103</mariadb.103.image>
+                                <mariadb.105.image>registry.redhat.io/rhel8/mariadb-105</mariadb.105.image>
+                                <amq-streams.image>registry.redhat.io/amq7/amq-streams-kafka-27-rhel7</amq-streams.image>
+                                <amq-streams.version>1.7.0</amq-streams.version>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>serverless</id>
             <activation>
                 <property>

--- a/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSsoAuthzSecurityIT.java
+++ b/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSsoAuthzSecurityIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.security.keycloak.authz;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -9,6 +10,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoAuthzSecurityIT extends BaseAuthzSecurityIT {
 

--- a/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/OpenShiftRhSsoAuthzSecurityReactiveIT.java
+++ b/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/OpenShiftRhSsoAuthzSecurityReactiveIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.security.keycloak.authz.reactive;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -9,6 +10,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoAuthzSecurityReactiveIT extends BaseAuthzSecurityReactiveIT {
 

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/OpenShiftRhSsoOidcJwtSecurityIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/OpenShiftRhSsoOidcJwtSecurityIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.security.keycloak.jwt;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -9,6 +10,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcJwtSecurityIT extends BaseOidcJwtSecurityIT {
 

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSsoMultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSsoMultiTenantSecurityIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.security.keycloak.multitenant;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -9,6 +10,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoMultiTenantSecurityIT extends BaseMultiTenantSecurityIT {
 

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/keycloak/oauth2/OpenShiftRhSsoOauth2SecurityIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/keycloak/oauth2/OpenShiftRhSsoOauth2SecurityIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.security.keycloak.oauth2;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -9,6 +10,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOauth2SecurityIT extends BaseOauth2SecurityIT {
 

--- a/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/OpenShiftRhSsoOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/OpenShiftRhSsoOidcClientSecurityIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.security.keycloak.oidcclient.basic;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -9,6 +10,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcClientSecurityIT extends BaseOidcClientSecurityIT {
 

--- a/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/OpenShiftRhSsoOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/OpenShiftRhSsoOidcClientSecurityIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.security.keycloak.oidcclient.reactive.basic;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -9,6 +10,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcClientSecurityIT extends BaseOidcClientSecurityIT {
 

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/OpenShiftRhSsoWebappSecurityIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/OpenShiftRhSsoWebappSecurityIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.security.keycloak.webapp;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -9,6 +10,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoWebappSecurityIT extends BaseWebappSecurityIT {
 

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftRhSsoOidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftRhSsoOidcSecurityIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.security.keycloak;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -9,6 +10,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcSecurityIT extends BaseOidcSecurityIT {
 

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/OpenShiftRhSsoOidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/OpenShiftRhSsoOidcMtlsIT.java
@@ -5,6 +5,7 @@ import static org.keycloak.representations.idm.CredentialRepresentation.PASSWORD
 
 import java.nio.file.Paths;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -14,6 +15,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcMtlsIT extends KeycloakMtlsAuthN {
 

--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionDockerBuildStrategyOpenShiftManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionDockerBuildStrategyOpenShiftManyExtensionsIT.java
@@ -3,11 +3,13 @@ package io.quarkus.ts.many.extensions;
 import static io.restassured.RestAssured.given;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1142")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)

--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionOpenShiftManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionOpenShiftManyExtensionsIT.java
@@ -3,11 +3,13 @@ package io.quarkus.ts.many.extensions;
 import static io.restassured.RestAssured.given;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1142")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)


### PR DESCRIPTION
### Summary

This PR contains a new profile for ARM running on OpenShift; updates to containers running test services to multiarch version and exclusion for tests that do not have required test services running on aarch64.

Issues that will need to be addressed for complete coverage:

* https://github.com/quarkus-qe/quarkus-test-suite/issues/1142
* https://github.com/quarkus-qe/quarkus-test-suite/issues/1144
* https://github.com/quarkus-qe/quarkus-test-suite/issues/1145
* https://github.com/quarkus-qe/quarkus-test-suite/issues/1146
* https://github.com/quarkus-qe/quarkus-test-suite/issues/1147

Test run with the profile: https://main-jenkins-csb-quarkusqe.apps.ocp-c1.prod.psi.redhat.com/job/quarkus-main-rhel8-jdk11-openshift-weekly-ts-jvm-ocp-4-stable/14/

Please select the relevant options.

- [] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [x] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)