### PR TITLE
Quarkus 3 OpenTelemetry hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,9 @@ Base application contains REST resource `TransferResource` and three main servic
 and `TransferTopUpService` which implement various bank transactions. The main scenario is implemented in `TransactionGeneralUsageIT` 
 and checks whether transactions and rollbacks always done in full.
 
+OpenTelemetry JDBC instrumentation test coverage is also placed here. JDBC tracing is tested for all supported 
+databases in JVM mode, native mode and OpenShift. Smoke tests for DEV mode are using PostgreSQL.
+
 ### `security/basic`
 
 Verifies the simplest way of doing authn/authz.

--- a/README.md
+++ b/README.md
@@ -796,7 +796,7 @@ Jaeger is deployed in an "all-in-one" configuration, and the OpenShift test veri
 Testing OpenTelemetry with Jaeger components
  - Extension `quarkus-opentelemetry` - responsible for traces generation in OpenTelemetry format and export into OpenTelemetry components (opentelemetry-agent, opentelemetry-collector)
  
-Scenarios that test proper traces export to Jaeger components and context propagation.  
+Scenarios that test proper traces export to Jaeger components, context propagation, OpenTelemetry SDK Autoconfiguration and CDI injection of OpenTelemetry beans.
 See also `monitoring/opentelemetry/README.md`
 
 ### `micrometer/prometheus`

--- a/README.md
+++ b/README.md
@@ -566,7 +566,8 @@ and `TransferTopUpService` which implement various bank transactions. The main s
 and checks whether transactions and rollbacks always done in full.
 
 OpenTelemetry JDBC instrumentation test coverage is also placed here. JDBC tracing is tested for all supported 
-databases in JVM mode, native mode and OpenShift. Smoke tests for DEV mode are using PostgreSQL.
+databases in JVM mode, native mode and OpenShift. Smoke tests for DEV mode are using PostgreSQL. Smallrye Context Propagation
+cooperation with OpenTelemetry in DEV mode is also placed in this module.
 
 ### `security/basic`
 

--- a/monitoring/opentelemetry-reactive/README.md
+++ b/monitoring/opentelemetry-reactive/README.md
@@ -4,7 +4,7 @@
 [Quarkus OpenTelemetry guide](https://quarkus.io/guides/opentelemetry)
 
 ## Scope of the test
-1. Testing OpenTelemetry with Jaeger components and RESTEasy Reactive
+1. Testing OpenTelemetry with Jaeger components, RESTEasy Reactive and Quarkus Scheduler
  - Extension `quarkus-opentelemetry` - responsible for traces generation in OpenTelemetry format and export into OpenTelemetry components (opentelemetry-agent, opentelemetry-collector)
  
 Scenarios that test proper traces export to Jaeger components and context propagation. 

--- a/monitoring/opentelemetry-reactive/pom.xml
+++ b/monitoring/opentelemetry-reactive/pom.xml
@@ -32,6 +32,10 @@
             <artifactId>quarkus-grpc</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-scheduler</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-jaeger</artifactId>
             <scope>test</scope>

--- a/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/SchedulerResource.java
+++ b/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/SchedulerResource.java
@@ -1,0 +1,22 @@
+package io.quarkus.ts.opentelemetry.reactive;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/scheduler")
+public class SchedulerResource {
+
+    @Inject
+    SchedulerService schedulerService;
+
+    @Path("/count")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public int getCount() {
+        return schedulerService.getCount();
+    }
+
+}

--- a/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/SchedulerService.java
+++ b/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/SchedulerService.java
@@ -1,0 +1,24 @@
+package io.quarkus.ts.opentelemetry.reactive;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.Scheduled.ApplicationNotRunning;
+
+@ApplicationScoped
+public class SchedulerService {
+
+    private final AtomicInteger counter = new AtomicInteger();
+
+    @Scheduled(every = "1s", skipExecutionIf = ApplicationNotRunning.class)
+    void increment() {
+        counter.incrementAndGet();
+    }
+
+    int getCount() {
+        return counter.get();
+    }
+
+}

--- a/monitoring/opentelemetry-reactive/src/test/resources/pong.properties
+++ b/monitoring/opentelemetry-reactive/src/test/resources/pong.properties
@@ -1,0 +1,1 @@
+quarkus.scheduler.tracing.enabled=true

--- a/monitoring/opentelemetry/src/main/java/io/quarkus/ts/opentelemetry/MicroProfileTelemetryDIResource.java
+++ b/monitoring/opentelemetry/src/main/java/io/quarkus/ts/opentelemetry/MicroProfileTelemetryDIResource.java
@@ -1,0 +1,69 @@
+package io.quarkus.ts.opentelemetry;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+
+/**
+ * Tests that following classes are injectable according to MicroProfile Telemetry Tracing specification:
+ * - io.opentelemetry.api.OpenTelemetry
+ * - io.opentelemetry.api.trace.Tracer
+ * - io.opentelemetry.api.trace.Span
+ * - io.opentelemetry.api.baggage.Baggage
+ */
+@Path("/mp-telemetry-di")
+public class MicroProfileTelemetryDIResource {
+
+    @Inject
+    Span span;
+
+    @Inject
+    OpenTelemetry openTelemetry;
+
+    @Inject
+    Baggage baggage;
+
+    @Inject
+    Tracer tracer;
+
+    @GET
+    @Path("/span")
+    public String getSpanId() {
+        return span.getSpanContext().getSpanId();
+    }
+
+    @GET
+    @Path("/tracer")
+    public String getTracerSpanId() {
+        return createSpanAndGetId(tracer);
+    }
+
+    @GET
+    @Path("/baggage")
+    public boolean getBaggage() {
+        return baggage.isEmpty();
+    }
+
+    @GET
+    @Path("/otel")
+    public String getOpenTelemetrySpanId() {
+        return createSpanAndGetId(openTelemetry.tracerBuilder("myuperdruper").build());
+    }
+
+    private static String createSpanAndGetId(Tracer tracer) {
+        var nestedSpan = tracer
+                .spanBuilder("tracer")
+                .setSpanKind(SpanKind.SERVER)
+                .startSpan();
+        try (var scope = nestedSpan.makeCurrent()) {
+            nestedSpan.end();
+            return nestedSpan.getSpanContext().getSpanId();
+        }
+    }
+}

--- a/monitoring/opentelemetry/src/main/java/io/quarkus/ts/opentelemetry/MicroProfileTelemetryDIResource.java
+++ b/monitoring/opentelemetry/src/main/java/io/quarkus/ts/opentelemetry/MicroProfileTelemetryDIResource.java
@@ -20,6 +20,9 @@ import io.opentelemetry.api.trace.Tracer;
 @Path("/mp-telemetry-di")
 public class MicroProfileTelemetryDIResource {
 
+    public static final int LONG_ATTRIBUTE_LENGTH = 54;
+    public static final String LONG_ATTRIBUTE_NAME = "QuarkusQELongAttribute";
+
     @Inject
     Span span;
 
@@ -35,6 +38,7 @@ public class MicroProfileTelemetryDIResource {
     @GET
     @Path("/span")
     public String getSpanId() {
+        span.setAttribute(LONG_ATTRIBUTE_NAME, "a".repeat(LONG_ATTRIBUTE_LENGTH));
         return span.getSpanContext().getSpanId();
     }
 

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenShiftOpenTelemetryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenShiftOpenTelemetryIT.java
@@ -3,6 +3,6 @@ package io.quarkus.ts.opentelemetry;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-public class OpenShiftOpentelemetryIT extends OpentelemetryIT {
+public class OpenShiftOpenTelemetryIT extends OpenTelemetryIT {
 
 }

--- a/monitoring/opentelemetry/src/test/resources/pong.properties
+++ b/monitoring/opentelemetry/src/test/resources/pong.properties
@@ -1,0 +1,1 @@
+quarkus.otel.attribute.value.length.limit=51

--- a/sql-db/narayana-transactions/pom.xml
+++ b/sql-db/narayana-transactions/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -52,6 +52,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
+        <!-- JDBC instrumentation -->
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-jdbc</artifactId>
         </dependency>
         <!-- Metrics extensions -->
         <dependency>

--- a/sql-db/narayana-transactions/src/main/java/io.quarkus.ts.transactions/SpanAsyncService.java
+++ b/sql-db/narayana-transactions/src/main/java/io.quarkus.ts.transactions/SpanAsyncService.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.transactions;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.context.ThreadContext;
+
+import io.opentelemetry.api.trace.Span;
+
+@ApplicationScoped
+public class SpanAsyncService {
+
+    private final ThreadContext threadContext;
+
+    public SpanAsyncService(ThreadContext threadContext) {
+        this.threadContext = threadContext;
+    }
+
+    public CompletionStage<String> runService(String greeting, ExecutorService executorService) {
+        return this.threadContext.withContextCapture(CompletableFuture.supplyAsync(() -> greeting, executorService))
+                .thenApplyAsync(message -> message + "-" + Span.current().getSpanContext().getTraceId(), executorService);
+    }
+
+}

--- a/sql-db/narayana-transactions/src/main/java/io.quarkus.ts.transactions/SpanResource.java
+++ b/sql-db/narayana-transactions/src/main/java/io.quarkus.ts.transactions/SpanResource.java
@@ -1,0 +1,52 @@
+package io.quarkus.ts.transactions;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.context.ThreadContext;
+
+import io.opentelemetry.api.trace.Span;
+import io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory;
+
+@Path("/span")
+public class SpanResource {
+
+    private final ExecutorService myExecutorService;
+
+    private final SpanAsyncService spanAsyncService;
+
+    private final ThreadContext threadContext;
+
+    @Inject
+    public SpanResource(ThreadContext threadContext, SpanAsyncService spanAsyncService) {
+        this.myExecutorService = createNewExecutor();
+        this.spanAsyncService = spanAsyncService;
+        this.threadContext = threadContext;
+    }
+
+    private static ForkJoinPool createNewExecutor() {
+        return new ForkJoinPool(32,
+                new QuarkusForkJoinWorkerThreadFactory(), null, true,
+                0, 0x7fff, 1, null, 500,
+                TimeUnit.MILLISECONDS);
+    }
+
+    @Path("/")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public CompletionStage<String> getSpans() {
+        return this.threadContext
+                .withContextCapture(this.spanAsyncService.runService("Hello " + Span.current().getSpanContext().getTraceId(),
+                        this.myExecutorService))
+                .thenApplyAsync(message -> message + "-" + Span.current().getSpanContext().getTraceId(),
+                        this.myExecutorService);
+    }
+}

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/DevModeOpenTelemetryIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/DevModeOpenTelemetryIT.java
@@ -1,0 +1,68 @@
+package io.quarkus.ts.transactions;
+
+import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
+import static io.quarkus.ts.transactions.TransactionCommons.getTracedOperationsForName;
+import static io.quarkus.ts.transactions.TransactionCommons.verifyRequestTraces;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.DevModeQuarkusService;
+import io.quarkus.test.bootstrap.JaegerService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.test.services.JaegerContainer;
+
+@QuarkusScenario
+public class DevModeOpenTelemetryIT {
+
+    private static final String APPLICATION_PROPERTIES = "src/main/resources/application.properties";
+    private static final String INSERT_OPERATION_NAME = "INSERT quarkus.journal";
+    private static final String UPDATE_OPERATION_NAME = "UPDATE quarkus.account";
+
+    @JaegerContainer(expectedLog = "\"Health Check state change\",\"status\":\"ready\"")
+    static final JaegerService jaeger = new JaegerService();
+
+    @DevModeQuarkusApplication
+    static DevModeQuarkusService app = (DevModeQuarkusService) new DevModeQuarkusService()
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
+            .withProperty("quarkus.datasource.jdbc.telemetry", "true")
+            .withProperty("quarkus.otel.enabled", "true");
+
+    @Test
+    void testJdbcTraces() {
+        // verifies that OpenTelemetry JDBC instrumentation works in DEV mode after reload
+        // see https://github.com/quarkusio/quarkus/issues/29645 for more information
+
+        // test JDBC tracing is enabled and works
+        given().get("/transfer/accounts/ES8521006742088984966816").then().statusCode(HttpStatus.SC_OK);
+        verifyRequestTraces("SELECT quarkus.account", jaeger);
+        verifyNoTracesForOperation(INSERT_OPERATION_NAME);
+        verifyNoTracesForOperation(UPDATE_OPERATION_NAME);
+
+        // disable JDBC tracing and expect no traces are recorded
+        app.modifyFile(APPLICATION_PROPERTIES, props -> props + System.lineSeparator() + getOtelEnabledProperty(false));
+        untilAsserted(TransactionCommons::makeTopUpTransfer);
+        verifyNoTracesForOperation(INSERT_OPERATION_NAME);
+        verifyNoTracesForOperation(UPDATE_OPERATION_NAME);
+
+        // enable JDBC tracing and expect new traces
+        app.modifyFile(APPLICATION_PROPERTIES, props -> props.replace(
+                getOtelEnabledProperty(false), getOtelEnabledProperty(true)));
+        untilAsserted(TransactionCommons::makeTopUpTransfer);
+        verifyRequestTraces(INSERT_OPERATION_NAME, jaeger);
+        verifyRequestTraces(UPDATE_OPERATION_NAME, jaeger);
+    }
+
+    private static void verifyNoTracesForOperation(String operationName) {
+        var operations = getTracedOperationsForName(operationName, jaeger);
+        assertTrue(operations.stream().noneMatch(operationName::equals));
+    }
+
+    private static String getOtelEnabledProperty(boolean enabled) {
+        return "quarkus.datasource.jdbc.telemetry.enabled=" + Boolean.toString(enabled);
+    }
+
+}

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
@@ -24,4 +24,9 @@ public class MssqlTransactionGeneralUsageIT extends TransactionCommons {
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+
+    @Override
+    protected String[] getExpectedJdbcOperationNames() {
+        return new String[] { "SELECT msdb.account", "INSERT msdb.journal", "UPDATE msdb.account" };
+    }
 }

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMysqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMysqlTransactionGeneralUsageIT.java
@@ -10,7 +10,7 @@ import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
-public class OpenShiftMsqlTransactionGeneralUsageIT extends TransactionCommons {
+public class OpenShiftMysqlTransactionGeneralUsageIT extends TransactionCommons {
     static final int MYSQL_PORT = 3306;
 
     @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OracleTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OracleTransactionGeneralUsageIT.java
@@ -24,4 +24,9 @@ public class OracleTransactionGeneralUsageIT extends TransactionCommons {
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+
+    @Override
+    protected String[] getExpectedJdbcOperationNames() {
+        return new String[] { "SELECT mydb", "INSERT mydb.journal", "UPDATE mydb.account" };
+    }
 }

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlTransactionGeneralUsageIT.java
@@ -22,6 +22,7 @@ public class PostgresqlTransactionGeneralUsageIT extends TransactionCommons {
     public static final RestService app = new RestService()
             .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl)
             .withProperty("quarkus.opentelemetry.enabled", "true")
+            .withProperty("quarkus.datasource.jdbc.telemetry", "true")
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/TransactionCommons.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/TransactionCommons.java
@@ -2,22 +2,26 @@ package io.quarkus.ts.transactions;
 
 import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import io.quarkus.test.bootstrap.JaegerService;
 import io.quarkus.test.services.JaegerContainer;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class) // we keep order to ensure JDBC traces are ready
 public abstract class TransactionCommons {
 
     static final String ACCOUNT_NUMBER_MIGUEL = "SK0389852379529966291984";
@@ -28,11 +32,11 @@ public abstract class TransactionCommons {
 
     static final String ACCOUNT_NUMBER_EDUARDO = "ES8521006742088984966899";
     static final int ASSERT_SERVICE_TIMEOUT_MINUTES = 1;
-    private Response jaegerResponse;
 
-    @JaegerContainer(useOtlpCollector = true, expectedLog = "\"Health Check state change\",\"status\":\"ready\"")
+    @JaegerContainer(expectedLog = "\"Health Check state change\",\"status\":\"ready\"")
     static final JaegerService jaeger = new JaegerService();
 
+    @Order(1)
     @Tag("QUARKUS-2492")
     @Test
     public void verifyNarayanaProgrammaticApproachTransaction() {
@@ -56,6 +60,7 @@ public abstract class TransactionCommons {
         Assertions.assertEquals(100, miguelJournal.getAmount(), "Unexpected journal amount.");
     }
 
+    @Order(2)
     @Tag("QUARKUS-2492")
     @Test
     public void verifyLegacyNarayanaLambdaApproachTransaction() {
@@ -77,18 +82,11 @@ public abstract class TransactionCommons {
         Assertions.assertEquals(100, garcilasoJournal.getAmount(), "Unexpected journal amount.");
     }
 
+    @Order(3)
     @Tag("QUARKUS-2492")
     @Test
     public void verifyNarayanaLambdaApproachTransaction() {
-        TransferDTO transferDTO = new TransferDTO();
-        transferDTO.setAccountFrom(ACCOUNT_NUMBER_EDUARDO);
-        transferDTO.setAccountTo(ACCOUNT_NUMBER_EDUARDO);
-        transferDTO.setAmount(100);
-
-        given()
-                .contentType(ContentType.JSON)
-                .body(transferDTO).post("/transfer/top-up")
-                .then().statusCode(HttpStatus.SC_CREATED);
+        makeTopUpTransfer();
 
         AccountEntity garcilasoAccount = getAccount(ACCOUNT_NUMBER_EDUARDO);
         Assertions.assertEquals(200, garcilasoAccount.getAmount(),
@@ -98,6 +96,19 @@ public abstract class TransactionCommons {
         Assertions.assertEquals(100, garcilasoJournal.getAmount(), "Unexpected journal amount.");
     }
 
+    static void makeTopUpTransfer() {
+        TransferDTO transferDTO = new TransferDTO();
+        transferDTO.setAccountFrom(ACCOUNT_NUMBER_EDUARDO);
+        transferDTO.setAccountTo(ACCOUNT_NUMBER_EDUARDO);
+        transferDTO.setAmount(100);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(transferDTO).post("/transfer/top-up")
+                .then().statusCode(HttpStatus.SC_CREATED);
+    }
+
+    @Order(4)
     @Tag("QUARKUS-2492")
     @Test
     public void verifyRollbackForNarayanaProgrammaticApproach() {
@@ -119,14 +130,28 @@ public abstract class TransactionCommons {
                 .statusCode(HttpStatus.SC_NO_CONTENT);
     }
 
+    @Order(5)
     @Tag("QUARKUS-2492")
     @Test
     public void smokeTestNarayanaProgrammaticTransactionTrace() {
         String operationName = "GET /transfer/accounts/{account_id}";
         given().get("/transfer/accounts/" + ACCOUNT_NUMBER_LUIS).then().statusCode(HttpStatus.SC_OK);
-        verifyRestRequestTraces(operationName);
+        verifyRequestTraces(operationName);
     }
 
+    @Order(6)
+    @Test
+    public void verifyJdbcTraces() {
+        for (String operationName : getExpectedJdbcOperationNames()) {
+            verifyRequestTraces(operationName);
+        }
+    }
+
+    protected String[] getExpectedJdbcOperationNames() {
+        return new String[] { "SELECT mydb.account", "INSERT mydb.journal", "UPDATE mydb.account" };
+    }
+
+    @Order(7)
     @Tag("QUARKUS-2492")
     @Test
     public void smokeTestMetricsNarayanaProgrammaticTransaction() {
@@ -162,12 +187,21 @@ public abstract class TransactionCommons {
                 .body().as(AccountEntity.class);
     }
 
-    private void verifyRestRequestTraces(String operationName) {
-        String[] operations = new String[] { operationName };
+    private void verifyRequestTraces(String operationName) {
+        verifyRequestTraces(operationName, jaeger);
+    }
+
+    static void verifyRequestTraces(String operationName, JaegerService jaeger) {
         await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(5)).untilAsserted(() -> {
-            retrieveTraces(20, "1h", "narayanaTransactions", operationName);
-            jaegerResponse.then().body("data[0].spans.operationName", containsInAnyOrder(operations));
+            var operations = getTracedOperationsForName(operationName, jaeger);
+            Assertions.assertNotNull(operations);
+            Assertions.assertTrue(operations.stream().anyMatch(operationName::equals));
         });
+    }
+
+    static List<String> getTracedOperationsForName(String operationName, JaegerService jaeger) {
+        var jaegerResponse = retrieveTraces(20, "1h", "narayanaTransactions", operationName, jaeger);
+        return jaegerResponse.jsonPath().getList("data[0].spans.operationName", String.class);
     }
 
     private JournalEntity getLatestJournalRecord(String accountNumber) {
@@ -178,8 +212,9 @@ public abstract class TransactionCommons {
                 .body().as(JournalEntity.class);
     }
 
-    private void retrieveTraces(int pageLimit, String lookBack, String serviceName, String operationName) {
-        jaegerResponse = given().when()
+    private static Response retrieveTraces(int pageLimit, String lookBack, String serviceName, String operationName,
+            JaegerService jaeger) {
+        return given().when()
                 .log().uri()
                 .queryParam("operation", operationName)
                 .queryParam("lookback", lookBack)

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/TransactionCommons.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/TransactionCommons.java
@@ -212,7 +212,7 @@ public abstract class TransactionCommons {
                 .body().as(JournalEntity.class);
     }
 
-    private static Response retrieveTraces(int pageLimit, String lookBack, String serviceName, String operationName,
+    static Response retrieveTraces(int pageLimit, String lookBack, String serviceName, String operationName,
             JaegerService jaeger) {
         return given().when()
                 .log().uri()

--- a/sql-db/narayana-transactions/src/test/resources/mariadb_app.properties
+++ b/sql-db/narayana-transactions/src/test/resources/mariadb_app.properties
@@ -3,4 +3,5 @@ quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDBDialect
 quarkus.hibernate-orm.sql-load-script=mariadb_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.opentelemetry.enabled=true
+quarkus.datasource.jdbc.telemetry=true
 quarkus.application.name=narayanaTransactions

--- a/sql-db/narayana-transactions/src/test/resources/mssql.properties
+++ b/sql-db/narayana-transactions/src/test/resources/mssql.properties
@@ -4,4 +4,5 @@ quarkus.hibernate-orm.sql-load-script=mssql_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.datasource.jdbc.additional-jdbc-properties.trustservercertificate=true
 quarkus.opentelemetry.enabled=true
+quarkus.datasource.jdbc.telemetry=true
 quarkus.application.name=narayanaTransactions

--- a/sql-db/narayana-transactions/src/test/resources/mysql.properties
+++ b/sql-db/narayana-transactions/src/test/resources/mysql.properties
@@ -2,4 +2,5 @@ quarkus.datasource.db-kind=mysql
 quarkus.hibernate-orm.sql-load-script=mysql_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.opentelemetry.enabled=true
+quarkus.datasource.jdbc.telemetry=true
 quarkus.application.name=narayanaTransactions

--- a/sql-db/narayana-transactions/src/test/resources/oracle.properties
+++ b/sql-db/narayana-transactions/src/test/resources/oracle.properties
@@ -2,4 +2,5 @@ quarkus.datasource.db-kind=oracle
 quarkus.hibernate-orm.sql-load-script=oracle_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.opentelemetry.enabled=true
+quarkus.datasource.jdbc.telemetry=true
 quarkus.application.name=narayanaTransactions


### PR DESCRIPTION
### Summary

- OpenTelemetry JDBC instrumentation added to Narayana Transactions module as we already test there REST traces and start Jaeger:
  - tests https://github.com/quarkusio/quarkus/pull/31567, covers scenarios missing in upstream test coverage:
    - works in native (also) for MySQL and MSSQL datasource, important for we need to verify their drivers in native
    - use actual Jaeger container, upstream uses InMemorySpanExporter or mocks everywhere
    - test instrumentation in OpenShift environment with Red Hat registry images
  - tests https://github.com/quarkusio/quarkus/pull/28792 as upstream doesn't test this at all
    - in order to verify this issue, module `sql-db/narayana-transactions` is now using RESTEasy Reactive, which is preferred REST stack anyway and not relevant for Narayana tests
- [Smallrye Context Propagation with OpenTelemetry](https://github.com/quarkusio/quarkus/issues/30362) is also placed in Narayana Transactions module as there we already have (transitive) Smallrye Propagation Context dependency and running tests so we don't have to start extra application for that (this way, impact on resources is minimal)
- [Quarkus Scheduler tracing](https://github.com/quarkusio/quarkus/pull/29802) because upstream only test this with unit test and doesn't even check traces go to exporter
- [OTEL beans available according to the MicroProfile Telemetry Tracing specification](https://github.com/quarkusio/quarkus/pull/28735), it's important as upstream:
  - only use `@QuarkusTest` so we want to check normal lifecycle and native mode
  - only tests static OTEL methods returns same stuff as injected (so basically tests used class loader is correct), but we are actually going to use them little bit and see that traces are propagated to Jaeger
  - I absolutely failed to find reasonable usage of injected Baggage. It is immutable and I can't see to be able to propagate anything in.I can see that OTEL java instrumentation git project basically use it as carrier within span context, but then you can't get it into injected immutable baggage anyway. Upstream docs doesn't mention baggage anyway and doesn't support it for MDC logging. Perhaps I needed to use Jaeger OTEL propagator...
- [RESTEasy Classic and Reactive now have filters](https://github.com/quarkusio/quarkus/pull/30073) that adds 2 of [recommended code attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#source-code-attributes)
  - it's probably not super important feature, but I thought it would be nice to have at least smoke test for there filters (in native) and verification was added to other test so it won't cost us more than couple of seconds
- [OpenTelemetry SDK autoconfiguration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md) has [now](https://github.com/quarkusio/quarkus/pull/30033) limited support for those OTEL configuration [properties we already support](https://github.com/quarkusio/quarkus/blob/main/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/OTelFallbackConfigSourceInterceptor.java#L85)
  - upstream PR was massive, however it's importance is mostly for future changes, right now from user point of view, it is basically cutting down `quarkus.otel.some-property-name` to `otel.some-property-name` https://github.com/quarkusio/quarkus/blob/43a53588daa126477e24e81c75abfbf017547df5/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryProducer.java#L143 and passing them to SDK builder, so what we want is to test that selected properties are passed to OTEL (otherwise we would be expensively testing whether someone didn't do typo)
    - we test that `quarkus.otel.service.name` has preference over `quarkus.application.name` and it doesn't https://github.com/quarkusio/quarkus/issues/33317 (so I opened issue)
    - we test that `quarkus.otel.attribute.value.length.limit` actually limits attribute length. that is OTEL business, but we want to ensure Quarkus OpenTelemetry extensions passed the property
  - important change is that `quarkus.opentelemetry` has changed to `quarkus.otel`, I didn't migrate properties as @linartova  is working on this and backwards compatibility should work for the moment being (and changes are not one to one, e.g. `quarkus.opentelemetry.tracer.exporter.otlp.endpoint` has changed to `quarkus.otel.exporter.otlp.traces.endpoint` as documented in [migration guide](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0#extension-re-write))


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)