### PR TITLE
PR CI workflow for JVM snapshot needs to be divided when full test coverage is required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,21 +77,40 @@ jobs:
                 CHANGED=$(echo $CHANGED" "$module)
             fi
           done
-
+          
+          # trim leading spaces so that module args don't start with comma
+          CHANGED="$(echo $CHANGED | xargs)"
+          
           MODULES_ARG="${CHANGED// /,}"
           echo "MODULES_ARG=$MODULES_ARG" >> $GITHUB_OUTPUT
     outputs:
       MODULES_ARG: ${{ steps.detect-changes.outputs.MODULES_ARG }}
+  prepare-jvm-latest-modules-mvn-param:
+    name: Prepare Maven Params For Linux JVM Build
+    runs-on: ubuntu-latest
+    needs: [ detect-test-suite-modules ]
+    env:
+      MODULES_ARG: ${{ needs.detect-test-suite-modules.outputs.MODULES_ARG }}
+    steps:
+      - id: prepare-modules-mvn-param
+        run: |
+          if [[ -n ${MODULES_ARG} ]]; then
+            echo "Running modules: ${MODULES_ARG}"
+            echo "MODULES_MAVEN_PARAM=[\" -pl ${MODULES_ARG} -Dall-modules\"]" >> $GITHUB_OUTPUT
+          else
+            echo "MODULES_MAVEN_PARAM=[' -P root-modules,spring-modules,http-modules,test-tooling-modules', ' -P security-modules,sql-db-modules,messaging-modules,websockets-modules,monitoring-modules']" >> $GITHUB_OUTPUT
+          fi
+    outputs:
+      MODULES_MAVEN_PARAM: ${{ steps.prepare-modules-mvn-param.outputs.MODULES_MAVEN_PARAM }}
   linux-build-jvm-latest:
     name: PR - Linux - JVM build - Latest Version
     runs-on: ubuntu-latest
     timeout-minutes: 240
-    needs: detect-test-suite-modules
-    env:
-      MODULES_ARG: ${{ needs.detect-test-suite-modules.outputs.MODULES_ARG }}
+    needs: prepare-jvm-latest-modules-mvn-param
     strategy:
       matrix:
         java: [ 11 ]
+        module-mvn-args: ${{ fromJSON(needs.prepare-jvm-latest-modules-mvn-param.outputs.MODULES_MAVEN_PARAM) }}
     steps:
       - uses: actions/checkout@v3
       - name: Reclaim Disk Space
@@ -122,13 +141,7 @@ jobs:
           ./quarkus-dev-cli version
       - name: Build with Maven
         run: |
-          MODULES_MAVEN_PARAM=""
-          if [[ -n ${MODULES_ARG} ]]; then
-            echo "Running modules: ${MODULES_ARG}"
-            MODULES_MAVEN_PARAM="-pl ${MODULES_ARG}"
-          fi
-
-          mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dall-modules -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" $MODULES_MAVEN_PARAM -am
+          mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"${{ matrix.module-mvn-args }} -am
       - name: Zip Artifacts
         if: failure()
         run: |


### PR DESCRIPTION
### Summary

Any PR that makes changes in POM or a file that is not specific for some module (like dependabot often does) has run full test coverage. Our 4 hours timeout is not enough, this PR makes sure that when the full test coverage is run, we divide it into 2 runners in JVM. Native is not an issue as we don't run there full test coverage.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)