### PR TITLE
Change PostgresqlService instances to use default properties

### DIFF
--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopVillainsIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopVillainsIT.java
@@ -49,10 +49,6 @@ public class OpenShiftWorkshopVillainsIT {
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static PostgresqlService database = new PostgresqlService()
-            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
-            .withProperty("POSTGRES_USER", "user")
-            .withProperty("POSTGRES_PASSWORD", "user")
-            .withProperty("POSTGRES_DB", "mydb")
             .withProperty("PGDATA", "/tmp/psql");
 
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-workshops.git", contextDir = "quarkus-workshop-super-heroes/super-heroes/rest-villains", branch = "3d3425a15daacf1c774cb7f5bc24228c4a623256", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/AbstractDbIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/AbstractDbIT.java
@@ -10,10 +10,6 @@ public class AbstractDbIT {
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static final PostgresqlService database = new PostgresqlService()
-            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
-            .withProperty("POSTGRES_USER", "user")
-            .withProperty("POSTGRES_PASSWORD", "user")
-            .withProperty("POSTGRES_DB", "mydb")
             .withProperty("PGDATA", "/tmp/psql");
 
     @QuarkusApplication

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/PostgresqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/PostgresqlMultitenantHibernateSearchIT.java
@@ -17,11 +17,7 @@ public class PostgresqlMultitenantHibernateSearchIT extends AbstractMultitenantH
     static DefaultService elastic = new DefaultService().withProperty("discovery.type", "single-node");
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static PostgresqlService database = new PostgresqlService()
-            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
-            .withProperty("POSTGRES_USER", "user")
-            .withProperty("POSTGRES_PASSWORD", "user")
-            .withProperty("POSTGRES_DB", "mydb");
+    static PostgresqlService database = new PostgresqlService();
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/PostgresqlDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/PostgresqlDatabaseHibernateReactiveIT.java
@@ -16,10 +16,6 @@ public class PostgresqlDatabaseHibernateReactiveIT extends AbstractDatabaseHiber
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRES_PORT, expectedLog = "listening on IPv4 address")
     static PostgresqlService database = new PostgresqlService()
-            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
-            .withProperty("POSTGRES_USER", POSTGRES_USER)
-            .withProperty("POSTGRES_PASSWORD", POSTGRES_PASSWORD)
-            .withProperty("POSTGRES_DB", POSTGRES_DATABASE)
             .withUser(POSTGRES_USER)
             .withPassword(POSTGRES_PASSWORD)
             .withDatabase(POSTGRES_DATABASE)

--- a/sql-db/hibernate/src/test/java/io/quarkus/qe/hibernate/ProdHibernateIT.java
+++ b/sql-db/hibernate/src/test/java/io/quarkus/qe/hibernate/ProdHibernateIT.java
@@ -12,11 +12,7 @@ public class ProdHibernateIT extends BaseHibernateIT {
     static final int POSTGRESQL_PORT = 5432;
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static final PostgresqlService database = new PostgresqlService()
-            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
-            .withProperty("POSTGRES_USER", "user")
-            .withProperty("POSTGRES_PASSWORD", "user")
-            .withProperty("POSTGRES_DB", "mydb");
+    static final PostgresqlService database = new PostgresqlService();
 
     @QuarkusApplication
     public static final RestService app = new RestService()

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiplePersistenceIT.java
@@ -18,11 +18,7 @@ public class MultiplePersistenceIT extends AbstractMultiplePersistenceIT {
     static MariaDbService mariadb = new MariaDbService();
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static PostgresqlService postgresql = new PostgresqlService()
-            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
-            .withProperty("POSTGRES_USER", "user")
-            .withProperty("POSTGRES_PASSWORD", "user")
-            .withProperty("POSTGRES_DB", "mydb");
+    static PostgresqlService postgresql = new PostgresqlService();
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
@@ -22,10 +22,6 @@ public class OpenShiftMultiplePersistenceIT extends AbstractMultiplePersistenceI
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static PostgresqlService postgresql = new PostgresqlService()
-            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
-            .withProperty("POSTGRES_USER", "user")
-            .withProperty("POSTGRES_PASSWORD", "user")
-            .withProperty("POSTGRES_DB", "mydb")
             .withProperty("PGDATA", "/tmp/psql");
 
     @QuarkusApplication

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/PostgresqlDatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/PostgresqlDatabaseIT.java
@@ -12,11 +12,7 @@ public class PostgresqlDatabaseIT extends AbstractSqlDatabaseIT {
     static final int POSTGRESQL_PORT = 5432;
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static PostgresqlService database = new PostgresqlService()
-            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
-            .withProperty("POSTGRES_USER", "user")
-            .withProperty("POSTGRES_PASSWORD", "user")
-            .withProperty("POSTGRES_DB", "mydb");
+    static PostgresqlService database = new PostgresqlService();
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("postgresql.properties")

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresqlDatabaseIT.java
@@ -16,10 +16,6 @@ public class OpenShiftPostgresqlDatabaseIT extends AbstractSqlDatabaseIT {
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static PostgresqlService database = new PostgresqlService()
-            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
-            .withProperty("POSTGRES_USER", "user")
-            .withProperty("POSTGRES_PASSWORD", "user")
-            .withProperty("POSTGRES_DB", "mydb")
             .withProperty("PGDATA", "/tmp/psql");
 
     @QuarkusApplication

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/PostgresqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/PostgresqlDatabaseIT.java
@@ -12,11 +12,7 @@ public class PostgresqlDatabaseIT extends AbstractSqlDatabaseIT {
     static final int POSTGRESQL_PORT = 5432;
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
-    static PostgresqlService database = new PostgresqlService()
-            //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
-            .withProperty("POSTGRES_USER", "user")
-            .withProperty("POSTGRES_PASSWORD", "user")
-            .withProperty("POSTGRES_DB", "mydb");
+    static PostgresqlService database = new PostgresqlService();
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("postgresql.properties")

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/PostgresqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/PostgresqlHandlerIT.java
@@ -12,10 +12,7 @@ public class PostgresqlHandlerIT extends CommonTestCases {
 
     @Container(image = "${postgresql.latest.image}", port = 5432, expectedLog = "listening on IPv4 address")
     static PostgresqlService postgres = new PostgresqlService()
-            .with("test", "test", POSTGRESQL_DATABASE)
-            .withProperty("POSTGRES_USER", "test") //fixme https://github.com/quarkus-qe/quarkus-test-framework/issues/455
-            .withProperty("POSTGRES_PASSWORD", "test")
-            .withProperty("POSTGRES_DB", POSTGRESQL_DATABASE);;
+            .with("test", "test", POSTGRESQL_DATABASE);
 
     @QuarkusApplication
     static final RestService app = new RestService()


### PR DESCRIPTION
### Summary

When PostgresqlService is used with postgres images from Docker Hub is no longer needed to define environment options POSTGRES_USER, POSTGRES_PASSWORD and POSTGRES_DB properties by hand.

Related issue https://github.com/quarkus-qe/quarkus-test-framework/issues/455 was closed.
Fixed in https://github.com/quarkus-qe/quarkus-test-framework/pull/456/files#diff-9cbca746aa7bb87ac0cecdc029d700331ba49a9bc9c54cbbcc8c7895062e346b

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)