### PR TITLE
Add http vertx client test cases to http/vertx scenario

### DIFF
--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/AbstractVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/AbstractVertxIT.java
@@ -88,7 +88,7 @@ public abstract class AbstractVertxIT {
         JsonObject jsonObject = new JsonObject().put("name", "Bender");
         HttpClient httpClient = Vertx.vertx().createHttpClient();
         httpClient.request(HttpMethod.GET, service.getPort(), service.getURI(Protocol.NONE).getHost(),
-                        "/hello?name=" + jsonObject.getString("name"))
+                "/hello?name=" + jsonObject.getString("name"))
                 .compose(request -> request.send())
                 .compose(HttpClientResponse::body)
                 .onSuccess(body -> {


### PR DESCRIPTION
### Summary

- Tweak vertx http client request in the test cases.
- Added http2 protocol and request with name parameter test cases.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)