### PR TITLE
Enable OperatorOpenShiftInfinispanCountersIT test

### DIFF
--- a/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanCountersIT.java
+++ b/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanCountersIT.java
@@ -9,7 +9,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -21,8 +20,6 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.utils.Command;
 
-// TODO mvavrik: investigate and enable test!
-@Disabled("fails over incorrect response status, mvavrik will investigate in week 14")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class OperatorOpenShiftInfinispanCountersIT extends BaseOpenShiftInfinispanIT {


### PR DESCRIPTION
### Summary

Enables `OperatorOpenShiftInfinispanCountersIT`. Failures were caused by old Infinispan cluster that hung in datagrid-cluster project.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)