### PR TITLE
Explicitly disable Flyway migration for Oracle datasource at start

### DIFF
--- a/sql-db/vertx-sql/src/main/resources/application.properties
+++ b/sql-db/vertx-sql/src/main/resources/application.properties
@@ -62,3 +62,5 @@ quarkus.datasource.oracle.reactive.url=oracle:thin:@localhost:1521:amadeus
 ## Flyway
 quarkus.datasource.oracle.jdbc.url=jdbc:oracle:thin:@localhost:1521:amadeus
 quarkus.flyway.oracle.locations=db/migration/oracle,db/migration/common
+# TODO: remove line below when https://github.com/quarkusio/quarkus/issues/33058 is fixed
+quarkus.flyway.oracle.migrate-at-start=false


### PR DESCRIPTION
### Summary

Fixes daily build by explicitly setting `migrate-at-start=false`, see https://github.com/quarkusio/quarkus/issues/33058 for more info.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)