### PR TITLE
Skip native executable build for sql-app modules as tests use custom one

### DIFF
--- a/sql-db/sql-app-compatibility/pom.xml
+++ b/sql-db/sql-app-compatibility/pom.xml
@@ -76,6 +76,10 @@
                     <name>native</name>
                 </property>
             </activation>
+            <properties>
+                <!-- Skipped Quarkus build in native as all tests use custom build -->
+                <quarkus.build.skip>true</quarkus.build.skip>
+            </properties>
         </profile>
         <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
         <profile>

--- a/sql-db/sql-app/pom.xml
+++ b/sql-db/sql-app/pom.xml
@@ -72,6 +72,10 @@
                     <name>native</name>
                 </property>
             </activation>
+            <properties>
+                <!-- Skipped Quarkus build in native as all tests use custom build -->
+                <quarkus.build.skip>true</quarkus.build.skip>
+            </properties>
         </profile>
         <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
         <profile>


### PR DESCRIPTION
### Summary

closes: #373

Today, daily build (number 793) got cancelled in native as sql-modules take too long to execute. We recently added sql-app-compatibility module that added to already packaged Maven profile. All tests in `sql-app` and `sql-app-compatibility` modules use custom build, therefore we can spare couple of minutes by skipping `quarkus-maven-build` in native mode.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)