### PR TITLE
Let Dev Services run database init for reactive vanilla clients

### DIFF
--- a/sql-db/reactive-vanilla/src/main/java/io/quarkus/ts/reactive/db/clients/CommonResource.java
+++ b/sql-db/reactive-vanilla/src/main/java/io/quarkus/ts/reactive/db/clients/CommonResource.java
@@ -4,33 +4,7 @@ import java.net.URI;
 
 import jakarta.ws.rs.core.UriInfo;
 
-import org.jboss.logging.Logger;
-
-import io.vertx.mutiny.sqlclient.Pool;
-
 public class CommonResource {
-
-    private static final Logger LOG = Logger.getLogger(CommonResource.class);
-
-    // TODO remove this onStart once this issue is resolved: https://github.com/quarkusio/quarkus/issues/19766
-    void setUpDB(Pool pool, String tableName) {
-        pool.query("DROP TABLE IF EXISTS " + tableName).execute()
-                .flatMap(r -> pool
-                        .query("CREATE TABLE " + tableName
-                                + " (id SERIAL PRIMARY KEY, title TEXT NOT NULL, author TEXT NOT NULL)")
-                        .execute())
-                .flatMap(r -> pool.query("INSERT INTO " + tableName + " (title, author) VALUES ('Foundation', 'Isaac Asimov')")
-                        .execute())
-                .flatMap(r -> pool
-                        .query("INSERT INTO " + tableName
-                                + " (title, author) VALUES ('2001: A Space Odyssey', 'Arthur C. Clarke')")
-                        .execute())
-                .flatMap(r -> pool
-                        .query("INSERT INTO " + tableName
-                                + " (title, author) VALUES ('Stranger in a Strange Land', 'Robert A. Heinlein')")
-                        .execute())
-                .subscribe().with(item -> LOG.info(tableName + " table created"));
-    }
 
     protected URI fromId(Long id, UriInfo uriInfo) {
         return URI.create(uriInfo.getPath() + "/" + id);

--- a/sql-db/reactive-vanilla/src/main/java/io/quarkus/ts/reactive/db/clients/HardCoverBookResource.java
+++ b/sql-db/reactive-vanilla/src/main/java/io/quarkus/ts/reactive/db/clients/HardCoverBookResource.java
@@ -2,7 +2,6 @@ package io.quarkus.ts.reactive.db.clients;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
-import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.GET;
@@ -13,49 +12,17 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
-import org.jboss.logging.Logger;
-
-import io.quarkus.runtime.StartupEvent;
 import io.quarkus.ts.reactive.db.clients.model.Book;
 import io.quarkus.ts.reactive.db.clients.model.HardCoverBook;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.mssqlclient.MSSQLPool;
-import io.vertx.mutiny.sqlclient.Pool;
 
 @Path("/book/mssql")
 public class HardCoverBookResource extends CommonResource {
 
-    private static final Logger LOG = Logger.getLogger(HardCoverBookResource.class);
-
     @Inject
     @Named("mssql")
     MSSQLPool mssql;
-
-    // TODO remove this onStart once this issue is resolved: https://github.com/quarkusio/quarkus/issues/19766
-    void onStart(@Observes StartupEvent ev) {
-        setUpDB(mssql, HardCoverBook.TABLE_NAME);
-    }
-
-    // Override for MSSQL specifics
-    @Override
-    void setUpDB(Pool pool, String tableName) {
-        pool.query("DROP TABLE IF EXISTS " + tableName).execute()
-                .flatMap(r -> pool
-                        .query("CREATE TABLE " + tableName
-                                + " (id int IDENTITY PRIMARY KEY, title varchar(max) NOT NULL, author varchar(max) NOT NULL)")
-                        .execute())
-                .flatMap(r -> pool.query("INSERT INTO " + tableName + " (title, author) VALUES ('Foundation', 'Isaac Asimov')")
-                        .execute())
-                .flatMap(r -> pool
-                        .query("INSERT INTO " + tableName
-                                + " (title, author) VALUES ('2001: A Space Odyssey', 'Arthur C. Clarke')")
-                        .execute())
-                .flatMap(r -> pool
-                        .query("INSERT INTO " + tableName
-                                + " (title, author) VALUES ('Stranger in a Strange Land', 'Robert A. Heinlein')")
-                        .execute())
-                .subscribe().with(item -> LOG.info(tableName + " table created"));
-    }
 
     @GET
     @Produces(APPLICATION_JSON)

--- a/sql-db/reactive-vanilla/src/main/java/io/quarkus/ts/reactive/db/clients/NoteBookResource.java
+++ b/sql-db/reactive-vanilla/src/main/java/io/quarkus/ts/reactive/db/clients/NoteBookResource.java
@@ -2,7 +2,6 @@ package io.quarkus.ts.reactive.db.clients;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
-import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.GET;
@@ -13,9 +12,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
-import org.jboss.logging.Logger;
-
-import io.quarkus.runtime.StartupEvent;
 import io.quarkus.ts.reactive.db.clients.model.Book;
 import io.quarkus.ts.reactive.db.clients.model.NoteBook;
 import io.smallrye.mutiny.Uni;
@@ -24,16 +20,9 @@ import io.vertx.mutiny.mysqlclient.MySQLPool;
 @Path("/book/mysql")
 public class NoteBookResource extends CommonResource {
 
-    private static final Logger LOG = Logger.getLogger(NoteBookResource.class);
-
     @Inject
     @Named("mysql")
     MySQLPool mysql;
-
-    // TODO remove this onStart once this issue is resolved: https://github.com/quarkusio/quarkus/issues/19766
-    void onStart(@Observes StartupEvent ev) {
-        setUpDB(mysql, NoteBook.TABLE_NAME);
-    }
 
     @GET
     @Produces(APPLICATION_JSON)

--- a/sql-db/reactive-vanilla/src/main/java/io/quarkus/ts/reactive/db/clients/SoftCoverBookResource.java
+++ b/sql-db/reactive-vanilla/src/main/java/io/quarkus/ts/reactive/db/clients/SoftCoverBookResource.java
@@ -2,7 +2,6 @@ package io.quarkus.ts.reactive.db.clients;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
-import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -12,9 +11,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
-import org.jboss.logging.Logger;
-
-import io.quarkus.runtime.StartupEvent;
 import io.quarkus.ts.reactive.db.clients.model.Book;
 import io.quarkus.ts.reactive.db.clients.model.SoftCoverBook;
 import io.smallrye.mutiny.Uni;
@@ -23,15 +19,8 @@ import io.vertx.mutiny.pgclient.PgPool;
 @Path("/book/postgresql")
 public class SoftCoverBookResource extends CommonResource {
 
-    private static final Logger LOG = Logger.getLogger(SoftCoverBookResource.class);
-
     @Inject
     PgPool postgresql;
-
-    // TODO remove this onStart once this issue is resolved: https://github.com/quarkusio/quarkus/issues/19766
-    void onStart(@Observes StartupEvent ev) {
-        setUpDB(postgresql, SoftCoverBook.TABLE_NAME);
-    }
 
     @GET
     @Produces(APPLICATION_JSON)

--- a/sql-db/reactive-vanilla/src/main/resources/mssql-init-script.sql
+++ b/sql-db/reactive-vanilla/src/main/resources/mssql-init-script.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS hardCoverBook;
+CREATE TABLE hardCoverBook (id int IDENTITY PRIMARY KEY, title varchar(max) NOT NULL, author varchar(max) NOT NULL);
+INSERT INTO hardCoverBook (title, author) VALUES ('Foundation', 'Isaac Asimov');
+INSERT INTO hardCoverBook (title, author) VALUES ('2001: A Space Odyssey', 'Arthur C. Clarke');
+INSERT INTO hardCoverBook (title, author) VALUES ('Stranger in a Strange Land', 'Robert A. Heinlein');

--- a/sql-db/reactive-vanilla/src/main/resources/mysql-init-script.sql
+++ b/sql-db/reactive-vanilla/src/main/resources/mysql-init-script.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS noteBook;
+CREATE TABLE noteBook (id SERIAL PRIMARY KEY, title TEXT NOT NULL, author TEXT NOT NULL);
+INSERT INTO noteBook (title, author) VALUES ('Foundation', 'Isaac Asimov');
+INSERT INTO noteBook (title, author) VALUES ('2001: A Space Odyssey', 'Arthur C. Clarke');
+INSERT INTO noteBook (title, author) VALUES ('Stranger in a Strange Land', 'Robert A. Heinlein');

--- a/sql-db/reactive-vanilla/src/main/resources/postgresql-init-script.sql
+++ b/sql-db/reactive-vanilla/src/main/resources/postgresql-init-script.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS softCoverBook;
+CREATE TABLE softCoverBook (id SERIAL PRIMARY KEY, title TEXT NOT NULL, author TEXT NOT NULL);
+INSERT INTO softCoverBook (title, author) VALUES ('Foundation', 'Isaac Asimov');
+INSERT INTO softCoverBook (title, author) VALUES ('2001: A Space Odyssey', 'Arthur C. Clarke');
+INSERT INTO softCoverBook (title, author) VALUES ('Stranger in a Strange Land', 'Robert A. Heinlein');

--- a/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeMultipleReactiveSqlClientsIT.java
+++ b/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeMultipleReactiveSqlClientsIT.java
@@ -26,7 +26,10 @@ import io.vertx.core.json.JsonObject;
 public class DevModeMultipleReactiveSqlClientsIT {
 
     @DevModeQuarkusApplication
-    static RestService app = new RestService();
+    static RestService app = new RestService()
+            .withProperty("quarkus.datasource.devservices.init-script-path", "postgresql-init-script.sql")
+            .withProperty("quarkus.datasource.mysql.devservices.init-script-path", "mysql-init-script.sql")
+            .withProperty("quarkus.datasource.mssql.devservices.init-script-path", "mssql-init-script.sql");
 
     @Test
     public void verifyReactivePostgresqlRetrieveEntities() {


### PR DESCRIPTION
### Summary

We discussed with @gtroitsk this TODO https://github.com/quarkus-qe/quarkus-test-suite/blob/main/sql-db/reactive-vanilla/src/main/java/io/quarkus/ts/reactive/db/clients/CommonResource.java#L15 and IMO https://github.com/quarkusio/quarkus/issues/19766 is not going to be fixed anytime soon. So when I looked at this, I can't see a point why we should use Flyway at all as these tests are only concerned with Dev Services and if you look to tickets https://issues.redhat.com/browse/QUARKUS-1080 https://issues.redhat.com/browse/QUARKUS-1408 I can't see relation to Flyway either. IMO running this manual init is not a good pattern as your tests don't wait for queries to finish, you just hope they finish before the first test query was triggered. I checked Flyway extension docs and code and while there is nothing that makes it JDBC datasource specific (it could work with reactive?) it is not tested anywhere and upstream issue also only discuss Dev Services. My proposal is to use init sql property that we already have.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)