### PR TITLE
Migrate deprecated configuration properties for Opentelemtry

### DIFF
--- a/http/graphql-telemetry/src/test/java/io/quarkus/ts/http/graphql/telemetry/GraphQLTelemetryIT.java
+++ b/http/graphql-telemetry/src/test/java/io/quarkus/ts/http/graphql/telemetry/GraphQLTelemetryIT.java
@@ -28,7 +28,7 @@ public class GraphQLTelemetryIT {
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl);
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
 
     @Test
     void verifyTelemetry() {

--- a/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
+++ b/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/VertxWebClientIT.java
@@ -63,7 +63,7 @@ public class VertxWebClientIT {
     @QuarkusApplication
     static RestService vertx = new RestService()
             .withProperty("chucknorris.api.domain", () -> wiremock.getURI(Protocol.HTTP).toString())
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl);
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
 
     @Test
     @DisplayName("Vert.x WebClient [flavor: mutiny] -> Map json response body to POJO")

--- a/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpenTelemetryGrpcIT.java
+++ b/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpenTelemetryGrpcIT.java
@@ -26,7 +26,7 @@ public class OpenTelemetryGrpcIT {
     @QuarkusApplication()
     static RestService app = new RestService()
             .withProperty("quarkus.application.name", "pingpong")
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl);
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
 
     private static final String PING_ENDPOINT = "/grpc-ping";
     private static final String PONG_ENDPOINT = "/grpc-pong";

--- a/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpenTelemetrySseIT.java
+++ b/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpenTelemetrySseIT.java
@@ -29,7 +29,7 @@ public class OpenTelemetrySseIT {
     @QuarkusApplication()
     static RestService app = new RestService()
             .withProperty("quarkus.application.name", "pingpong")
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl);
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
 
     private static final String PING_ENDPOINT = "/server-sent-events-ping";
     private static final String PONG_ENDPOINT = "/server-sent-events-pong";

--- a/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpentelemetryReactiveIT.java
+++ b/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpentelemetryReactiveIT.java
@@ -40,13 +40,13 @@ public class OpentelemetryReactiveIT {
             SchedulerService.class }, properties = "pong.properties")
     static final RestService pongservice = new RestService()
             .withProperty("quarkus.application.name", "pongservice")
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl);
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
 
     @QuarkusApplication(classes = { PingResource.class, PingPongService.class })
     static final RestService pingservice = new RestService()
             .withProperty("pongservice_url", () -> pongservice.getURI(HTTP).getRestAssuredStyleUri())
             .withProperty("pongservice_port", () -> Integer.toString(pongservice.getURI(HTTP).getPort()))
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl)
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
             // verify OTEL service name has priority over default Quarkus application name
             .withProperty("quarkus.otel.service.name", OTEL_PING_SERVICE_NAME)
             // FIXME: change Quarkus app name when https://github.com/quarkusio/quarkus/issues/33317 is fixed

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryGrpcIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryGrpcIT.java
@@ -26,7 +26,7 @@ public class OpenTelemetryGrpcIT {
     @QuarkusApplication()
     static RestService app = new RestService()
             .withProperty("quarkus.application.name", "pingpong")
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl);
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
 
     private static final String PING_ENDPOINT = "/grpc-ping";
     private static final String PONG_ENDPOINT = "/grpc-pong";

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryIT.java
@@ -47,14 +47,14 @@ public class OpenTelemetryIT {
             PongResource.class }, properties = "pong.properties")
     static final RestService pongservice = new RestService()
             .withProperty("quarkus.application.name", "pongservice")
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl);
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
 
     @QuarkusApplication(classes = { PingResource.class, PingPongService.class })
     static final RestService pingservice = new RestService()
             .withProperty("quarkus.application.name", "pingservice")
             .withProperty("pongservice_url", () -> pongservice.getURI(HTTP).getRestAssuredStyleUri())
             .withProperty("pongservice_port", () -> Integer.toString(pongservice.getURI(HTTP).getPort()))
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl);
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
 
     @Order(1)
     @Test

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetrySseIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetrySseIT.java
@@ -31,7 +31,7 @@ public class OpenTelemetrySseIT {
     @QuarkusApplication()
     static RestService app = new RestService()
             .withProperty("quarkus.application.name", "pingpong")
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl);
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
 
     private static final String PING_ENDPOINT = "/server-sent-events-ping";
     private static final String PONG_ENDPOINT = "/server-sent-events-pong";

--- a/sql-db/narayana-transactions/src/main/resources/application.properties
+++ b/sql-db/narayana-transactions/src/main/resources/application.properties
@@ -2,5 +2,5 @@ quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.database.charset=utf-8
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
-quarkus.opentelemetry.enabled=false
+quarkus.otel.enabled=false
 quarkus.application.name=narayanaTransactions

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
@@ -21,7 +21,7 @@ public class MariaDbTransactionGeneralUsageIT extends TransactionCommons {
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("mariadb_app.properties")
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl)
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
@@ -20,7 +20,7 @@ public class MssqlTransactionGeneralUsageIT extends TransactionCommons {
 
     @QuarkusApplication
     public static final RestService app = new RestService().withProperties("mssql.properties")
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl)
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MysqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MysqlTransactionGeneralUsageIT.java
@@ -23,7 +23,7 @@ public class MysqlTransactionGeneralUsageIT extends TransactionCommons {
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("mysql.properties")
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl)
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMariaDbTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMariaDbTransactionGeneralUsageIT.java
@@ -19,7 +19,7 @@ public class OpenShiftMariaDbTransactionGeneralUsageIT extends TransactionCommon
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("mariadb_app.properties")
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl)
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMysqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMysqlTransactionGeneralUsageIT.java
@@ -18,7 +18,7 @@ public class OpenShiftMysqlTransactionGeneralUsageIT extends TransactionCommons 
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("mysql.properties")
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl)
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OracleTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OracleTransactionGeneralUsageIT.java
@@ -20,7 +20,7 @@ public class OracleTransactionGeneralUsageIT extends TransactionCommons {
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("oracle.properties")
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl)
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlTransactionGeneralUsageIT.java
@@ -19,10 +19,8 @@ public class PostgresqlTransactionGeneralUsageIT extends TransactionCommons {
     static final PostgresqlService database = new PostgresqlService().withProperty("PGDATA", "/tmp/psql");
 
     @QuarkusApplication
-    public static final RestService app = new RestService()
+    public static final RestService app = new RestService().withProperties("mssql.properties")
             .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
-            .withProperty("quarkus.otel.enabled", "true")
-            .withProperty("quarkus.datasource.jdbc.telemetry", "true")
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlTransactionGeneralUsageIT.java
@@ -20,8 +20,8 @@ public class PostgresqlTransactionGeneralUsageIT extends TransactionCommons {
 
     @QuarkusApplication
     public static final RestService app = new RestService()
-            .withProperty("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", jaeger::getCollectorUrl)
-            .withProperty("quarkus.opentelemetry.enabled", "true")
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
+            .withProperty("quarkus.otel.enabled", "true")
             .withProperty("quarkus.datasource.jdbc.telemetry", "true")
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())

--- a/sql-db/narayana-transactions/src/test/resources/mariadb_app.properties
+++ b/sql-db/narayana-transactions/src/test/resources/mariadb_app.properties
@@ -2,6 +2,6 @@ quarkus.datasource.db-kind=mariadb
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDBDialect
 quarkus.hibernate-orm.sql-load-script=mariadb_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
-quarkus.opentelemetry.enabled=true
 quarkus.datasource.jdbc.telemetry=true
+quarkus.otel.enabled=true
 quarkus.application.name=narayanaTransactions

--- a/sql-db/narayana-transactions/src/test/resources/mssql.properties
+++ b/sql-db/narayana-transactions/src/test/resources/mssql.properties
@@ -3,6 +3,6 @@ quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServer2012Dialect
 quarkus.hibernate-orm.sql-load-script=mssql_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.datasource.jdbc.additional-jdbc-properties.trustservercertificate=true
-quarkus.opentelemetry.enabled=true
 quarkus.datasource.jdbc.telemetry=true
+quarkus.otel.enabled=true
 quarkus.application.name=narayanaTransactions

--- a/sql-db/narayana-transactions/src/test/resources/mysql.properties
+++ b/sql-db/narayana-transactions/src/test/resources/mysql.properties
@@ -1,6 +1,6 @@
 quarkus.datasource.db-kind=mysql
 quarkus.hibernate-orm.sql-load-script=mysql_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
-quarkus.opentelemetry.enabled=true
+quarkus.otel.enabled=true
 quarkus.datasource.jdbc.telemetry=true
 quarkus.application.name=narayanaTransactions

--- a/sql-db/narayana-transactions/src/test/resources/oracle.properties
+++ b/sql-db/narayana-transactions/src/test/resources/oracle.properties
@@ -1,6 +1,6 @@
 quarkus.datasource.db-kind=oracle
 quarkus.hibernate-orm.sql-load-script=oracle_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
-quarkus.opentelemetry.enabled=true
 quarkus.datasource.jdbc.telemetry=true
+quarkus.otel.enabled=true
 quarkus.application.name=narayanaTransactions


### PR DESCRIPTION
### Summary

Resolution of this [issue](https://github.com/quarkus-qe/quarkus-test-suite/pull/1299)

Splitting the previous PR into two, this one is about Opentelemetry.

According to [Migration Guide](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0#opentelemetry) we need to migrate `quarkus.opentelemetry.enabled` on `quarkus.otel.enabled`.

Then we migrate `quarkus.otel.tracer.exporter.otlp.endpoint` on `quarkus.otel.exporter.otlp.traces.endpoint`.  
We don't use `quarkus.otel.exporter.otlp.traces.legacy-endpoint` from the  [Migration Guide](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0#opentelemetry) because of the reasons mentioned in the previous  [PR](https://github.com/quarkus-qe/quarkus-test-suite/pull/1299#pullrequestreview-1510535072).

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)