### PR TITLE
Move fully to RESTEasy Reactive for opentracing-reactive-grpc, disable SSE scenario

### DIFF
--- a/monitoring/opentracing-reactive-grpc/pom.xml
+++ b/monitoring/opentracing-reactive-grpc/pom.xml
@@ -12,7 +12,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny</artifactId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/monitoring/opentracing-reactive-grpc/src/test/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/ServerSentEventsTraceOpentracingIT.java
+++ b/monitoring/opentracing-reactive-grpc/src/test/java/io/quarkus/ts/monitoring/opentracing/reactive/grpc/ServerSentEventsTraceOpentracingIT.java
@@ -1,8 +1,12 @@
 package io.quarkus.ts.monitoring.opentracing.reactive.grpc;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.QuarkusScenario;
 
 @QuarkusScenario
+@Disabled("RESTEasy Reactive + SSE + OpenTracing are not friends, works with OpenTelemetry," +
+        "https://github.com/quarkusio/quarkus/issues/29539 closed as won't fix")
 public class ServerSentEventsTraceOpentracingIT extends AbstractTraceIT {
 
     @Override


### PR DESCRIPTION
### Summary

Move fully to RESTEasy Reactive, disable SSE scenario

Quarkus main now detects mixture of RESTEasy Reactive and RESTEasy Classic. Thus the build fails for monitoring/opentracing-reactive-grpc which used Mutiny on top of RESTEasy Classic.
Example: https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/5950642487/job/16140058276?pr=1372

I had to disable SSE scenario because of https://github.com/quarkusio/quarkus/issues/29539 which was closed as won't fix

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)