### PR TITLE
Revert "Disable HTTP Basic authentication for OpenAPI OIDC tests"

### DIFF
--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseOidcIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseOidcIT.java
@@ -23,8 +23,7 @@ public abstract class BaseOidcIT {
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
-            .withProperty("quarkus.http.auth.basic", "false");
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
 
     private AuthzClient authzClient;
 

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenApiStoreSchemaIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenApiStoreSchemaIT.java
@@ -83,13 +83,15 @@ public class OpenApiStoreSchemaIT extends BaseOidcIT {
         assertTrue(content.getJsonObject("paths").containsKey("/rest-pong"), "Missing expected path: /rest-pong");
 
         // verify that path /secured/admin is only accessible by user with role 'admin'
-        var expectedRole = getRequiredRoleForPath(content, "/secured/admin");
-        assertEquals("admin", expectedRole);
+        // TODO: enable when https://github.com/quarkusio/quarkus/issues/32112 is fixed
+        // var expectedRole = getRequiredRoleForPath(content, "/secured/admin");
+        // assertEquals("admin", expectedRole);
 
         // verify that path /secured/getClaimsFromBeans is accessible by any authenticated user
-        expectedRole = getRequiredRoleForPath(content, "/secured/getClaimsFromBeans");
+        // TODO: enable when https://github.com/quarkusio/quarkus/issues/32112 is fixed
+        // expectedRole = getRequiredRoleForPath(content, "/secured/getClaimsFromBeans");
         // note: '**' is equivalent of @Authenticated and @RolesAllowed("**")
-        assertEquals("**", expectedRole);
+        // assertEquals("**", expectedRole);
 
         // verify 'oidc' security schema
         var securitySchema = content

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/BaseOidcIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/BaseOidcIT.java
@@ -23,8 +23,7 @@ public abstract class BaseOidcIT {
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
-            .withProperty("quarkus.http.auth.basic", "false");
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
 
     private AuthzClient authzClient;
 

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenApiStoreSchemaIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenApiStoreSchemaIT.java
@@ -83,13 +83,15 @@ public class OpenApiStoreSchemaIT extends BaseOidcIT {
         assertTrue(content.getJsonObject("paths").containsKey("/rest-pong"), "Missing expected path: /rest-pong");
 
         // verify that path /secured/admin is only accessible by user with role 'admin'
-        var expectedRole = getRequiredRoleForPath(content, "/secured/admin");
-        assertEquals("admin", expectedRole);
+        // TODO: enable when https://github.com/quarkusio/quarkus/issues/32112 get fixed
+        // var expectedRole = getRequiredRoleForPath(content, "/secured/admin");
+        // assertEquals("admin", expectedRole);
 
         // verify that path /secured/getClaimsFromBeans is accessible by any authenticated user
-        expectedRole = getRequiredRoleForPath(content, "/secured/getClaimsFromBeans");
+        // TODO: enable when https://github.com/quarkusio/quarkus/issues/32112 get fixed
+        // expectedRole = getRequiredRoleForPath(content, "/secured/getClaimsFromBeans");
         // note: '**' is equivalent of @Authenticated and @RolesAllowed("**")
-        assertEquals("**", expectedRole);
+        // assertEquals("**", expectedRole);
 
         // verify 'oidc' security schema
         var securitySchema = content


### PR DESCRIPTION
Reverts quarkus-qe/quarkus-test-suite#1217

The first daily build after #1217  failed https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/4921408854/jobs/8791517634 over expected `admin` role and from logs it is clear that Basic auth was disabled.