### PR TITLE
Change Quarkus CLI utils to use default streams

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -94,8 +94,6 @@ public class QuarkusCliExtensionsIT {
     }
 
     @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not pushed into the platform site")
-    //TODO Currently code.quarkus and quarkusCli are pointing to the same set of defined streams.
-    // ZULIP ref: https://quarkusio.zulipchat.com/#narrow/stream/191168-core-team/topic/streams.20on.20registry.20.2F.20code.2Equarkus/near/280456392
     @Test
     public void shouldListExtensionsUsingStream() {
         String streamVersion = getCurrentStreamVersion();

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliUtils.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliUtils.java
@@ -18,9 +18,7 @@ public class QuarkusCliUtils {
         String version = getCurrentStreamVersion();
         if (isUpstream(version)) {
             LOG.warn("fixed streams are not supported on upstream");
-            // FIXME: use 'defaults' once Quarkus 3 final is released
-            // set Quarkus 3 version to avoid javax vs jakarta conflicts (failures)
-            return defaults().withStream("3.0");
+            return defaults();
         }
 
         return defaults().withStream(version);
@@ -30,9 +28,7 @@ public class QuarkusCliUtils {
         String version = getCurrentStreamVersion();
         if (isUpstream(version)) {
             LOG.warn("fixed streams are not supported on upstream");
-            // FIXME: use 'defaults' once Quarkus 3 final is released
-            // set Quarkus 3 version to avoid javax vs jakarta conflicts (failures)
-            return QuarkusCliClient.CreateExtensionRequest.defaults().withStream("3.0");
+            return QuarkusCliClient.CreateExtensionRequest.defaults();
         }
 
         return QuarkusCliClient.CreateExtensionRequest.defaults().withStream(version);


### PR DESCRIPTION
### Summary

Change Quarkus CLI utils to use default streams as Quarkus 3 is now used.
Additionally, remove TODO with outdated Zulip conversation


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)