### PR TITLE
Disable DevModeConfigIT on Windows as it requires Docker

### DIFF
--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/DevModeConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/DevModeConfigIT.java
@@ -6,6 +6,7 @@ import static io.quarkus.ts.configmap.api.server.SecretKeysHandler.BASE64;
 import static io.quarkus.ts.configmap.api.server.SecretKeysHandler.CRYPTO_AES_GCM_NO_PADDING;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Duration.ofSeconds;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import java.util.Base64;
@@ -13,11 +14,13 @@ import java.util.Base64;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
+@DisabledOnOs(value = WINDOWS, disabledReason = "Needs Docker support") // Windows containers are not supported by TestContainers
 @QuarkusScenario
 public class DevModeConfigIT {
 


### PR DESCRIPTION
### Summary

Addresses https://github.com/quarkus-qe/quarkus-test-suite/pull/1176#issuecomment-1512828391
Looks like Quarkus checks for TestContainers when running `DevModeConfigIT`, not sure why as there is no DevService started when I run it on Linux, but log is clear here. I suggest to disable it, but understanding it would be also nice (when there is time...).

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)