### PR TITLE
Move to MultipartFormDataInput from RESTEasy Reactive

### DIFF
--- a/http/http-advanced-reactive/pom.xml
+++ b/http/http-advanced-reactive/pom.xml
@@ -52,8 +52,8 @@
             <artifactId>okhttp</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-multipart-provider</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MultipartResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MultipartResource.java
@@ -3,7 +3,6 @@ package io.quarkus.ts.http.advanced.reactive;
 import static io.quarkus.ts.http.advanced.reactive.MultipartResource.MULTIPART_FORM_PATH;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 import jakarta.ws.rs.Consumes;
@@ -14,9 +13,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
-import org.apache.commons.io.IOUtils;
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
+import org.jboss.resteasy.reactive.server.multipart.MultipartFormDataInput;
 
 @Path(MULTIPART_FORM_PATH)
 public class MultipartResource {
@@ -30,12 +28,13 @@ public class MultipartResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
     public Response multipartFormData(final MultipartFormDataInput input) {
-        var inputPartText = input.getFormDataMap().get(TEXT).stream().findAny().orElse(null);
+        var inputPartText = input.getValues().get(TEXT).stream().findAny().orElse(null);
         if (inputPartText != null) {
             try {
-                String fileContent = IOUtils.toString(input.getFormDataPart(FILE, InputStream.class, null),
+                var inputPartFile = input.getValues().get(FILE).stream().findAny().orElse(null);
+                String fileContent = new String(inputPartFile.getFileItem().getInputStream().readAllBytes(),
                         StandardCharsets.UTF_8);
-                String text = inputPartText.getBodyAsString();
+                String text = inputPartText.getValue();
                 return Response.ok(new MultipartFormDataDTO(text, fileContent)).build();
             } catch (IOException e) {
                 LOGGER.errorf("Failed to retrieve form field value: %s", e.getMessage());


### PR DESCRIPTION
Move to MultipartFormDataInput from RESTEasy Reactive for `http/http-advanced-reactive` module

https://github.com/quarkusio/quarkus/pull/30307 introduced MultipartFormDataInput for RESTEasy Reactive in Quarkus 3.0.0.

resteasy-multipart-provider causes troubles in native as it pulls in several RESTEasy Classic dependencies.

`jakarta.validation` dependency needs to defined explicitly (needed by io.quarkus.ts.http.advanced.reactive.Hello), before it was pulled in transitively by RESTEasy Classic.

Fixes https://issues.redhat.com/browse/QUARKUS-3308 issue, needs to be backported to 3.2 branch.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)