### PR TITLE
Dependency management cleanup: drop unused JJWT and use Quarkus IDE config version matching tested Quarkus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
         <impsort-maven-plugin.version>1.8.0</impsort-maven-plugin.version>
         <xml-format-maven-plugin.version>3.2.2</xml-format-maven-plugin.version>
         <checkstyle.version>10.9.3</checkstyle.version>
-        <jjwt.version>0.11.5</jjwt.version>
         <jsoup.version>1.15.4</jsoup.version>
         <!-- TODO: uncomment Camel Quarkus BOM when Camel Quarkus 3 is released -->
         <!-- <camel-quarkus-bom.version>2.16.0</camel-quarkus-bom.version> -->
@@ -96,21 +95,6 @@
                 <groupId>org.amqphub.quarkus</groupId>
                 <artifactId>quarkus-qpid-jms</artifactId>
                 <version>${quarkus-qpid-jms.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.jsonwebtoken</groupId>
-                <artifactId>jjwt-api</artifactId>
-                <version>${jjwt.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.jsonwebtoken</groupId>
-                <artifactId>jjwt-impl</artifactId>
-                <version>${jjwt.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.jsonwebtoken</groupId>
-                <artifactId>jjwt-jackson</artifactId>
-                <version>${jjwt.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jsoup</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,6 @@
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <quarkus.qe.framework.version>1.3.0.Beta14</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.42.0</quarkus-qpid-jms.version>
-        <quarkus-ide-config.version>3.0.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.14</apache-httpclient-fluent.version>
         <confluent.kafka-avro-serializer.version>7.3.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.21.0</formatter-maven-plugin.version>
@@ -258,7 +257,7 @@
                     <dependency>
                         <artifactId>quarkus-ide-config</artifactId>
                         <groupId>io.quarkus</groupId>
-                        <version>${quarkus-ide-config.version}</version>
+                        <version>${quarkus.platform.version}</version>
                     </dependency>
                 </dependencies>
                 <configuration>


### PR DESCRIPTION
### Summary

- we don't use `io.jsonwebtoken` anywhere
- we use different version of Quarkus IDE Config then Quarkus version that we test. Quarkus IDE Config is independent project inside Quarkus main repo and AFAICT it has same release versions as Quarkus have, let see https://mvnrepository.com/artifact/io.quarkus/quarkus-ide-config Also this way, we don't have dependabot to raise version and we spare CI runs

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)