### PR TITLE
Initialise Quarkus CLI before running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
           java -jar ~/.m2/repository/io/quarkus/quarkus-cli/999-SNAPSHOT/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
           EOF
           chmod +x ./quarkus-dev-cli
+          ./quarkus-dev-cli version
       - name: Build with Maven
         run: |
           MODULES_MAVEN_PARAM=""
@@ -173,6 +174,7 @@ jobs:
           java -jar ~/.m2/repository/io/quarkus/quarkus-cli/999-SNAPSHOT/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
           EOF
           chmod +x ./quarkus-dev-cli
+          ./quarkus-dev-cli version
       - name: Build with Maven
         run: |
           if [[ -n ${MODULES_ARG} ]]; then

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -68,6 +68,7 @@ jobs:
           java -jar ~/.m2/repository/io/quarkus/quarkus-cli/999-SNAPSHOT/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
           EOF
           chmod +x ./quarkus-dev-cli
+          ./quarkus-dev-cli version
       - name: Test in JVM mode
         run: |
           mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P ${{ matrix.profiles }} -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
@@ -120,6 +121,7 @@ jobs:
           java -jar ~/.m2/repository/io/quarkus/quarkus-cli/999-SNAPSHOT/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
           EOF
           chmod +x ./quarkus-dev-cli
+          ./quarkus-dev-cli version
       - name: Test in Native mode
         run: |
           mvn -fae -V -B -s .github/mvn-settings.xml -P ${{ matrix.profiles }} -fae clean verify -Dnative \


### PR DESCRIPTION
### Summary

Due to recent changes[1][2], Quarkus CLI is now tries to initalise plugin catalog before running. Message about that breaks our tests, which doesn't expect it [1] https://github.com/quarkusio/quarkus/pull/33469 [2] https://github.com/quarkusio/quarkus/issues/33402

[1] https://github.com/quarkusio/quarkus/pull/33469
[2] https://github.com/quarkusio/quarkus/issues/33402

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)