### PR TITLE
[2.13] Fix external application test - quickstart branch

### DIFF
--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/QuickstartIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/QuickstartIT.java
@@ -12,7 +12,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 @QuarkusScenario
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class QuickstartIT {
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", branch = "2.13", contextDir = "getting-started", mavenArgs = "-Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
     static final RestService app = new RestService();
 
     @Test


### PR DESCRIPTION
### Summary

Add 2.13 branch specification to the `getting-started` quickstart app. The quickstart `main` has been upgraded to Quarkus 3 in https://github.com/quarkusio/quarkus-quickstarts/commit/cf3ad53b03c2ab2d1df904382e21d8c77118035a.

Related to https://github.com/quarkus-qe/quarkus-test-suite/pull/1198.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)