### PR TITLE
Rename outdated properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Quarkus Test Suite
 
 Test Suite for Quarkus integration scenarios. Among the standard Quarkus test features, scenarios hardly rely on [Quarkus-test-framework](https://github.com/quarkus-qe/quarkus-test-framework) features
@@ -936,8 +937,8 @@ This test could be extended with some metric gathering.
 ### `external-applications`
 
 External applications need a base image which is used by OpenShift to build the app on. So, one base image needs to be supplied forJVM and Native:
-- For JVM: `ts.global.s2i.quarkus.jvm.builder.image`
-- For Native: `ts.global.s2i.quarkus.native.builder.image`
+- For JVM: `quarkus.s2i.base-jvm-image`
+- For Native: `quarkus.s2i.base-native-image`
 
 These properties have default values set in the pom.xml file.
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
         <!-- Faster build when using -DskipTests -->
         <quarkus.build.skip>${skipTests}</quarkus.build.skip>
         <!-- S2i configuration -->
-        <ts.global.s2i.quarkus.jvm.builder.image>registry.access.redhat.com/ubi8/openjdk-11:latest</ts.global.s2i.quarkus.jvm.builder.image>
-        <ts.global.s2i.quarkus.native.builder.image>quay.io/quarkus/ubi-quarkus-graalvmce-s2i:22.3-java17</ts.global.s2i.quarkus.native.builder.image>
+        <quarkus.s2i.base-jvm-image>registry.access.redhat.com/ubi8/openjdk-17:latest</quarkus.s2i.base-jvm-image>
+        <quarkus.s2i.base-native-image>quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0</quarkus.s2i.base-native-image>
         <!-- Default values for format -->
         <src.format.goal>format</src.format.goal>
         <src.sort.goal>sort</src.sort.goal>
@@ -232,8 +232,8 @@
                             <systemPropertyVariables>
                                 <profile.id>${profile.id}</profile.id>
                                 <!-- S2i configuration for OpenShift -->
-                                <ts.global.s2i.quarkus.jvm.builder.image>${ts.global.s2i.quarkus.jvm.builder.image}</ts.global.s2i.quarkus.jvm.builder.image>
-                                <ts.global.s2i.quarkus.native.builder.image>${ts.global.s2i.quarkus.native.builder.image}</ts.global.s2i.quarkus.native.builder.image>
+                                <quarkus.s2i.base-jvm-image>${quarkus.s2i.base-jvm-image}</quarkus.s2i.base-jvm-image>
+                                <quarkus.s2i.base-native-image>${quarkus.s2i.base-native-image}</quarkus.s2i.base-native-image>
                                 <!-- Services used in test suite -->
                                 <postgresql.latest.image>${postgresql.latest.image}</postgresql.latest.image>
                                 <elastic.71.image>docker.io/library/elasticsearch:7.17.10</elastic.71.image>


### PR DESCRIPTION
### Summary
Rename properties, which were removed[1] two years ago and use recommended image[2] as a base for s2i
    
[1] https://github.com/quarkus-qe/quarkus-test-framework/pull/309
[2] https://github.com/quarkusio/quarkus-images#quarkus-images-1:
```
ubi-quarkus-native-binary-s2i - S2I builder image for OpenShift taking a pre-built native executable as input
```


Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)