### PR TITLE
Bump to Quarkus 3.2.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <failsafe-plugin.version>3.1.0</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.2.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.2.3.Final</quarkus.platform.version>
         <quarkus.qe.framework.version>1.3.0.Beta22</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.4.0</quarkus-qpid-jms.version>
         <apache-httpclient-fluent.version>4.5.14</apache-httpclient-fluent.version>


### PR DESCRIPTION
### Summary

* Bump Quarkus Platform to 3.2.3.Final

Note: There's two issues that are supposedly fixed - https://github.com/quarkusio/quarkus/issues/31117 and https://github.com/quarkusio/quarkus/issues/13660 ; but the tests are still failing:

* `GrpcTraceIT` is disabled because of https://github.com/quarkusio/quarkus/issues/13660
* `AbstractDatabaseHibernateReactiveIT#newLineInQuery` is disabled because of https://github.com/quarkusio/quarkus/issues/31117

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)