### PR TITLE
[2.13] Disable SslAlertMonitorIT on FIPS compatible machines

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SslAlertMonitorIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SslAlertMonitorIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.messaging.kafka.reactive.streams;
 
+import org.junit.jupiter.api.Tag;
+
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -8,6 +10,8 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaProtocol;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
+// TODO: enable on FIPS when https://github.com/quarkus-qe/quarkus-test-suite/issues/1284 is fixed
+@Tag("fips-incompatible")
 @QuarkusScenario
 public class SslAlertMonitorIT extends BaseKafkaStreamTest {
     /**


### PR DESCRIPTION
### Summary

This test was enabled https://github.com/quarkus-qe/quarkus-test-suite/pull/869 due to upstream issue being fixed https://github.com/quarkusio/quarkus/issues/23964, however I believe that is only the client side as I tested Quarkus Integration test both with and without `kafka.ssl.engine.factory.class` (and so I did with our test) and fact is that Strimzi container won't start as `PBE AlgorithmParameters not available` (when SSL engine factory is set on our TS, ex. is little different but signals provider doesn't know the algorithm).

It should be possible with 0.33+ (by default in 2.13 we are using 0.31) https://strimzi.io/blog/2023/01/25/running-apache-kafka-on-fips-enabled-kubernetes-cluster/ but only thing that I did experienced was different exception. If we want it to work, we need to update Strimzi version and algorithm.

Opened: https://github.com/quarkus-qe/quarkus-test-suite/issues/1284

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)