### PR TITLE
Workaround Oracle Vert.x issue with auto-generated ids

### DIFF
--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/OracleHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/OracleHandlerIT.java
@@ -24,4 +24,9 @@ public class OracleHandlerIT extends CommonTestCases {
             .withProperty("app.selected.db", "oracle")
             // Enable Flyway for Oracle
             .withProperty("quarkus.flyway.oracle.migrate-at-start", "true");
+
+    @Override
+    public void wrongBasketFormatCheckout() {
+        // FIXME: drop this method when https://github.com/eclipse-vertx/vertx-sql-client/issues/1343 is fixed
+    }
 }


### PR DESCRIPTION
### Summary

After https://github.com/quarkus-qe/quarkus-test-suite/pull/1339 we experience https://github.com/eclipse-vertx/vertx-sql-client/issues/1343. We didn't run full CI there I think for it cancelled, that is worked on in https://github.com/quarkus-qe/quarkus-test-suite/pull/1340. Daily build fails also because of this issue.

You can reproduce failure on main in `sql-db/vertx-sql` module with `mvn clean verify -Dit.test=OracleHandlerIT`.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)