### PR TITLE
Enable test in SecuredRepositoryRestResourcesIT

### DIFF
--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/rest/secured/SecuredRepositoryRestResourcesIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/rest/secured/SecuredRepositoryRestResourcesIT.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.ts.spring.data.AbstractDbIT;
 import io.restassured.http.ContentType;
 
@@ -148,8 +147,6 @@ public class SecuredRepositoryRestResourcesIT extends AbstractDbIT {
                 .then().statusCode(HttpStatus.SC_OK);
     }
 
-    // Fix for https://github.com/quarkusio/quarkus/issues/30358 has been backported to Quarkus 2.13 and 2.16, but not to 2.14 and 2.15.
-    @DisabledOnQuarkusVersion(version = "(2\\.14\\..*)|(2\\.15\\..*)", reason = "https://github.com/quarkusio/quarkus/issues/30358")
     @Test
     void rolesAllowedResourcePermitAllMethodWithoutRestResourceAnnotation() {
         app.given()


### PR DESCRIPTION
### Summary

rolesAllowedResourcePermitAllMethodWithoutRestResourceAnnotation test was enabled, because actual Quarkus project version is 3.0.0.CR2

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)