### PR TITLE
Add retention-days for storing maven repo artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           name: maven-repo
           path: maven-repo.tgz
+          retention-days: 1
   linux-validate-format:
     name: Linux - Validate format
     runs-on: ubuntu-latest

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -31,6 +31,7 @@ jobs:
         with:
           name: maven-repo
           path: maven-repo.tgz
+          retention-days: 1
   linux-build-jvm-latest:
     name: Daily - Linux - JVM build - Latest Version
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary

Add retention-days for storing maven repo artifact (1GB)

The default retention policy is 90 days - https://github.com/actions/upload-artifact#retention-period

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)