### PR TITLE
Disable HTTP Basic authentication at build time for extended OIDC ITs

### DIFF
--- a/security/keycloak-oidc-client-extended/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client-extended/src/main/resources/application.properties
@@ -3,6 +3,7 @@ quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/test-realm
 quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 
+quarkus.http.auth.basic=false
 quarkus.http.auth.permission.unsecured.paths=/generate-token/*
 quarkus.http.auth.permission.unsecured.policy=permit
 

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseOidcIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseOidcIT.java
@@ -23,8 +23,7 @@ public abstract class BaseOidcIT {
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
-            .withProperty("quarkus.http.auth.basic", "false");
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
 
     private AuthzClient authzClient;
 

--- a/security/keycloak-oidc-client-reactive-extended/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/resources/application.properties
@@ -3,6 +3,7 @@ quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/test-realm
 quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 
+quarkus.http.auth.basic=false
 quarkus.http.auth.permission.unsecured.paths=/generate-token/*
 quarkus.http.auth.permission.unsecured.policy=permit
 

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/BaseOidcIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/BaseOidcIT.java
@@ -23,8 +23,7 @@ public abstract class BaseOidcIT {
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
-            .withProperty("quarkus.http.auth.basic", "false");
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
 
     private AuthzClient authzClient;
 


### PR DESCRIPTION
### Summary

`quarkus.http.auth.basic` is a build-time option and is not effective via run-time parameters set using `withProperty`. The earlier PR #1217 was verified using the debugger which seemingly has different behavior around build-time/run-time property setting.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)