### PR TITLE
Enable and fix OpenShiftMysqlMultitenantHibernateSearchIT

### DIFF
--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftMysqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftMysqlMultitenantHibernateSearchIT.java
@@ -1,6 +1,5 @@
 package io.quarkus.ts.hibernate.search;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.DefaultService;
@@ -12,19 +11,27 @@ import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
-@Disabled("https://github.com/quarkus-qe/quarkus-test-framework/issues/427")
 public class OpenShiftMysqlMultitenantHibernateSearchIT extends AbstractMultitenantHibernateSearchIT {
-    static final int ELASTIC_PORT = 9200;
-    static final int MYSQL_PORT = 3306;
+    private static final int ELASTIC_PORT = 9200;
+    private static final int MYSQL_PORT = 3306;
+    private static final String MAX_ALLOWED_PACKET_VALUE = "5526600";
+    private static final String MAX_ALLOWED_PACKET_KEY = "MYSQL_MAX_ALLOWED_PACKET";
+    private static final String EXPECTED_LOG = "Only MySQL server logs after this point";
 
-    @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point", command = " --max-allowed-packet=5526600")
-    static MySqlService base = new MySqlService().withDatabase("base");
+    @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = EXPECTED_LOG)
+    static MySqlService base = new MySqlService()
+            .withDatabase("base")
+            .withProperty(MAX_ALLOWED_PACKET_KEY, MAX_ALLOWED_PACKET_VALUE);
 
-    @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point", command = " --max-allowed-packet=5526600")
-    static MySqlService company1 = new MySqlService().withDatabase("company1");
+    @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = EXPECTED_LOG)
+    static MySqlService company1 = new MySqlService()
+            .withDatabase("company1")
+            .withProperty(MAX_ALLOWED_PACKET_KEY, MAX_ALLOWED_PACKET_VALUE);
 
-    @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point", command = " --max-allowed-packet=5526600")
-    static MySqlService company2 = new MySqlService().withDatabase("company2");;
+    @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = EXPECTED_LOG)
+    static MySqlService company2 = new MySqlService()
+            .withDatabase("company2")
+            .withProperty(MAX_ALLOWED_PACKET_KEY, MAX_ALLOWED_PACKET_VALUE);
 
     @Container(image = "${elastic.71.image}", port = ELASTIC_PORT, expectedLog = "started")
     static DefaultService elastic = new DefaultService().withProperty("discovery.type", "single-node");

--- a/sql-db/hibernate-fulltext-search/src/test/resources/test.properties
+++ b/sql-db/hibernate-fulltext-search/src/test/resources/test.properties
@@ -1,2 +1,5 @@
 ts.database.openshift.use-internal-service-as-url=true
 ts.database.container.delete.image.on.stop=true
+ts.company1.openshift.use-internal-service-as-url=true
+ts.company2.openshift.use-internal-service-as-url=true
+ts.base.openshift.use-internal-service-as-url=true


### PR DESCRIPTION
### Summary

Enables `OpenShiftMysqlMultitenantHibernateSearchIT`. I use env variable for max allowed packets according to container file (basically previous `--max-allowed-packed` is not supported by current image) and enable internal service as URL as for some reason we use HTTP port only for non-internal services https://github.com/quarkus-qe/quarkus-test-framework/blob/c4aa750f09e09e5b69060a285f220d1ac09bf97a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/containers/OpenShiftContainerManagedResource.java#L74. But after all, we already use internal service for PG test in the same module and I don't see anything wrong about that.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)