### PR TITLE
Fix flaky build time analytics failure due to slow app startup

### DIFF
--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/DevModeIT.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/DevModeIT.java
@@ -126,7 +126,9 @@ public class DevModeIT extends AbstractAnalyticsIT {
 
     private void startDevMode(RestService app) {
         // Always provide fake analytics URI to avoid sending data.
-        app.withProperty(QUARKUS_ANALYTICS_URI_BASE_PROPERTY, QUARKUS_ANALYTICS_FAKE_URI_BASE).start();
+        app.withProperty(QUARKUS_ANALYTICS_URI_BASE_PROPERTY, QUARKUS_ANALYTICS_FAKE_URI_BASE)
+                // save execution time by disabling all dev services
+                .withProperty("quarkus.devservices.enabled", "false").start();
     }
 
     private void verifyPromptPresent(RestService app) {


### PR DESCRIPTION
### Summary

Daily build failed over build time analytics https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/5687247780. I can't reproduce it, so I am guessing (therefore let see CI). Here is my conclusion:

- service didn't start fast enough because it tried to pull and start several containers (Keycloak, Infinispan, k8s.gcr.io/etcd, k8s.gcr.io/kube-apiserver, vectorized/redpanda
- this is right step anyway (fix or not) as we can save execution time and it has no effect on collected analytics.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)