### PR TITLE
Limit Java heap used during native image generation to fix build time analytics native failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
           if [[ -n ${MODULES_ARG} ]]; then
             echo "Running modules: ${MODULES_ARG}"
             mvn -fae -V -B -s .github/mvn-settings.xml -fae -Dall-modules \
+                        -Dquarkus.native.native-image-xmx=5g \
                         -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" \
                         -pl $MODULES_ARG clean verify -Dnative -am
           fi

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -127,6 +127,7 @@ jobs:
         run: |
           mvn -fae -V -B -s .github/mvn-settings.xml -P ${{ matrix.profiles }} -fae clean verify -Dnative \
             -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }} \
+            -Dquarkus.native.native-image-xmx=5g \
             -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
         if: failure()


### PR DESCRIPTION
### Summary

Daily build in native is failing for several days in row as 

```
2023-08-04T04:57:17.3514775Z 04:40:29,705 INFO  [org.inf.HOTROD] ISPN004074: Native Epoll transport not available, using NIO instead: io.netty.channel.epoll.Epoll
2023-08-04T04:57:17.3515138Z 04:40:29,709 INFO  [org.inf.HOTROD] ISPN004108: Native IOUring transport not available, using NIO instead: io.netty.incubator.channel.uring.IOUring
2023-08-04T04:57:17.3515380Z Terminating due to java.lang.OutOfMemoryError: GC overhead limit exceeded
```

GraalVM GC use max 80% of physical memory https://www.graalvm.org/latest/reference-manual/native-image/optimizations-and-performance/MemoryManagement/ by default. Not sure that setting `MaximumHeapSizePercent` is great idea though, for we can't really tell how much memory is available and if we set it too high, GC won't be able to reclaim enough memory in some cases and fail again.

I can't reproduce it, but I think that setting max Java heap used during native image generation to 5 g similarly as Quarkus main project does https://github.com/quarkusio/quarkus/blob/main/.github/workflows/ci-actions-incremental.yml#L46 should help.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)