### PR TITLE
Fix app URL parsing bug in BaseWebappSecurityIT

### DIFF
--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/BaseWebappSecurityIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/BaseWebappSecurityIT.java
@@ -177,6 +177,6 @@ public abstract class BaseWebappSecurityIT {
     protected abstract RestService getApp();
 
     private String appUrl(String path) {
-        return getApp().getURI(Protocol.HTTP).withScheme(path).toString();
+        return getApp().getURI(Protocol.HTTP).withPath(path).toString();
     }
 }


### PR DESCRIPTION
### Summary

There was failure in keycloak-webapp module because of typo in BaseWebappSecurityIT appUrl method from https://github.com/quarkus-qe/quarkus-test-suite/pull/1274

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)