### PR TITLE
Enable PG service binding tests as upstream issue is fixed

### DIFF
--- a/service-binding/postgresql-crunchy-classic/src/main/resources/application.properties
+++ b/service-binding/postgresql-crunchy-classic/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.kubernetes-service-binding.services.postgresql.api-version=postgres-operator.crunchydata.com/v1beta1
 quarkus.kubernetes-service-binding.services.postgresql.kind=PostgresCluster
-quarkus.kubernetes-service-binding.services.postgresql.name=hippo
+quarkus.kubernetes-service-binding.services.postgresql.name=postgresql
 
 quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.database.generation=drop-and-create

--- a/service-binding/postgresql-crunchy-classic/src/main/resources/import.sql
+++ b/service-binding/postgresql-crunchy-classic/src/main/resources/import.sql
@@ -1,1 +1,1 @@
-INSERT INTO todo(id, title, completed) VALUES (nextval('hibernate_sequence'), 'Finish the blog post', false);
+INSERT INTO todo(id, title, completed) VALUES (nextval('todo_seq'), 'Finish the blog post', false);

--- a/service-binding/postgresql-crunchy-classic/src/test/java/io/quarkus/ts/sb/postgresql/OpenShiftPostgreSqlSbIT.java
+++ b/service-binding/postgresql-crunchy-classic/src/test/java/io/quarkus/ts/sb/postgresql/OpenShiftPostgreSqlSbIT.java
@@ -11,7 +11,6 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -22,7 +21,6 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.utils.Command;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
-@Disabled("https://github.com/quarkusio/quarkus/issues/30682")
 public class OpenShiftPostgreSqlSbIT {
 
     @Inject

--- a/service-binding/postgresql-crunchy-classic/src/test/resources/pg-cluster.yml
+++ b/service-binding/postgresql-crunchy-classic/src/test/resources/pg-cluster.yml
@@ -1,7 +1,7 @@
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
-  name: hippo
+  name: postgresql
 spec:
   openshift: true
   image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.2-1

--- a/service-binding/postgresql-crunchy-reactive/src/main/resources/application.properties
+++ b/service-binding/postgresql-crunchy-reactive/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.kubernetes-service-binding.services.postgresql.api-version=postgres-operator.crunchydata.com/v1beta1
 quarkus.kubernetes-service-binding.services.postgresql.kind=PostgresCluster
-quarkus.kubernetes-service-binding.services.postgresql.name=hippo
+quarkus.kubernetes-service-binding.services.postgresql.name=postgresql
 
 quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.database.generation=drop-and-create

--- a/service-binding/postgresql-crunchy-reactive/src/main/resources/import.sql
+++ b/service-binding/postgresql-crunchy-reactive/src/main/resources/import.sql
@@ -1,1 +1,1 @@
-INSERT INTO todo(id, title, completed) VALUES (nextval('hibernate_sequence'), 'Finish the blog post', false);
+INSERT INTO todo(id, title, completed) VALUES (nextval('todo_seq'), 'Finish the blog post', false);

--- a/service-binding/postgresql-crunchy-reactive/src/test/java/io/quarkus/ts/sb/reactive/OpenShiftPostgreSqlReactiveSbIT.java
+++ b/service-binding/postgresql-crunchy-reactive/src/test/java/io/quarkus/ts/sb/reactive/OpenShiftPostgreSqlReactiveSbIT.java
@@ -12,7 +12,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -23,7 +22,6 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.utils.Command;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
-@Disabled("https://github.com/quarkusio/quarkus/issues/30682")
 public class OpenShiftPostgreSqlReactiveSbIT {
 
     private static final String PG_CLUSTER_YML = "pg-cluster.yml";

--- a/service-binding/postgresql-crunchy-reactive/src/test/resources/pg-cluster.yml
+++ b/service-binding/postgresql-crunchy-reactive/src/test/resources/pg-cluster.yml
@@ -1,7 +1,7 @@
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
-  name: hippo
+  name: postgresql
 spec:
   openshift: true
   image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.2-1


### PR DESCRIPTION
### Summary

closes: #993

According to https://github.com/quarkusio/quarkus/issues/32773#issuecomment-1515786557 the issue was fixed by https://github.com/quarkusio/quarkus/pull/32651.

- sequence change goes down to Hibernate 6
- `hippo` -> `postgresql`: it doesn't work with hippo, I think that's because the name is also used for named datasource (so it looks for hippo ds), it is documented at the very end of this page https://quarkus.io/guides/deploying-to-kubernetes#customizing-automatic-service-binding (full disclosure: I'm not sure here. Do you read it same way I do?)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)