### PR TITLE
Fail fast as Ecosystem CI can't handle matrix status update

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'quarkusbot' || github.actor == 'Sgitario' || github.actor == 'rsvoboda'
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         profiles: [ "root-modules-no-qute,monitoring-modules,spring-modules,test-tooling-modules",
                     "http-modules",


### PR DESCRIPTION
Fail fast as Ecosystem CI can't handle matrix status update

We have cases when on module fails, GH issue gets reopened and once another module finishes, the issue gets closed. And thus https://status.quarkus.io/ status is always green.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)