### PR TITLE
Expect remote DEV UI to be avaialable

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/RemoteDevModeHttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/RemoteDevModeHttpAdvancedReactiveIT.java
@@ -4,7 +4,6 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -25,9 +24,8 @@ public class RemoteDevModeHttpAdvancedReactiveIT {
         given().get("/api/hello").then().statusCode(HttpStatus.SC_OK).body("content", is("Hello, World!"));
     }
 
-    @Tag("QUARKUS-834")
     @Test
-    public void devUiShouldBeNotFound() {
-        app.given().get("/q/dev").then().statusCode(HttpStatus.SC_NOT_FOUND);
+    public void devUiShouldBeAvailable() {
+        app.given().get("/q/dev-ui").then().statusCode(HttpStatus.SC_OK);
     }
 }

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/RemoteDevModeHttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/RemoteDevModeHttpAdvancedIT.java
@@ -4,7 +4,6 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -25,9 +24,8 @@ public class RemoteDevModeHttpAdvancedIT {
         given().get("/api/hello").then().statusCode(HttpStatus.SC_OK).body("content", is("Hello, World!"));
     }
 
-    @Tag("QUARKUS-834")
     @Test
-    public void devUiShouldBeNotFound() {
-        app.given().get("/q/dev").then().statusCode(HttpStatus.SC_NOT_FOUND);
+    public void devUiShouldBeAvailable() {
+        app.given().get("/q/dev-ui").then().statusCode(HttpStatus.SC_OK);
     }
 }


### PR DESCRIPTION
### Summary

With https://github.com/quarkusio/quarkus/pull/32673 our test now can reach DEV UI in remote DEV mode on non-app path. Sadly I'm not able to determine why https://github.com/quarkus-qe/quarkus-test-suite/pull/244 expected it to be not found as https://issues.redhat.com/browse/QUARKUS-834 doesn't exist anymore and upstream docs doesn't speak about this expectation https://quarkus.io/guides/maven-tooling#remote-development-mode.

Related to https://github.com/quarkusio/quarkus/issues/32836

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)