### PR TITLE
Force Openapi to use non-management interface

### DIFF
--- a/http/management/src/main/resources/application.properties
+++ b/http/management/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 # Only run tests annotated with @QuarkusTest
 quarkus.test.type=quarkus-test
 quarkus.management.enabled=true
+quarkus.smallrye-openapi.management.enabled=false


### PR DESCRIPTION
### Summary

Due to a change[1] made upstream  OpenAPI is now deployed on management interface by default. This breaks our tests, so we should use an option to disable this behavior (and verify, that this option works).

[1] https://github.com/quarkusio/quarkus/issues/34353


Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)