### PR TITLE
Enable tests previously disabled on specific Quarkus versions

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/BaseHttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/BaseHttpAdvancedReactiveIT.java
@@ -71,7 +71,6 @@ import io.quarkus.example.HelloWorldProto;
 import io.quarkus.example.StreamingGrpc;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.scenarios.annotations.EnabledOnQuarkusVersion;
 import io.quarkus.ts.http.advanced.reactive.clients.HttpVersionClientService;
 import io.quarkus.ts.http.advanced.reactive.clients.HttpVersionClientServiceAsync;
@@ -340,7 +339,6 @@ public abstract class BaseHttpAdvancedReactiveIT {
                 .body(TEXT, is(TEXT));
     }
 
-    @DisabledOnQuarkusVersion(version = "(2\\.[0-8]\\..*)|(2\\.9\\.[0-1]\\..*)", reason = "Fixed in Quarkus 2.9.2.Final")
     @DisplayName("Jakarta REST RouterFilter and Vert.x Web Routes integration")
     @Test
     public void multipleResponseFilter() {
@@ -372,7 +370,6 @@ public abstract class BaseHttpAdvancedReactiveIT {
                         .anyMatch(headerValue::equals));
     }
 
-    @DisabledOnQuarkusVersion(version = "(2\\.[0-6]\\..*)|(2\\.7\\.[0-5]\\..*)|(2\\.8\\.[0-2]\\..*)", reason = "Fixed in Quarkus 2.8.3.Final. and backported to 2.7.6.Final")
     @DisplayName("Jakarta REST MessageBodyWriter test")
     @Test
     public void messageBodyWriter() {
@@ -388,7 +385,6 @@ public abstract class BaseHttpAdvancedReactiveIT {
                 .body(mediaTypeProperty + ".subtype", is("json"));
     }
 
-    @DisabledOnQuarkusVersion(version = "(2\\.[0-8]\\..*)|(2\\.9\\.0\\..*)", reason = "Fixed in Quarkus 2.9.1.Final")
     @DisplayName("Jakarta REST Response Content type test")
     @Test
     public void responseContentType() {
@@ -405,7 +401,6 @@ public abstract class BaseHttpAdvancedReactiveIT {
         testResponseContentType(IMAGE_JPEG, IMAGE_JPEG);
     }
 
-    @DisabledOnQuarkusVersion(version = "(2\\.[0-6]\\..*)|(2\\.7\\.[0-5]\\..*)|(2\\.8\\.0\\..*)", reason = "Fixed in Quarkus 2.8.1 and backported to 2.7.6.")
     @Test
     public void testMediaTypePassedToMessageBodyWriter() {
         // Accepted Media Type must be passed to 'MessageBodyWriter'

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.condition.OS;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.http.restclient.reactive.json.Book;
 import io.quarkus.ts.http.restclient.reactive.json.BookRepository;
@@ -25,8 +24,6 @@ import io.restassured.response.Response;
 public class ReactiveRestClientIT {
 
     private static final String HEMINGWAY_BOOKS = "In Our Time, The Sun Also Rises, A Farewell to Arms, The Old Man and the Sea";
-    private static final String DISABLE_IF_NOT_QUARKUS_2_7_6_OR_2_8_3_OR_HIGHER = "(2\\.[0-6]\\..*)|(2\\.7\\.[0-5]\\..*)|(2\\.8\\.[0-2]\\..*)";
-    private static final String FIXED_IN_2_7_6_AND_2_8_3 = "Fixed in Quarkus 2.8.3.Final and 2.7.6.Final";
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("modern.properties");
@@ -132,7 +129,6 @@ public class ReactiveRestClientIT {
         assertEquals("USD", response.getBody().asString());
     }
 
-    @DisabledOnQuarkusVersion(version = DISABLE_IF_NOT_QUARKUS_2_7_6_OR_2_8_3_OR_HIGHER, reason = FIXED_IN_2_7_6_AND_2_8_3)
     @Test
     public void decodedRequestPath() {
         Response response = app.given().given().queryParam("searchTerm", SEARCH_TERM_VAL)
@@ -141,7 +137,6 @@ public class ReactiveRestClientIT {
         assertEquals(HEMINGWAY_BOOKS, response.getBody().asString());
     }
 
-    @DisabledOnQuarkusVersion(version = DISABLE_IF_NOT_QUARKUS_2_7_6_OR_2_8_3_OR_HIGHER, reason = FIXED_IN_2_7_6_AND_2_8_3)
     @Test
     public void encodedRequestPath() {
         Response response = app.given().given().queryParam("searchTerm", SEARCH_TERM_VAL)
@@ -154,7 +149,6 @@ public class ReactiveRestClientIT {
      * Test class annotated with {@link jakarta.ws.rs.Path} and registered as client via
      * {@link org.eclipse.microprofile.rest.client.inject.RegisterRestClient} must not be included in OpenAPI Document.
      */
-    @DisabledOnQuarkusVersion(version = "(2\\.[0-6]\\..*)|(2\\.7\\.[0-5]\\..*)", reason = "Fixed in Quarkus 2.7.6.")
     @Test
     public void restClientIsNotIncludedInOpenApiDocument() {
         // Path '/books/author/profession/name' is unique to AuthorClient#getProfession() and should not be part of OpenAPI document

--- a/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/BaseMicrometerOidcSecurityIT.java
+++ b/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/BaseMicrometerOidcSecurityIT.java
@@ -13,10 +13,8 @@ import org.keycloak.authorization.client.AuthzClient;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.KeycloakContainer;
 
-@DisabledOnQuarkusVersion(version = "(2\\.[2-9]\\..*)|(2\\.1[0-5]\\..*)", reason = "Fixed in Quarkus 2.16")
 public abstract class BaseMicrometerOidcSecurityIT {
 
     static final String NORMAL_USER = "test-normal-user";

--- a/monitoring/micrometer-prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/MicroProfileApiIT.java
+++ b/monitoring/micrometer-prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/MicroProfileApiIT.java
@@ -10,12 +10,10 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 
 @QuarkusScenario
-@DisabledOnQuarkusVersion(version = "(2\\.[2-9]\\..*)|(2\\.1[0-5]\\..*)", reason = "Fixed in Quarkus 2.16")
 public class MicroProfileApiIT {
 
     private static final String PING_PONG = "ping pong";

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -18,7 +18,6 @@ import io.quarkus.builder.Version;
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 /**
@@ -95,7 +94,6 @@ public class QuarkusCliExtensionsIT {
     }
 
     @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not pushed into the platform site")
-    @DisabledOnQuarkusVersion(version = "2.7.5.Final", reason = "Quarkus 2.7 stream was removed from code.quarkus.io")
     //TODO Currently code.quarkus and quarkusCli are pointing to the same set of defined streams.
     // ZULIP ref: https://quarkusio.zulipchat.com/#narrow/stream/191168-core-team/topic/streams.20on.20registry.20.2F.20code.2Equarkus/near/280456392
     @Test

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/SpringDataCompositeEntityIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/SpringDataCompositeEntityIT.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.ts.spring.data.AbstractDbIT;
 import io.quarkus.ts.spring.data.primitivetypes.model.Book;
 import io.restassured.http.ContentType;
@@ -26,7 +25,6 @@ import io.restassured.response.Response;
 @QuarkusScenario
 public class SpringDataCompositeEntityIT extends AbstractDbIT {
 
-    @DisabledOnQuarkusVersion(version = "(2\\.[0-6]\\..*)|(2\\.7\\.[0-5]\\..*)|(2\\.8\\.0\\..*)", reason = "Fixed in Quarkus 2.8.1 and backported to 2.7.6.")
     @Test
     void testInterfaceBasedProjection() {
         app


### PR DESCRIPTION
### Summary

Enable tests previously disabled on specific Quarkus versions (2.*) as current Quarkus version is 3.0.0.CR2

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)