### PR TITLE
Enable external application quickstart test

### DIFF
--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftQuickstartIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftQuickstartIT.java
@@ -1,13 +1,9 @@
 package io.quarkus.ts.external.applications;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
-// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
-@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @DisabledOnNative(reason = "Native + s2i not supported")
 @OpenShiftScenario

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/QuickstartIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/QuickstartIT.java
@@ -1,7 +1,6 @@
 package io.quarkus.ts.external.applications;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -10,8 +9,6 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
-@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @QuarkusScenario
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class QuickstartIT {


### PR DESCRIPTION

### Summary

`getting-started` quickstart migrated to Quarkus 3 in https://github.com/quarkusio/quarkus-quickstarts/commit/cf3ad53b03c2ab2d1df904382e21d8c77118035a.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)