### PR TITLE
Drop test as session ID is not supported in Reactive Resteasy

### DIFF
--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/CommonsHeadersIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/CommonsHeadersIT.java
@@ -2,20 +2,16 @@ package io.quarkus.ts.spring.data.primitivetypes;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.ts.spring.data.AbstractDbIT;
 import io.restassured.http.Headers;
-import io.restassured.response.Response;
 
 @QuarkusScenario
 public class CommonsHeadersIT extends AbstractDbIT {
@@ -61,40 +57,4 @@ public class CommonsHeadersIT extends AbstractDbIT {
                 requestIds.size(), is(3));
     }
 
-    //This is for regression test for https://github.com/quarkusio/quarkus/pull/12234
-    @Test
-    @Disabled("Session ID is not supported in Reactive Resteasy. https://github.com/quarkus-qe/quarkus-test-suite/issues/567")
-    @DisplayName("session scope")
-    public void testSessionScope() {
-        final Response first = app.given().get("/cat/customFindDistinctivePrimitive/2");
-        final String sessionId = first.sessionId();
-        Headers headers = app.given()
-                .sessionId(sessionId)
-                .get("/cat/customFindDistinctivePrimitive/2")
-                .headers();
-        String msg = "Unexpected x-session header value(Spring Session Scope). Two request from the same http session must have the same x-session header.";
-        assertEquals(first.header("x-session"), headers.getValue("x-session"), msg);
-
-        headers = app.given()
-                .sessionId(sessionId)
-                .get("/cat/customFindDistinctivePrimitive/2")
-                .headers();
-
-        assertEquals(first.header("x-session"), headers.getValue("x-session"), msg);
-
-        app.given()
-                .sessionId(sessionId)
-                .when()
-                .put("/session/invalidate")
-                .then();
-
-        Response second = app.given()
-                .sessionId(sessionId)
-                .get("/cat/customFindDistinctivePrimitive/2");
-
-        assertNotEquals(first.header("x-session"), second.header("x-session"),
-                "First http session can't be the same as second http session");
-        assertNotEquals(sessionId, second.sessionId(),
-                "(Spring Session scope) Two request from different sessions must have different x-session header.");
-    }
 }


### PR DESCRIPTION
### Summary

closes: #567

The way I read upstream comment, expectation tested by the `CommonsHeadersIT#testSessionScope` wasn't supposed to work at first place. I don't see what should be replacement for this place, therefore I suggest to drop it.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)