### PR TITLE
Fix daily build by re-coupling modules run together so that we don't timeout and avoid OOM

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -39,9 +39,9 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        profiles: [ "root-modules,http-modules,security-modules,monitoring-modules,spring-modules,test-tooling-modules",
+        profiles: [ "root-modules,http-modules,security-modules,spring-modules",
                    "sql-db-modules",
-                   "messaging-modules,websockets-modules"]
+                   "messaging-modules,websockets-modules,monitoring-modules,test-tooling-modules"]
     steps:
       - uses: actions/checkout@v3
       - name: Reclaim Disk Space
@@ -90,12 +90,12 @@ jobs:
       matrix:
         java: [ 11 ]
         image: [ "ubi-quarkus-graalvmce-builder-image:22.3-java17", "ubi-quarkus-mandrel-builder-image:22.3-java17" ]
-        profiles: [ "root-modules,monitoring-modules,spring-modules,test-tooling-modules",
+        profiles: [ "root-modules,spring-modules",
                    "http-modules",
                    "security-modules",
                     "sql-db-modules -pl env-info,sql-db/hibernate,sql-db/sql-app,sql-db/sql-app-compatibility,sql-db/multiple-pus,sql-db/panache-flyway,sql-db/hibernate-reactive",
                     "sql-db-modules -pl env-info,sql-db/reactive-rest-data-panache,sql-db/vertx-sql,sql-db/reactive-vanilla,sql-db/hibernate-fulltext-search,sql-db/narayana-transactions",
-                   "messaging-modules,websockets-modules"]
+                   "messaging-modules,websockets-modules,monitoring-modules,test-tooling-modules"]
     steps:
       - uses: actions/checkout@v3
       - name: Reclaim Disk Space


### PR DESCRIPTION
### Summary

Daily build is failing several days in row over native build timeout (mostly) and sometimes over OOM when building build time analytics executable for tests of many extensions together. I went couple of builds back and messaging/websockets are always by far the fastest both in native and JVM. By moving monitoring modules and testing tooling module we should have load spread better over runs. Just the fact that it times out after 6 hours is a bad sign when messaging/websockets takes about hour and half.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)