### PR TITLE
Cover separate management interface deployed by openshift-extension

### DIFF
--- a/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftBaseDeploymentIT.java
+++ b/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftBaseDeploymentIT.java
@@ -1,20 +1,15 @@
-package io.quarkus.qe;
+package io.quarkus.qe.extension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
-import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.response.Response;
 
-@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
-@Disabled("Requires fixing https://github.com/quarkusio/quarkus/issues/32135 and changes in the Framework")
-public class OpenShiftExtensionIT {
+public abstract class OpenShiftBaseDeploymentIT {
     @QuarkusApplication
     static final RestService app = new RestService();
 

--- a/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftDockerBuildIT.java
+++ b/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftDockerBuildIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe.extension;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
+public class OpenShiftDockerBuildIT extends OpenShiftBaseDeploymentIT {
+}

--- a/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftExtensionIT.java
+++ b/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftExtensionIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe.extension;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
+public class OpenShiftExtensionIT extends OpenShiftBaseDeploymentIT {
+}

--- a/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftRegistryIT.java
+++ b/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftRegistryIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe.extension;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
+public class OpenShiftRegistryIT extends OpenShiftBaseDeploymentIT {
+}

--- a/monitoring/micrometer-prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/OpenShiftCustomMetricsIT.java
+++ b/monitoring/micrometer-prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/OpenShiftCustomMetricsIT.java
@@ -51,13 +51,11 @@ public class OpenShiftCustomMetricsIT {
     @QuarkusApplication
     static RestService app = new RestService()
             /*
-             * TODO fix deployment with OpenShiftDeploymentStrategies in the Framework
-             * see https://github.com/quarkusio/quarkus/issues/32135#issuecomment-1486740862 for details
-             * .withProperty("quarkus.management.ssl.certificate.key-store-file",
-             * "META-INF/resources/server.keystore")
+             * TODO use https when https://github.com/quarkusio/quarkus/issues/32225 is fixed
+             * .withProperty("quarkus.management.ssl.certificate.key-store-file", "META-INF/resources/server.keystore")
              * .withProperty("quarkus.management.ssl.certificate.key-store-password", "password")
-             * .withProperty("quarkus.management.enabled", "true")
              */
+            .withProperty("quarkus.management.enabled", "true")
             .onPostStart(OpenShiftCustomMetricsIT::loadServiceMonitor);
 
     @Inject

--- a/monitoring/micrometer-prometheus/src/test/resources/service-monitor.yaml
+++ b/monitoring/micrometer-prometheus/src/test/resources/service-monitor.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   endpoints:
   - interval: 30s
-    targetPort: 8080
+    targetPort: 9000
     path: /q/metrics
     scheme: http
   selector:

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <!-- please keep Quarkus version used in lifecycle-application module same as is used in framework -->
-        <quarkus.qe.framework.version>1.3.0.Beta13</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.3.0.Beta14</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.42.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.12.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.14</apache-httpclient-fluent.version>


### PR DESCRIPTION
### Summary
Follow-up to 2b483fa2165907e5d0f18687896915ccab05e07c
Apps with separate management interface can now be deployed by quarkus openshift-extension

Test plans for the change: https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-2738.md Related links:
    https://github.com/quarkusio/quarkus/pull/30506
    https://issues.redhat.com/browse/QUARKUS-2738

Depends on https://github.com/quarkus-qe/quarkus-test-framework/pull/747

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)