### PR TITLE
Enable disabled test of OTel + OpenAPI

### DIFF
--- a/javaee-like-getting-started/src/test/java/io/quarkus/ts/javaee/gettingstarted/OpenAPITracingIT.java
+++ b/javaee-like-getting-started/src/test/java/io/quarkus/ts/javaee/gettingstarted/OpenAPITracingIT.java
@@ -7,7 +7,6 @@ import static org.hamcrest.Matchers.is;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -64,7 +63,6 @@ public class OpenAPITracingIT {
     }
 
     @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/34376")
     public void swaggerUiUntraced() {
         testUntraced(SWAGGER_UI_PATH, SWAGGER_UI_OPERATION);
     }


### PR DESCRIPTION
### Summary

See resolved issue: https://github.com/quarkusio/quarkus/issues/34376.

Related to https://github.com/quarkus-qe/quarkus-test-suite/pull/1295.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)