### PR TITLE
Use only major version tj-actions/changed-files to limit number of bump PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: files
-        uses: tj-actions/changed-files@v36.0.10
+        uses: tj-actions/changed-files@v36
         continue-on-error: true
       - id: detect-changes
         run: |


### PR DESCRIPTION
### Summary

There has been 21 merged PR for `tj-actions/changed-files` since 11/14/22 when we introduced them. And that's not counting superseded PRs. I analyzed previous major version v35 https://github.com/tj-actions/changed-files/releases/tag/v35 and there are not breaking changes in minor/micro releases. Breaking changes were introduced in v36.0.0 https://github.com/tj-actions/changed-files/releases/tag/v36. IMO we should not waste resources and time for bumps and simply use major version.

```
1a9c138d Bump tj-actions/changed-files from 36.0.8 to 36.0.10
aa33c540 Bump tj-actions/changed-files from 35.9.2 to 36.0.8
856c9350 Bump tj-actions/changed-files from 35.9.1 to 35.9.2
efa1736a Bump tj-actions/changed-files from 35.9.0 to 35.9.1
47c97208 Bump tj-actions/changed-files from 35.8.0 to 35.9.0
9dfc7d92 Bump tj-actions/changed-files from 35.7.12 to 35.8.0
4e9bd370 Bump tj-actions/changed-files from 35.7.8 to 35.7.12
979fb2b3 Bump tj-actions/changed-files from 35.7.6 to 35.7.8
18245832 Bump tj-actions/changed-files from 35.7.1 to 35.7.6
80775239 Bump tj-actions/changed-files from 35.6.4 to 35.7.1
f57d5bf2 Bump tj-actions/changed-files from 35.6.2 to 35.6.4
a039447a Bump tj-actions/changed-files from 35.6.1 to 35.6.2
b520bfdc Bump tj-actions/changed-files from 35.6.0 to 35.6.1 (#1085)
5fe83b2d Bump tj-actions/changed-files from 35.4.1 to 35.6.0 (#1081)
3385b183 Bump tj-actions/changed-files from 35.4.0 to 35.4.1
8f67e752 Bump tj-actions/changed-files from 35.1.0 to 35.4.0
9d174642 Bump tj-actions/changed-files from 34.6.1 to 35.1.0
0f5c94d8 Bump tj-actions/changed-files from 34.6.0 to 34.6.1
f2a00416 Bump tj-actions/changed-files from 34.5.1 to 34.6.0
11713ce7 Bump tj-actions/changed-files from 34.5.0 to 34.5.1
3f4fd149 Bump tj-actions/changed-files from 34.0.0 to 34.5.0
```

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)