### PR TITLE
[2.13.] Bump Quarkus Test Framework to 1.2.4.Final to fix S2I issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.13.8.Final</quarkus.platform.version>
-        <quarkus.qe.framework.version>1.2.3.Final</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.2.4.Final</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>0.38.0</quarkus-qpid-jms.version>
         <quarkus-ide-config.version>2.12.1.Final</quarkus-ide-config.version>
         <apache-httpclient-fluent.version>4.5.13</apache-httpclient-fluent.version>


### PR DESCRIPTION
### Summary

Bumps FW to 1.2.4.Final in order to fix issues related to the latest OpenJDK bump of Maven to 3.8.5.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)