### PR TITLE
Remove magical constant in PostgresPoolTest

### DIFF
--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/dbpool/PostgresPoolTest.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/dbpool/PostgresPoolTest.java
@@ -124,6 +124,6 @@ public class PostgresPoolTest {
     }
 
     private boolean checkDbActiveConnections(long active) {
-        return active <= datasourceMaxSize + (7); // TODO: double check this condition ... this magical number is scary!.
+        return active <= datasourceMaxSize;
     }
 }


### PR DESCRIPTION
### Summary

Remove magical constant in PostgresPoolTest.
Run this test 10 times, no errors occurred.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)