### PR TITLE
Revert service binding key back to hippo

### DIFF
--- a/service-binding/postgresql-crunchy-classic/src/main/resources/application.properties
+++ b/service-binding/postgresql-crunchy-classic/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.kubernetes-service-binding.services.postgresql.api-version=postgres-operator.crunchydata.com/v1beta1
 quarkus.kubernetes-service-binding.services.postgresql.kind=PostgresCluster
-quarkus.kubernetes-service-binding.services.postgresql.name=postgresql
+quarkus.kubernetes-service-binding.services.postgresql.name=hippo
 
 quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.database.generation=drop-and-create

--- a/service-binding/postgresql-crunchy-classic/src/test/resources/pg-cluster.yml
+++ b/service-binding/postgresql-crunchy-classic/src/test/resources/pg-cluster.yml
@@ -1,7 +1,7 @@
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
-  name: postgresql
+  name: hippo
 spec:
   openshift: true
   image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.2-1

--- a/service-binding/postgresql-crunchy-reactive/src/main/resources/application.properties
+++ b/service-binding/postgresql-crunchy-reactive/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.kubernetes-service-binding.services.postgresql.api-version=postgres-operator.crunchydata.com/v1beta1
 quarkus.kubernetes-service-binding.services.postgresql.kind=PostgresCluster
-quarkus.kubernetes-service-binding.services.postgresql.name=postgresql
+quarkus.kubernetes-service-binding.services.postgresql.name=hippo
 
 quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.database.generation=drop-and-create

--- a/service-binding/postgresql-crunchy-reactive/src/test/resources/pg-cluster.yml
+++ b/service-binding/postgresql-crunchy-reactive/src/test/resources/pg-cluster.yml
@@ -1,7 +1,7 @@
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
-  name: postgresql
+  name: hippo
 spec:
   openshift: true
   image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.2-1


### PR DESCRIPTION
### Summary

Partially reverts https://github.com/quarkus-qe/quarkus-test-suite/pull/1164, I was convinced it didn't work for me before with `hippo`, but  I made mistake, this puts back original setup.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)