### PR TITLE
Disable DEV mode continuous testing scenarios due to upstream re-working

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeGrpcIntegrationReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeGrpcIntegrationReactiveIT.java
@@ -18,6 +18,7 @@ import org.apache.http.HttpStatus;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -41,6 +42,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.WebSocket;
 
+// TODO mvavrik: enable test and adjust it to new DEV UI
+@Disabled("Disabled as DEV UI is work in progress currenlty")
 @Tag("QUARKUS-1026")
 @Tag("QUARKUS-1094")
 @QuarkusScenario

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeGrpcIntegrationIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeGrpcIntegrationIT.java
@@ -17,6 +17,7 @@ import org.apache.http.HttpStatus;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -40,6 +41,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.WebSocket;
 
+// TODO mvavrik: enable test and adjust it to new DEV UI
+@Disabled("Disabled as DEV UI is work in progress currenlty")
 @Tag("QUARKUS-1026")
 @Tag("QUARKUS-1094")
 @QuarkusScenario

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/DevModeHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/DevModeHttpMinimumReactiveIT.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -15,6 +16,8 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.AwaitilityUtils;
 
+// TODO: mvavrik enable and adapt to new continuous testing page
+@Disabled("Disabled as DEV UI continuous testing is currently re-worked")
 @Tag("QUARKUS-1026")
 @QuarkusScenario
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/DevModeHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/DevModeHttpMinimumIT.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -15,6 +16,8 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.AwaitilityUtils;
 
+// TODO: mvavrik enable and adapt to new continuous testing page
+@Disabled("Disabled as DEV UI continuous testing is currently re-worked")
 @Tag("QUARKUS-1026")
 @QuarkusScenario
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)


### PR DESCRIPTION
### Summary

Disabled DEV mode tests using continuous testing. Currently there is no button to enable continuous testing, new dedicated page is expected in next days, then we need to adapt FW, release it and enable tests here.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)