### PR TITLE
Fix AgroalPoolTest by removing interfering datasource connections

### DIFF
--- a/sql-db/panache-flyway/src/main/resources/application.properties
+++ b/sql-db/panache-flyway/src/main/resources/application.properties
@@ -30,6 +30,12 @@ quarkus.flyway.schemas=test
 %agroal_pool_test.quarkus.datasource.jdbc.acquisition-timeout=60S
 %agroal_pool_test.quarkus.datasource.jdbc.validation-query-sql=SELECT CURRENT_TIMESTAMP
 %agroal_pool_test.quarkus.datasource.jdbc.new-connection-sql=SELECT CURRENT_TIMESTAMP
+# make sure all 'with-xa' connections are removed, and we only test default datasource ones
+%agroal_pool_test.quarkus.datasource.with-xa.jdbc.max-size=1
+%agroal_pool_test.quarkus.datasource.with-xa.jdbc.min-size=0
+%agroal_pool_test.quarkus.datasource.with-xa.jdbc.background-validation-interval=1S
+%agroal_pool_test.quarkus.datasource.with-xa.jdbc.idle-removal-interval=1S
+
 
 # Basic security setup
 quarkus.http.auth.basic=true


### PR DESCRIPTION
### Summary

With https://github.com/quarkusio/quarkus/pull/34262 our `AgroalPoolTest` is failing, without https://github.com/quarkusio/quarkus/pull/34262, it is not (no flakyness, always fails). Flyway is using Agroal datasources to open connection, so `jdbc.max-size`, `idle-removal-interval` and so on should work even for Flyway. I'm not sure what underlying Flyway changes are (it already took me long to find this one), but it is clear that we **actually** test both opened connections for both datasources, but expect only opened connections for one datasource. So when I ensured that idle connections are removed for `with-xa` and that `min-size` is zero, problem got fixed.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)