### PR TITLE
Use official docker image for Elasticsearch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,8 +236,7 @@
                                 <ts.global.s2i.quarkus.native.builder.image>${ts.global.s2i.quarkus.native.builder.image}</ts.global.s2i.quarkus.native.builder.image>
                                 <!-- Services used in test suite -->
                                 <postgresql.latest.image>${postgresql.latest.image}</postgresql.latest.image>
-                                <!-- TODO: investigate further in https://github.com/quarkus-qe/quarkus-test-suite/issues/627 -->
-                                <elastic.71.image>docker.io/bitnami/elasticsearch:7.17.9</elastic.71.image>
+                                <elastic.71.image>docker.io/library/elasticsearch:7.17.10</elastic.71.image>
                                 <mysql.57.image>docker.io/library/mysql:5.7.42</mysql.57.image>
                                 <mysql.upstream.80.image>docker.io/library/mysql:8.0</mysql.upstream.80.image>
                                 <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7</mysql.80.image>

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/MysqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/MysqlMultitenantHibernateSearchIT.java
@@ -27,7 +27,10 @@ public class MysqlMultitenantHibernateSearchIT extends AbstractMultitenantHibern
     static MySqlService company2 = new MySqlService().withDatabase("company2");;
 
     @Container(image = "${elastic.71.image}", port = ELASTIC_PORT, expectedLog = "started")
-    static DefaultService elastic = new DefaultService().withProperty("discovery.type", "single-node");
+    static DefaultService elastic = new DefaultService()
+            .withProperty("discovery.type", "single-node")
+            // Limit resources as Elasticsearch official docker image use half of available RAM
+            .withProperty("ES_JAVA_OPTS", "-Xms1g -Xmx1g");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftMysqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftMysqlMultitenantHibernateSearchIT.java
@@ -35,7 +35,10 @@ public class OpenShiftMysqlMultitenantHibernateSearchIT extends AbstractMultiten
             .withProperty(MAX_ALLOWED_PACKET_KEY, MAX_ALLOWED_PACKET_VALUE);
 
     @Container(image = "${elastic.71.image}", port = ELASTIC_PORT, expectedLog = "started")
-    static DefaultService elastic = new DefaultService().withProperty("discovery.type", "single-node");
+    static DefaultService elastic = new DefaultService()
+            .withProperty("discovery.type", "single-node")
+            // Limit resources as Elasticsearch official docker image use half of available RAM
+            .withProperty("ES_JAVA_OPTS", "-Xms1g -Xmx1g");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
@@ -17,7 +17,10 @@ public class OpenShiftPostgresqlMultitenantHibernateSearchIT extends AbstractMul
     static final int POSTGRESQL_PORT = 5432;
 
     @Container(image = "${elastic.71.image}", port = ELASTIC_PORT, expectedLog = "started")
-    static DefaultService elastic = new DefaultService().withProperty("discovery.type", "single-node");
+    static DefaultService elastic = new DefaultService()
+            .withProperty("discovery.type", "single-node")
+            // Limit resources as Elasticsearch official docker image use half of available RAM
+            .withProperty("ES_JAVA_OPTS", "-Xms1g -Xmx1g");
 
     @Container(image = "${postgresql.10.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static PostgresqlService database = new PostgresqlService();

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/PostgresqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/PostgresqlMultitenantHibernateSearchIT.java
@@ -15,7 +15,10 @@ public class PostgresqlMultitenantHibernateSearchIT extends AbstractMultitenantH
     static final int POSTGRESQL_PORT = 5432;
 
     @Container(image = "${elastic.71.image}", port = ELASTIC_PORT, expectedLog = "started")
-    static DefaultService elastic = new DefaultService().withProperty("discovery.type", "single-node");
+    static DefaultService elastic = new DefaultService()
+            .withProperty("discovery.type", "single-node")
+            // Limit resources as Elasticsearch official docker image use half of available RAM
+            .withProperty("ES_JAVA_OPTS", "-Xms1g -Xmx1g");
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static PostgresqlService database = new PostgresqlService();


### PR DESCRIPTION
### Summary

Use official docker image for Elasticsearch and bump it to 7.17.10
Limit resources to use at max 1 GB as Elasticsearch official docker image use be default half of available RAM

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)