### PR TITLE
Update deprecated usage of RestSseElementType

### DIFF
--- a/monitoring/micrometer-prometheus-kafka-reactive/src/main/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/AlertConsumer.java
+++ b/monitoring/micrometer-prometheus-kafka-reactive/src/main/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/AlertConsumer.java
@@ -3,11 +3,10 @@ package io.quarkus.ts.micrometer.prometheus.kafka.reactive;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.jboss.resteasy.reactive.RestSseElementType;
+import org.jboss.resteasy.reactive.RestStreamElementType;
 import org.reactivestreams.Publisher;
 
 @Path("/")
@@ -19,8 +18,7 @@ public class AlertConsumer {
 
     @GET
     @Path("/monitor/stream")
-    @Produces(MediaType.SERVER_SENT_EVENTS)
-    @RestSseElementType(MediaType.TEXT_PLAIN)
+    @RestStreamElementType(MediaType.TEXT_PLAIN)
     public Publisher<String> stream() {
         return alerts;
     }


### PR DESCRIPTION
### Summary

* Updating test app to use RestStreamElementType rather than the deprecated RestSseElementType. This also fixes failure of the Kafka tests running with the test app.

Note: I've also opened https://github.com/quarkusio/quarkus/issues/33652 as the deprecated SSE endpoint annotation is broken. Not sure if we want to keep tests for deprecated stuff in main.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)