### PR TITLE
[2.13] Use Red Hat maven repository for lifecycle application

### DIFF
--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-di</artifactId>
-            <version>2.7.6.Final-redhat-00006</version>
+            <version>2.13.8.Final-redhat-00004</version>
         </dependency>
     </dependencies>
     <profiles>
@@ -40,7 +40,7 @@
             </activation>
             <properties>
                 <!-- please keep Mandrel and RHBQ version compatible -->
-                <quarkus.platform.version>2.13.7.Final</quarkus.platform.version>
+                <quarkus.platform.version>2.13.8.Final-redhat-00004</quarkus.platform.version>
             </properties>
             <repositories>
                 <repository>
@@ -48,6 +48,12 @@
                     <url>https://maven.repository.redhat.com/ga/</url>
                 </repository>
             </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>red-hat-enterprise-repository</id>
+                    <url>https://maven.repository.redhat.com/ga/</url>
+                </pluginRepository>
+            </pluginRepositories>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
### Summary

Use 2.13.8 from Red Hat maven repository. Also adds plugin repository as Quarkus Maven plugin requires it.

Related to https://issues.redhat.com/browse/QUARKUS-3101

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)