### PR TITLE
Revert "Explicitly disable Flyway migration for Oracle datasource at start" as upstream PR is now reverted too

### DIFF
--- a/sql-db/vertx-sql/src/main/resources/application.properties
+++ b/sql-db/vertx-sql/src/main/resources/application.properties
@@ -62,5 +62,3 @@ quarkus.datasource.oracle.reactive.url=oracle:thin:@localhost:1521:amadeus
 ## Flyway
 quarkus.datasource.oracle.jdbc.url=jdbc:oracle:thin:@localhost:1521:amadeus
 quarkus.flyway.oracle.locations=db/migration/oracle,db/migration/common
-# TODO: remove line below when https://github.com/quarkusio/quarkus/issues/33058 is fixed
-quarkus.flyway.oracle.migrate-at-start=false


### PR DESCRIPTION
Reverts quarkus-qe/quarkus-test-suite#1208 due to https://github.com/quarkusio/quarkus/pull/33078.