### PR TITLE
Give AgroalPoolTest#idleTimeoutTest more time to succeed

### DIFF
--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalPoolTest.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalPoolTest.java
@@ -41,6 +41,7 @@ import io.smallrye.mutiny.tuples.Tuple2;
 public class AgroalPoolTest {
 
     private final int CONCURRENCY_LEVEL = 20;
+    private final int SAFETY_INTERVAL = 200;
 
     @Inject
     EntityManager em;
@@ -66,7 +67,7 @@ public class AgroalPoolTest {
     @Test
     public void idleTimeoutTest() throws InterruptedException {
         makeApplicationQuery();
-        Thread.sleep(getIdleMs() + getIdleBackgroundValidationMs());
+        Thread.sleep(getIdleMs() + getIdleBackgroundValidationMs() + SAFETY_INTERVAL);
         assertEquals(1, activeConnections(), "agroalCheckIdleTimeout: Expected " + datasourceMinSize + " active connections");
     }
 


### PR DESCRIPTION
### Summary

Lately we enabled this test https://github.com/quarkus-qe/quarkus-test-suite/pull/1159 with idea that idle connections should be removed after idle timeout and removal  is executed when validation timeout expires (based on https://agroal.github.io/docs.html `validationTimeout` and `reapTimeout`). I'm not sure whether I read Agroal docs correctly, but one thing is clear - locally test never fails, while in CI it failed couple of days in row now (check daily build), so it must be down to resources.

My thinking is that we should give Agroal time to find out + execute (close connections) and we need to do something as failing test cancel execution of others (we are losing information).

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)