### PR TITLE
Enable tests which were disabled on outdated Podman 4.5.1

### DIFF
--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMariadbDevServicesUserExperienceIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMariadbDevServicesUserExperienceIT.java
@@ -15,7 +15,6 @@ import io.quarkus.test.utils.SocketUtils;
 
 @Tag("QUARKUS-959")
 @QuarkusScenario
-@Tag("podman-incompatible") //todo https://github.com/quarkusio/quarkus/issues/33985
 public class DevModeMariadbDevServicesUserExperienceIT {
 
     private static final String MARIA_DB_NAME = DbUtil.getImageName("mariadb.10.image");

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMariadbIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMariadbIT.java
@@ -9,7 +9,6 @@ import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @Tag("QUARKUS-959")
 @QuarkusScenario
-@Tag("podman-incompatible") //todo https://github.com/quarkusio/quarkus/issues/33985
 public class DevModeMariadbIT extends AbstractSqlDatabaseIT {
 
     @DevModeQuarkusApplication

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMssqlDevServicesUserExperienceIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMssqlDevServicesUserExperienceIT.java
@@ -15,7 +15,6 @@ import io.quarkus.test.utils.SocketUtils;
 
 @Tag("QUARKUS-959")
 @QuarkusScenario
-@Tag("podman-incompatible") //todo https://github.com/quarkusio/quarkus/issues/33985
 public class DevModeMssqlDevServicesUserExperienceIT {
 
     private static final String MSSQL_NAME = DbUtil.getImageName("mssql.image");

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMssqlIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMssqlIT.java
@@ -9,7 +9,6 @@ import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @Tag("QUARKUS-959")
 @QuarkusScenario
-@Tag("podman-incompatible") //todo https://github.com/quarkusio/quarkus/issues/33985
 public class DevModeMssqlIT extends AbstractSqlDatabaseIT {
 
     @DevModeQuarkusApplication

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMysqlDevServiceUserExperienceIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMysqlDevServiceUserExperienceIT.java
@@ -18,7 +18,6 @@ import io.quarkus.test.utils.SocketUtils;
 
 @Tag("QUARKUS-959")
 @QuarkusScenario
-@Tag("podman-incompatible") //todo https://github.com/quarkusio/quarkus/issues/33985
 public class DevModeMysqlDevServiceUserExperienceIT {
 
     private static final String MYSQL_NAME = getImageName("mysql.upstream.80.image");

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMysqlIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMysqlIT.java
@@ -9,7 +9,6 @@ import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @Tag("QUARKUS-959")
 @QuarkusScenario
-@Tag("podman-incompatible") //todo https://github.com/quarkusio/quarkus/issues/33985
 public class DevModeMysqlIT extends AbstractSqlDatabaseIT {
 
     @DevModeQuarkusApplication

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeOracleDevServiceUserExperienceIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeOracleDevServiceUserExperienceIT.java
@@ -5,7 +5,6 @@ import static io.quarkus.ts.sqldb.sqlapp.DbUtil.getImageVersion;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import com.github.dockerjava.api.model.Image;
@@ -17,7 +16,6 @@ import io.quarkus.test.utils.DockerUtils;
 import io.quarkus.test.utils.SocketUtils;
 
 @QuarkusScenario
-@Tag("podman-incompatible") //todo https://github.com/quarkusio/quarkus/issues/33985
 public class DevModeOracleDevServiceUserExperienceIT {
 
     private static final String ORACLE_NAME = getImageName("oracle.image");

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeOracleIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeOracleIT.java
@@ -1,6 +1,5 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -8,7 +7,6 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @QuarkusScenario
-@Tag("podman-incompatible") //todo https://github.com/quarkusio/quarkus/issues/33985
 public class DevModeOracleIT extends AbstractSqlDatabaseIT {
 
     @DevModeQuarkusApplication

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlDevServiceUserExperienceIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlDevServiceUserExperienceIT.java
@@ -18,7 +18,6 @@ import io.quarkus.test.utils.SocketUtils;
 
 @Tag("QUARKUS-959")
 @QuarkusScenario
-@Tag("podman-incompatible") //todo https://github.com/quarkusio/quarkus/issues/33985
 public class DevModePostgresqlDevServiceUserExperienceIT {
 
     // we use '-alpine' version as no other test is using it, which mitigates the fact that sometimes

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlIT.java
@@ -10,7 +10,6 @@ import io.quarkus.test.services.DevModeQuarkusApplication;
 @Tag("QUARKUS-959")
 @Tag("QUARKUS-1026")
 @QuarkusScenario
-@Tag("podman-incompatible") //todo https://github.com/quarkusio/quarkus/issues/33985
 public class DevModePostgresqlIT extends AbstractSqlDatabaseIT {
 
     @DevModeQuarkusApplication


### PR DESCRIPTION
### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)