### PR TITLE
Fix lifecycle-application failure by syncing Quarkus version

### DIFF
--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -28,7 +28,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-di</artifactId>
             <!-- TODO  switch to 3.something-redhat-0000X based version once available in maven.repository.redhat.com -->
-            <version>3.0.0.Alpha3</version>
+            <version>3.0.0.CR2</version>
         </dependency>
     </dependencies>
     <profiles>
@@ -42,7 +42,7 @@
             <properties>
                 <!-- please keep Mandrel and RHBQ version compatible -->
                 <!-- TODO  switch to 3.something-redhat-0000X based version once available in maven.repository.redhat.com -->
-                <quarkus.platform.version>3.0.0.Alpha3</quarkus.platform.version>
+                <quarkus.platform.version>3.0.0.CR2</quarkus.platform.version>
             </properties>
             <repositories>
                 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <!-- please keep Quarkus version used in lifecycle-application module same as is used in framework -->
         <quarkus.qe.framework.version>1.3.0.Beta13</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.42.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.12.1.Final</quarkus-ide-config.version>


### PR DESCRIPTION
### Summary

Fixes failure in lifecycle-application module. Looks like I didn't realize this needs to be done when bumping framework https://github.com/quarkus-qe/quarkus-test-suite/pull/1175 and CI was green as this test didn't run.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)