### PR TITLE
Fix Oracle Flyway migration by adding `org.flywaydb:flyway-database-oracle` to Vert.X SQL module

### DIFF
--- a/sql-db/vertx-sql/pom.xml
+++ b/sql-db/vertx-sql/pom.xml
@@ -57,6 +57,10 @@
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-oracle</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
             <artifactId>flyway-sqlserver</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Summary

Flyway has been bumped https://github.com/quarkusio/quarkus/pull/34262 to 9.20.0 and our daily build fails over `org.flywaydb.core.api.FlywayException: Unsupported Database: Oracle 21.3`. In order to pass this condition https://github.com/flyway/flyway/blob/5bda08d4b101b30ad6eb9c7ffd6b10a416d5f6ef/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseTypeRegister.java#L100C71-L100C71 we need https://github.com/flyway/flyway/blob/5bda08d4b101b30ad6eb9c7ffd6b10a416d5f6ef/flyway-database-oracle/src/main/java/org/flywaydb/database/oracle/OracleDatabaseType.java#L99 from `flyway-database-oracle` dependency.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)