### PR TITLE
Enable Agroal idleTimeoutTest

### DIFF
--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalPoolTest.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalPoolTest.java
@@ -20,7 +20,6 @@ import jakarta.persistence.Query;
 import org.apache.http.HttpStatus;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -55,6 +54,9 @@ public class AgroalPoolTest {
     @ConfigProperty(name = "quarkus.datasource.jdbc.idle-removal-interval")
     String idleSec;
 
+    @ConfigProperty(name = "quarkus.datasource.jdbc.background-validation-interval")
+    String idleBackgroundValidationSec;
+
     @ConfigProperty(name = "quarkus.datasource.jdbc.max-size")
     int datasourceMaxSize;
 
@@ -62,10 +64,9 @@ public class AgroalPoolTest {
     int datasourceMinSize;
 
     @Test
-    @Disabled("Pending Zulip conversation about quarkus.datasource.jdbc.idle-removal-interval")
     public void idleTimeoutTest() throws InterruptedException {
         makeApplicationQuery();
-        Thread.sleep(Duration.ofMillis(getIdleMs() + 1).toMillis());
+        Thread.sleep(getIdleMs() + getIdleBackgroundValidationMs());
         assertEquals(1, activeConnections(), "agroalCheckIdleTimeout: Expected " + datasourceMinSize + " active connections");
     }
 
@@ -139,8 +140,13 @@ public class AgroalPoolTest {
     }
 
     private long getIdleMs() {
-        int idle = Integer.parseInt(idleSec.replaceAll("[A-Z]", ""));
-        return Duration.ofSeconds(idle).toMillis();
+        float idle = Float.parseFloat(idleSec.replaceAll("[A-Z]", ""));
+        return Duration.ofMillis(Math.round(1000 * idle)).toMillis();
+    }
+
+    private long getIdleBackgroundValidationMs() {
+        float idleBg = Float.parseFloat(idleBackgroundValidationSec.replaceAll("[A-Z]", ""));
+        return Duration.ofMillis(Math.round(1000 * idleBg)).toMillis();
     }
 
     private Multi<Long> activeConnectionsAsync(int events) {


### PR DESCRIPTION
### Summary

Enable Agroal idle timeout test. Add quarkus.datasource.jdbc.background-validation-interval property that defines the interval at which idle connections has been validated in the background

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)