### PR TITLE
Use Alpine image for flaky DevModePostgresqlDevServiceUserExperienceIT to mitigate possible causes of failure

### DIFF
--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlDevServiceUserExperienceIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlDevServiceUserExperienceIT.java
@@ -19,14 +19,19 @@ import io.quarkus.test.utils.SocketUtils;
 @QuarkusScenario
 public class DevModePostgresqlDevServiceUserExperienceIT {
 
-    private static final String POSTGRESQL_VERSION = getImageVersion("postgresql.latest.image");
+    // we use '-alpine' version as no other test is using it, which reduce changes that image will be already pulled
+    // we verified removing of Docker image in Github CI works, but either (extremely unlikely) Docker is shared between
+    // instances, or this test is started when previous PostgreSQL container is being terminated and operation sometimes
+    // fails; for whatever reason, using Alpine version makes CI less flaky
+    // TODO: we should revise above-mentioned comments in order to determine if we still need this workaround
+    private static final String POSTGRESQL_VERSION = getImageVersion("postgresql.latest.image") + "-alpine";
     private static final String POSTGRES_NAME = getImageName("postgresql.latest.image");
 
     @DevModeQuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.datasource.db-kind", "postgresql")
             .withProperty("quarkus.datasource.devservices.port", Integer.toString(SocketUtils.findAvailablePort()))
-            .withProperty("quarkus.datasource.devservices.image-name", "${postgresql.latest.image}")
+            .withProperty("quarkus.datasource.devservices.image-name", "${postgresql.latest.image}-alpine")
             .withProperty("quarkus.hibernate-orm.database.generation", "none")
             .onPreStart(s -> DockerUtils.removeImage(POSTGRES_NAME, POSTGRESQL_VERSION));
 


### PR DESCRIPTION
### Summary

Literally every dependabot bump I've reviewed in past weeks had failed `DevModePostgresqlDevServiceUserExperienceIT`. Here https://github.com/quarkus-qe/quarkus-test-suite/pull/1196 I experimentally verified that removing of PG images from Docker works in Github CI and also that test only fails when full CI is running, when just selected modules (those combinations I tested) are run in CI, test passes. Locally it's impossible to reproduce (at least for me).

Only idea I have is to try to use image that no other test is using and see if the test is still flaky. It only "covers" flakyness, but failing test is doing us no good as other runs are cancelled. I do't have better solution, but if there is one, please go ahead.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)