### PR TITLE
Bump Quarkus version used by Lifecycle app to 3.0.1.Final

### DIFF
--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -28,7 +28,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-di</artifactId>
             <!-- TODO  switch to 3.something-redhat-0000X based version once available in maven.repository.redhat.com -->
-            <version>3.0.0.CR2</version>
+            <version>3.0.1.Final</version>
         </dependency>
     </dependencies>
     <profiles>


### PR DESCRIPTION
### Summary

Quarkus Test Framework is now using Quarkus 3.0.1.Final and we should keep versions as close as possible considering latest issues https://github.com/quarkus-qe/quarkus-test-suite/pull/1185.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)