### PR TITLE
Trailing comma is no longer present in Micrometer Prometheus

### DIFF
--- a/monitoring/micrometer-prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/HttpServerMetricsIT.java
+++ b/monitoring/micrometer-prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/HttpServerMetricsIT.java
@@ -1,7 +1,6 @@
 package io.quarkus.ts.micrometer.prometheus;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.RestAssured.when;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -23,14 +22,7 @@ public class HttpServerMetricsIT {
 
     private static final int ASSERT_METRICS_TIMEOUT_MINUTES = 1;
     private static final List<String> HTTP_SERVER_REQUESTS_METRICS_SUFFIX = Arrays.asList("count", "sum", "max");
-
-    /*
-     * In versions before 2.16 metrics have format '{a,b,}' (with trailing comma)
-     * Starting from 2.16 the format changed to '{a,b}'
-     * See https://github.com/quarkusio/quarkus/issues/30343 for details
-     * TODO: add '}' to the end, when this stabilizes
-     */
-    private static final String HTTP_SERVER_REQUESTS_METRICS_FORMAT = "http_server_requests_seconds_%s{method=\"GET\",outcome=\"SUCCESS\",status=\"200\",uri=\"%s\"";
+    private static final String HTTP_SERVER_REQUESTS_METRICS_FORMAT = "http_server_requests_seconds_%s{method=\"GET\",outcome=\"SUCCESS\",status=\"200\",uri=\"%s\"}";
     private static final String PING_PONG_ENDPOINT = "/without-metrics-pingpong";
 
     @QuarkusApplication


### PR DESCRIPTION
### Summary

Micrometer Prometheus now uses new format without trailing comma.
https://github.com/quarkusio/quarkus/issues/30343


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)