### PR TITLE
Debug websockets producer with additional time and logging

### DIFF
--- a/websockets/quarkus-websockets/src/test/java/io/quarkus/ts/websockets/producer/WebSocketsProducerConsumerIT.java
+++ b/websockets/quarkus-websockets/src/test/java/io/quarkus/ts/websockets/producer/WebSocketsProducerConsumerIT.java
@@ -130,10 +130,13 @@ public class WebSocketsProducerConsumerIT {
     private static void assertMessage(String expectedMessage, Client... clients) {
         for (Client client : clients) {
             // message has been sent asynchronously, therefore we should wait a little
+            final long start = System.currentTimeMillis();
             Awaitility
                     .await()
-                    .atMost(ofSeconds(2))
+                    .atMost(ofSeconds(10)) // TODO: revise this timeout as it is too high
                     .untilAsserted(() -> Assertions.assertEquals(expectedMessage, client.getMessage()));
+            long timeSpentWaiting = System.currentTimeMillis() - start;
+            LOG.infof("Waited %s milliseconds for asynchronous message to arrive", timeSpentWaiting);
         }
     }
 


### PR DESCRIPTION
### Summary

This test is flaky and every couple of days daily build fails, however even after Pablo's addition we still don't have any useful information for debugging failure. As I can't really reproduce it locally, I need 2 things:

1. would it succeed eventually? (=> enlarge waiting period)
3. how long does it take for asynchronously sent message to arrive

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)