### PR TITLE
Bump FW to 1.3.0.Beta16, manage HTMLUnit dependency and silent its logging

### DIFF
--- a/http/http-advanced-reactive/src/test/resources/test.properties
+++ b/http/http-advanced-reactive/src/test/resources/test.properties
@@ -1,2 +1,3 @@
 ts.keycloak.log.enable=true
 ts.app.log.enable=true
+com.gargoylesoftware.htmlunit.level=OFF

--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -28,7 +28,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-di</artifactId>
             <!-- TODO  switch to 3.something-redhat-0000X based version once available in maven.repository.redhat.com -->
-            <version>3.0.1.Final</version>
+            <version>3.0.3.Final</version>
         </dependency>
     </dependencies>
     <profiles>
@@ -42,7 +42,7 @@
             <properties>
                 <!-- please keep Mandrel and RHBQ version compatible -->
                 <!-- TODO  switch to 3.something-redhat-0000X based version once available in maven.repository.redhat.com -->
-                <quarkus.platform.version>3.0.0.CR2</quarkus.platform.version>
+                <quarkus.platform.version>3.0.3.Final</quarkus.platform.version>
             </properties>
             <repositories>
                 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <quarkus.qe.framework.version>1.3.0.Beta15</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.3.0.Beta16</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.1.0</quarkus-qpid-jms.version>
         <apache-httpclient-fluent.version>4.5.14</apache-httpclient-fluent.version>
         <confluent.kafka-avro-serializer.version>7.3.1</confluent.kafka-avro-serializer.version>
@@ -36,6 +36,7 @@
         <smallrye-stork.version>2.2.0</smallrye-stork.version>
         <assertj.version>3.24.2</assertj.version>
         <profile.id>jvm</profile.id>
+        <htmlunit.version>2.70.0</htmlunit.version>
         <!-- Faster build when using -DskipTests -->
         <quarkus.build.skip>${skipTests}</quarkus.build.skip>
         <!-- S2i configuration -->
@@ -111,6 +112,12 @@
                 <artifactId>assertj-core</artifactId>
                 <scope>test</scope>
                 <version>${assertj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.sourceforge.htmlunit</groupId>
+                <artifactId>htmlunit</artifactId>
+                <version>${htmlunit.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/security/keycloak-jwt/src/test/resources/test.properties
+++ b/security/keycloak-jwt/src/test/resources/test.properties
@@ -1,2 +1,3 @@
 ts.keycloak.log.enable=true
 ts.app.log.enable=true
+com.gargoylesoftware.htmlunit.level=OFF

--- a/security/keycloak-multitenant/src/test/resources/test.properties
+++ b/security/keycloak-multitenant/src/test/resources/test.properties
@@ -1,2 +1,3 @@
 ts.keycloak.log.enable=true
 ts.app.log.enable=true
+com.gargoylesoftware.htmlunit.level=OFF

--- a/security/keycloak-oidc-client-extended/src/test/resources/test.properties
+++ b/security/keycloak-oidc-client-extended/src/test/resources/test.properties
@@ -1,0 +1,1 @@
+com.gargoylesoftware.htmlunit.level=OFF

--- a/security/keycloak-oidc-client-reactive-extended/src/test/resources/test.properties
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/resources/test.properties
@@ -1,0 +1,1 @@
+com.gargoylesoftware.htmlunit.level=OFF

--- a/security/keycloak-webapp/src/test/resources/test.properties
+++ b/security/keycloak-webapp/src/test/resources/test.properties
@@ -1,2 +1,3 @@
 ts.keycloak.log.enable=true
 ts.app.log.enable=true
+com.gargoylesoftware.htmlunit.level=OFF


### PR DESCRIPTION
### Summary

https://github.com/quarkus-qe/quarkus-test-framework/pull/781 follow up. Bumps FW, manages HTMLUnit dependency itself and sets is logging to off level

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)