### PR TITLE
Faster build when using -DskipTests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,8 @@
         <smallrye-stork.version>2.1.0</smallrye-stork.version>
         <assertj.version>3.24.2</assertj.version>
         <profile.id>jvm</profile.id>
+        <!-- Faster build when using -DskipTests -->
+        <quarkus.build.skip>${skipTests}</quarkus.build.skip>
         <!-- S2i configuration -->
         <ts.global.s2i.quarkus.jvm.builder.image>registry.access.redhat.com/ubi8/openjdk-11:latest</ts.global.s2i.quarkus.jvm.builder.image>
         <ts.global.s2i.quarkus.native.builder.image>quay.io/quarkus/ubi-quarkus-graalvmce-s2i:22.3-java17</ts.global.s2i.quarkus.native.builder.image>


### PR DESCRIPTION
Faster build when using -DskipTests

Fixes https://github.com/quarkus-qe/quarkus-test-suite/issues/107

BEFORE: `[INFO] Total time:  06:49 min`
AFTER: `[INFO] Total time:  02:29 min`

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)