### PR TITLE
Add test coverage for build analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ pom.xml.releaseBackup
 pom.xml.versionsBackup
 release.properties
 impsort-maven-cache.properties
+
+# Quarkus
+.quarkus

--- a/README.md
+++ b/README.md
@@ -1152,3 +1152,9 @@ Test coverage includes:
   - Cloud Event Binary mode
   - Structured Mode
 - Multiple functions declared in one application
+
+### `build-time-analytics`
+
+Verifies the Quarkus build-time analytics feature: https://quarkus.io/guides/build-analytics.
+
+For details, see the module-specific README.md.

--- a/build-time-analytics/README.md
+++ b/build-time-analytics/README.md
@@ -1,0 +1,24 @@
+# Build-time analytics
+
+Verifies the Quarkus build-time analytics feature: https://quarkus.io/guides/build-analytics.
+
+The module uses Quarkus CLI to create/build applications and verify various scenarios of the analytics functionality.
+For scope of testing, see related test plan https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-2812.md
+and feature request https://issues.redhat.com/browse/QUARKUS-2812.
+
+Most of the tests invoke dev or prod build on the generated application and verify the presence/absence of a build
+analytics payload file and its contents. All the tests are using a custom `quarkus.analytics.uri.base` (see the upstream
+docs) to prevent Quarkus from actually sending data to the analytics service.
+
+Due to the usage of Quarkus CLI, this module is similar to the `quarkus-cli` module and also expects the Quarkus CLI
+command to be available in the environment and to be called `quarkus` by default or configured by the
+`-Dts.quarkus.cli.cmd=/path/to/quarkus-dev-cli` property.
+
+Unlike the `quarkus-cli`, this module is not affected by the `include.quarkus-cli-tests` / `exclude.quarkus.cli.tests`
+properties, because the test classes names do not match the `**/QuarkusCli*IT.java` pattern.
+
+The test scenarios in this module are labeled with `@Tag("quarkus-cli")`, so that they can be grouped with other
+CLI-based tests.
+
+To simulate different user scenarios, the tests modify environment setup by interacting with the user-specific
+build-time analytics configuration located in `<user.home>/.redhat/`.

--- a/build-time-analytics/pom.xml
+++ b/build-time-analytics/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>build-time-analytics</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: Build Time Analytics</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-cli</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <profile>
+            <!-- Disable native build on this module -->
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- To not build the module on Native -->
+                <quarkus.build.skip>true</quarkus.build.skip>
+            </properties>
+        </profile>
+        <!-- Skipped on Windows as CLI is not installed in Windows yet -->
+        <profile>
+            <id>skip-tests-on-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AbstractAnalyticsIT.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AbstractAnalyticsIT.java
@@ -1,0 +1,160 @@
+package io.quarkus.ts.buildtimeanalytics;
+
+import static io.quarkus.test.bootstrap.QuarkusCliClient.CreateApplicationRequest.defaults;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsFilesUtils.getAnalyticsPayloadFile;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsFilesUtils.getPomFile;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsFilesUtils.getRemoteConfigFile;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.APP_NAME_WITH_DENIED_GROUP_ID;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.APP_NAME_WITH_NON_DENIED_GROUP_ID;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.QUARKUS_ANALYTICS_FAKE_URI_BASE;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.QUARKUS_ANALYTICS_IP;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.QUARKUS_ANALYTICS_URI_BASE_PROPERTY;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.QUARKUS_EXTENSION_VERSION_PATTERN;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.UNRECOGNIZED_PROPERTY_FORMAT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import jakarta.inject.Inject;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.bootstrap.QuarkusCliClient.Result;
+import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+import io.restassured.path.json.JsonPath;
+
+public abstract class AbstractAnalyticsIT {
+    @Inject
+    static QuarkusCliClient cliClient;
+
+    protected QuarkusCliRestService createAppDefault() {
+        return createApp(APP_NAME_WITH_NON_DENIED_GROUP_ID);
+    }
+
+    protected QuarkusCliRestService createAppWithDeniedGroupId() {
+        return createApp(APP_NAME_WITH_DENIED_GROUP_ID);
+    }
+
+    protected QuarkusCliRestService createAppWithExtensions(String... extensions) {
+        return createApp(APP_NAME_WITH_NON_DENIED_GROUP_ID, extensions);
+    }
+
+    private QuarkusCliRestService createApp(String appName, String... extensions) {
+        String gav = QuarkusProperties.PLATFORM_GROUP_ID.get() + ":quarkus-bom:" + QuarkusProperties.getVersion();
+        QuarkusCliClient.CreateApplicationRequest createApplicationRequest = defaults()
+                .withPlatformBom(gav)
+                .withExtraArgs("--no-code", "--no-wrapper")
+                .withExtensions(extensions);
+        return cliClient.createApplication(appName, createApplicationRequest);
+    }
+
+    protected Result buildApp(Function<String[], Result> buildFunction, String... buildProperties) {
+        Set<String> properties = new HashSet<>();
+        // Always provide fake analytics URI to avoid sending data.
+        properties.add(formatBuildProperty(QUARKUS_ANALYTICS_URI_BASE_PROPERTY, QUARKUS_ANALYTICS_FAKE_URI_BASE));
+        properties.addAll(Arrays.asList(buildProperties));
+        return buildFunction.apply(properties.toArray(new String[] {}));
+    }
+
+    protected String formatBuildProperty(String property, String value) {
+        return String.format("-D%s=%s", property, value);
+    }
+
+    protected void verifyRemoteConfigRefreshed() {
+        File remoteConfigFile = getRemoteConfigFile();
+        assertTrue(remoteConfigFile.exists());
+        JsonPath json = JsonPath.from(remoteConfigFile);
+        assertFalse(json.getList("deny_anonymous_ids", String.class).contains("fake-anonymous-id"));
+    }
+
+    protected void verifyBuildSuccessful(Result buildResult) {
+        assertTrue(buildResult.isSuccessful(), "The application didn't build on JVM. Output: " + buildResult.getOutput());
+    }
+
+    protected void verifyBuildPropertyRecognized(Result buildResult, String property) {
+        assertFalse(buildResult.getOutput().contains(String.format(UNRECOGNIZED_PROPERTY_FORMAT, property)));
+    }
+
+    protected void verifyPayloadAbsent(QuarkusCliRestService app) {
+        File payload = getAnalyticsPayloadFile(app);
+        assertFalse(payload.exists());
+    }
+
+    protected void verifyValidPayloadPresent(QuarkusCliRestService app) {
+        File payload = getAnalyticsPayloadFile(app);
+        assertTrue(payload.exists());
+        validatePayload(app, payload);
+    }
+
+    private void validatePayload(QuarkusCliRestService app, File payload) {
+        JsonPath json = JsonPath.from(payload);
+        validateJsonValues(json);
+        validateExtensions(app, json);
+    }
+
+    private void validateJsonValues(JsonPath json) {
+        Map<String, String> values = Map.of(
+                "event", getEventType(),
+                "context.ip", QUARKUS_ANALYTICS_IP,
+                "context.quarkus.version", QuarkusProperties.getVersion(),
+                "context.java.vendor", System.getProperty("java.vendor"),
+                "context.java.version", System.getProperty("java.version"),
+                "context.os.name", System.getProperty("os.name"),
+                "context.os.os_arch", System.getProperty("os.arch"),
+                "context.os.version", System.getProperty("os.version"));
+        values.forEach((key, value) -> assertEquals(value, json.getString(key)));
+    }
+
+    private void validateExtensions(QuarkusCliRestService app, JsonPath json) {
+        List<Dependency> pomDependencies = getPomDependencies(app);
+        List<String> pomDependencyGAs = pomDependencies.stream()
+                .map(dependency -> mapToGA(dependency.getGroupId(), dependency.getArtifactId()))
+                .collect(Collectors.toList());
+        List<PayloadExtension> payloadExtensions = json.getList("properties.app_extensions", PayloadExtension.class);
+        List<String> payloadExtensionGAs = payloadExtensions.stream()
+                .map(payloadExtension -> mapToGA(payloadExtension.getGroupId(), payloadExtension.getArtifactId()))
+                .collect(Collectors.toList());
+        assertEquals(pomDependencyGAs, payloadExtensionGAs);
+        List<PayloadExtension> extensionsWithMismatchedVersion = payloadExtensions.stream()
+                .filter(extension -> !QUARKUS_EXTENSION_VERSION_PATTERN.matcher(extension.getVersion()).matches())
+                .collect(Collectors.toList());
+        assertEquals(0, extensionsWithMismatchedVersion.size(),
+                String.format("All extensions versions must match pattern: '%s'. Offending extensions: %s",
+                        QUARKUS_EXTENSION_VERSION_PATTERN.pattern(), extensionsWithMismatchedVersion));
+    }
+
+    private List<Dependency> getPomDependencies(QuarkusCliRestService app) {
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        try {
+            Model model = reader.read(new FileReader(getPomFile(app)));
+            return model.getDependencies().stream()
+                    .filter(dependency -> !Objects.equals(dependency.getScope(), "test"))
+                    .collect(Collectors.toList());
+        } catch (IOException | XmlPullParserException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String mapToGA(String groupId, String artifactId) {
+        return String.format("%s:%s", groupId, artifactId);
+    }
+
+    protected abstract String getEventType();
+}

--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AnalyticsFilesUtils.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AnalyticsFilesUtils.java
@@ -1,0 +1,66 @@
+package io.quarkus.ts.buildtimeanalytics;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.utils.FileUtils;
+
+public class AnalyticsFilesUtils {
+    private static final String USER_HOME = System.getProperty("user.home");
+    private static final String CONFIG_DIR_NAME = ".redhat";
+    private static final String LOCAL_CONFIG_FILE_NAME = "io.quarkus.analytics.localconfig";
+    private static final String REMOTE_CONFIG_FILE_NAME = "io.quarkus.analytics.remoteconfig";
+    private static final String APP_TARGET_DIR_NAME = "target";
+    private static final String APP_ANALYTICS_PAYLOAD_FILE_NAME = "build-analytics-event.json";
+    private static final String APP_ANALYTICS_POM_FILE_NAME = "pom.xml";
+    private static final Path CONFIG_DIR_PATH = Path.of(USER_HOME, CONFIG_DIR_NAME);
+    private static final Path LOCAL_CONFIG_PATH = Path.of(USER_HOME, CONFIG_DIR_NAME, LOCAL_CONFIG_FILE_NAME);
+    private static final Path REMOTE_CONFIG_PATH = Path.of(USER_HOME, CONFIG_DIR_NAME, REMOTE_CONFIG_FILE_NAME);
+    private static final Path APP_ANALYTICS_PAYLOAD_RELATIVE_PATH = Path.of(APP_TARGET_DIR_NAME,
+            APP_ANALYTICS_PAYLOAD_FILE_NAME);
+    private static final Path APP_ANALYTICS_POM_RELATIVE_PATH = Path.of(APP_ANALYTICS_POM_FILE_NAME);
+    private static final String LOCAL_CONFIG_ENABLED_RESOURCE = "local-config-enabled.json";
+    private static final String LOCAL_CONFIG_DISABLED_RESOURCE = "local-config-disabled.json";
+    private static final String REMOTE_CONFIG_ENABLED_RESOURCE = "remote-config-enabled.json";
+    private static final String REMOTE_CONFIG_DISABLED_RESOURCE = "remote-config-disabled.json";
+    private static final String REMOTE_CONFIG_REFRESHABLE_RESOURCE = "remote-config-refreshable.json";
+
+    public static void deleteConfigDir() {
+        FileUtils.deletePath(CONFIG_DIR_PATH);
+    }
+
+    public static void recreateConfigDir() {
+        FileUtils.recreateDirectory(CONFIG_DIR_PATH);
+        FileUtils.copyFileTo(LOCAL_CONFIG_ENABLED_RESOURCE, LOCAL_CONFIG_PATH);
+        FileUtils.copyFileTo(REMOTE_CONFIG_ENABLED_RESOURCE, REMOTE_CONFIG_PATH);
+    }
+
+    public static void disableAnalyticsByLocalConfig() {
+        FileUtils.copyFileTo(LOCAL_CONFIG_DISABLED_RESOURCE, LOCAL_CONFIG_PATH);
+    }
+
+    public static void disableAnalyticsByRemoteConfig() {
+        FileUtils.copyFileTo(REMOTE_CONFIG_DISABLED_RESOURCE, REMOTE_CONFIG_PATH);
+    }
+
+    public static void useRefreshableRemoteConfig() {
+        FileUtils.copyFileTo(REMOTE_CONFIG_REFRESHABLE_RESOURCE, REMOTE_CONFIG_PATH);
+    }
+
+    public static File getRemoteConfigFile() {
+        return REMOTE_CONFIG_PATH.toFile();
+    }
+
+    public static File getAnalyticsPayloadFile(QuarkusCliRestService app) {
+        return getFileFromApp(app, APP_ANALYTICS_PAYLOAD_RELATIVE_PATH);
+    }
+
+    public static File getPomFile(QuarkusCliRestService app) {
+        return getFileFromApp(app, APP_ANALYTICS_POM_RELATIVE_PATH);
+    }
+
+    private static File getFileFromApp(QuarkusCliRestService app, Path relativeFilePath) {
+        return app.getServiceFolder().resolve(relativeFilePath).toFile();
+    }
+}

--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AnalyticsUtils.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AnalyticsUtils.java
@@ -1,0 +1,108 @@
+package io.quarkus.ts.buildtimeanalytics;
+
+import java.util.regex.Pattern;
+
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+
+public class AnalyticsUtils {
+    private static final String QUARKUS_SNAPSHOT_VERSION = "999-SNAPSHOT";
+    // Quarkus reports extensions' versions in the analytics payload as full artifact version.
+    // So for 999-SNAPSHOT, it can look like e.g. 999-20230718.203351-1091
+    private static final String QUARKUS_EXTENSION_SNAPSHOT_VERSION_REGEX = "999-.*";
+    private static final String QUARKUS_EXTENSION_VERSION_REGEX = getExtensionVersionRegex();
+    public static final Pattern QUARKUS_EXTENSION_VERSION_PATTERN = Pattern.compile(QUARKUS_EXTENSION_VERSION_REGEX);
+
+    public static final String QUARKUS_ANALYTICS_DISABLED_PROPERTY = "quarkus.analytics.disabled";
+    public static final String QUARKUS_ANALYTICS_URI_BASE_PROPERTY = "quarkus.analytics.uri.base";
+    public static final String QUARKUS_ANALYTICS_TIMEOUT_PROPERTY = "quarkus.analytics.timeout";
+    public static final String QUARKUS_ANALYTICS_FAKE_URI_BASE = "http://fake.url";
+    public static final String QUARKUS_ANALYTICS_EVENT_DEV = "DEV_MODE";
+    public static final String QUARKUS_ANALYTICS_EVENT_PROD = "BUILD";
+    public static final String QUARKUS_ANALYTICS_IP = "0.0.0.0";
+    // Denied groupIds defined by https://github.com/quarkusio/quarkus/blob/main/independent-projects/tools/analytics-common/src/main/java/io/quarkus/analytics/config/GroupIdFilter.java
+    public static final String APP_NAME_WITH_DENIED_GROUP_ID = "io.quarkus.qe:app";
+    public static final String APP_NAME_WITH_NON_DENIED_GROUP_ID = "rh.quarkus.qe:app";
+    public static final String UNRECOGNIZED_PROPERTY_FORMAT = "Unrecognized configuration key \"%s\" was provided";
+    public static final String ANALYTICS_ACTIVATION_LINK = "https://quarkus.io/usage";
+    public static final String ANALYTICS_ACTIVATION_PROMPT = "Do you agree to contribute anonymous build time data to the Quarkus community? (y/n)";
+    public static final String[] EXTENSION_SET_A = new String[] {
+            "quarkus-agroal",
+            "quarkus-arc",
+            "quarkus-cache",
+            "quarkus-config-yaml",
+            "quarkus-core",
+            "quarkus-grpc",
+            "quarkus-hibernate-orm",
+            "quarkus-hibernate-orm-panache",
+            "quarkus-hibernate-validator",
+            "quarkus-infinispan-client",
+            "quarkus-jackson",
+            "quarkus-jaxb",
+            "quarkus-jdbc-mysql",
+            "quarkus-jdbc-postgresql",
+            "quarkus-jsonb",
+            "quarkus-jsonp",
+            "quarkus-kafka-client",
+            "quarkus-micrometer",
+            "quarkus-micrometer-registry-prometheus",
+            "quarkus-narayana-jta",
+            "quarkus-oidc",
+            "quarkus-openshift-client",
+            "quarkus-quartz",
+            "quarkus-reactive-pg-client",
+            "quarkus-reactive-routes",
+            "quarkus-rest-client",
+            "quarkus-rest-client-jaxb",
+            "quarkus-resteasy",
+            "quarkus-resteasy-jackson",
+            "quarkus-resteasy-jaxb",
+            "quarkus-resteasy-jsonb",
+            "quarkus-scheduler",
+            "quarkus-smallrye-graphql-client",
+            "quarkus-smallrye-reactive-streams-operators",
+            "quarkus-spring-boot-properties",
+            "quarkus-spring-data-jpa",
+            "quarkus-spring-di",
+            "quarkus-spring-security",
+            "quarkus-undertow",
+            "quarkus-vertx",
+    };
+    public static final String[] EXTENSION_SET_B = new String[] {
+            "quarkus-avro",
+            "quarkus-container-image-openshift",
+            "quarkus-hibernate-orm-rest-data-panache",
+            "quarkus-jaxrs-client-reactive",
+            "quarkus-jdbc-mariadb",
+            "quarkus-jdbc-mssql",
+            "quarkus-mutiny",
+            "quarkus-oidc-client",
+            "quarkus-oidc-client-reactive-filter",
+            "quarkus-qute",
+            "quarkus-reactive-mysql-client",
+            "quarkus-rest-client-reactive",
+            "quarkus-resteasy-reactive",
+            "quarkus-resteasy-reactive-jackson",
+            "quarkus-smallrye-context-propagation",
+            "quarkus-smallrye-fault-tolerance",
+            "quarkus-smallrye-health",
+            "quarkus-smallrye-jwt",
+            "quarkus-smallrye-jwt-build",
+            "quarkus-smallrye-metrics",
+            "quarkus-smallrye-openapi",
+            "quarkus-smallrye-opentracing",
+            "quarkus-smallrye-reactive-messaging",
+            "quarkus-smallrye-reactive-messaging-kafka",
+            "quarkus-spring-cache",
+            "quarkus-spring-cloud-config-client",
+            "quarkus-spring-data-rest",
+            "quarkus-spring-scheduled",
+            "quarkus-spring-web",
+            "quarkus-websockets",
+            "quarkus-websockets-client",
+    };
+
+    private static String getExtensionVersionRegex() {
+        String version = QuarkusProperties.getVersion();
+        return version.equalsIgnoreCase(QUARKUS_SNAPSHOT_VERSION) ? QUARKUS_EXTENSION_SNAPSHOT_VERSION_REGEX : version;
+    }
+}

--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/DevModeIT.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/DevModeIT.java
@@ -1,0 +1,155 @@
+package io.quarkus.ts.buildtimeanalytics;
+
+import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
+import static io.quarkus.test.utils.AwaitilityUtils.AwaitilitySettings.usingTimeout;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsFilesUtils.deleteConfigDir;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsFilesUtils.disableAnalyticsByLocalConfig;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsFilesUtils.recreateConfigDir;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsFilesUtils.useRefreshableRemoteConfig;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.ANALYTICS_ACTIVATION_LINK;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.ANALYTICS_ACTIVATION_PROMPT;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.EXTENSION_SET_A;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.EXTENSION_SET_B;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.QUARKUS_ANALYTICS_DISABLED_PROPERTY;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.QUARKUS_ANALYTICS_EVENT_DEV;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.QUARKUS_ANALYTICS_FAKE_URI_BASE;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.QUARKUS_ANALYTICS_TIMEOUT_PROPERTY;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.QUARKUS_ANALYTICS_URI_BASE_PROPERTY;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.UNRECOGNIZED_PROPERTY_FORMAT;
+
+import java.time.Duration;
+
+import org.awaitility.core.ThrowingRunnable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+
+@Tag("QUARKUS-2812")
+@Tag("quarkus-cli")
+@QuarkusScenario
+@DisabledOnNative(reason = "Only for JVM verification")
+public class DevModeIT extends AbstractAnalyticsIT {
+    private static final Duration DEV_MODE_TIME_TO_LOG_READY = Duration.ofSeconds(10);
+
+    @BeforeEach
+    public void beforeEach() {
+        recreateConfigDir();
+    }
+
+    @Test
+    public void promptPresentIfConfigAbsent() {
+        deleteConfigDir();
+        QuarkusCliRestService app = createAppDefault();
+        startDevMode(app);
+        verifyPromptPresent(app);
+    }
+
+    @Test
+    public void promptAbsentIfDisabledByProperty() {
+        deleteConfigDir();
+        QuarkusCliRestService app = createAppDefault();
+        startDevMode(app.withProperty(QUARKUS_ANALYTICS_DISABLED_PROPERTY, "true"));
+        verifyPromptAbsent(app);
+    }
+
+    @Test
+    public void promptAbsentIfConfigPresentAndEnabled() {
+        QuarkusCliRestService app = createAppDefault();
+        startDevMode(app);
+        verifyPromptAbsent(app);
+    }
+
+    @Test
+    public void promptAbsentIfConfigPresentAndDisabled() {
+        disableAnalyticsByLocalConfig();
+        QuarkusCliRestService app = createAppDefault();
+        startDevMode(app);
+        verifyPromptAbsent(app);
+    }
+
+    @Test
+    public void noExtensions() {
+        QuarkusCliRestService app = createAppDefault();
+        startDevMode(app);
+        verifyValidPayloadPresent(app);
+    }
+
+    @Test
+    public void extensionSetA() {
+        QuarkusCliRestService app = createAppWithExtensions(EXTENSION_SET_A);
+        startDevMode(app);
+        verifyValidPayloadPresent(app);
+    }
+
+    @Test
+    public void extensionSetB() {
+        QuarkusCliRestService app = createAppWithExtensions(EXTENSION_SET_B);
+        startDevMode(app);
+        verifyValidPayloadPresent(app);
+    }
+
+    @Test
+    public void disabledPropertyRecognized() {
+        QuarkusCliRestService app = createAppDefault();
+        startDevMode(app.withProperty(QUARKUS_ANALYTICS_DISABLED_PROPERTY, "true"));
+        verifyDevModePropertyRecognized(app, QUARKUS_ANALYTICS_DISABLED_PROPERTY);
+    }
+
+    @Test
+    public void timeoutPropertyRecognized() {
+        QuarkusCliRestService app = createAppDefault();
+        startDevMode(app.withProperty(QUARKUS_ANALYTICS_TIMEOUT_PROPERTY, "100"));
+        verifyDevModePropertyRecognized(app, QUARKUS_ANALYTICS_TIMEOUT_PROPERTY);
+    }
+
+    @Disabled("https://github.com/quarkusio/quarkus/issues/34825")
+    @Test
+    public void uriPropertyRecognized() {
+        QuarkusCliRestService app = createAppDefault();
+        startDevMode(app.withProperty(QUARKUS_ANALYTICS_URI_BASE_PROPERTY, QUARKUS_ANALYTICS_FAKE_URI_BASE));
+        verifyDevModePropertyRecognized(app, QUARKUS_ANALYTICS_URI_BASE_PROPERTY);
+    }
+
+    @Test
+    public void remoteConfigRefreshed() {
+        useRefreshableRemoteConfig();
+        QuarkusCliRestService app = createAppDefault();
+        startDevMode(app);
+        verifyRemoteConfigRefreshed();
+    }
+
+    private void startDevMode(RestService app) {
+        // Always provide fake analytics URI to avoid sending data.
+        app.withProperty(QUARKUS_ANALYTICS_URI_BASE_PROPERTY, QUARKUS_ANALYTICS_FAKE_URI_BASE).start();
+    }
+
+    private void verifyPromptPresent(RestService app) {
+        waitUntilAsserted(() -> app.logs().assertContains(ANALYTICS_ACTIVATION_LINK, ANALYTICS_ACTIVATION_PROMPT));
+    }
+
+    private void verifyPromptAbsent(RestService app) {
+        waitUntilAsserted(() -> {
+            app.logs().assertDoesNotContain(ANALYTICS_ACTIVATION_LINK);
+            app.logs().assertDoesNotContain(ANALYTICS_ACTIVATION_PROMPT);
+        });
+    }
+
+    protected void verifyDevModePropertyRecognized(RestService app, String property) {
+        waitUntilAsserted(() -> app.logs().assertDoesNotContain(String.format(UNRECOGNIZED_PROPERTY_FORMAT, property)));
+    }
+
+    private void waitUntilAsserted(ThrowingRunnable assertion) {
+        untilAsserted(assertion, usingTimeout(DEV_MODE_TIME_TO_LOG_READY));
+    }
+
+    @Override
+    protected String getEventType() {
+        return QUARKUS_ANALYTICS_EVENT_DEV;
+    }
+}

--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/PayloadExtension.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/PayloadExtension.java
@@ -1,0 +1,43 @@
+package io.quarkus.ts.buildtimeanalytics;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PayloadExtension {
+    @JsonProperty("version")
+    private String version;
+
+    @JsonProperty("group_id")
+    private String groupId;
+
+    @JsonProperty("artifact_id")
+    private String artifactId;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s:%s:%s", groupId, artifactId, version);
+    }
+}

--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/ProdModeJvmIT.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/ProdModeJvmIT.java
@@ -1,0 +1,138 @@
+package io.quarkus.ts.buildtimeanalytics;
+
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsFilesUtils.deleteConfigDir;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsFilesUtils.disableAnalyticsByLocalConfig;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsFilesUtils.disableAnalyticsByRemoteConfig;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsFilesUtils.recreateConfigDir;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsFilesUtils.useRefreshableRemoteConfig;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.EXTENSION_SET_A;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.EXTENSION_SET_B;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.QUARKUS_ANALYTICS_DISABLED_PROPERTY;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.QUARKUS_ANALYTICS_EVENT_PROD;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.QUARKUS_ANALYTICS_FAKE_URI_BASE;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.QUARKUS_ANALYTICS_TIMEOUT_PROPERTY;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.QUARKUS_ANALYTICS_URI_BASE_PROPERTY;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient.Result;
+import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+
+@Tag("QUARKUS-2812")
+@Tag("quarkus-cli")
+@QuarkusScenario
+@DisabledOnNative(reason = "Only for JVM verification")
+public class ProdModeJvmIT extends AbstractAnalyticsIT {
+    @BeforeEach
+    public void beforeEach() {
+        recreateConfigDir();
+    }
+
+    @Test
+    public void noExtensions() {
+        QuarkusCliRestService app = createAppDefault();
+        Result buildResult = buildApp(app::buildOnJvm);
+        verifyBuildSuccessful(buildResult);
+        verifyValidPayloadPresent(app);
+    }
+
+    @Test
+    public void extensionSetA() {
+        QuarkusCliRestService app = createAppWithExtensions(EXTENSION_SET_A);
+        Result buildResult = buildApp(app::buildOnJvm);
+        verifyBuildSuccessful(buildResult);
+        verifyValidPayloadPresent(app);
+    }
+
+    @Test
+    public void extensionSetB() {
+        QuarkusCliRestService app = createAppWithExtensions(EXTENSION_SET_B);
+        Result buildResult = buildApp(app::buildOnJvm);
+        verifyBuildSuccessful(buildResult);
+        verifyValidPayloadPresent(app);
+    }
+
+    @Test
+    public void disabledByNoConfig() {
+        deleteConfigDir();
+        QuarkusCliRestService app = createAppDefault();
+        Result buildResult = buildApp(app::buildOnJvm);
+        verifyBuildSuccessful(buildResult);
+        verifyPayloadAbsent(app);
+    }
+
+    @Test
+    public void disabledByLocalConfig() {
+        disableAnalyticsByLocalConfig();
+        QuarkusCliRestService app = createAppDefault();
+        Result buildResult = buildApp(app::buildOnJvm);
+        verifyBuildSuccessful(buildResult);
+        verifyPayloadAbsent(app);
+    }
+
+    @Test
+    public void disabledByRemoteConfig() {
+        disableAnalyticsByRemoteConfig();
+        QuarkusCliRestService app = createAppDefault();
+        Result buildResult = buildApp(app::buildOnJvm);
+        verifyBuildSuccessful(buildResult);
+        verifyPayloadAbsent(app);
+    }
+
+    @Test
+    public void disabledByProperty() {
+        QuarkusCliRestService app = createAppDefault();
+        Result buildResult = buildApp(app::buildOnJvm, formatBuildProperty(QUARKUS_ANALYTICS_DISABLED_PROPERTY, "true"));
+        verifyBuildSuccessful(buildResult);
+        verifyPayloadAbsent(app);
+    }
+
+    @Test
+    public void disabledByGroupId() {
+        QuarkusCliRestService app = createAppWithDeniedGroupId();
+        Result buildResult = buildApp(app::buildOnJvm);
+        verifyBuildSuccessful(buildResult);
+        verifyPayloadAbsent(app);
+    }
+
+    @Test
+    public void disabledPropertyRecognized() {
+        QuarkusCliRestService app = createAppDefault();
+        Result buildResult = buildApp(app::buildOnJvm, formatBuildProperty(QUARKUS_ANALYTICS_DISABLED_PROPERTY, "true"));
+        verifyBuildPropertyRecognized(buildResult, QUARKUS_ANALYTICS_DISABLED_PROPERTY);
+    }
+
+    @Test
+    public void timeoutPropertyRecognized() {
+        QuarkusCliRestService app = createAppDefault();
+        Result buildResult = buildApp(app::buildOnJvm, formatBuildProperty(QUARKUS_ANALYTICS_TIMEOUT_PROPERTY, "100"));
+        verifyBuildPropertyRecognized(buildResult, QUARKUS_ANALYTICS_TIMEOUT_PROPERTY);
+    }
+
+    @Disabled("https://github.com/quarkusio/quarkus/issues/34825")
+    @Test
+    public void uriPropertyRecognized() {
+        QuarkusCliRestService app = createAppDefault();
+        Result buildResult = buildApp(app::buildOnJvm,
+                formatBuildProperty(QUARKUS_ANALYTICS_URI_BASE_PROPERTY, QUARKUS_ANALYTICS_FAKE_URI_BASE));
+        verifyBuildPropertyRecognized(buildResult, QUARKUS_ANALYTICS_URI_BASE_PROPERTY);
+    }
+
+    @Test
+    public void remoteConfigRefreshed() {
+        useRefreshableRemoteConfig();
+        QuarkusCliRestService app = createAppDefault();
+        buildApp(app::buildOnJvm);
+        verifyRemoteConfigRefreshed();
+    }
+
+    @Override
+    protected String getEventType() {
+        return QUARKUS_ANALYTICS_EVENT_PROD;
+    }
+}

--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/ProdModeNativeIT.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/ProdModeNativeIT.java
@@ -1,0 +1,47 @@
+package io.quarkus.ts.buildtimeanalytics;
+
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsFilesUtils.recreateConfigDir;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.EXTENSION_SET_A;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.EXTENSION_SET_B;
+import static io.quarkus.ts.buildtimeanalytics.AnalyticsUtils.QUARKUS_ANALYTICS_EVENT_PROD;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient.Result;
+import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.EnabledOnNative;
+
+@Tag("QUARKUS-2812")
+@Tag("quarkus-cli")
+@QuarkusScenario
+@EnabledOnNative
+public class ProdModeNativeIT extends AbstractAnalyticsIT {
+    @BeforeEach
+    public void beforeEach() {
+        recreateConfigDir();
+    }
+
+    @Test
+    public void extensionSetA() {
+        QuarkusCliRestService app = createAppWithExtensions(EXTENSION_SET_A);
+        Result buildResult = buildApp(app::buildOnNative);
+        verifyBuildSuccessful(buildResult);
+        verifyValidPayloadPresent(app);
+    }
+
+    @Test
+    public void extensionSetB() {
+        QuarkusCliRestService app = createAppWithExtensions(EXTENSION_SET_B);
+        Result buildResult = buildApp(app::buildOnNative);
+        verifyBuildSuccessful(buildResult);
+        verifyValidPayloadPresent(app);
+    }
+
+    @Override
+    protected String getEventType() {
+        return QUARKUS_ANALYTICS_EVENT_PROD;
+    }
+}

--- a/build-time-analytics/src/test/resources/local-config-disabled.json
+++ b/build-time-analytics/src/test/resources/local-config-disabled.json
@@ -1,0 +1,3 @@
+{
+  "disabled": true
+}

--- a/build-time-analytics/src/test/resources/local-config-enabled.json
+++ b/build-time-analytics/src/test/resources/local-config-enabled.json
@@ -1,0 +1,3 @@
+{
+  "disabled": false
+}

--- a/build-time-analytics/src/test/resources/remote-config-disabled.json
+++ b/build-time-analytics/src/test/resources/remote-config-disabled.json
@@ -1,0 +1,6 @@
+{
+  "active": false,
+  "deny_anonymous_ids": [],
+  "deny_quarkus_versions": [],
+  "refresh_interval": 999999
+}

--- a/build-time-analytics/src/test/resources/remote-config-enabled.json
+++ b/build-time-analytics/src/test/resources/remote-config-enabled.json
@@ -1,0 +1,6 @@
+{
+  "active": true,
+  "deny_anonymous_ids": [],
+  "deny_quarkus_versions": [],
+  "refresh_interval": 999999
+}

--- a/build-time-analytics/src/test/resources/remote-config-refreshable.json
+++ b/build-time-analytics/src/test/resources/remote-config-refreshable.json
@@ -1,0 +1,8 @@
+{
+  "active": true,
+  "deny_anonymous_ids": [
+    "fake-anonymous-id"
+  ],
+  "deny_quarkus_versions": [],
+  "refresh_interval": 0
+}

--- a/build-time-analytics/src/test/resources/test.properties
+++ b/build-time-analytics/src/test/resources/test.properties
@@ -1,0 +1,2 @@
+ts.global.generated-service.enabled=false
+ts.global.quarkus.analytics.disabled=false

--- a/pom.xml
+++ b/pom.xml
@@ -405,6 +405,7 @@
                 <!-- TODO: https://github.com/quarkiverse/quarkus-helm/issues/114-->
                 <!-- <module>helm/helm-minimum</module> -->
                 <module>funqy/knative-events</module>
+                <module>build-time-analytics</module>
             </modules>
         </profile>
         <profile>
@@ -427,6 +428,7 @@
                 <!-- <module>kamelet</module> -->
                 <module>logging/jboss</module>
                 <module>cache/caffeine</module>
+                <module>build-time-analytics</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
### Summary

Add test coverage for build analytics
- JIRA: https://issues.redhat.com/browse/QUARKUS-2812
- Test plan: https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-2812.md
- Introduce 3 new scenarios: dev mode, JVM, native.
- Uses Quarkus CLI to create/build/run applications and inspects the build analytics behavior.

Add .quarkus directory to .gitignore
- `.quarkus` directory is created by Quarkus CLI, which stores catalog information in `.quarkus/cli/plugins/quarkus-cli-catalog.json`.

Please select the relevant options.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)