### PR TITLE
Fix OpenShiftWorkshopHeroesIT so that it does not fail with RHBQ Ghost

### DIFF
--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.testcontainers.shaded.org.hamcrest.Matchers.empty;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -18,12 +17,10 @@ import io.quarkus.test.bootstrap.PostgresqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 import io.restassured.http.ContentType;
 
-@DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @DisabledOnNative(reason = "Native + s2i not supported")
 @OpenShiftScenario
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -48,7 +45,7 @@ public class OpenShiftWorkshopHeroesIT {
     static PostgresqlService database = new PostgresqlService()
             .withProperty("PGDATA", "/tmp/psql");
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-workshops.git", branch = "5bb433fb7a2c8d80dda88dac9dcabc50f7494dc3", contextDir = "quarkus-workshop-super-heroes/super-heroes/rest-heroes", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-workshops.git", contextDir = "quarkus-workshop-super-heroes/super-heroes/rest-heroes", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
     static final RestService app = new RestService()
             .withProperty("quarkus.http.port", "8080")
             .withProperty("quarkus.datasource.reactive.url", () -> database.getReactiveUrl())
@@ -88,16 +85,6 @@ public class OpenShiftWorkshopHeroesIT {
         app.given()
                 .accept(ContentType.JSON)
                 .when().get("/q/health/ready")
-                .then()
-                .statusCode(HttpStatus.SC_OK);
-    }
-
-    @Test
-    @Disabled("Metrics is not available on this service at this point: 5bb433fb7a2c8d80dda88dac9dcabc50f7494dc3")
-    public void testMetrics() {
-        app.given()
-                .accept(ContentType.JSON)
-                .when().get("/q/metrics/application")
                 .then()
                 .statusCode(HttpStatus.SC_OK);
     }
@@ -175,20 +162,6 @@ public class OpenShiftWorkshopHeroesIT {
                 .when().delete("/api/heroes/{id}")
                 .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
-    }
-
-    @Test
-    @Order(4)
-    @Disabled("Metrics is not available on this service at this point: 5bb433fb7a2c8d80dda88dac9dcabc50f7494dc3")
-    public void testCalledOperationMetrics() {
-        app.given()
-                .accept(ContentType.JSON)
-                .when().get("/q/metrics/application")
-                .then()
-                .statusCode(HttpStatus.SC_OK)
-                .body("'io.quarkus.workshop.superheroes.hero.HeroResource.countCreateHero'", is(1))
-                .body("'io.quarkus.workshop.superheroes.hero.HeroResource.countUpdateHero'", is(1))
-                .body("'io.quarkus.workshop.superheroes.hero.HeroResource.countDeleteHero'", is(1));
     }
 
     static class Hero {

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopVillainsIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopVillainsIT.java
@@ -19,14 +19,11 @@ import io.quarkus.test.bootstrap.PostgresqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 import io.restassured.http.ContentType;
 
-// TODO: enable when Quarkus Workshops migrates to Quarkus 3
-@Disabled("Disabled until Quarkus Workshops migrates to Quarkus 3")
-@DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
+@Disabled("Disabled until https://github.com/quarkus-qe/quarkus-test-framework/issues/432 is fixed")
 @DisabledOnNative(reason = "Native + s2i not supported")
 @OpenShiftScenario
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -51,7 +48,7 @@ public class OpenShiftWorkshopVillainsIT {
     static PostgresqlService database = new PostgresqlService()
             .withProperty("PGDATA", "/tmp/psql");
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-workshops.git", contextDir = "quarkus-workshop-super-heroes/super-heroes/rest-villains", branch = "3d3425a15daacf1c774cb7f5bc24228c4a623256", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-workshops.git", contextDir = "quarkus-workshop-super-heroes/super-heroes/rest-villains", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
     static final RestService app = new RestService()
             .withProperty("quarkus.http.port", "8080")
             .withProperty("quarkus.datasource.username", database.getUser())
@@ -90,16 +87,6 @@ public class OpenShiftWorkshopVillainsIT {
         app.given()
                 .accept(ContentType.JSON)
                 .when().get("/q/health/ready")
-                .then()
-                .statusCode(HttpStatus.SC_OK);
-    }
-
-    @Test
-    @Disabled("Metrics is not available on this service at this point: 3d3425a15daacf1c774cb7f5bc24228c4a623256")
-    public void testMetrics() {
-        app.given()
-                .accept(ContentType.JSON)
-                .when().get("/q/metrics/application")
                 .then()
                 .statusCode(HttpStatus.SC_OK);
     }
@@ -177,20 +164,6 @@ public class OpenShiftWorkshopVillainsIT {
                 .when().delete("/api/villains/{id}")
                 .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
-    }
-
-    @Test
-    @Order(4)
-    @Disabled("Metrics is not available on this service at this point: 3d3425a15daacf1c774cb7f5bc24228c4a623256")
-    public void testCalledOperationMetrics() {
-        app.given()
-                .accept(ContentType.JSON)
-                .when().get("/q/metrics/application")
-                .then()
-                .statusCode(HttpStatus.SC_OK)
-                .body("'io.quarkus.workshop.superheroes.villain.VillainResource.countCreateVillain'", is(1))
-                .body("'io.quarkus.workshop.superheroes.villain.VillainResource.countUpdateVillain'", is(1))
-                .body("'io.quarkus.workshop.superheroes.villain.VillainResource.countDeleteVillain'", is(1));
     }
 
     static class Villain {


### PR DESCRIPTION
### Summary

- `OpenShiftWorkshopHeroesIT` is using specific commit `5bb433fb7a2c8d80dda88dac9dcabc50f7494dc3` from Quarkus 2.x, therefore tests failed when run with Quarkus 3.x over Jakarta imports. Pablo insisted here https://github.com/quarkus-qe/quarkus-test-suite/pull/547#discussion_r826789844 it was necessary and opened https://github.com/quarkus-qe/quarkus-test-framework/issues/432, however import issue only affects `OpenShiftWorkshopVillainsIT` now
- removing metrics scenarios because it is unclear to me why it should work - there is no Micrometer or Smallrye Metrics dependency in https://github.com/quarkusio/quarkus-workshops/blob/main/quarkus-workshop-super-heroes/super-heroes/rest-heroes/pom.xml or parent, it probably changed
- Enables the test for snapshot as now we support that in our FW and Jenkins jobs and we should detect problems early
 
Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)