### PR TITLE
Update Red Panda, Strimzi Kafka and Apicurio registry image version

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeRedPandaDevServiceUserExperienceIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeRedPandaDevServiceUserExperienceIT.java
@@ -15,7 +15,7 @@ import io.quarkus.test.utils.DockerUtils;
 @QuarkusScenario
 public class DevModeRedPandaDevServiceUserExperienceIT {
 
-    private static final String RED_PANDA_VERSION = "v21.10.3";
+    private static final String RED_PANDA_VERSION = "v22.3.4";
     private static final String RED_PANDA_IMAGE = "vectorized/redpanda";
 
     @DevModeQuarkusApplication

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/main/resources/docker-compose-strimzi.yaml
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/main/resources/docker-compose-strimzi.yaml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   zookeeper:
-    image: strimzi/kafka:0.18.0-kafka-2.5.0
+    image: strimzi/kafka:0.34.0-kafka-3.4.0
     command: [
         "sh", "-c",
         "bin/zookeeper-server-start.sh config/zookeeper.properties"
@@ -14,7 +14,7 @@ services:
       LOG_DIR: /tmp/logs
 
   kafka:
-    image: strimzi/kafka:0.18.0-kafka-2.5.0
+    image: strimzi/kafka:0.34.0-kafka-3.4.0
     command: [
         "sh", "-c",
         "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT}"
@@ -32,7 +32,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
   schema-registry:
-    image: apicurio/apicurio-registry-mem:2.0.1.Final
+    image: apicurio/apicurio-registry-mem:2.2.5.Final
     ports:
       - 8081:8080
     depends_on:

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/DevModeApicurioDevServiceUserExperienceIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/DevModeApicurioDevServiceUserExperienceIT.java
@@ -9,13 +9,14 @@ import com.github.dockerjava.api.model.Image;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.test.services.containers.model.KafkaRegistry;
 import io.quarkus.test.utils.DockerUtils;
 
 @Tag("QUARKUS-959")
 @Tag("QUARKUS-1087")
 @QuarkusScenario
 public class DevModeApicurioDevServiceUserExperienceIT {
-    private static final String APICURIO_VERSION = "2.0.1.Final";
+    private static final String APICURIO_VERSION = KafkaRegistry.APICURIO.getDefaultVersion();
     private static final String APICURIO_IMAGE = "apicurio/apicurio-registry-mem";
 
     @DevModeQuarkusApplication


### PR DESCRIPTION
### Summary

Updates Red Panda, Strimzi Kafka and Apicurio registry docker images. There is opened follow-up MR in Jenkins job project.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)