### PR TITLE
Enable OpenShiftQuickstartIT with Quarkus 999-SNAPSHOT

### DIFF
--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftQuickstartIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftQuickstartIT.java
@@ -2,9 +2,7 @@ package io.quarkus.ts.external.applications;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
-@DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @DisabledOnNative(reason = "Native + s2i not supported")
 @OpenShiftScenario
 public class OpenShiftQuickstartIT extends QuickstartIT {


### PR DESCRIPTION
### Summary

It is now possible to run `OpenShiftQuickstartIT` with Quarkus `999-SNAPSHOT` - https://github.com/quarkus-qe/quarkus-test-framework/pull/768

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)