### PR TITLE
Use same Oracle image as dev services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,8 @@
                                 <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7</mysql.80.image>
                                 <mariadb.10.image>docker.io/library/mariadb:10.10</mariadb.10.image>
                                 <mssql.image>mcr.microsoft.com/mssql/rhel/server:2022-latest</mssql.image>
-                                <oracle.image>docker.io/gvenzl/oracle-xe:21-slim-faststart</oracle.image>
+                                <!-- Oracle image - we aim to use same version as Dev Services for Oracle so that we only download one image -->
+                                <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
                                 <db2.image>quay.io/quarkusqeteam/db2:11.5.7.0</db2.image>
                                 <mongodb.image>docker.io/bitnami/mongodb:5.0</mongodb.image>
                                 <redis.image>docker.io/library/redis:6.0</redis.image>


### PR DESCRIPTION
### Summary

Here https://github.com/quarkus-qe/quarkus-test-suite/pull/1338. we saw failure in modules `SQL Database: Narayana-transactions`, `Hibernate Reactive`, `Vert.x SQL`, `RESTEasy Reactive + Rest Data Panache` as Oracle image run out of space In fact, we already saw it few times in past (I'm only going to find it on demand) and we also saw the same thing in Test Framework https://github.com/quarkus-qe/quarkus-test-suite/pull/1338. I think it is super suspicious that 4 modules run out of space when pulling and starting the very same image. My proposal is to use newer Oracle image also used by dev services as we don't have specific reason to use Oracle 21 (and the reason to use `oracle-xe` instead of `oracle-free`). So far I didn't see the same failure there and it is worth trying.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)