### PR TITLE
Workaround DevModeReactivePostgresqlDevServiceUserExperienceIT flakyness and don't start other ignored services

### DIFF
--- a/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeReactiveMssqlDevServiceUserExperienceIT.java
+++ b/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeReactiveMssqlDevServiceUserExperienceIT.java
@@ -23,6 +23,8 @@ public class DevModeReactiveMssqlDevServiceUserExperienceIT {
     @DevModeQuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.datasource.mssql.devservices.image-name", "${mssql.image}")
+            .withProperty("quarkus.datasource.mysql.devservices.enabled", "false")
+            .withProperty("quarkus.datasource.devservices.enabled", "false")
             .onPreStart(s -> DockerUtils.removeImage(MSSQL_NAME, MSSQL_VERSION));
 
     @Test

--- a/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeReactiveMysqlDevServiceUserExperienceIT.java
+++ b/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeReactiveMysqlDevServiceUserExperienceIT.java
@@ -23,6 +23,8 @@ public class DevModeReactiveMysqlDevServiceUserExperienceIT {
     @DevModeQuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.datasource.mysql.devservices.image-name", "${mysql.upstream.80.image}")
+            .withProperty("quarkus.datasource.mssql.devservices.enabled", "false")
+            .withProperty("quarkus.datasource.devservices.enabled", "false")
             .onPreStart(s -> DockerUtils.removeImage(MYSQL_NAME, MYSQL_VERSION));
 
     @Test

--- a/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeReactivePostgresqlDevServiceUserExperienceIT.java
+++ b/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeReactivePostgresqlDevServiceUserExperienceIT.java
@@ -17,12 +17,18 @@ import io.quarkus.test.utils.DockerUtils;
 @Tag("QUARKUS-1080")
 @QuarkusScenario
 public class DevModeReactivePostgresqlDevServiceUserExperienceIT {
-    private static final String POSTGRESQL_VERSION = getImageVersion("postgresql.latest.image");
+
+    // we use '-bullseye' version as no other test is using it, which mitigates the fact that sometimes
+    // io.quarkus.test.utils.DockerUtils.removeImage doesn't work as expected
+    // TODO: drop suffix when https://github.com/quarkus-qe/quarkus-test-suite/issues/1227 is fixed
+    private static final String POSTGRESQL_VERSION = getImageVersion("postgresql.latest.image") + "-bullseye";
     private static final String POSTGRES_NAME = getImageName("postgresql.latest.image");
 
     @DevModeQuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.datasource.devservices.image-name", "${postgresql.latest.image}")
+            .withProperty("quarkus.datasource.devservices.image-name", "${postgresql.latest.image}-bullseye")
+            .withProperty("quarkus.datasource.mysql.devservices.enabled", "false")
+            .withProperty("quarkus.datasource.mssql.devservices.enabled", "false")
             .onPreStart(s -> DockerUtils.removeImage(POSTGRES_NAME, POSTGRESQL_VERSION));
 
     @Test

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlDevServiceUserExperienceIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlDevServiceUserExperienceIT.java
@@ -19,11 +19,9 @@ import io.quarkus.test.utils.SocketUtils;
 @QuarkusScenario
 public class DevModePostgresqlDevServiceUserExperienceIT {
 
-    // we use '-alpine' version as no other test is using it, which reduce changes that image will be already pulled
-    // we verified removing of Docker image in Github CI works, but either (extremely unlikely) Docker is shared between
-    // instances, or this test is started when previous PostgreSQL container is being terminated and operation sometimes
-    // fails; for whatever reason, using Alpine version makes CI less flaky
-    // TODO: we should revise above-mentioned comments in order to determine if we still need this workaround
+    // we use '-alpine' version as no other test is using it, which mitigates the fact that sometimes
+    // io.quarkus.test.utils.DockerUtils.removeImage doesn't work as expected
+    // TODO: drop suffix when https://github.com/quarkus-qe/quarkus-test-suite/issues/1227 is fixed
     private static final String POSTGRESQL_VERSION = getImageVersion("postgresql.latest.image") + "-alpine";
     private static final String POSTGRES_NAME = getImageName("postgresql.latest.image");
 


### PR DESCRIPTION
### Summary

Daily build 827 failed over `DevModeReactivePostgresqlDevServiceUserExperienceIT`, so I follow strategy described in https://github.com/quarkus-qe/quarkus-test-suite/pull/1223. These 3 UX DEV mode tests were always starting other dev services they didn't need, therefore I disabled them so that we safe time on test execution. Bullseye is current stable Debian, so that will change over time (we will be informed when test fails).

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)