### PR TITLE
Enable DomainSocketIT as upstream issue was fixed

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DomainSocketIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DomainSocketIT.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -26,7 +25,6 @@ import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.ext.web.codec.BodyCodec;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/33679")
 @QuarkusScenario
 @Tag("https://github.com/quarkusio/quarkus/issues/24739")
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Netty Native Transport not supported on Windows, see https://quarkus.io/guides/vertx-reference#native-transport")


### PR DESCRIPTION
### Summary

Enables `DomainSocketIT` as https://github.com/quarkusio/quarkus/issues/33679 was fixed.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)