### PR TITLE
Fix wrong CORS Keycloak origin in OpenShift

### DIFF
--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/LogoutSinglePageAppFlowIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/LogoutSinglePageAppFlowIT.java
@@ -25,6 +25,7 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.utils.TestExecutionProperties;
 import io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.LogoutFlow;
 
 @QuarkusScenario
@@ -40,6 +41,15 @@ public class LogoutSinglePageAppFlowIT {
     @QuarkusApplication(classes = { LogoutFlow.class })
     static RestService app = new RestService()
             .withProperty("keycloak.url", () -> keycloak.getURI(Protocol.HTTP).toString())
+            .withProperty("keycloak.origin", () -> {
+                if (TestExecutionProperties.isOpenshiftPlatform()) {
+                    // in OpenShift we need scheme + host
+                    return keycloak.getURI(Protocol.HTTP).getRestAssuredStyleUri();
+                } else {
+                    // on Bare Metal we need scheme + host + port
+                    return "${keycloak.url}";
+                }
+            })
             .withProperties("logout.properties");
 
     @Tag("QUARKUS-2491")

--- a/security/keycloak-oidc-client-reactive-extended/src/test/resources/logout.properties
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/resources/logout.properties
@@ -14,7 +14,7 @@ quarkus.http.auth.permission.unsecured.policy=permit
 quarkus.http.auth.permission.unsecured.methods=GET
 
 quarkus.http.cors=true
-quarkus.http.cors.origins=*
+quarkus.http.cors.origins=${keycloak.origin}
 quarkus.http.auth.permission.logout.paths=/code-flow/logout
 quarkus.http.auth.permission.logout.policy=authenticated
 


### PR DESCRIPTION
### Summary

Cherry-picked from 32a86701f30a26c10f8322f9269cb283ab2f6542. See related PR
https://github.com/quarkus-qe/quarkus-test-suite/pull/1280.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)