### PR TITLE
Install Quarkus CLI in Quarkus Ecosystem GH action

### DIFF
--- a/.github/ci-init.sh
+++ b/.github/ci-init.sh
@@ -1,0 +1,8 @@
+echo "Installing Quarkus CLI"
+jbang app install --force --name quarkus "io.quarkus:quarkus-cli:${QUARKUS_VERSION}:runner"
+if "${HOME}/.jbang/bin/quarkus" --version; then
+  echo "Quarkus CLI installed successfully"
+else
+  echo "Failed to install Quarkus CLI"
+  exit 1
+fi

--- a/.github/quarkus-ecosystem-test
+++ b/.github/quarkus-ecosystem-test
@@ -2,7 +2,7 @@
 set -e
 
 # run the tests on JVM
-mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P $MAVEN_PROFILES
+mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P $MAVEN_PROFILES -Dts.quarkus.cli.cmd="${HOME}/.jbang/bin/quarkus"
 
 # run the tests on Native
-mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P $MAVEN_PROFILES -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=5g
+mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P $MAVEN_PROFILES -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=5g -Dts.quarkus.cli.cmd="${HOME}/.jbang/bin/quarkus"


### PR DESCRIPTION
### Summary

Install the command in a custom init script (provided by https://github.com/quarkusio/quarkus-ecosystem-ci/pull/140).

The custom script uses `jbang` to install Quarkus CLI from most recently built Quarkus artifacts.

This should ensure that tests which use the CLI don't fail in the Quarkus ecosystem GH environment.

See an example of such a failure at
https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/5947272576/job/16129106765.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)