### PR TITLE
Remove todos from WebSockets modules

### DIFF
--- a/websockets/quarkus-websockets/src/main/java/io/quarkus/ts/websockets/producer/Pusher.java
+++ b/websockets/quarkus-websockets/src/main/java/io/quarkus/ts/websockets/producer/Pusher.java
@@ -23,7 +23,6 @@ public class Pusher {
     @OnOpen
     public void onOpen(Session session) {
         this.session = session;
-        //todo messages are not sent on opening of session. Need to investigate and create reproducer
     }
 
     @OnMessage

--- a/websockets/quarkus-websockets/src/test/java/io/quarkus/ts/websockets/producer/WebSocketsProducerConsumerIT.java
+++ b/websockets/quarkus-websockets/src/test/java/io/quarkus/ts/websockets/producer/WebSocketsProducerConsumerIT.java
@@ -177,7 +177,6 @@ public class WebSocketsProducerConsumerIT {
 
         @OnMessage
         void message(String msg) {
-            // TODO sometimes sessions are reopened several times without closing, need to check, if this is right
             if (!msg.endsWith("joined")) {
                 messages.add(msg);
             }

--- a/websockets/websockets-client/src/main/java/io/quarkus/ts/websockets/client/Pusher.java
+++ b/websockets/websockets-client/src/main/java/io/quarkus/ts/websockets/client/Pusher.java
@@ -22,7 +22,6 @@ public class Pusher {
     @OnOpen
     public void onOpen(Session session) {
         this.session = session;
-        //todo messages are not sent on opening of session. Need to investigate and create reproducer
     }
 
     @OnMessage


### PR DESCRIPTION
### Summary

Quarkus WebSockets session handling working as expected. I prove it with debug prints.

Client onMessage: Several identical messages are sent asynchronously to all connected clients through broadcast. Each client has own session opened once and closed at the end. 

Pusher onOpen: In debug helpful prints I see all messages


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)