### PR TITLE
Add JDBC transaction recovery for JVM and native scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ invalid input, filtering, sorting, pagination.
 
 ### `sql-db/narayana-transactions`
 
-Verifies Quarkus transaction programmatic API.
+Verifies Quarkus transaction programmatic API, JDBC object store and transaction recovery.
 Base application contains REST resource `TransferResource` and three main services: `TransferTransactionService`, `TransferWithdrawalService`
 and `TransferTopUpService` which implement various bank transactions. The main scenario is implemented in `TransactionGeneralUsageIT` 
 and checks whether transactions and rollbacks always done in full.

--- a/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/TransactionExecutor.java
+++ b/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/TransactionExecutor.java
@@ -1,0 +1,17 @@
+package io.quarkus.ts.transactions.recovery;
+
+public enum TransactionExecutor {
+    TRANSACTIONAL_ANNOTATION(100),
+    STATIC_TRANSACTION_MANAGER(1000),
+    INJECTED_TRANSACTION_MANAGER(10000),
+    INJECTED_USER_TRANSACTION(100000),
+    STATIC_USER_TRANSACTION(1000000),
+    QUARKUS_TRANSACTION(10000000),
+    QUARKUS_TRANSACTION_CALL(100000000);
+
+    final int idOffset;
+
+    TransactionExecutor(int idOffset) {
+        this.idOffset = idOffset;
+    }
+}

--- a/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/TransactionLogsResource.java
+++ b/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/TransactionLogsResource.java
@@ -1,0 +1,95 @@
+package io.quarkus.ts.transactions.recovery;
+
+import static io.quarkus.ts.transactions.recovery.driver.CrashingXAResource.RECOVERY_SUBPATH;
+import static io.quarkus.ts.transactions.recovery.driver.CrashingXAResource.TRANSACTION_LOGS_PATH;
+
+import java.sql.SQLException;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.RestQuery;
+
+import io.quarkus.arc.All;
+
+import javax.sql.DataSource;
+
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Path(TRANSACTION_LOGS_PATH)
+public class TransactionLogsResource {
+
+    private final DataSource dataSource;
+    private final EnumMap<TransactionExecutor, TransactionRecoveryService> typeToSvc;
+
+    public TransactionLogsResource(DataSource dataSource, @All List<TransactionRecoveryService> serviceList) {
+        this.dataSource = dataSource;
+        this.typeToSvc = new EnumMap<>(serviceList
+                .stream()
+                .collect(
+                        Collectors.toMap(
+                                TransactionRecoveryService::transactionExecutor,
+                                Function.identity())));
+    }
+
+    @Path(RECOVERY_SUBPATH)
+    @POST
+    public int makeTransactionAndCrash(@RestQuery boolean rollback, @RestQuery TransactionExecutor executor) {
+        return typeToSvc.get(executor).makeTransaction(rollback);
+    }
+
+    @POST
+    public int makeTransaction(@RestQuery boolean rollback, @RestQuery TransactionExecutor executor) {
+        return typeToSvc.get(executor).makeTransaction(rollback);
+    }
+
+    @Transactional
+    @GET
+    public int transactionCount() {
+        return executeCountQuery("recovery_log");
+    }
+
+    @Path("/jdbc-object-store")
+    @Transactional
+    @GET
+    public int jdbcObjectStoreCount() {
+        return executeCountQuery("quarkus_qe_JBossTSTxTable");
+    }
+
+    @Transactional
+    @DELETE
+    public void deleteRecoveryLog() {
+        // all transactions write into 'recovery_log' table
+        try (var con = dataSource.getConnection()) {
+            try (var st = con.createStatement()) {
+                st.executeUpdate("DELETE FROM recovery_log");
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private int executeCountQuery(String tableName) {
+        try (var con = dataSource.getConnection()) {
+            try (var st = con.createStatement()) {
+                var res = st.executeQuery("SELECT COUNT(*) FROM " + tableName);
+                if (res.next()) {
+                    return res.getInt(1);
+                }
+                return 0;
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/TransactionRecoveryService.java
+++ b/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/TransactionRecoveryService.java
@@ -1,0 +1,58 @@
+package io.quarkus.ts.transactions.recovery;
+
+import java.sql.SQLException;
+import java.util.function.Supplier;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import javax.sql.DataSource;
+
+public abstract class TransactionRecoveryService {
+
+    @Named("xa-ds-1")
+    @Inject
+    DataSource xaDataSource1;
+
+    @Named("xa-ds-2")
+    @Inject
+    DataSource xaDataSource2;
+
+    public int makeTransaction(boolean rollback) {
+        if (rollback) {
+            return withTransactionAndRollback(this::makeTransactionInternal);
+        }
+        return withTransaction(this::makeTransactionInternal);
+    }
+
+    public abstract TransactionExecutor transactionExecutor();
+
+    protected abstract <T> T withTransaction(Supplier<T> runInsideTransaction);
+
+    protected abstract <T> T withTransactionAndRollback(Supplier<T> runInsideTransaction);
+
+    private int idOffset() {
+        return transactionExecutor().idOffset;
+    }
+
+    private int makeTransactionInternal() {
+        return makeTransactionInternal(0, idOffset(), xaDataSource1, xaDataSource2);
+    }
+
+    private static int makeTransactionInternal(int idx, int idOffset, DataSource... dataSources) {
+        try (var con = dataSources[idx].getConnection()) {
+            try (var statement = con.createStatement()) {
+                int pk = idOffset + idx++;
+                var result = statement.executeUpdate("INSERT INTO recovery_log (id) VALUES (" + pk + ")");
+                if (idx < dataSources.length) {
+                    return result + makeTransactionInternal(idx, idOffset, dataSources);
+                } else {
+                    return result;
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/driver/CrashingXAConnection.java
+++ b/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/driver/CrashingXAConnection.java
@@ -1,0 +1,53 @@
+package io.quarkus.ts.transactions.recovery.driver;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.ConnectionEventListener;
+import javax.sql.StatementEventListener;
+import javax.sql.XAConnection;
+import javax.transaction.xa.XAResource;
+
+public class CrashingXAConnection implements XAConnection {
+
+    private final XAConnection delegate;
+
+    CrashingXAConnection(XAConnection delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public XAResource getXAResource() throws SQLException {
+        return new CrashingXAResource(delegate.getXAResource());
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return delegate.getConnection();
+    }
+
+    @Override
+    public void close() throws SQLException {
+        delegate.close();
+    }
+
+    @Override
+    public void addConnectionEventListener(ConnectionEventListener listener) {
+        delegate.addConnectionEventListener(listener);
+    }
+
+    @Override
+    public void removeConnectionEventListener(ConnectionEventListener listener) {
+        delegate.removeConnectionEventListener(listener);
+    }
+
+    @Override
+    public void addStatementEventListener(StatementEventListener listener) {
+        delegate.addStatementEventListener(listener);
+    }
+
+    @Override
+    public void removeStatementEventListener(StatementEventListener listener) {
+        delegate.removeStatementEventListener(listener);
+    }
+}

--- a/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/driver/CrashingXADataSource.java
+++ b/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/driver/CrashingXADataSource.java
@@ -1,0 +1,162 @@
+package io.quarkus.ts.transactions.recovery.driver;
+
+import static io.quarkus.datasource.common.runtime.DataSourceUtil.DEFAULT_DATASOURCE_NAME;
+import static io.quarkus.datasource.common.runtime.DatabaseKind.MARIADB;
+import static io.quarkus.datasource.common.runtime.DatabaseKind.MSSQL;
+import static io.quarkus.datasource.common.runtime.DatabaseKind.MYSQL;
+import static io.quarkus.datasource.common.runtime.DatabaseKind.ORACLE;
+import static io.quarkus.datasource.common.runtime.DatabaseKind.POSTGRESQL;
+
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.ShardingKeyBuilder;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+import org.mariadb.jdbc.MariaDbDataSource;
+import org.postgresql.xa.PGXADataSource;
+
+import com.microsoft.sqlserver.jdbc.SQLServerXADataSource;
+import com.mysql.cj.jdbc.MysqlXADataSource;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
+import io.quarkus.datasource.runtime.DatabaseKindConverter;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import javax.sql.XAConnection;
+import javax.sql.XAConnectionBuilder;
+import javax.sql.XADataSource;
+import oracle.jdbc.xa.client.OracleXADataSource;
+
+// Agroal extension register directly used drivers, but since we are delegating, we need to register it ourselves
+@RegisterForReflection(targets = { OracleXADataSource.class, MariaDbDataSource.class, MysqlXADataSource.class,
+        SQLServerXADataSource.class })
+public final class CrashingXADataSource implements XADataSource {
+
+    /**
+     * Prefix of named XA datasource to default driver.
+     * Should default XA driver used by Quarkus change, we need to update this map.
+     */
+    private static final Map<String, Supplier<XADataSource>> dbKindToDelegateSupplier = Map.of(
+            POSTGRESQL, PGXADataSource::new,
+            ORACLE, () -> {
+                try {
+                    return new OracleXADataSource();
+                } catch (SQLException e) {
+                    throw new RuntimeException(e);
+                }
+            },
+            MARIADB, MariaDbDataSource::new,
+            MSSQL, SQLServerXADataSource::new,
+            MYSQL, MysqlXADataSource::new);
+
+    private final XADataSource delegate;
+    private String user;
+    private String password;
+    private String URL;
+
+    public CrashingXADataSource() {
+
+        // find which database we are dealing with
+        var dbKind = Arc
+                .container()
+                .instance(DataSourcesBuildTimeConfig.class)
+                .get()
+                .dataSources()
+                .get(DEFAULT_DATASOURCE_NAME) // use default ds in order to determine db kind
+                .dbKind()
+                .map(dbKindRaw -> new DatabaseKindConverter().convert(dbKindRaw))
+                .orElseThrow(); // we require explicitly set db kind for sake of this test
+
+        // create actual XA datasource
+        delegate = dbKindToDelegateSupplier.get(dbKind).get();
+    }
+
+    @Override
+    public XAConnection getXAConnection() throws SQLException {
+        return getXAConnection(getUser(), getPassword());
+    }
+
+    @Override
+    public XAConnection getXAConnection(String user, String password) throws SQLException {
+        return new CrashingXAConnection(delegate.getXAConnection(user, password));
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return delegate.getLogWriter();
+    }
+
+    public String getUser() {
+        return this.user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public String getPassword() {
+        return this.password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        delegate.setLogWriter(out);
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+        delegate.setLoginTimeout(seconds);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return delegate.getLoginTimeout();
+    }
+
+    @Override
+    public XAConnectionBuilder createXAConnectionBuilder() throws SQLException {
+        return delegate.createXAConnectionBuilder();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return delegate.getParentLogger();
+    }
+
+    @Override
+    public ShardingKeyBuilder createShardingKeyBuilder() throws SQLException {
+        return delegate.createShardingKeyBuilder();
+    }
+
+    public String getURL() {
+        return URL;
+    }
+
+    public void setURL(String url) {
+        this.URL = url;
+        // we need to use reflection for there is no common interface, but still XA ds implements it
+        Arrays
+                .stream(this.delegate.getClass().getMethods())
+                .filter(method -> "setURL".equalsIgnoreCase(method.getName()))
+                .findFirst()
+                .ifPresentOrElse(method -> {
+                    try {
+                        method.invoke(this.delegate, url);
+                    } catch (IllegalAccessException | InvocationTargetException e) {
+                        throw new RuntimeException(e);
+                    }
+                }, () -> {
+                    throw new RuntimeException();
+                });
+    }
+}

--- a/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/driver/CrashingXAResource.java
+++ b/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/driver/CrashingXAResource.java
@@ -1,0 +1,99 @@
+package io.quarkus.ts.transactions.recovery.driver;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.vertx.ext.web.RoutingContext;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+public class CrashingXAResource implements XAResource {
+
+    public static final String TRANSACTION_LOGS_PATH = "/transaction-logs";
+    public static final String RECOVERY_SUBPATH = "/recovery";
+    private static final Logger LOG = Logger.getLogger(CrashingXAResource.class);
+    private volatile InstanceHandle<RoutingContext> routingContextInstanceHandle = null;
+    private final XAResource delegate;
+
+    public CrashingXAResource(XAResource delegate) {
+        this.delegate = delegate;
+    }
+
+    private RoutingContext getRoutingContext() {
+        if (Arc.container() == null || !Arc.container().requestContext().isActive()) {
+            // during transaction recovery, request context is not active
+            return null;
+        }
+
+        if (routingContextInstanceHandle == null) {
+            routingContextInstanceHandle = Arc.container().instance(RoutingContext.class);
+        }
+
+        return routingContextInstanceHandle.get();
+    }
+
+    private boolean shouldCrash() {
+        var ctx = getRoutingContext();
+        if (ctx == null) {
+            return false;
+        }
+        return ctx.request().path().endsWith(TRANSACTION_LOGS_PATH + RECOVERY_SUBPATH);
+    }
+
+    @Override
+    public void commit(Xid xid, boolean onePhase) throws XAException {
+        if (shouldCrash()) {
+            LOG.info("Crashing the system");
+            Runtime.getRuntime().halt(1);
+        }
+        delegate.commit(xid, onePhase);
+    }
+
+    @Override
+    public void end(Xid xid, int flags) throws XAException {
+        delegate.end(xid, flags);
+    }
+
+    @Override
+    public void forget(Xid xid) throws XAException {
+        delegate.forget(xid);
+    }
+
+    @Override
+    public int getTransactionTimeout() throws XAException {
+        return delegate.getTransactionTimeout();
+    }
+
+    @Override
+    public boolean isSameRM(XAResource xares) throws XAException {
+        return delegate.isSameRM(xares);
+    }
+
+    @Override
+    public int prepare(Xid xid) throws XAException {
+        return delegate.prepare(xid);
+    }
+
+    @Override
+    public Xid[] recover(int flag) throws XAException {
+        return delegate.recover(flag);
+    }
+
+    @Override
+    public void rollback(Xid xid) throws XAException {
+        delegate.rollback(xid);
+    }
+
+    @Override
+    public boolean setTransactionTimeout(int seconds) throws XAException {
+        return delegate.setTransactionTimeout(seconds);
+    }
+
+    @Override
+    public void start(Xid xid, int flags) throws XAException {
+        delegate.start(xid, flags);
+    }
+}

--- a/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/service/AnnotationTransactionRecoveryService.java
+++ b/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/service/AnnotationTransactionRecoveryService.java
@@ -1,0 +1,43 @@
+package io.quarkus.ts.transactions.recovery.service;
+
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.Transactional;
+
+import io.quarkus.ts.transactions.recovery.TransactionExecutor;
+import io.quarkus.ts.transactions.recovery.TransactionRecoveryService;
+
+@ApplicationScoped
+public class AnnotationTransactionRecoveryService extends TransactionRecoveryService {
+
+    @Inject
+    TransactionManager manager;
+
+    @Override
+    public TransactionExecutor transactionExecutor() {
+        return TransactionExecutor.TRANSACTIONAL_ANNOTATION;
+    }
+
+    @Transactional
+    @Override
+    protected <T> T withTransaction(Supplier<T> runInsideTransaction) {
+        return runInsideTransaction.get();
+    }
+
+    @Transactional
+    @Override
+    protected <T> T withTransactionAndRollback(Supplier<T> runInsideTransaction) {
+        var result = runInsideTransaction.get();
+        try {
+            manager.getTransaction().setRollbackOnly();
+        } catch (SystemException e) {
+            throw new RuntimeException(e);
+        }
+        return result;
+    }
+
+}

--- a/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/service/InjectedTransactionManagerRecoveryService.java
+++ b/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/service/InjectedTransactionManagerRecoveryService.java
@@ -1,0 +1,47 @@
+package io.quarkus.ts.transactions.recovery.service;
+
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.TransactionManager;
+
+import io.quarkus.ts.transactions.recovery.TransactionExecutor;
+import io.quarkus.ts.transactions.recovery.TransactionRecoveryService;
+
+@ApplicationScoped
+public class InjectedTransactionManagerRecoveryService extends TransactionRecoveryService {
+
+    @Inject
+    TransactionManager transactionManager;
+
+    @Override
+    public TransactionExecutor transactionExecutor() {
+        return TransactionExecutor.INJECTED_TRANSACTION_MANAGER;
+    }
+
+    @Override
+    protected <T> T withTransaction(Supplier<T> runInsideTransaction) {
+        try {
+            transactionManager.begin();
+            var result = runInsideTransaction.get();
+            transactionManager.commit();
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected <T> T withTransactionAndRollback(Supplier<T> runInsideTransaction) {
+        try {
+            transactionManager.begin();
+            var result = runInsideTransaction.get();
+            transactionManager.rollback();
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/service/InjectedUserTransactionRecoveryService.java
+++ b/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/service/InjectedUserTransactionRecoveryService.java
@@ -1,0 +1,47 @@
+package io.quarkus.ts.transactions.recovery.service;
+
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.UserTransaction;
+
+import io.quarkus.ts.transactions.recovery.TransactionExecutor;
+import io.quarkus.ts.transactions.recovery.TransactionRecoveryService;
+
+@ApplicationScoped
+public class InjectedUserTransactionRecoveryService extends TransactionRecoveryService {
+
+    @Inject
+    UserTransaction userTransaction;
+
+    @Override
+    public TransactionExecutor transactionExecutor() {
+        return TransactionExecutor.INJECTED_USER_TRANSACTION;
+    }
+
+    @Override
+    protected <T> T withTransaction(Supplier<T> runInsideTransaction) {
+        try {
+            userTransaction.begin();
+            var result = runInsideTransaction.get();
+            userTransaction.commit();
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected <T> T withTransactionAndRollback(Supplier<T> runInsideTransaction) {
+        try {
+            userTransaction.begin();
+            var result = runInsideTransaction.get();
+            userTransaction.rollback();
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/service/QuarkusTransactionCallRecoveryService.java
+++ b/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/service/QuarkusTransactionCallRecoveryService.java
@@ -1,0 +1,33 @@
+package io.quarkus.ts.transactions.recovery.service;
+
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.ts.transactions.recovery.TransactionExecutor;
+import io.quarkus.ts.transactions.recovery.TransactionRecoveryService;
+
+@ApplicationScoped
+public class QuarkusTransactionCallRecoveryService extends TransactionRecoveryService {
+
+    @Override
+    public TransactionExecutor transactionExecutor() {
+        return TransactionExecutor.QUARKUS_TRANSACTION_CALL;
+    }
+
+    @Override
+    protected <T> T withTransaction(Supplier<T> runInsideTransaction) {
+        return QuarkusTransaction.requiringNew().call(runInsideTransaction::get);
+    }
+
+    @Override
+    protected <T> T withTransactionAndRollback(Supplier<T> runInsideTransaction) {
+        return QuarkusTransaction.requiringNew().call(() -> {
+            var result = runInsideTransaction.get();
+            QuarkusTransaction.rollback();
+            return result;
+        });
+    }
+
+}

--- a/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/service/QuarkusTransactionRecoveryService.java
+++ b/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/service/QuarkusTransactionRecoveryService.java
@@ -1,0 +1,35 @@
+package io.quarkus.ts.transactions.recovery.service;
+
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.ts.transactions.recovery.TransactionExecutor;
+import io.quarkus.ts.transactions.recovery.TransactionRecoveryService;
+
+@ApplicationScoped
+public class QuarkusTransactionRecoveryService extends TransactionRecoveryService {
+
+    @Override
+    public TransactionExecutor transactionExecutor() {
+        return TransactionExecutor.QUARKUS_TRANSACTION;
+    }
+
+    @Override
+    protected <T> T withTransaction(Supplier<T> runInsideTransaction) {
+        QuarkusTransaction.begin();
+        var result = runInsideTransaction.get();
+        QuarkusTransaction.commit();
+        return result;
+    }
+
+    @Override
+    protected <T> T withTransactionAndRollback(Supplier<T> runInsideTransaction) {
+        QuarkusTransaction.begin();
+        var result = runInsideTransaction.get();
+        QuarkusTransaction.rollback();
+        return result;
+    }
+
+}

--- a/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/service/StaticTransactionManagerRecoveryService.java
+++ b/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/service/StaticTransactionManagerRecoveryService.java
@@ -1,0 +1,44 @@
+package io.quarkus.ts.transactions.recovery.service;
+
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import com.arjuna.ats.jta.TransactionManager;
+
+import io.quarkus.ts.transactions.recovery.TransactionExecutor;
+import io.quarkus.ts.transactions.recovery.TransactionRecoveryService;
+
+@ApplicationScoped
+public class StaticTransactionManagerRecoveryService extends TransactionRecoveryService {
+
+    @Override
+    public TransactionExecutor transactionExecutor() {
+        return TransactionExecutor.STATIC_TRANSACTION_MANAGER;
+    }
+
+    @Override
+    protected <T> T withTransaction(Supplier<T> runInsideTransaction) {
+        try {
+            TransactionManager.transactionManager().begin();
+            var result = runInsideTransaction.get();
+            TransactionManager.transactionManager().commit();
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected <T> T withTransactionAndRollback(Supplier<T> runInsideTransaction) {
+        try {
+            TransactionManager.transactionManager().begin();
+            var result = runInsideTransaction.get();
+            TransactionManager.transactionManager().rollback();
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/service/StaticUserTransactionRecoveryService.java
+++ b/sql-db/narayana-transactions/src/main/java/io/quarkus/ts/transactions/recovery/service/StaticUserTransactionRecoveryService.java
@@ -1,0 +1,44 @@
+package io.quarkus.ts.transactions.recovery.service;
+
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import com.arjuna.ats.jta.UserTransaction;
+
+import io.quarkus.ts.transactions.recovery.TransactionExecutor;
+import io.quarkus.ts.transactions.recovery.TransactionRecoveryService;
+
+@ApplicationScoped
+public class StaticUserTransactionRecoveryService extends TransactionRecoveryService {
+
+    @Override
+    public TransactionExecutor transactionExecutor() {
+        return TransactionExecutor.STATIC_USER_TRANSACTION;
+    }
+
+    @Override
+    protected <T> T withTransaction(Supplier<T> runInsideTransaction) {
+        try {
+            UserTransaction.userTransaction().begin();
+            var result = runInsideTransaction.get();
+            UserTransaction.userTransaction().commit();
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected <T> T withTransactionAndRollback(Supplier<T> runInsideTransaction) {
+        try {
+            UserTransaction.userTransaction().begin();
+            var result = runInsideTransaction.get();
+            UserTransaction.userTransaction().rollback();
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/sql-db/narayana-transactions/src/main/resources/application.properties
+++ b/sql-db/narayana-transactions/src/main/resources/application.properties
@@ -4,3 +4,32 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
 quarkus.otel.enabled=false
 quarkus.application.name=narayanaTransactions
+
+## Transaction logs
+# first XA datasource used for transaction logs recovery test
+quarkus.datasource.xa-ds-1.jdbc.transactions=xa
+quarkus.datasource.xa-ds-1.db-kind=${quarkus.datasource.db-kind}
+quarkus.datasource.xa-ds-1.username=${quarkus.datasource.username}
+quarkus.datasource.xa-ds-1.password=${quarkus.datasource.password}
+quarkus.datasource.xa-ds-1.jdbc.url=${quarkus.datasource.jdbc.url}
+quarkus.datasource.xa-ds-1.jdbc.driver=io.quarkus.ts.transactions.recovery.driver.CrashingXADataSource
+# second XA datasource used for transaction logs recovery test
+quarkus.datasource.xa-ds-2.jdbc.transactions=${quarkus.datasource.xa-ds-1.jdbc.transactions}
+quarkus.datasource.xa-ds-2.db-kind=${quarkus.datasource.xa-ds-1.db-kind}
+quarkus.datasource.xa-ds-2.username=${quarkus.datasource.xa-ds-1.username}
+quarkus.datasource.xa-ds-2.password=${quarkus.datasource.xa-ds-1.password}
+quarkus.datasource.xa-ds-2.jdbc.url=${quarkus.datasource.xa-ds-1.jdbc.url}
+quarkus.datasource.xa-ds-2.jdbc.driver=${quarkus.datasource.xa-ds-1.jdbc.driver}
+# object store datasource
+quarkus.datasource.object-store-ds.jdbc.transactions=disabled
+quarkus.datasource.object-store-ds.db-kind=${quarkus.datasource.db-kind}
+quarkus.datasource.object-store-ds.username=${quarkus.datasource.username}
+quarkus.datasource.object-store-ds.password=${quarkus.datasource.password}
+quarkus.datasource.object-store-ds.jdbc.url=${quarkus.datasource.jdbc.url}
+# configure transaction manager to use JDBC object store and enable automatic recovery
+quarkus.transaction-manager.node-name=quarkus-qe
+quarkus.transaction-manager.object-store.type=jdbc
+quarkus.transaction-manager.object-store.datasource=object-store-ds
+quarkus.transaction-manager.enable-recovery=true
+quarkus.transaction-manager.object-store.create-table=true
+quarkus.transaction-manager.object-store.table-prefix=quarkus_qe_

--- a/sql-db/narayana-transactions/src/main/resources/import.sql
+++ b/sql-db/narayana-transactions/src/main/resources/import.sql
@@ -5,3 +5,4 @@ INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, creat
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('Account_SEQ'), 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('Account_SEQ'), 'Eduardo', 'Mendoza', 'ES8521006742088984966899', 100, null, CURRENT_TIMESTAMP);
 
+CREATE TABLE IF NOT EXISTS recovery_log (id INT);

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
@@ -8,6 +8,7 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 
 @QuarkusScenario
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux Containers / Testcontainers (Jaeger)")
@@ -25,4 +26,14 @@ public class MariaDbTransactionGeneralUsageIT extends TransactionCommons {
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+
+    @Override
+    protected TransactionExecutor getTransactionExecutorUsedForRecovery() {
+        return TransactionExecutor.QUARKUS_TRANSACTION;
+    }
 }

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MysqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MysqlTransactionGeneralUsageIT.java
@@ -9,6 +9,7 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 
 // TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
 @Tag("fips-incompatible") // native-mode
@@ -27,4 +28,14 @@ public class MysqlTransactionGeneralUsageIT extends TransactionCommons {
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+
+    @Override
+    protected TransactionExecutor getTransactionExecutorUsedForRecovery() {
+        return TransactionExecutor.INJECTED_TRANSACTION_MANAGER;
+    }
 }

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMariaDbTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMariaDbTransactionGeneralUsageIT.java
@@ -7,6 +7,7 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 
 @OpenShiftScenario
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
@@ -23,4 +24,19 @@ public class OpenShiftMariaDbTransactionGeneralUsageIT extends TransactionCommon
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+
+    @Override
+    protected TransactionExecutor getTransactionExecutorUsedForRecovery() {
+        return TransactionExecutor.STATIC_TRANSACTION_MANAGER;
+    }
+
+    @Override
+    protected void testTransactionRecoveryInternal() {
+        // disabled on OpenShift as there are required changes in Test Framework in container restart
+    }
 }

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMysqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMysqlTransactionGeneralUsageIT.java
@@ -7,6 +7,7 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 
 @OpenShiftScenario
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
@@ -22,4 +23,19 @@ public class OpenShiftMysqlTransactionGeneralUsageIT extends TransactionCommons 
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+
+    @Override
+    protected TransactionExecutor getTransactionExecutorUsedForRecovery() {
+        return TransactionExecutor.STATIC_USER_TRANSACTION;
+    }
+
+    @Override
+    protected void testTransactionRecoveryInternal() {
+        // disabled on OpenShift as there are required changes in Test Framework in container restart
+    }
 }

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftPostgresqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftPostgresqlTransactionGeneralUsageIT.java
@@ -4,4 +4,9 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
 public class OpenShiftPostgresqlTransactionGeneralUsageIT extends PostgresqlTransactionGeneralUsageIT {
+
+    @Override
+    protected void testTransactionRecoveryInternal() {
+        // disabled on OpenShift as there are required changes in Test Framework in container restart
+    }
 }

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OracleTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OracleTransactionGeneralUsageIT.java
@@ -8,6 +8,7 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 
 @QuarkusScenario
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux Containers / Testcontainers (Jaeger)")
@@ -26,7 +27,23 @@ public class OracleTransactionGeneralUsageIT extends TransactionCommons {
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
 
     @Override
+    protected RestService getApp() {
+        return app;
+    }
+
+    @Override
+    protected TransactionExecutor getTransactionExecutorUsedForRecovery() {
+        return TransactionExecutor.QUARKUS_TRANSACTION_CALL;
+    }
+
+    @Override
     protected String[] getExpectedJdbcOperationNames() {
         return new String[] { "SELECT mydb", "INSERT mydb.journal", "UPDATE mydb.account" };
+    }
+
+    @Override
+    protected void testTransactionRecoveryInternal() {
+        // disables transaction recovery test for Oracle due to upstream issue
+        // TODO: remove this method when https://github.com/quarkusio/quarkus/issues/35333 gets fixed
     }
 }

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlTransactionGeneralUsageIT.java
@@ -8,14 +8,16 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 
 @QuarkusScenario
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux Containers / Testcontainers (Jaeger)")
 public class PostgresqlTransactionGeneralUsageIT extends TransactionCommons {
 
+    private static final String ENABLE_PREPARED_TRANSACTIONS = "--max_prepared_transactions=100";
     static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address", command = ENABLE_PREPARED_TRANSACTIONS)
     static final PostgresqlService database = new PostgresqlService().withProperty("PGDATA", "/tmp/psql");
 
     @QuarkusApplication
@@ -25,4 +27,14 @@ public class PostgresqlTransactionGeneralUsageIT extends TransactionCommons {
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+
+    @Override
+    protected TransactionExecutor getTransactionExecutorUsedForRecovery() {
+        return TransactionExecutor.TRANSACTIONAL_ANNOTATION;
+    }
 }

--- a/sql-db/narayana-transactions/src/test/resources/mariadb_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/mariadb_import.sql
@@ -4,3 +4,5 @@ INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, creat
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Eduardo', 'Mendoza', 'ES8521006742088984966899', 100, null, CURRENT_TIMESTAMP);
+
+CREATE TABLE IF NOT EXISTS recovery_log (id INT);

--- a/sql-db/narayana-transactions/src/test/resources/mssql_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/mssql_import.sql
@@ -4,3 +4,5 @@ INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, creat
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR Account_SEQ, 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR Account_SEQ, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Eduardo', 'Mendoza', 'ES8521006742088984966899', 100, null, CURRENT_TIMESTAMP);
+
+CREATE TABLE recovery_log (id INT);

--- a/sql-db/narayana-transactions/src/test/resources/mysql_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/mysql_import.sql
@@ -5,3 +5,5 @@ INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, creat
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) SELECT MAX(id) + 1, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP FROM account;
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) SELECT MAX(id) + 1, 'Eduardo', 'Mendoza', 'ES8521006742088984966899', 100, null, CURRENT_TIMESTAMP FROM account;
 UPDATE account_SEQ SET next_val=(SELECT MAX(id) + 1 FROM account);
+
+CREATE TABLE IF NOT EXISTS recovery_log (id INT);

--- a/sql-db/narayana-transactions/src/test/resources/oracle_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/oracle_import.sql
@@ -4,3 +4,5 @@ INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, creat
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (Account_SEQ.NEXTVAL, 'Lope', 'de Vega', 'FR9317569000409377431694J37', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (Account_SEQ.NEXTVAL, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (Account_SEQ.NEXTVAL, 'Eduardo', 'Mendoza', 'ES8521006742088984966899', 100, null, CURRENT_TIMESTAMP);
+
+CREATE TABLE IF NOT EXISTS recovery_log (id INT);


### PR DESCRIPTION
### Summary

Adds transaction recovery test coverage for native and JVM. OpenShift will require changes in Test Framework that I didn't really explore yet. IMHO there is plenty of changes already and we should wait for OCP. DEV mode is something that is worth to do (especially due to https://github.com/quarkusio/quarkus/issues/34576#event-10010650889), but not part of original test plan here https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-2739.md and I didn't get to it yet.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)