### PR TITLE
Use special class for parsing service URI

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/BaseHttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/BaseHttpAdvancedReactiveIT.java
@@ -455,7 +455,7 @@ public abstract class BaseHttpAdvancedReactiveIT {
     }
 
     private String getAppEndpoint() {
-        return getApp().getHost(getProtocol()) + ":" + getApp().getPort(getProtocol()) + ROOT_PATH;
+        return getApp().getURI(getProtocol()).withPath(ROOT_PATH).toString();
     }
 
     private ResponsePredicateResult isHttp2x(HttpResponse<Void> resp) {

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeGrpcIntegrationReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeGrpcIntegrationReactiveIT.java
@@ -189,7 +189,7 @@ public class DevModeGrpcIntegrationReactiveIT {
         OkHttpClient client = new OkHttpClient();
 
         Request request = new Request.Builder()
-                .url("ws://localhost:" + app.getPort() + "/q/dev/io.quarkus.quarkus-grpc/grpc-test")
+                .url(app.getURI().withScheme("ws").withPath("/q/dev/io.quarkus.quarkus-grpc/grpc-test").toString())
                 .build();
         webSocket = client.newWebSocket(request, webSocketListener);
     }

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/BaseHttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/BaseHttpAdvancedIT.java
@@ -247,7 +247,7 @@ public abstract class BaseHttpAdvancedIT {
     }
 
     private String getAppEndpoint() {
-        return getApp().getHost(getProtocol()) + ":" + getApp().getPort(getProtocol()) + ROOT_PATH;
+        return getApp().getURI(getProtocol()).withPath(ROOT_PATH).toString();
     }
 
     private ResponsePredicateResult isHttp2x(HttpResponse<Void> resp) {

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeGrpcIntegrationIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeGrpcIntegrationIT.java
@@ -188,7 +188,7 @@ public class DevModeGrpcIntegrationIT {
         OkHttpClient client = new OkHttpClient();
 
         Request request = new Request.Builder()
-                .url("ws://localhost:" + app.getPort() + "/q/dev/io.quarkus.quarkus-grpc/grpc-test")
+                .url(app.getURI().withScheme("ws").withPath("/q/dev/io.quarkus.quarkus-grpc/grpc-test").toString())
                 .build();
         webSocket = client.newWebSocket(request, webSocketListener);
     }

--- a/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
+++ b/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
@@ -35,6 +35,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.JaegerService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.EnabledOnNative;
@@ -61,7 +62,7 @@ public class VertxWebClientIT {
 
     @QuarkusApplication
     static RestService vertx = new RestService()
-            .withProperty("chucknorris.api.domain", () -> wiremock.getHost() + ":" + wiremock.getPort())
+            .withProperty("chucknorris.api.domain", () -> wiremock.getURI(Protocol.HTTP).toString())
             .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl);
 
     @Test
@@ -212,7 +213,7 @@ public class VertxWebClientIT {
     }
 
     private WireMock wireMockClient() {
-        return new WireMock(wiremock.getHost().substring("http://".length()), wiremock.getPort());
+        return new WireMock(wiremock.getURI(Protocol.HTTP).getHost(), wiremock.getURI(Protocol.HTTP).getPort());
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/messaging/kafka-confluent-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/BaseKafkaAvroGroupIdIT.java
+++ b/messaging/kafka-confluent-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/BaseKafkaAvroGroupIdIT.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.sse.SseEventSource;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.restassured.http.ContentType;
 
@@ -93,7 +94,7 @@ abstract class BaseKafkaAvroGroupIdIT {
     }
 
     private String getEndpoint(RestService app) {
-        return app.getHost() + ":" + app.getPort();
+        return app.getURI(Protocol.HTTP).toString();
     }
 
     private StockPriceDto randomStockPrice() {

--- a/messaging/kafka-confluent-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/BaseKafkaAvroIT.java
+++ b/messaging/kafka-confluent-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/BaseKafkaAvroIT.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.sse.SseEventSource;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 
 public abstract class BaseKafkaAvroIT {
@@ -71,6 +72,6 @@ public abstract class BaseKafkaAvroIT {
     }
 
     private String getEndpoint() {
-        return getApp().getHost() + ":" + getApp().getPort();
+        return getApp().getURI(Protocol.HTTP).toString();
     }
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeStrimziKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeStrimziKafkaStreamIT.java
@@ -3,6 +3,7 @@ package io.quarkus.ts.messaging.kafka.reactive.streams;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
@@ -24,7 +25,7 @@ public class DevModeStrimziKafkaStreamIT extends BaseKafkaStreamTest {
 
     @Override
     protected String getAppUrl() {
-        return app.getHost() + ":" + app.getPort();
+        return app.getURI(Protocol.HTTP).toString();
     }
 
     @Test

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftAmqStreamsKafkaStreamIT.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KafkaService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.KafkaContainer;
@@ -25,6 +26,6 @@ public class OpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTest {
 
     @Override
     protected String getAppUrl() {
-        return app.getHost() + ":" + app.getPort();
+        return app.getURI(Protocol.HTTP).toString();
     }
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.messaging.kafka.reactive.streams;
 
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.Operator;
@@ -21,6 +22,6 @@ public class OperatorOpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTes
 
     @Override
     protected String getAppUrl() {
-        return app.getHost() + ":" + app.getPort();
+        return app.getURI(Protocol.HTTP).toString();
     }
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SslAlertMonitorIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SslAlertMonitorIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.messaging.kafka.reactive.streams;
 
 import io.quarkus.test.bootstrap.KafkaService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.KafkaContainer;
@@ -28,6 +29,6 @@ public class SslAlertMonitorIT extends BaseKafkaStreamTest {
 
     @Override
     protected String getAppUrl() {
-        return app.getHost() + ":" + app.getPort();
+        return app.getURI(Protocol.HTTP).toString();
     }
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/StrimziKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/StrimziKafkaStreamIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.messaging.kafka.reactive.streams;
 
 import io.quarkus.test.bootstrap.KafkaService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.KafkaContainer;
@@ -20,6 +21,6 @@ public class StrimziKafkaStreamIT extends BaseKafkaStreamTest {
 
     @Override
     protected String getAppUrl() {
-        return app.getHost() + ":" + app.getPort();
+        return app.getURI(Protocol.HTTP).toString();
     }
 }

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/BaseKafkaAvroGroupIdIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/BaseKafkaAvroGroupIdIT.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.sse.SseEventSource;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.restassured.http.ContentType;
 
@@ -93,7 +94,7 @@ abstract class BaseKafkaAvroGroupIdIT {
     }
 
     private String getEndpoint(RestService app) {
-        return app.getHost() + ":" + app.getPort();
+        return app.getURI(Protocol.HTTP).toString();
     }
 
     private StockPriceDto randomStockPrice() {

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/BaseKafkaAvroIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/BaseKafkaAvroIT.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.sse.SseEventSource;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 
 public abstract class BaseKafkaAvroIT {
@@ -71,6 +72,6 @@ public abstract class BaseKafkaAvroIT {
     }
 
     private String getEndpoint() {
-        return getApp().getHost() + ":" + getApp().getPort();
+        return getApp().getURI(Protocol.HTTP).toString();
     }
 }

--- a/monitoring/micrometer-prometheus-kafka-reactive/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/BaseOpenShiftAlertEventsReactiveIT.java
+++ b/monitoring/micrometer-prometheus-kafka-reactive/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/BaseOpenShiftAlertEventsReactiveIT.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.util.Strings;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.Service;
 import io.quarkus.test.bootstrap.inject.OpenShiftClient;
@@ -62,7 +63,7 @@ public abstract class BaseOpenShiftAlertEventsReactiveIT {
     private void whenWaitUntilReceiveSomeAlerts() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(WAIT_FOR_ALERTS_COUNT);
 
-        WebTarget target = ClientBuilder.newClient().target(getApp().getHost() + ":" + getApp().getPort() + PATH);
+        WebTarget target = ClientBuilder.newClient().target(getApp().getURI(Protocol.HTTP).withPath(PATH).toString());
         SseEventSource source = SseEventSource.target(target).build();
         source.register(inboundSseEvent -> {
             receive.add(inboundSseEvent.readData(String.class, MediaType.APPLICATION_JSON_TYPE));

--- a/monitoring/micrometer-prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/BaseOpenShiftAlertEventsIT.java
+++ b/monitoring/micrometer-prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/BaseOpenShiftAlertEventsIT.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.util.Strings;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.Service;
 import io.quarkus.test.bootstrap.inject.OpenShiftClient;
@@ -61,7 +62,7 @@ public abstract class BaseOpenShiftAlertEventsIT {
     private void whenWaitUntilReceiveSomeAlerts() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(WAIT_FOR_ALERTS_COUNT);
 
-        WebTarget target = ClientBuilder.newClient().target(getApp().getHost() + ":" + getApp().getPort() + PATH);
+        WebTarget target = ClientBuilder.newClient().target(getApp().getURI(Protocol.HTTP).withPath(PATH).toString());
         SseEventSource source = SseEventSource.target(target).build();
         source.register(inboundSseEvent -> {
             receive.add(inboundSseEvent.readData(String.class, MediaType.APPLICATION_JSON_TYPE));

--- a/monitoring/microprofile-opentracing/src/test/java/io/quarkus/ts/microprofile/opentracing/MicroProfileIT.java
+++ b/monitoring/microprofile-opentracing/src/test/java/io/quarkus/ts/microprofile/opentracing/MicroProfileIT.java
@@ -135,6 +135,6 @@ public class MicroProfileIT {
     }
 
     protected int getAppPort() {
-        return app.getPort();
+        return app.getURI().getPort();
     }
 }

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryIT.java
@@ -52,8 +52,8 @@ public class OpenTelemetryIT {
     @QuarkusApplication(classes = { PingResource.class, PingPongService.class })
     static final RestService pingservice = new RestService()
             .withProperty("quarkus.application.name", "pingservice")
-            .withProperty("pongservice_url", pongservice::getHost)
-            .withProperty("pongservice_port", () -> String.valueOf(pongservice.getPort()))
+            .withProperty("pongservice_url", () -> pongservice.getURI(HTTP).getRestAssuredStyleUri())
+            .withProperty("pongservice_port", () -> Integer.toString(pongservice.getURI(HTTP).getPort()))
             .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl);
 
     @Order(1)
@@ -132,7 +132,7 @@ public class OpenTelemetryIT {
 
     public void whenDoPingPongRequest() {
         given().when()
-                .get(pingservice.getHost() + ":" + pingservice.getPort() + "/ping/pong")
+                .get(pingservice.getURI(HTTP).withPath("/ping/pong").toString())
                 .then()
                 .statusCode(HttpStatus.SC_OK).body(equalToIgnoringCase("ping pong"));
     }

--- a/security/https/src/test/java/io/quarkus/ts/security/https/enabled/BaseEnabledHttpsSecurityIT.java
+++ b/security/https/src/test/java/io/quarkus/ts/security/https/enabled/BaseEnabledHttpsSecurityIT.java
@@ -108,6 +108,6 @@ public abstract class BaseEnabledHttpsSecurityIT {
     protected abstract RestService getApp();
 
     private String url(Protocol protocol) {
-        return getApp().getHost(protocol) + ":" + getApp().getPort(protocol) + "/hello/simple";
+        return getApp().getURI(protocol).withPath("/hello/simple").toString();
     }
 }

--- a/security/https/src/test/java/io/quarkus/ts/security/https/redirect/BaseRedirectHttpsSecurityIT.java
+++ b/security/https/src/test/java/io/quarkus/ts/security/https/redirect/BaseRedirectHttpsSecurityIT.java
@@ -77,6 +77,6 @@ public abstract class BaseRedirectHttpsSecurityIT {
     protected abstract RestService getApp();
 
     private String url(Protocol protocol) {
-        return getApp().getHost(protocol) + ":" + getApp().getPort(protocol) + "/hello/simple";
+        return getApp().getURI(protocol).withPath("/hello/simple").toString();
     }
 }

--- a/security/https/src/test/java/io/quarkus/ts/security/https/secured/BaseAuthzHttpsSecurityIT.java
+++ b/security/https/src/test/java/io/quarkus/ts/security/https/secured/BaseAuthzHttpsSecurityIT.java
@@ -138,10 +138,10 @@ public abstract class BaseAuthzHttpsSecurityIT {
     }
 
     private String url(Protocol protocol) {
-        return getApp().getHost(protocol) + ":" + getApp().getPort(protocol) + "/hello/full";
+        return getApp().getURI(protocol).withPath("/hello/full").toString();
     }
 
     private String urlWithAuthz() {
-        return getApp().getHost(Protocol.HTTPS) + ":" + getApp().getPort(Protocol.HTTPS) + "/secured";
+        return getApp().getURI(Protocol.HTTPS).withPath("/secured").toString();
     }
 }

--- a/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/BaseAuthzSecurityIT.java
+++ b/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/BaseAuthzSecurityIT.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.keycloak.authorization.client.AuthzClient;
 
 import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 
 public abstract class BaseAuthzSecurityIT {
@@ -45,7 +46,8 @@ public abstract class BaseAuthzSecurityIT {
                 .get("/user/issuer")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body(startsWith("user token issued by " + getKeycloak().getHost()));
+                .body(startsWith("user token issued by " +
+                        getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri()));
     }
 
     @Test
@@ -88,7 +90,8 @@ public abstract class BaseAuthzSecurityIT {
                 .get("/admin/issuer")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body(startsWith("admin token issued by " + getKeycloak().getHost()));
+                .body(startsWith("admin token issued by " +
+                        getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri()));
     }
 
     @Test

--- a/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/BaseAuthzSecurityReactiveIT.java
+++ b/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/BaseAuthzSecurityReactiveIT.java
@@ -12,6 +12,7 @@ import org.junit.platform.commons.util.StringUtils;
 import org.keycloak.authorization.client.AuthzClient;
 
 import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.vertx.core.http.HttpMethod;
@@ -64,7 +65,7 @@ public abstract class BaseAuthzSecurityReactiveIT {
     public void normalUserUserResourceIssuer() {
         whenMakeRequestTo(HttpMethod.GET, "/user/issuer", getToken(NORMAL_USER, NORMAL_USER));
         thenStatusCodeIs(HttpStatus.SC_OK);
-        thenBodyStartWith("user token issued by " + getKeycloak().getHost());
+        thenBodyStartWith("user token issued by " + getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri());
     }
 
     @Test
@@ -91,7 +92,7 @@ public abstract class BaseAuthzSecurityReactiveIT {
     public void adminUserAdminResourceIssuer() {
         whenMakeRequestTo(HttpMethod.GET, "/admin/issuer", getToken(ADMIN_USER, ADMIN_USER));
         thenStatusCodeIs(HttpStatus.SC_OK);
-        thenBodyStartWith("admin token issued by " + getKeycloak().getHost());
+        thenBodyStartWith("admin token issued by " + getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri());
     }
 
     @Test

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/BaseOidcJwtSecurityIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/BaseOidcJwtSecurityIT.java
@@ -18,6 +18,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 
 public abstract class BaseOidcJwtSecurityIT {
@@ -48,7 +49,8 @@ public abstract class BaseOidcJwtSecurityIT {
         thenRedirectToLoginPage();
 
         whenLoginAs("test-admin");
-        thenPageReturns("Hello, test-admin, your token was issued by " + getKeycloak().getHost());
+        thenPageReturns(
+                "Hello, test-admin, your token was issued by " + getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri());
     }
 
     @Test
@@ -66,7 +68,8 @@ public abstract class BaseOidcJwtSecurityIT {
         thenRedirectToLoginPage();
 
         whenLoginAs("test-user");
-        thenPageReturns("Hello, test-user, your token was issued by " + getKeycloak().getHost());
+        thenPageReturns(
+                "Hello, test-user, your token was issued by " + getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri());
     }
 
     @Test
@@ -87,7 +90,7 @@ public abstract class BaseOidcJwtSecurityIT {
     }
 
     private void whenGoTo(String path) throws Exception {
-        page = webClient.getPage(getApp().getHost() + ":" + getApp().getPort() + path);
+        page = webClient.getPage(getApp().getURI(Protocol.HTTP).withPath(path).toString());
     }
 
     private void thenRedirectToLoginPage() {

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseMultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseMultiTenantSecurityIT.java
@@ -22,6 +22,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 
 public abstract class BaseMultiTenantSecurityIT {
@@ -51,9 +52,8 @@ public abstract class BaseMultiTenantSecurityIT {
         webClient.getOptions().setRedirectEnabled(false);
         String loc = webClient.loadWebResponse(new WebRequest(URI.create(getEndpointByTenant(webAppTenant)).toURL()))
                 .getResponseHeaderValue("location");
-
-        assertTrue(loc.startsWith(getKeycloak().getHost()),
-                "Unexpected location for " + getKeycloak().getHost() + ". Got: " + loc);
+        assertTrue(loc.startsWith(getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri()),
+                "Unexpected location for " + getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri() + ". Got: " + loc);
         assertTrue(loc.contains("scope=openid"), "Unexpected scope. Got: " + loc);
         assertTrue(loc.contains("response_type=code"), "Unexpected response type. Got: " + loc);
         assertTrue(loc.contains("client_id=" + webAppTenant.getClientId()),
@@ -126,7 +126,7 @@ public abstract class BaseMultiTenantSecurityIT {
     protected abstract RestService getApp();
 
     private String appUrl(String path) {
-        return getApp().getHost() + ":" + getApp().getPort() + path;
+        return getApp().getURI(Protocol.HTTP).withPath(path).toString();
     }
 
     private String getEndpointByTenant(Tenant tenant) {

--- a/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/BaseOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/BaseOidcClientSecurityIT.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 
 public abstract class BaseOidcClientSecurityIT {
@@ -56,7 +57,7 @@ public abstract class BaseOidcClientSecurityIT {
                 .get("/user/issuer")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body(startsWith("user token issued by " + getKeycloak().getHost()));
+                .body(startsWith("user token issued by " + getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri()));
     }
 
     @Test

--- a/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/BaseOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/BaseOidcClientSecurityIT.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 
 public abstract class BaseOidcClientSecurityIT {
@@ -56,7 +57,7 @@ public abstract class BaseOidcClientSecurityIT {
                 .get("/user/issuer")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body(startsWith("user token issued by " + getKeycloak().getHost()));
+                .body(startsWith("user token issued by " + getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri()));
     }
 
     @Test

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/BaseWebappSecurityIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/BaseWebappSecurityIT.java
@@ -24,6 +24,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 
 public abstract class BaseWebappSecurityIT {
@@ -54,8 +55,8 @@ public abstract class BaseWebappSecurityIT {
         String loc = webClient.loadWebResponse(new WebRequest(URI.create(appUrl("/user")).toURL()))
                 .getResponseHeaderValue("location");
 
-        assertTrue(loc.startsWith(getKeycloak().getHost()),
-                "Unexpected location for " + getKeycloak().getHost() + ". Got: " + loc);
+        assertTrue(loc.startsWith(getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri()),
+                "Unexpected location for " + getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri() + ". Got: " + loc);
         assertTrue(loc.contains("scope=openid"), "Unexpected scope. Got: " + loc);
         assertTrue(loc.contains("response_type=code"), "Unexpected response type. Got: " + loc);
         assertTrue(loc.contains("client_id=test-application-client"), "Unexpected client id. Got: " + loc);
@@ -76,7 +77,7 @@ public abstract class BaseWebappSecurityIT {
         thenRedirectToLoginPage();
 
         whenLoginAs("test-user");
-        thenPageReturns("user token issued by " + getKeycloak().getHost());
+        thenPageReturns("user token issued by " + getKeycloak().getURI(Protocol.HTTP).toString());
     }
 
     @Test
@@ -111,7 +112,7 @@ public abstract class BaseWebappSecurityIT {
         thenRedirectToLoginPage();
 
         whenLoginAs("test-admin");
-        thenPageReturns("admin token issued by " + getKeycloak().getHost());
+        thenPageReturns("admin token issued by " + getKeycloak().getURI(Protocol.HTTP).toString());
     }
 
     @Test
@@ -176,6 +177,6 @@ public abstract class BaseWebappSecurityIT {
     protected abstract RestService getApp();
 
     private String appUrl(String path) {
-        return getApp().getHost() + ":" + getApp().getPort() + path;
+        return getApp().getURI(Protocol.HTTP).withScheme(path).toString();
     }
 }

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/BaseOidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/BaseOidcSecurityIT.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.keycloak.authorization.client.AuthzClient;
 
 import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.Protocol;
 
 public abstract class BaseOidcSecurityIT {
 
@@ -48,7 +49,8 @@ public abstract class BaseOidcSecurityIT {
                 .get("/user/issuer")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body(startsWith("user token issued by " + getKeycloak().getHost()));
+                .body(startsWith("user token issued by " +
+                        getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri()));
     }
 
     @Test
@@ -91,7 +93,8 @@ public abstract class BaseOidcSecurityIT {
                 .get("/admin/issuer")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body(startsWith("admin token issued by " + getKeycloak().getHost()));
+                .body(startsWith("admin token issued by " +
+                        getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri()));
     }
 
     @Test

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/MutualTlsKeycloakService.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/MutualTlsKeycloakService.java
@@ -68,12 +68,12 @@ public class MutualTlsKeycloakService extends KeycloakService {
      */
     @Override
     public String getRealmUrl() {
-        return format("%s:%s/%s/%s", getHost(Protocol.HTTPS), getPort(), realmBasePath, realm);
+        return format("%s:%s/%s/%s", getURI(Protocol.HTTPS).getRestAssuredStyleUri(), getPort(), realmBasePath, realm);
     }
 
     @Override
     public Integer getPort() {
-        return openshiftScenario ? 443 : super.getPort();
+        return openshiftScenario ? 443 : super.getURI().getPort();
     }
 
 }

--- a/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/AbstractCommonIT.java
+++ b/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/AbstractCommonIT.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 import io.quarkus.test.bootstrap.DefaultService;
-import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
@@ -40,8 +39,8 @@ public abstract class AbstractCommonIT {
     static RestService app = new RestService()
             .withProperty("quarkus.redis.hosts",
                     () -> {
-                        String redisHost = redis.getHost().replaceAll(Protocol.HTTP.getValue(), "redis");
-                        return String.format("%s:%d", redisHost, redis.getPort());
+                        String redisHost = redis.getURI().withScheme("redis").getRestAssuredStyleUri();
+                        return String.format("%s:%d", redisHost, redis.getURI().getPort());
                     });
 
     @BeforeEach

--- a/service-discovery/stork/src/test/java/io/quarkus/ts/stork/NativeStorkServiceDiscoveryIT.java
+++ b/service-discovery/stork/src/test/java/io/quarkus/ts/stork/NativeStorkServiceDiscoveryIT.java
@@ -24,14 +24,16 @@ public class NativeStorkServiceDiscoveryIT extends AbstractCommonTestCases {
             .withProperty("pung-service-port", PUNG_PORT)
             .withProperty("pung-service-host", "localhost")
             .withProperty("quarkus.stork.pung.service-discovery.type", "consul")
-            .withProperty("quarkus.stork.pung.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
+            .withProperty("quarkus.stork.pung.service-discovery.consul-port",
+                    () -> Integer.toString(consul.getURI().getPort()))
             .withProperty("quarkus.stork.pung.service-discovery.consul-host",
                     () -> getConsultEndpoint(consul.getConsulEndpoint()));
 
     @QuarkusApplication(classes = { PingResource.class, MyBackendPungProxy.class, MyBackendPongProxy.class })
     static RestService pingService = new RestService()
             .withProperty("quarkus.stork.pung.service-discovery.type", "consul")
-            .withProperty("quarkus.stork.pung.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
+            .withProperty("quarkus.stork.pung.service-discovery.consul-port",
+                    () -> Integer.toString(consul.getURI().getPort()))
             .withProperty("quarkus.stork.pung.service-discovery.consul-host",
                     () -> getConsultEndpoint(consul.getConsulEndpoint()));
 

--- a/service-discovery/stork/src/test/java/io/quarkus/ts/stork/StorkLoadBalancerIT.java
+++ b/service-discovery/stork/src/test/java/io/quarkus/ts/stork/StorkLoadBalancerIT.java
@@ -37,7 +37,8 @@ public class StorkLoadBalancerIT extends AbstractCommonTestCases {
             .withProperty("pong-service-host", "localhost")
             .withProperty("quarkus.stork.pong.service-discovery.refresh-period", "1")
             .withProperty("quarkus.stork.pong.service-discovery.type", "consul")
-            .withProperty("quarkus.stork.pong.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
+            .withProperty("quarkus.stork.pong.service-discovery.consul-port",
+                    () -> Integer.toString(consul.getURI().getPort()))
             .withProperty("quarkus.stork.pong.service-discovery.consul-host",
                     () -> getConsultEndpoint(consul.getConsulEndpoint()));
 
@@ -48,7 +49,8 @@ public class StorkLoadBalancerIT extends AbstractCommonTestCases {
             .withProperty("pong-replica-service-host", "localhost")
             .withProperty("quarkus.stork.pong-replica.service-discovery.refresh-period", "1")
             .withProperty("quarkus.stork.pong-replica.service-discovery.type", "consul")
-            .withProperty("quarkus.stork.pong-replica.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
+            .withProperty("quarkus.stork.pong-replica.service-discovery.consul-port",
+                    () -> Integer.toString(consul.getURI().getPort()))
             .withProperty("quarkus.stork.pong-replica.service-discovery.consul-host",
                     () -> getConsultEndpoint(consul.getConsulEndpoint()));
 
@@ -57,13 +59,15 @@ public class StorkLoadBalancerIT extends AbstractCommonTestCases {
             .withProperty("quarkus.stork.pong-replica.service-discovery.type", "consul")
             .withProperty("quarkus.stork.pong-replica.service-discovery.refresh-period", "1")
             .withProperty("quarkus.stork.pong-replica.load-balancer", "round-robin")
-            .withProperty("quarkus.stork.pong-replica.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
+            .withProperty("quarkus.stork.pong-replica.service-discovery.consul-port",
+                    () -> Integer.toString(consul.getURI().getPort()))
             .withProperty("quarkus.stork.pong-replica.service-discovery.consul-host",
                     () -> getConsultEndpoint(consul.getConsulEndpoint()))
             .withProperty("quarkus.stork.pong.service-discovery.type", "consul")
             .withProperty("quarkus.stork.pong.service-discovery.refresh-period", "1")
             .withProperty("quarkus.stork.pong.load-balancer", "round-robin")
-            .withProperty("quarkus.stork.pong.service-discovery.consul-port", () -> String.valueOf(consul.getPort()))
+            .withProperty("quarkus.stork.pong.service-discovery.consul-port",
+                    () -> Integer.toString(consul.getURI().getPort()))
             .withProperty("quarkus.stork.pong.service-discovery.consul-host",
                     () -> getConsultEndpoint(consul.getConsulEndpoint()));
 

--- a/spring/spring-cloud-config/src/test/java/io/quarkus/ts/spring/cloud/config/SpringCloudConfigIT.java
+++ b/spring/spring-cloud-config/src/test/java/io/quarkus/ts/spring/cloud/config/SpringCloudConfigIT.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
@@ -23,7 +24,7 @@ public class SpringCloudConfigIT {
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.profile", "SpringCloudConfigIT")
-            .withProperty("quarkus.spring-cloud-config.url", () -> spring.getHost() + ":" + spring.getPort());
+            .withProperty("quarkus.spring-cloud-config.url", () -> spring.getURI(Protocol.HTTP).toString());
 
     @Tag("QUARKUS-1218")
     @ParameterizedTest

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/OpenShiftSpringWebQuteReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/OpenShiftSpringWebQuteReactiveIT.java
@@ -20,9 +20,7 @@ public class OpenShiftSpringWebQuteReactiveIT extends AbstractSpringWebQuteReact
     private static final RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.reactive.url",
-                    () -> "vertx-reactive:" + database.getHost().replace("http", "mysql") + ":" + database.getPort() + "/"
-                            + database.getDatabase());
+            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl);
 
     @Override
     public RestService getApp() {

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/OpenShiftSpringWebRestReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/OpenShiftSpringWebRestReactiveIT.java
@@ -20,9 +20,7 @@ public class OpenShiftSpringWebRestReactiveIT extends AbstractSpringWebRestReact
     private static final RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.reactive.url",
-                    () -> "vertx-reactive:" + database.getHost().replace("http", "mysql") + ":" + database.getPort() + "/"
-                            + database.getDatabase());
+            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl);
 
     @Override
     protected RestService getApp() {

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/SpringWebQuteReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/SpringWebQuteReactiveIT.java
@@ -17,9 +17,7 @@ public class SpringWebQuteReactiveIT extends AbstractSpringWebQuteReactiveIT {
     private static final RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.reactive.url",
-                    () -> "vertx-reactive:" + database.getHost().replace("http", "mysql") + ":" + database.getPort() + "/"
-                            + database.getDatabase());
+            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl);
 
     @Override
     public RestService getApp() {

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/SpringWebRestReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/SpringWebRestReactiveIT.java
@@ -17,9 +17,7 @@ public class SpringWebRestReactiveIT extends AbstractSpringWebRestReactiveIT {
     private static final RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.reactive.url",
-                    () -> "vertx-reactive:" + database.getHost().replace("http", "mysql") + ":" + database.getPort() + "/"
-                            + database.getDatabase());
+            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl);
 
     @Override
     protected RestService getApp() {

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/OpenShiftSpringWebOpenApiReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/OpenShiftSpringWebOpenApiReactiveIT.java
@@ -23,9 +23,7 @@ public class OpenShiftSpringWebOpenApiReactiveIT extends AbstractSpringWebOpenAp
     private static final RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.reactive.url",
-                    () -> "vertx-reactive:" + database.getHost().replace("http", "mysql") + ":" + database.getPort() + "/"
-                            + database.getDatabase());
+            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl);
 
     @Override
     protected RestService getApp() {

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/SpringWebOpenApiReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/SpringWebOpenApiReactiveIT.java
@@ -21,9 +21,7 @@ public class SpringWebOpenApiReactiveIT extends AbstractSpringWebOpenApiReactive
     private static final RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.reactive.url",
-                    () -> "vertx-reactive:" + database.getHost().replace("http", "mysql") + ":" + database.getPort() + "/"
-                            + database.getDatabase());
+            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl);
 
     @Override
     protected RestService getApp() {

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/AbstractMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/AbstractMultitenantHibernateSearchIT.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.services.URILike;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 
@@ -118,8 +119,8 @@ public abstract class AbstractMultitenantHibernateSearchIT {
         return EMPTY_LIST;
     }
 
-    protected static String getElasticSearchConnectionChain(String host, int port) {
-        return (host + ":" + port).replaceAll("http://", "");
+    protected static String getElasticSearchConnectionChain(URILike uri) {
+        return uri.toString().replaceAll("http://", "");
     }
 
     protected abstract RestService getApp();

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/MysqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/MysqlMultitenantHibernateSearchIT.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.MySqlService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
@@ -44,7 +45,7 @@ public class MysqlMultitenantHibernateSearchIT extends AbstractMultitenantHibern
             .withProperty("quarkus.datasource.company2.password", company2.getPassword())
             .withProperty("quarkus.datasource.company2.jdbc.url", company2::getJdbcUrl)
             .withProperty("quarkus.hibernate-search-orm.elasticsearch.hosts",
-                    () -> getElasticSearchConnectionChain(elastic.getHost(), elastic.getPort()));
+                    () -> getElasticSearchConnectionChain(elastic.getURI(Protocol.HTTP)));
 
     @Override
     protected RestService getApp() {

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftMysqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftMysqlMultitenantHibernateSearchIT.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.MySqlService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.Container;
@@ -52,7 +53,7 @@ public class OpenShiftMysqlMultitenantHibernateSearchIT extends AbstractMultiten
             .withProperty("quarkus.datasource.company2.password", company2.getPassword())
             .withProperty("quarkus.datasource.company2.jdbc.url", company2::getJdbcUrl)
             .withProperty("quarkus.hibernate-search-orm.elasticsearch.hosts",
-                    () -> getElasticSearchConnectionChain(elastic.getHost(), elastic.getPort()));
+                    () -> getElasticSearchConnectionChain(elastic.getURI(Protocol.HTTP)));
 
     @Override
     protected RestService getApp() {

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.Container;
@@ -28,7 +29,7 @@ public class OpenShiftPostgresqlMultitenantHibernateSearchIT extends AbstractMul
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
             .withProperty("quarkus.hibernate-search-orm.elasticsearch.hosts",
-                    () -> getElasticSearchConnectionChain(elastic.getHost(), elastic.getPort()));
+                    () -> getElasticSearchConnectionChain(elastic.getURI(Protocol.HTTP)));
 
     @Override
     protected RestService getApp() {

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/PostgresqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/PostgresqlMultitenantHibernateSearchIT.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.hibernate.search;
 
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
@@ -26,7 +27,7 @@ public class PostgresqlMultitenantHibernateSearchIT extends AbstractMultitenantH
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
             .withProperty("quarkus.hibernate-search-orm.elasticsearch.hosts",
-                    () -> getElasticSearchConnectionChain(elastic.getHost(), elastic.getPort()));
+                    () -> getElasticSearchConnectionChain(elastic.getURI(Protocol.HTTP)));
 
     @Override
     protected RestService getApp() {

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MariaDbDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MariaDbDatabaseHibernateReactiveIT.java
@@ -29,8 +29,7 @@ public class MariaDbDatabaseHibernateReactiveIT extends AbstractDatabaseHibernat
     static RestService app = new RestService().withProperties("mysql.properties")
             .withProperty("quarkus.datasource.username", MYSQL_USER)
             .withProperty("quarkus.datasource.password", MYSQL_PASSWORD)
-            .withProperty("quarkus.datasource.reactive.url",
-                    () -> database.getReactiveUrl().replace("mariadb", "mysql"));
+            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl);
 
     @Override
     protected RestService getApp() {

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/OracleDatabaseIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/OracleDatabaseIT.java
@@ -19,7 +19,7 @@ public class OracleDatabaseIT extends AbstractDatabaseHibernateReactiveIT {
     private static final int ORACLE_PORT = 1521;
 
     @Container(image = "${oracle.image}", port = ORACLE_PORT, expectedLog = "DATABASE IS READY TO USE!")
-    static OracleService database = new ProvisionalOracleService()
+    static OracleService database = new OracleService()
             .with(ORACLE_USER, ORACLE_PASSWORD, ORACLE_DATABASE);
 
     @QuarkusApplication
@@ -31,14 +31,5 @@ public class OracleDatabaseIT extends AbstractDatabaseHibernateReactiveIT {
     @Override
     protected RestService getApp() {
         return app;
-    }
-
-    // TODO: Remove after https://github.com/quarkus-qe/quarkus-test-framework/issues/503 is resolved
-    private static class ProvisionalOracleService extends OracleService {
-        @Override
-        public String getReactiveUrl() {
-            return getHost().replace("http://", getJdbcName() + ":thin:@") + ":" + getPort() + "/"
-                    + getDatabase();
-        }
     }
 }

--- a/websockets/quarkus-websockets/src/test/java/io/quarkus/ts/websockets/producer/WebSocketsProducerConsumerIT.java
+++ b/websockets/quarkus-websockets/src/test/java/io/quarkus/ts/websockets/producer/WebSocketsProducerConsumerIT.java
@@ -22,6 +22,7 @@ import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.QuarkusApplication;
@@ -118,9 +119,8 @@ public class WebSocketsProducerConsumerIT {
         }
     }
 
-    // TODO change following code when this will be fixed https://github.com/quarkus-qe/quarkus-test-framework/issues/263
     private static URI getUri(String with) throws URISyntaxException {
-        return new URI(server.getHost() + ":" + server.getPort()).resolve(with);
+        return new URI(server.getURI(Protocol.HTTP).toString()).resolve(with);
     }
 
     private static Session connect(Client client, URI uri) throws DeploymentException, IOException {

--- a/websockets/websockets-client/src/test/java/io/quarkus/ts/websockets/client/WebSocketsClientIT.java
+++ b/websockets/websockets-client/src/test/java/io/quarkus/ts/websockets/client/WebSocketsClientIT.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Dependency;
@@ -22,7 +23,7 @@ public class WebSocketsClientIT {
     // Using `quarkus-websockets-client` extension by default
     @QuarkusApplication
     static final RestService client = new RestService()
-            .withProperty("app.chat.uri", () -> server.getHost() + ":" + server.getPort());
+            .withProperty("app.chat.uri", () -> server.getURI(Protocol.HTTP).toString());
 
     @Test
     public void smoke() {


### PR DESCRIPTION
### Summary

Remove deprecated methods getHost and getPort for parsing service URIs.
New method getURI was added by solving this issue https://github.com/quarkus-qe/quarkus-test-framework/issues/263

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)