### PR TITLE
Fix analytics disabled by CI

### DIFF
--- a/build-time-analytics/pom.xml
+++ b/build-time-analytics/pom.xml
@@ -17,6 +17,30 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <!-- We run the tests with CI set to false as otherwise analytics are disabled -->
+                        <!-- See https://github.com/quarkusio/quarkus/pull/35456 -->
+                        <CI>false</CI>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <!-- We run the analytics integration test with CI set to false as otherwise analytics are disabled -->
+                        <!-- See https://github.com/quarkusio/quarkus/pull/35456 -->
+                        <CI>false</CI>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <!-- Disable native build on this module -->


### PR DESCRIPTION
### Summary

Build-time analytics can be disabled by `CI` environment variable. This fix explicitly sets the value of the variable to `false` for both surefire and failsafe executions in the analytics module, so that it gets executed in every environment.
The module itself works around the reasons this feature has been added to Quarkus, which is the fact that the initial analytics user prompt cannot be acted upon in CI environments.

See https://github.com/quarkusio/quarkus/pull/35456.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)