### PR TITLE
[on hold] Verify, that grpc can be used for Openshift probes

### DIFF
--- a/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/grpc/GrpcHealthService.java
+++ b/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/grpc/GrpcHealthService.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.opentelemetry.reactive.grpc;
+
+import io.quarkus.example.HealthCheckRequest;
+import io.quarkus.example.HealthCheckResponse;
+import io.quarkus.example.HealthService;
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+@GrpcService
+// todo this should return statuses, but it isn't failing the deployment
+public class GrpcHealthService implements HealthService {
+
+    @Override
+    public Uni<HealthCheckResponse> check(HealthCheckRequest request) {
+        return Uni.createFrom().failure(new RuntimeException("Error!"));
+    }
+
+    @Override
+    public Multi<HealthCheckResponse> watch(HealthCheckRequest request) {
+        return Multi.createFrom().failure(new RuntimeException("Error!"));
+    }
+}

--- a/monitoring/opentelemetry-reactive/src/main/proto/health.proto
+++ b/monitoring/opentelemetry-reactive/src/main/proto/health.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.quarkus.example";
+
+package grpc.health.v1;;
+
+message HealthCheckRequest {
+    string service = 1;
+}
+
+message HealthCheckResponse {
+    enum ServingStatus {
+        UNKNOWN = 0;
+        SERVING = 1;
+        NOT_SERVING = 2;
+        SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
+    }
+    ServingStatus status = 1;
+}
+
+service HealthService {
+    rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+    rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}

--- a/monitoring/opentelemetry-reactive/src/main/resources/application.properties
+++ b/monitoring/opentelemetry-reactive/src/main/resources/application.properties
@@ -8,3 +8,7 @@ io.quarkus.ts.opentelemetry.reactive.sse.ServerSentEventsPongClient/mp-rest/scop
 quarkus.grpc.clients.pong.host=localhost
 
 quarkus.application.name=pingpong
+
+quarkus.openshift.readiness-probe.grpc-action=9000:grpc.health.v1.HealthService
+quarkus.openshift.startup-probe.grpc-action=9000:grpc.health.v1.HealthService
+quarkus.openshift.liveness-probe.grpc-action=9000:grpc.health.v1.HealthService

--- a/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/GrpcIT.java
+++ b/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/GrpcIT.java
@@ -18,7 +18,7 @@ import io.quarkus.test.services.JaegerContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-public class OpenTelemetryGrpcIT {
+public class GrpcIT {
 
     @JaegerContainer(useOtlpCollector = true)
     static final JaegerService jaeger = new JaegerService();
@@ -61,5 +61,4 @@ public class OpenTelemetryGrpcIT {
 
         assertEquals(expected, pongTraceId);
     }
-
 }

--- a/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpenShiftGrpcIT.java
+++ b/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpenShiftGrpcIT.java
@@ -1,0 +1,42 @@
+package io.quarkus.ts.opentelemetry.reactive;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GRPCAction;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Probe;
+import io.quarkus.test.bootstrap.inject.OpenShiftClient;
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
+public class OpenShiftGrpcIT extends GrpcIT {
+
+    @Inject
+    static OpenShiftClient oc;
+
+    @Test
+    void grpcProbes() {
+        List<Pod> pods = oc.podsInService(app);
+        Assertions.assertEquals(1, pods.size());
+        List<Container> containers = pods.get(0).getSpec().getContainers();
+        Assertions.assertEquals(1, containers.size());
+        Container container = containers.get(0);
+        validateProbe(container.getLivenessProbe());
+        validateProbe(container.getReadinessProbe());
+    }
+
+    private static void validateProbe(Probe probe) {
+        Assertions.assertNotNull(probe);
+        GRPCAction grpcAction = probe.getGrpc();
+        Assertions.assertNotNull(grpcAction);
+        Assertions.assertEquals("grpc.health.v1.HealthService", grpcAction.getService());
+        Assertions.assertEquals(9000, grpcAction.getPort());
+    }
+}


### PR DESCRIPTION
### Summary

See https://github.com/quarkusio/quarkus/pull/32113 for details.

Requires https://github.com/quarkus-qe/quarkus-test-framework/pull/772

Waits for https://github.com/quarkusio/quarkus/issues/33219 to be fixed, since right now it is not possible for user to create a custom health service using GRPC.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)