### PR TITLE
Migrate deprecated configuration properties for Artemis URL and kafka

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/main/resources/application.properties
+++ b/messaging/kafka-streams-reactive-messaging/src/main/resources/application.properties
@@ -21,7 +21,7 @@ quarkus.kafka-streams.application-server=localhost:${quarkus.http.port}
 quarkus.kafka-streams.topics=login-http-response-values
 
 # streams options
-kafka-streams.cache.max.bytes.buffering=10240
+kafka-streams.statestore.cache.max.bytes=10240
 kafka-streams.commit.interval.ms=1000
 kafka-streams.metadata.max.age.ms=500
 kafka-streams.auto.offset.reset=earliest

--- a/messaging/kafka-streams-reactive-messaging/src/test/resources/kafka.grateful.shutdown.application.properties
+++ b/messaging/kafka-streams-reactive-messaging/src/test/resources/kafka.grateful.shutdown.application.properties
@@ -12,7 +12,7 @@ quarkus.kafka-streams.application-server=localhost:${quarkus.http.port}
 quarkus.kafka-streams.topics=slow-topic
 
 # streams options
-kafka-streams.cache.max.bytes.buffering=10240
+kafka-streams.statestore.cache.max.bytes=10240
 kafka-streams.commit.interval.ms=1000
 kafka-streams.metadata.max.age.ms=500
 kafka-streams.auto.offset.reset=earliest

--- a/scaling/src/main/resources/application.properties
+++ b/scaling/src/main/resources/application.properties
@@ -1,7 +1,0 @@
-
-quarkus.s2i.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-11:latest
-
-# Openshift
-quarkus.openshift.readiness-probe.period=5s
-quarkus.openshift.readiness-probe.initial-delay=0s
-quarkus.openshift.readiness-probe.failure-threshold=5

--- a/security/jwt/src/main/resources/application.properties
+++ b/security/jwt/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 smallrye.jwt.sign.key.location=private-key.pem
 mp.jwt.verify.publickey.location=public-key.pem
 mp.jwt.verify.issuer=https://my.auth.server/
-smallrye.jwt.expiration.grace=120
+mp.jwt.verify.clock.skew=120
 quarkus.security.deny-unannotated-members=true
 quarkus.native.additional-build-args=-H:IncludeResources=.*\\.pem

--- a/sql-db/hibernate-reactive/src/main/resources/application.properties
+++ b/sql-db/hibernate-reactive/src/main/resources/application.properties
@@ -1,7 +1,6 @@
 quarkus.hibernate-orm.database.charset=utf-8
 quarkus.hibernate-orm.database.generation=drop-and-create
 
-quarkus.hibernate-orm.provider=org.hibernate.reactive.provider.ReactivePersistenceProvider
 
 # HttpClient config
 SomeApi/mp-rest/url=http://localhost:${quarkus.http.port}

--- a/super-size/many-extensions/src/main/resources/application.properties
+++ b/super-size/many-extensions/src/main/resources/application.properties
@@ -5,7 +5,6 @@ quarkus.http.root-path=/api
 %ServerlessExtensionDockerBuildStrategyOpenShiftManyExtensionsIT.quarkus.kubernetes.deployment-target=knative
 %ServerlessExtensionDockerBuildStrategyOpenShiftManyExtensionsIT.quarkus.container-image.registry=image-registry.openshift-image-registry.svc:5000
 
-quarkus.artemis.url=foo
 quarkus.oidc.auth-server-url=https://localhost:8180/auth/realms/quarkus
 quarkus.oidc.client-id=quarkus-app
 


### PR DESCRIPTION
### Summary

Resolution of this [issue](https://github.com/quarkus-qe/quarkus-test-suite/pull/1299)

Splitting the previous PR into two, this one is about Artemis URL, kafka-streams, and openshift. 

`kafka-streams` and `smallrye.jwt` are migrated. 

`quarkus.openshift.*` are deleted, because openshift is not in the maven profile.

According to [Migration guide](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0#using-persistence-xml-files-and-quarkus-hibernate-orm-configuration-properties-in-the-same-application-will-fail) is `quarkus.hibernate-orm.provider` deleted.

`quarkus.artemis.url` is deprecated, so it is deleted.


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)
