### PR TITLE
Revert "Fix Spring Web test as ex. thrown for constraint violation is wrapped"

### DIFF
--- a/spring/spring-web/src/main/java/io/quarkus/ts/spring/web/reactive/boostrap/web/RestExceptionHandler.java
+++ b/spring/spring-web/src/main/java/io/quarkus/ts/spring/web/reactive/boostrap/web/RestExceptionHandler.java
@@ -1,11 +1,13 @@
 package io.quarkus.ts.spring.web.reactive.boostrap.web;
 
+import jakarta.persistence.PersistenceException;
+
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import io.quarkus.arc.ArcUndeclaredThrowableException;
 import io.quarkus.ts.spring.web.reactive.boostrap.web.exception.BookIdMismatchException;
 import io.quarkus.ts.spring.web.reactive.boostrap.web.exception.BookNotFoundException;
 
@@ -19,7 +21,8 @@ public class RestExceptionHandler {
 
     @ExceptionHandler({
             BookIdMismatchException.class,
-            ArcUndeclaredThrowableException.class
+            ConstraintViolationException.class,
+            PersistenceException.class
     })
     public ResponseEntity<Object> handleBadRequest(Exception ex) {
         return new ResponseEntity<>(ex.getLocalizedMessage(), HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
Revert "Fix Spring Web test as ex. thrown for constraint violation is wrapped"

This fixes the recent CI failures after Hibernate 6.2.0.Final merge into Quarkus main, some details in https://github.com/quarkusio/quarkus/issues/32397#issuecomment-1495887017.

https://docs.jboss.org/hibernate/orm/6.2/javadocs/org/hibernate/PropertyValueException.html extends  jakarta.persistence.PersistenceException  

Also aligning with https://github.com/quarkus-qe/quarkus-test-suite/blob/main/spring/spring-web-reactive/src/main/java/io/quarkus/ts/spring/web/reactive/boostrap/web/RestExceptionHandler.java

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)