### PR TITLE
Fix for Openshift builds

### DIFF
--- a/config/src/main/resources/application.properties
+++ b/config/src/main/resources/application.properties
@@ -21,3 +21,5 @@ secrets.app-prop-sha256-handler=${sha256::0e8c2a8b8ecfbd52c3ef17acd44498ee2b892c
 
 # disable k8 dev services as we don't use them and currently Windows instances don't support them
 quarkus.kubernetes-client.devservices.enabled=false
+
+quarkus.kubernetes-config.secrets.enabled=true

--- a/config/src/test/resources/config-source-priority.properties
+++ b/config/src/test/resources/config-source-priority.properties
@@ -1,5 +1,4 @@
 quarkus.kubernetes-config.enabled=true
 quarkus.kubernetes-config.config-maps=app-config-yml,app-config-yaml,app-config
 quarkus.kubernetes-config.secrets=app-config,app-config-yml
-quarkus.kubernetes-config.secrets.enabled=true
 quarkus.openshift.env.vars.side-note=side note environment variable

--- a/config/src/test/resources/secret.api-server.properties
+++ b/config/src/test/resources/secret.api-server.properties
@@ -1,3 +1,2 @@
 quarkus.kubernetes-config.enabled=true
-quarkus.kubernetes-config.secrets.enabled=true
 quarkus.kubernetes-config.secrets=app-config


### PR DESCRIPTION
### Summary

Our openshift builds now fail with error`java.lang.StringIndexOutOfBoundsException: begin 34, end -1, length 41`.
Bisection shows, that this is caused by parameter `quarkus.kubernetes-config.secrets.enabled=true`.
It seems, that the Framework changes this parameter into some kind of environment variable (or even two) and thus breaks Smallrye.
Since this option is fixed[1] at build time anyway, I suggest to simply move it into application.properties.

[1] https://quarkus.io/guides/kubernetes-config#quarkus-kubernetes-config_quarkus.kubernetes-config.secrets.enabled

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)