### PR TITLE
[2.13] Fix LogoutSinglePageAppFlowIT.singlePageAppLogoutFlow reactive and classic tests failing over missing CORS origin

### DIFF
--- a/security/bouncycastle-fips/bcFipsJsse/src/main/java/io/quarkus/ts/security/bouncycastle/fips/jsse/SecretProvider.java
+++ b/security/bouncycastle-fips/bcFipsJsse/src/main/java/io/quarkus/ts/security/bouncycastle/fips/jsse/SecretProvider.java
@@ -3,8 +3,8 @@ package io.quarkus.ts.security.bouncycastle.fips.jsse;
 import java.util.HashMap;
 import java.util.Map;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Named;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
 
 import io.quarkus.arc.Unremovable;
 import io.quarkus.credentials.CredentialsProvider;

--- a/security/keycloak-oidc-client-extended/src/test/resources/logout.properties
+++ b/security/keycloak-oidc-client-extended/src/test/resources/logout.properties
@@ -19,6 +19,7 @@ quarkus.http.auth.permission.unsecured.policy=permit
 quarkus.http.auth.permission.unsecured.methods=GET
 
 quarkus.http.cors=true
+quarkus.http.cors.origins=${keycloak.url}
 quarkus.http.auth.permission.logout.paths=/code-flow/logout
 quarkus.http.auth.permission.logout.policy=authenticated
 

--- a/security/keycloak-oidc-client-reactive-extended/src/test/resources/logout.properties
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/resources/logout.properties
@@ -14,6 +14,7 @@ quarkus.http.auth.permission.unsecured.policy=permit
 quarkus.http.auth.permission.unsecured.methods=GET
 
 quarkus.http.cors=true
+quarkus.http.cors.origins=${keycloak.url}
 quarkus.http.auth.permission.logout.paths=/code-flow/logout
 quarkus.http.auth.permission.logout.policy=authenticated
 

--- a/spring/spring-web-reactive/src/main/java/io/quarkus/ts/spring/web/reactive/bootstrap/web/BookController.java
+++ b/spring/spring-web-reactive/src/main/java/io/quarkus/ts/spring/web/reactive/bootstrap/web/BookController.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.spring.web.reactive.boostrap.web;
+package io.quarkus.ts.spring.web.reactive.bootstrap.web;
 
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
@@ -28,6 +28,7 @@ import io.quarkus.ts.spring.web.reactive.bootstrap.persistence.model.Book;
 import io.quarkus.ts.spring.web.reactive.bootstrap.persistence.repo.BookRepository;
 import io.quarkus.ts.spring.web.reactive.bootstrap.web.exception.BookIdMismatchException;
 import io.quarkus.ts.spring.web.reactive.bootstrap.web.exception.BookNotFoundException;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 @RestController

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/MariaDBConstants.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/MariaDBConstants.java
@@ -4,5 +4,6 @@ public class MariaDBConstants {
     public static final int PORT = 3306;
     public static final String START_LOG = "Only MySQL server logs after this point";
     public static final String IMAGE_103 = "${mariadb.103.image}";
-    public static final String IMAGE_105 = "${mariadb.105.image}";
+    public static final String START_LOG_10 = "socket: '/run/mysqld/mysqld.sock'  port: " + PORT;
+    public static final String IMAGE_10 = "${mariadb.10.image}";
 }


### PR DESCRIPTION
### Summary

- As you can see in our Jenkins job rhbq-2.13-rhel8-jdk11-baremetal-ts-jvm/jdk=openjdk-11,label=RHEL8%20&&%20large,scenario=security-modules/23/#showFailuresLink branch 2.13 is failing over wrong CORS origin. This change goes down to https://issues.redhat.com/browse/QUARKUS-3159.

- Fixes imports and missing constants as project does not compile. I did poor job when solving merge conflicts of  https://github.com/quarkus-qe/quarkus-test-suite/pull/1270.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)