### PR TITLE
Enable tests from security JWT module on FIPS compatible machines

### DIFF
--- a/security/jwt/src/test/java/io/quarkus/ts/security/jwt/CookieJwtSecurityIT.java
+++ b/security/jwt/src/test/java/io/quarkus/ts/security/jwt/CookieJwtSecurityIT.java
@@ -1,14 +1,11 @@
 package io.quarkus.ts.security.jwt;
 
-import org.junit.jupiter.api.Tag;
-
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
 @QuarkusScenario
-@Tag("fips-incompatible")
 public class CookieJwtSecurityIT extends BaseJwtSecurityIT {
 
     static final String COOKIE_NAME = "MY_COOKIE_NAME";

--- a/security/jwt/src/test/java/io/quarkus/ts/security/jwt/Oauth2JwtSecurityIT.java
+++ b/security/jwt/src/test/java/io/quarkus/ts/security/jwt/Oauth2JwtSecurityIT.java
@@ -2,13 +2,10 @@ package io.quarkus.ts.security.jwt;
 
 import static io.restassured.RestAssured.given;
 
-import org.junit.jupiter.api.Tag;
-
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.restassured.specification.RequestSpecification;
 
 @QuarkusScenario
-@Tag("fips-incompatible")
 public class Oauth2JwtSecurityIT extends BaseJwtSecurityIT {
 
     @Override


### PR DESCRIPTION
### Summary

Related issue was solved https://issues.redhat.com/browse/QUARKUS-2066
Tested in Jenkins on machine with FIPS enabled.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)