### PR TITLE
Propagate max Java heap used during native image generation down to build time analytics app builder

### DIFF
--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/ProdModeNativeIT.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/ProdModeNativeIT.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient.Result;
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.EnabledOnNative;
 
@@ -19,6 +20,9 @@ import io.quarkus.test.scenarios.annotations.EnabledOnNative;
 @QuarkusScenario
 @EnabledOnNative
 public class ProdModeNativeIT extends AbstractAnalyticsIT {
+
+    private static final PropertyLookup NATIVE_IMG_XMX = new PropertyLookup("quarkus.native.native-image-xmx");
+
     @BeforeEach
     public void beforeEach() {
         recreateConfigDir();
@@ -27,7 +31,7 @@ public class ProdModeNativeIT extends AbstractAnalyticsIT {
     @Test
     public void extensionSetA() {
         QuarkusCliRestService app = createAppWithExtensions(EXTENSION_SET_A);
-        Result buildResult = buildApp(app::buildOnNative);
+        Result buildResult = buildNativeApp(app);
         verifyBuildSuccessful(buildResult);
         verifyValidPayloadPresent(app);
     }
@@ -35,9 +39,17 @@ public class ProdModeNativeIT extends AbstractAnalyticsIT {
     @Test
     public void extensionSetB() {
         QuarkusCliRestService app = createAppWithExtensions(EXTENSION_SET_B);
-        Result buildResult = buildApp(app::buildOnNative);
+        Result buildResult = buildNativeApp(app);
         verifyBuildSuccessful(buildResult);
         verifyValidPayloadPresent(app);
+    }
+
+    private Result buildNativeApp(QuarkusCliRestService app) {
+        final String nativeImgXmx = NATIVE_IMG_XMX.get();
+        if (nativeImgXmx != null) {
+            return buildApp(app::buildOnNative, formatBuildProperty(NATIVE_IMG_XMX.getPropertyKey(), nativeImgXmx));
+        }
+        return buildApp(app::buildOnNative);
     }
 
     @Override


### PR DESCRIPTION
### Summary

Native build fails with OOM as Github CI runners don't have that much of a memory. So we set maximum here https://github.com/quarkus-qe/quarkus-test-suite/pull/1346 but I didn't realize it is not propagated down to the application.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)