### PR TITLE
Modest Hibernate hardening

### DIFF
--- a/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/nameddatasource/AlternativeArticle.java
+++ b/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/nameddatasource/AlternativeArticle.java
@@ -1,0 +1,58 @@
+package io.quarkus.ts.spring.data.nameddatasource;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotBlank;
+
+import org.hibernate.validator.constraints.Length;
+
+@Entity
+public class AlternativeArticle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Length(min = 2, max = 50, message = "length must be between {min} and {max}")
+    @NotBlank(message = "Name may not be blank")
+    private String name;
+
+    @Length(min = 2, max = 50, message = "length must be between {min} and {max}")
+    @NotBlank(message = "Author may not be blank")
+    private String author;
+
+    public AlternativeArticle() {
+    }
+
+    public AlternativeArticle(String name, String author) {
+        this.name = name;
+        this.author = author;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+}

--- a/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/nameddatasource/AlternativeArticleJpaRepository.java
+++ b/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/nameddatasource/AlternativeArticleJpaRepository.java
@@ -1,0 +1,6 @@
+package io.quarkus.ts.spring.data.nameddatasource;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlternativeArticleJpaRepository extends JpaRepository<AlternativeArticle, Long> {
+}

--- a/spring/spring-data/src/main/resources/application.properties
+++ b/spring/spring-data/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
+quarkus.hibernate-orm.packages=io.quarkus.ts.spring.data.primitivetypes.model,io.quarkus.ts.spring.data.rest
 
 # Basic security setup
 quarkus.http.auth.basic=true
@@ -10,3 +11,9 @@ quarkus.security.users.embedded.users.admin=admin
 quarkus.security.users.embedded.users.user=user
 quarkus.security.users.embedded.roles.admin=admin
 quarkus.security.users.embedded.roles.user=user
+
+# Named ORM persistence unit
+quarkus.hibernate-orm.named.datasource=<default>
+quarkus.hibernate-orm.named.packages=io.quarkus.ts.spring.data.nameddatasource
+quarkus.hibernate-orm.named.database.generation=drop-and-create
+quarkus.hibernate-orm.named.sql-load-script=named-ds-import.sql

--- a/spring/spring-data/src/main/resources/named-ds-import.sql
+++ b/spring/spring-data/src/main/resources/named-ds-import.sql
@@ -1,0 +1,4 @@
+INSERT INTO alternativearticle(name, author) VALUES ('Alternative Cadillac Desert','Marc Reisner');
+INSERT INTO alternativearticle(name, author) VALUES ('Alternative Dagon and Other Macabre Tales','H.P. Lovecraft ');
+INSERT INTO alternativearticle(name, author) VALUES ('Alternative Aeneid','Virgil');
+INSERT INTO alternativearticle(name, author) VALUES ('Alternative Beach House','James Patterson');

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/di/SpringDiIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/di/SpringDiIT.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.spring.data.rest;
+package io.quarkus.ts.spring.data.di;
 
 import static org.hamcrest.core.Is.is;
 
@@ -13,7 +13,8 @@ public class SpringDiIT {
 
     @QuarkusApplication
     public static final RestService app = new RestService()
-            .withProperty("quarkus.hibernate-orm.active", "false");
+            .withProperty("quarkus.hibernate-orm.active", "false")
+            .withProperty("quarkus.hibernate-orm.named.active", "false");
 
     @Test
     public void testBeanExists() {

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/rest/JpaRepositoryRestResourceIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/rest/JpaRepositoryRestResourceIT.java
@@ -1,11 +1,21 @@
 package io.quarkus.ts.spring.data.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 
 @QuarkusScenario
 public class JpaRepositoryRestResourceIT extends AbstractPagingAndSortingRepositoryRestResourceIT {
+
+    private static final String ALTERNATIVE_PREFIX = "Alternative ";
 
     @Override
     protected String getUrl() {
@@ -26,4 +36,23 @@ public class JpaRepositoryRestResourceIT extends AbstractPagingAndSortingReposit
     protected String getItemIdUrl(long id) {
         return getUrl() + "/" + id;
     }
+
+    @Test
+    public void testNamedDataSourceJpaRepository() {
+        List<String> actualItems = app.given()
+                .accept("application/json")
+                .when().get("/alternative-article-jpa")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract()
+                .jsonPath()
+                .getList("collect{it.name}");
+        assertEquals(ORIGINAL_ITEMS.size(), actualItems.size());
+        Set<String> expectedItems = ORIGINAL_ITEMS
+                .stream()
+                .map(ALTERNATIVE_PREFIX::concat)
+                .collect(Collectors.toSet());
+        assertTrue(expectedItems.containsAll(actualItems));
+    }
+
 }

--- a/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/analyze/Analyze.java
+++ b/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/analyze/Analyze.java
@@ -1,0 +1,24 @@
+package io.quarkus.qe.hibernate.analyze;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "analyze")
+public class Analyze {
+
+    @Id
+    public Long id;
+
+    public String author;
+
+    public Analyze(Long id, String author) {
+        this.id = id;
+        this.author = author;
+    }
+
+    public Analyze() {
+        // default contractor
+    }
+}

--- a/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/analyze/AnalyzeResource.java
+++ b/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/analyze/AnalyzeResource.java
@@ -1,0 +1,33 @@
+package io.quarkus.qe.hibernate.analyze;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+@Path("/analyze")
+public class AnalyzeResource {
+
+    public static final String AUTHOR = "Churchill";
+
+    @Inject
+    EntityManager entityManager;
+
+    @Path("/{id}/author")
+    @GET
+    public String getAnalyzeAuthor(@PathParam("id") long id) {
+        return entityManager.find(Analyze.class, id).author;
+    }
+
+    @Transactional
+    @POST
+    public long create() {
+        var analyze = new Analyze(1L, AUTHOR);
+        entityManager.persist(analyze);
+        return analyze.id;
+    }
+
+}

--- a/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/Account.java
+++ b/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/Account.java
@@ -11,12 +11,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @Entity
+@Table(name = "account") // import script expects lower case table name, identifiers are quoted, hence case-sensitive
 public class Account {
 
     @Id

--- a/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/Customer.java
+++ b/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/Customer.java
@@ -8,11 +8,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 import jakarta.persistence.Version;
 
 @Entity
+@Table(name = "customer") // import script expects lower case table name, identifiers are quoted, hence case-sensitive
 public class Customer {
 
     @Id

--- a/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/Item.java
+++ b/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/Item.java
@@ -5,8 +5,10 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 @Entity
+@Table(name = "item") // import script expects lower case table name, identifiers are quoted, hence case-sensitive
 public class Item {
 
     @Id

--- a/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/Role.java
+++ b/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/Role.java
@@ -3,8 +3,10 @@ package io.quarkus.qe.hibernate.items;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
+@Table(name = "role") // import script expects lower case table name, identifiers are quoted, hence case-sensitive
 public class Role {
 
     @Id

--- a/sql-db/hibernate/src/main/resources/application.properties
+++ b/sql-db/hibernate/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
+
+# verify https://github.com/quarkusio/quarkus/issues/28593 by using quote identifiers strategy
+quarkus.hibernate-orm.quote-identifiers.strategy=all-except-column-definitions

--- a/sql-db/hibernate/src/main/resources/import.sql
+++ b/sql-db/hibernate/src/main/resources/import.sql
@@ -2,4 +2,6 @@ insert into account (id, email) values (1, 'foo@bar.com');
 insert into role (id, name) values  (1, 'admin');
 insert into account_in_role (accountid, roleid) values (1, 1);
 insert into customer (id, version, account_id) values (1,  1, 1);
-insert into item (id, note, customerid) values (1, 'Item 1', 1);
+-- Table Item is created with customerId due to quote identifier strategy while unquoted Postgres
+-- columns are transformed to lowercase, therefore we quote customer id column
+insert into item (id, note, `customerId`) values (1, 'Item 1', 1);

--- a/sql-db/hibernate/src/test/java/io/quarkus/qe/hibernate/BaseHibernateIT.java
+++ b/sql-db/hibernate/src/test/java/io/quarkus/qe/hibernate/BaseHibernateIT.java
@@ -1,11 +1,15 @@
 package io.quarkus.qe.hibernate;
 
+import static io.quarkus.qe.hibernate.analyze.AnalyzeResource.AUTHOR;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.apache.http.HttpStatus;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 public abstract class BaseHibernateIT {
@@ -47,6 +51,25 @@ public abstract class BaseHibernateIT {
                 .body(containsString("hello"))
                 .body(not(containsString("HV000041")))
                 .body(not(containsString("HV000")));
+    }
+
+    @Test
+    public void useReservedWordAsTableName() {
+        // verifies https://github.com/quarkusio/quarkus/issues/28593
+        var id = given()
+                .post("/analyze")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(notNullValue())
+                .extract()
+                .asString();
+
+        given()
+                .pathParam("id", id)
+                .get("/analyze/{id}/author")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(Matchers.is(AUTHOR));
     }
 
     private void givenPostConstructAndPreDestroyAreNotInvoked() {

--- a/sql-db/multiple-pus/src/main/java/io/quarkus/ts/sqldb/multiplepus/FungiTenantResolver.java
+++ b/sql-db/multiple-pus/src/main/java/io/quarkus/ts/sqldb/multiplepus/FungiTenantResolver.java
@@ -1,0 +1,34 @@
+package io.quarkus.ts.sqldb.multiplepus;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.HttpHeaders;
+
+import io.quarkus.hibernate.orm.PersistenceUnitExtension;
+import io.quarkus.hibernate.orm.runtime.tenant.TenantResolver;
+
+@PersistenceUnitExtension("fungi")
+@RequestScoped
+public class FungiTenantResolver implements TenantResolver {
+
+    public static final String TENANT_HEADER = "tenantId";
+
+    @Inject
+    HttpHeaders headers;
+
+    @Override
+    public String getDefaultTenantId() {
+        return "Sarcoscypha";
+    }
+
+    @Override
+    public String resolveTenantId() {
+        var tenantId = headers.getHeaderString(TENANT_HEADER);
+        if (tenantId != null && !tenantId.isEmpty()) {
+            return tenantId;
+        }
+
+        return getDefaultTenantId();
+    }
+
+}

--- a/sql-db/multiple-pus/src/main/java/io/quarkus/ts/sqldb/multiplepus/FungusResource.java
+++ b/sql-db/multiple-pus/src/main/java/io/quarkus/ts/sqldb/multiplepus/FungusResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.sqldb.multiplepus;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.quarkus.ts.sqldb.multiplepus.model.fungus.Fungus;
+
+@Path("fungus")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class FungusResource {
+
+    @GET
+    public long countAll() {
+        return Fungus.count();
+    }
+
+}

--- a/sql-db/multiple-pus/src/main/java/io/quarkus/ts/sqldb/multiplepus/model/fungus/Fungus.java
+++ b/sql-db/multiple-pus/src/main/java/io/quarkus/ts/sqldb/multiplepus/model/fungus/Fungus.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.sqldb.multiplepus.model.fungus;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+
+import org.hibernate.annotations.TenantId;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+@Table(name = "fungus")
+public class Fungus extends PanacheEntity {
+
+    @TenantId
+    @Column(length = 40)
+    public String tenantId;
+
+    @NotBlank(message = "Fungus name must be set!")
+    public String name;
+
+}

--- a/sql-db/multiple-pus/src/main/resources/application.properties
+++ b/sql-db/multiple-pus/src/main/resources/application.properties
@@ -18,3 +18,10 @@ quarkus.hibernate-orm."vegetables".database.generation=drop-and-create
 quarkus.hibernate-orm."vegetables".sql-load-script=import-vegetables.sql
 quarkus.hibernate-orm."vegetables".datasource=vegetables
 quarkus.hibernate-orm."vegetables".packages=io.quarkus.ts.sqldb.multiplepus.model.vegetable
+# Fungi using PostgreSQL
+quarkus.hibernate-orm."fungi".database.charset=utf-8
+quarkus.hibernate-orm."fungi".database.generation=drop-and-create
+quarkus.hibernate-orm."fungi".sql-load-script=import-fungi.sql
+quarkus.hibernate-orm."fungi".datasource=vegetables
+quarkus.hibernate-orm."fungi".multitenant=discriminator
+quarkus.hibernate-orm."fungi".packages=io.quarkus.ts.sqldb.multiplepus.model.fungus

--- a/sql-db/multiple-pus/src/main/resources/import-fungi.sql
+++ b/sql-db/multiple-pus/src/main/resources/import-fungi.sql
@@ -1,0 +1,7 @@
+INSERT INTO fungus (id, name, tenantId) VALUES (nextval('fungus_SEQ'), 'S. knixoniana', 'Sarcoscypha');
+INSERT INTO fungus (id, name, tenantId) VALUES (nextval('fungus_SEQ'), 'S. korfiana', 'Sarcoscypha');
+INSERT INTO fungus (id, name, tenantId) VALUES (nextval('fungus_SEQ'), 'S. lilliputiana', 'Sarcoscypha');
+INSERT INTO fungus (id, name, tenantId) VALUES (nextval('fungus_SEQ'), 'S. macaronesica', 'Sarcoscypha');
+INSERT INTO fungus (id, name, tenantId) VALUES (nextval('fungus_SEQ'), 'W. americana', 'Wynnea');
+INSERT INTO fungus (id, name, tenantId) VALUES (nextval('fungus_SEQ'), 'W. gigantea', 'Wynnea');
+INSERT INTO fungus (id, name, tenantId) VALUES (nextval('fungus_SEQ'), 'W. intermedia', 'Wynnea');


### PR DESCRIPTION
### Summary

Verifies:

- https://github.com/quarkusio/quarkus/issues/28593 - allows setting quotation strategy
- https://github.com/quarkusio/quarkus/issues/28644 - multitennancy with discriminator column (as so far, we only tested db and scheme)
- https://github.com/quarkusio/quarkus/issues/24075 - Spring Data JPA repositories should support named datasources

Refactor:

- move `SpringDiIT` from `io.quarkus.ts.spring.data.rest` to `io.quarkus.ts.spring.data.di` package

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)