### PR TITLE
Fix PostgresqlTransactionGeneralUsageIT traces by migrating to otel config property

### DIFF
--- a/sql-db/narayana-transactions/src/main/resources/application.properties
+++ b/sql-db/narayana-transactions/src/main/resources/application.properties
@@ -2,5 +2,5 @@ quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.database.charset=utf-8
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
-quarkus.opentelemetry.enabled=false
+quarkus.otel.enabled=false
 quarkus.application.name=narayanaTransactions

--- a/sql-db/narayana-transactions/src/test/resources/postgresql.properties
+++ b/sql-db/narayana-transactions/src/test/resources/postgresql.properties
@@ -1,1 +1,1 @@
-quarkus.opentelemetry.enabled=true
+quarkus.otel.enabled=true


### PR DESCRIPTION
### Summary

I changed expected build time property from `quarkus.opentelemetry.enabled` to `quarkus.otel.enabled` for former is deprecated and latter didn't trigger customized build https://github.com/quarkus-qe/quarkus-test-framework/pull/829. Here https://github.com/quarkus-qe/quarkus-test-suite/pull/1326 I didn't realize failure is related. Now we use `quarkus.otel.enabled` which triggers custom build and therefore, runs PG test with enabled OpenTelemetry.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)