### PR TITLE
Free up more disk space on GH Actions runners

### DIFF
--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -1,22 +1,32 @@
-# Reclaim ~14 GB disk space, otherwise we do not have enough disk space for TS execution
+# Reclaim ~30 GB disk space, otherwise we do not have enough disk space for TS execution
 echo "Reclaim disk space."
 df -h /
 docker images
-time docker rmi node:12 node:14 node:16 buildpack-deps:stretch buildpack-deps:buster buildpack-deps:bullseye ubuntu:18.04 ubuntu:16.04 debian:10 debian:11 debian:9 moby/buildkit node:16-alpine node:14-alpine node:12-alpine alpine:3.14 alpine:3.15 alpine:3.16
+time docker rmi node:12 node:14 node:16 buildpack-deps:buster buildpack-deps:bullseye ubuntu:18.04 ubuntu:20.04 debian:10 debian:11 moby/buildkit node:16-alpine node:14-alpine alpine:3.16 alpine:3.17
 
 du -cskh /usr/share/dotnet /usr/share/swift /usr/share/gradle-*
 sudo rm -rf /usr/share/dotnet
 sudo rm -rf /usr/share/swift
 sudo rm -rf /usr/share/gradle-*
 
-du -cskh /opt/az /opt/google /opt/hhvm /opt/hostedtoolcache/CodeQL /opt/microsoft /usr/local/graalvm /usr/local/julia*
+du -cskh /opt/az /opt/google /opt/hostedtoolcache/CodeQL /opt/microsoft /usr/local/julia*
 sudo rm -rf /opt/az
 sudo rm -rf /opt/google
-sudo rm -rf /opt/hhvm
 sudo rm -rf /opt/hostedtoolcache/CodeQL
 sudo rm -rf /opt/microsoft
-sudo rm -rf /usr/local/graalvm
 sudo rm -rf /usr/local/julia*
+
+du -cskh /usr/local/lib/android /opt/pipx
+sudo rm -rf /usr/local/lib/android
+sudo rm -rf /opt/pipx
+
+du -cskh /imagegeneration/installers/*.tar.gz /opt/hostedtoolcache/PyPy /opt/hostedtoolcache/Python /opt/hostedtoolcache/Ruby /opt/hostedtoolcache/go /opt/hostedtoolcache/node
+sudo rm -rf /imagegeneration/installers/*.tar.gz
+sudo rm -rf /opt/hostedtoolcache/PyPy
+sudo rm -rf /opt/hostedtoolcache/Python
+sudo rm -rf /opt/hostedtoolcache/Ruby
+sudo rm -rf /opt/hostedtoolcache/go
+sudo rm -rf /opt/hostedtoolcache/node
 
 echo "Reclaim disk space end."
 df -h /


### PR DESCRIPTION
Free up more disk space on GH Actions runners

58G free now, 18G more comparing with the current version of cleanup script.

Current version in the main branch achieves this cleanup (df -h):
{code}
Before cleanup: /dev/root        84G   62G   22G  75% /
After cleanup: /dev/root        84G   44G   40G  53% /
{code}

Proposed version achieves this cleanup (df -h):
{code}
Before cleanup: /dev/root        84G   62G   22G  75% /
After cleanup: /dev/root        84G   26G   58G  31% /
{code}


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)