### PR TITLE
Disable tests which use management interface

### DIFF
--- a/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftDockerBuildIT.java
+++ b/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftDockerBuildIT.java
@@ -1,8 +1,14 @@
 package io.quarkus.qe.extension;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftDockerBuildIT extends OpenShiftBaseDeploymentIT {
+    @Override
+    @Disabled("https://github.com/quarkusio/quarkus/issues/34645")
+    public void health() {
+    }
 }

--- a/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftExtensionIT.java
+++ b/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftExtensionIT.java
@@ -1,8 +1,14 @@
 package io.quarkus.qe.extension;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftExtensionIT extends OpenShiftBaseDeploymentIT {
+    @Override
+    @Disabled("https://github.com/quarkusio/quarkus/issues/34645")
+    public void health() {
+    }
 }

--- a/monitoring/micrometer-prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/OpenShiftCustomMetricsIT.java
+++ b/monitoring/micrometer-prometheus/src/test/java/io/quarkus/ts/micrometer/prometheus/OpenShiftCustomMetricsIT.java
@@ -12,6 +12,7 @@ import jakarta.inject.Inject;
 import org.apache.http.HttpStatus;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -27,6 +28,7 @@ import io.quarkus.test.services.QuarkusApplication;
  * - `prime_number_test_{uniqueId}`: with information about the calculation of the prime number.
  */
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
+@Disabled("https://github.com/quarkusio/quarkus/issues/34645")
 public class OpenShiftCustomMetricsIT {
 
     private static final Logger LOG = Logger.getLogger(OpenShiftCustomMetricsIT.class);


### PR DESCRIPTION
### Summary

Disable tests which use management interface, since [1] does not seem to be fixed soon and we need working weeklies

[1] https://github.com/quarkusio/quarkus/issues/34645

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)