### PR TITLE
Cover GitOps friendly Kubernetes additions

### DIFF
--- a/config/src/main/resources/application.properties
+++ b/config/src/main/resources/application.properties
@@ -23,3 +23,9 @@ secrets.app-prop-sha256-handler=${sha256::0e8c2a8b8ecfbd52c3ef17acd44498ee2b892c
 quarkus.kubernetes-client.devservices.enabled=false
 
 quarkus.kubernetes-config.secrets.enabled=true
+
+quarkus.openshift.idempotent=true
+# this variable is relative to the "current directory" and not to the project root
+# see https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/deploying-to-kubernetes.adoc?plain=1#L212
+# or https://quarkus.io/guides/deploying-to-kubernetes#generating-idempotent-resources
+# quarkus.kubernetes.output-directory=target/openshift todo https://github.com/quarkusio/quarkus/issues/34673


### PR DESCRIPTION
### Summary

Quarkus 3 allows making K8s manifests more Git-friendly [1]
We cover them with these changes, with a single exception[2]

[1] https://github.com/quarkusio/quarkus/pull/31373
[2] https://github.com/quarkusio/quarkus/issues/34673

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)