### PR TITLE
Enable spring-web-reactive module for GitHub Actions

### DIFF
--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/MariaDBConstants.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/MariaDBConstants.java
@@ -4,5 +4,6 @@ public class MariaDBConstants {
     public static final int PORT = 3306;
     public static final String START_LOG = "Only MySQL server logs after this point";
     public static final String IMAGE_103 = "${mariadb.103.image}";
-    public static final String IMAGE_105 = "${mariadb.105.image}";
+    public static final String START_LOG_10 = "socket: '/run/mysqld/mysqld.sock'  port: " + PORT;
+    public static final String IMAGE_10 = "${mariadb.10.image}";
 }

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/boostrap/SpringWebQuteReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/boostrap/SpringWebQuteReactiveIT.java
@@ -1,10 +1,8 @@
 package io.quarkus.ts.spring.web.reactive.reactive.boostrap;
 
-import static io.quarkus.ts.spring.web.reactive.reactive.MariaDBConstants.IMAGE_105;
+import static io.quarkus.ts.spring.web.reactive.reactive.MariaDBConstants.IMAGE_10;
 import static io.quarkus.ts.spring.web.reactive.reactive.MariaDBConstants.PORT;
-import static io.quarkus.ts.spring.web.reactive.reactive.MariaDBConstants.START_LOG;
-
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import static io.quarkus.ts.spring.web.reactive.reactive.MariaDBConstants.START_LOG_10;
 
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
@@ -13,10 +11,9 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class SpringWebQuteReactiveIT extends AbstractSpringWebQuteReactiveIT {
 
-    @Container(image = IMAGE_105, port = PORT, expectedLog = START_LOG)
+    @Container(image = IMAGE_10, port = PORT, expectedLog = START_LOG_10)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/boostrap/SpringWebRestReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/boostrap/SpringWebRestReactiveIT.java
@@ -1,10 +1,8 @@
 package io.quarkus.ts.spring.web.reactive.reactive.boostrap;
 
-import static io.quarkus.ts.spring.web.reactive.reactive.MariaDBConstants.IMAGE_105;
+import static io.quarkus.ts.spring.web.reactive.reactive.MariaDBConstants.IMAGE_10;
 import static io.quarkus.ts.spring.web.reactive.reactive.MariaDBConstants.PORT;
-import static io.quarkus.ts.spring.web.reactive.reactive.MariaDBConstants.START_LOG;
-
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import static io.quarkus.ts.spring.web.reactive.reactive.MariaDBConstants.START_LOG_10;
 
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
@@ -13,10 +11,9 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class SpringWebRestReactiveIT extends AbstractSpringWebRestReactiveIT {
 
-    @Container(image = IMAGE_105, port = PORT, expectedLog = START_LOG)
+    @Container(image = IMAGE_10, port = PORT, expectedLog = START_LOG_10)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/openapi/SpringWebOpenApiReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/reactive/openapi/SpringWebOpenApiReactiveIT.java
@@ -1,12 +1,11 @@
 package io.quarkus.ts.spring.web.reactive.reactive.openapi;
 
-import static io.quarkus.ts.spring.web.reactive.reactive.MariaDBConstants.IMAGE_105;
+import static io.quarkus.ts.spring.web.reactive.reactive.MariaDBConstants.IMAGE_10;
 import static io.quarkus.ts.spring.web.reactive.reactive.MariaDBConstants.PORT;
-import static io.quarkus.ts.spring.web.reactive.reactive.MariaDBConstants.START_LOG;
+import static io.quarkus.ts.spring.web.reactive.reactive.MariaDBConstants.START_LOG_10;
 
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
@@ -16,10 +15,9 @@ import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class SpringWebOpenApiReactiveIT extends AbstractSpringWebOpenApiReactiveIT {
 
-    @Container(image = IMAGE_105, port = PORT, expectedLog = START_LOG)
+    @Container(image = IMAGE_10, port = PORT, expectedLog = START_LOG_10)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication


### PR DESCRIPTION
Enable spring-web-reactive module for GitHub Actions

MariaDB 10.5 image is tested in OpenShift scenarios, using public `mariadb.10.image` for bare metal scenarios

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)