### PR TITLE
Fix corrupted channel trouble with native binary build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${failsafe-plugin.version}</version>
+                    <configuration>
+                        <!-- fixes unavailable native binary build logs, https://github.com/quarkus-qe/quarkus-test-framework/issues/785 -->
+                        <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Fix corrupted channel trouble with native binary build

Details in https://github.com/quarkus-qe/quarkus-test-framework/issues/785

Relates to https://github.com/quarkus-qe/quarkus-test-framework/pull/786

Example command: `mvn clean verify -Dit.test=WebSocketsClientIT -f websockets/websockets-client -Dnative -Dquarkus.native.container-build=false`

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)