### PR TITLE
Support running tests with Docker on Windows when Linux containers are available

### DIFF
--- a/build-time-analytics/pom.xml
+++ b/build-time-analytics/pom.xml
@@ -55,30 +55,5 @@
                 <quarkus.build.skip>true</quarkus.build.skip>
             </properties>
         </profile>
-        <!-- Skipped on Windows as CLI is not installed in Windows yet -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/DevModeIT.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/DevModeIT.java
@@ -24,12 +24,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 
+@DisabledOnOs(OS.WINDOWS) // TODO mvavrik: must only run when Quarkus CLI and Docker are available
 @Tag("QUARKUS-2812")
 @Tag("quarkus-cli")
 @QuarkusScenario

--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/ProdModeJvmIT.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/ProdModeJvmIT.java
@@ -17,12 +17,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient.Result;
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 
+@DisabledOnOs(OS.WINDOWS) // TODO mvavrik: must only run when Quarkus CLI is available
 @Tag("QUARKUS-2812")
 @Tag("quarkus-cli")
 @QuarkusScenario

--- a/http/graphql-telemetry/pom.xml
+++ b/http/graphql-telemetry/pom.xml
@@ -35,30 +35,5 @@
                 </dependency>
             </dependencies>
         </profile>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/http/http-advanced-reactive/pom.xml
+++ b/http/http-advanced-reactive/pom.xml
@@ -86,31 +86,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/http/http-advanced/pom.xml
+++ b/http/http-advanced/pom.xml
@@ -95,31 +95,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientProxyIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientProxyIT.java
@@ -5,8 +5,6 @@ import java.util.Base64;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -15,7 +13,6 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.response.Response;
 
 @QuarkusScenario
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux Containers / Testcontainers")
 public class ReactiveRestClientProxyIT {
     private static final String USER = "proxyuser";
     private static final String PASSWORD = "proxypassword";

--- a/http/vertx-web-client/pom.xml
+++ b/http/vertx-web-client/pom.xml
@@ -35,31 +35,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/javaee-like-getting-started/src/test/java/io/quarkus/ts/javaee/gettingstarted/OpenAPITracingIT.java
+++ b/javaee-like-getting-started/src/test/java/io/quarkus/ts/javaee/gettingstarted/OpenAPITracingIT.java
@@ -8,8 +8,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.JaegerService;
 import io.quarkus.test.bootstrap.RestService;
@@ -19,7 +17,6 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.response.Response;
 
 @QuarkusScenario
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux Containers / Testcontainers")
 public class OpenAPITracingIT {
 
     private static final String SUPPRESS_NON_APPLICATION_URIS = "quarkus.otel.traces.suppress-non-application-uris";

--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -51,35 +51,5 @@
                 </repository>
             </repositories>
         </profile>
-        <profile>
-            <id>windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <systemProperties>
-                                <!-- disable Dev Services for Kubernetes on Windows due to Docker limitations -->
-                                <quarkus.kubernetes-client.devservices.enabled>false</quarkus.kubernetes-client.devservices.enabled>
-                            </systemProperties>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <systemProperties>
-                                <!-- disable Dev Services for Kubernetes on Windows due to Docker limitations -->
-                                <quarkus.kubernetes-client.devservices.enabled>false</quarkus.kubernetes-client.devservices.enabled>
-                            </systemProperties>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/messaging/amqp-reactive/pom.xml
+++ b/messaging/amqp-reactive/pom.xml
@@ -25,31 +25,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/messaging/cloud-events/amqp-binary/pom.xml
+++ b/messaging/cloud-events/amqp-binary/pom.xml
@@ -29,31 +29,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/messaging/cloud-events/amqp-json/pom.xml
+++ b/messaging/cloud-events/amqp-json/pom.xml
@@ -29,31 +29,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/messaging/infinispan-grpc-kafka/pom.xml
+++ b/messaging/infinispan-grpc-kafka/pom.xml
@@ -71,31 +71,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/messaging/kafka-confluent-avro-reactive-messaging/pom.xml
+++ b/messaging/kafka-confluent-avro-reactive-messaging/pom.xml
@@ -53,31 +53,4 @@
             </snapshots>
         </repository>
     </repositories>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/messaging/kafka-producer/pom.xml
+++ b/messaging/kafka-producer/pom.xml
@@ -24,31 +24,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/messaging/kafka-streams-reactive-messaging/pom.xml
+++ b/messaging/kafka-streams-reactive-messaging/pom.xml
@@ -33,31 +33,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/messaging/kafka-strimzi-avro-reactive-messaging/pom.xml
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/pom.xml
@@ -43,31 +43,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/messaging/kafkaSSL/pom.xml
+++ b/messaging/kafkaSSL/pom.xml
@@ -54,31 +54,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/messaging/qpid/pom.xml
+++ b/messaging/qpid/pom.xml
@@ -25,31 +25,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/monitoring/micrometer-prometheus-oidc/pom.xml
+++ b/monitoring/micrometer-prometheus-oidc/pom.xml
@@ -33,31 +33,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/monitoring/microprofile-opentracing/pom.xml
+++ b/monitoring/microprofile-opentracing/pom.xml
@@ -37,31 +37,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/monitoring/opentelemetry-reactive/pom.xml
+++ b/monitoring/opentelemetry-reactive/pom.xml
@@ -58,31 +58,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpentelemetryReactiveIT.java
+++ b/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpentelemetryReactiveIT.java
@@ -15,8 +15,6 @@ import org.apache.http.HttpStatus;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.JaegerService;
 import io.quarkus.test.bootstrap.RestService;
@@ -26,7 +24,6 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.response.Response;
 
 @QuarkusScenario
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux Containers / Testcontainers")
 public class OpentelemetryReactiveIT {
 
     private static final String OTEL_PING_SERVICE_NAME = "pingservice";

--- a/monitoring/opentelemetry/pom.xml
+++ b/monitoring/opentelemetry/pom.xml
@@ -58,31 +58,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryIT.java
@@ -23,8 +23,6 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.JaegerService;
 import io.quarkus.test.bootstrap.RestService;
@@ -35,7 +33,6 @@ import io.restassured.response.Response;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class) // order methods as SDK autoconfigure test expects previous traces
 @QuarkusScenario
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux Containers / Testcontainers")
 public class OpenTelemetryIT {
 
     private Response resp;

--- a/monitoring/opentracing-reactive-grpc/pom.xml
+++ b/monitoring/opentracing-reactive-grpc/pom.xml
@@ -54,31 +54,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/nosql-db/infinispan/pom.xml
+++ b/nosql-db/infinispan/pom.xml
@@ -25,31 +25,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/nosql-db/mongodb-reactive/pom.xml
+++ b/nosql-db/mongodb-reactive/pom.xml
@@ -29,31 +29,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/nosql-db/mongodb/pom.xml
+++ b/nosql-db/mongodb/pom.xml
@@ -29,31 +29,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/properties/src/test/java/io/quarkus/ts/properties/consul/ConsulConfigSourceIT.java
+++ b/properties/src/test/java/io/quarkus/ts/properties/consul/ConsulConfigSourceIT.java
@@ -10,8 +10,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.ConsulService;
 import io.quarkus.test.bootstrap.RestService;
@@ -21,7 +19,6 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux Containers / Testcontainers")
 public class ConsulConfigSourceIT {
 
     private static final String CONSUL_KEY = "config/app";

--- a/quarkus-cli/pom.xml
+++ b/quarkus-cli/pom.xml
@@ -31,30 +31,5 @@
                 <quarkus.build.skip>true</quarkus.build.skip>
             </properties>
         </profile>
-        <!-- Skipped on Windows as CLI is not installed in Windows yet -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/scheduling/quartz/pom.xml
+++ b/scheduling/quartz/pom.xml
@@ -40,31 +40,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/security/keycloak-authz-classic/pom.xml
+++ b/security/keycloak-authz-classic/pom.xml
@@ -30,31 +30,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/security/keycloak-authz-reactive/pom.xml
+++ b/security/keycloak-authz-reactive/pom.xml
@@ -30,31 +30,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/security/keycloak-jwt/pom.xml
+++ b/security/keycloak-jwt/pom.xml
@@ -30,31 +30,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/security/keycloak-multitenant/pom.xml
+++ b/security/keycloak-multitenant/pom.xml
@@ -30,31 +30,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/security/keycloak-oauth2/pom.xml
+++ b/security/keycloak-oauth2/pom.xml
@@ -25,31 +25,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/security/keycloak-oidc-client-basic/pom.xml
+++ b/security/keycloak-oidc-client-basic/pom.xml
@@ -33,31 +33,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/security/keycloak-oidc-client-extended/pom.xml
+++ b/security/keycloak-oidc-client-extended/pom.xml
@@ -60,31 +60,4 @@
             </exclusions>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/security/keycloak-oidc-client-reactive-basic/pom.xml
+++ b/security/keycloak-oidc-client-reactive-basic/pom.xml
@@ -33,31 +33,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/security/keycloak-oidc-client-reactive-extended/pom.xml
+++ b/security/keycloak-oidc-client-reactive-extended/pom.xml
@@ -56,31 +56,4 @@
             </exclusions>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/security/keycloak-webapp/pom.xml
+++ b/security/keycloak-webapp/pom.xml
@@ -30,31 +30,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/security/keycloak/pom.xml
+++ b/security/keycloak/pom.xml
@@ -25,31 +25,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/security/oidc-client-mutual-tls/pom.xml
+++ b/security/oidc-client-mutual-tls/pom.xml
@@ -25,31 +25,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/security/vertx-jwt/pom.xml
+++ b/security/vertx-jwt/pom.xml
@@ -32,31 +32,4 @@
             <artifactId>quarkus-smallrye-openapi</artifactId>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/service-discovery/stork-custom/pom.xml
+++ b/service-discovery/stork-custom/pom.xml
@@ -47,31 +47,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/service-discovery/stork/pom.xml
+++ b/service-discovery/stork/pom.xml
@@ -49,31 +49,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/spring/spring-cloud-config/pom.xml
+++ b/spring/spring-cloud-config/pom.xml
@@ -24,31 +24,4 @@
             <artifactId>quarkus-spring-cloud-config-client</artifactId>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/spring/spring-data/pom.xml
+++ b/spring/spring-data/pom.xml
@@ -49,31 +49,4 @@
             <artifactId>quarkus-smallrye-openapi</artifactId>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/spring/spring-web-reactive/pom.xml
+++ b/spring/spring-web-reactive/pom.xml
@@ -41,31 +41,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/spring/spring-web/pom.xml
+++ b/spring/spring-web/pom.xml
@@ -41,31 +41,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/sql-db/hibernate-fulltext-search/pom.xml
+++ b/sql-db/hibernate-fulltext-search/pom.xml
@@ -45,31 +45,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/sql-db/hibernate-reactive/pom.xml
+++ b/sql-db/hibernate-reactive/pom.xml
@@ -57,31 +57,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/sql-db/hibernate/pom.xml
+++ b/sql-db/hibernate/pom.xml
@@ -33,31 +33,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/sql-db/multiple-pus/pom.xml
+++ b/sql-db/multiple-pus/pom.xml
@@ -46,31 +46,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/sql-db/narayana-transactions/pom.xml
+++ b/sql-db/narayana-transactions/pom.xml
@@ -84,30 +84,5 @@
                 </property>
             </activation>
         </profile>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.transactions;
 
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
-
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -11,7 +8,6 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 
 @QuarkusScenario
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux Containers / Testcontainers (Jaeger)")
 public class MariaDbTransactionGeneralUsageIT extends TransactionCommons {
 
     static final int MARIADB_PORT = 3306;

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.transactions;
 
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
-
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.SqlServerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -11,7 +8,6 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 
 @QuarkusScenario
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux Containers / Testcontainers (Jaeger)")
 public class MssqlTransactionGeneralUsageIT extends TransactionCommons {
 
     private static final int MSSQL_PORT = 1433;

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MysqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MysqlTransactionGeneralUsageIT.java
@@ -1,8 +1,6 @@
 package io.quarkus.ts.transactions;
 
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
@@ -14,7 +12,6 @@ import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 // TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
 @Tag("fips-incompatible") // native-mode
 @QuarkusScenario
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux Containers / Testcontainers (Jaeger)")
 public class MysqlTransactionGeneralUsageIT extends TransactionCommons {
 
     static final int MYSQL_PORT = 3306;

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OracleTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OracleTransactionGeneralUsageIT.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.transactions;
 
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
-
 import io.quarkus.test.bootstrap.OracleService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -11,7 +8,6 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 
 @QuarkusScenario
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux Containers / Testcontainers (Jaeger)")
 public class OracleTransactionGeneralUsageIT extends TransactionCommons {
 
     static final int ORACLE_PORT = 1521;

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlTransactionGeneralUsageIT.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.transactions;
 
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
-
 import io.quarkus.test.bootstrap.PostgresqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -11,7 +8,6 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 
 @QuarkusScenario
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux Containers / Testcontainers (Jaeger)")
 public class PostgresqlTransactionGeneralUsageIT extends TransactionCommons {
 
     private static final String ENABLE_PREPARED_TRANSACTIONS = "--max_prepared_transactions=100";

--- a/sql-db/panache-flyway/pom.xml
+++ b/sql-db/panache-flyway/pom.xml
@@ -50,31 +50,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalPoolTest.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalPoolTest.java
@@ -22,6 +22,8 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import io.agroal.api.AgroalDataSource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -35,6 +37,7 @@ import io.smallrye.mutiny.tuples.Tuple2;
  * The aim of these tests is verified agroal and entityManager pool management
  * Some of these tests required some extra load, in order to reproduce concurrency issues.
  */
+@DisabledOnOs(OS.WINDOWS) // TODO mvavrik: FW must handle this and run test when Docker is available
 @Tag("fips-incompatible") // native-mode
 @QuarkusTest
 @TestProfile(AgroalTestProfile.class)

--- a/sql-db/reactive-rest-data-panache/pom.xml
+++ b/sql-db/reactive-rest-data-panache/pom.xml
@@ -53,31 +53,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/sql-db/reactive-vanilla/pom.xml
+++ b/sql-db/reactive-vanilla/pom.xml
@@ -32,31 +32,4 @@
             <artifactId>quarkus-reactive-mssql-client</artifactId>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/sql-db/sql-app-compatibility/pom.xml
+++ b/sql-db/sql-app-compatibility/pom.xml
@@ -81,30 +81,5 @@
                 <quarkus.build.skip>true</quarkus.build.skip>
             </properties>
         </profile>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/sql-db/sql-app/pom.xml
+++ b/sql-db/sql-app/pom.xml
@@ -77,30 +77,5 @@
                 <quarkus.build.skip>true</quarkus.build.skip>
             </properties>
         </profile>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/sql-db/vertx-sql/pom.xml
+++ b/sql-db/vertx-sql/pom.xml
@@ -77,31 +77,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/dbpool/PostgresPoolTest.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/dbpool/PostgresPoolTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
@@ -26,6 +28,7 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.pgclient.PgPool;
 import io.vertx.mutiny.sqlclient.RowSet;
 
+@DisabledOnOs(OS.WINDOWS) // TODO mvavrik: FW must handle this and run test when Docker is available
 @QuarkusTest
 @TestProfile(PostgresqlTestProfile.class)
 @TestMethodOrder(OrderAnnotation.class)

--- a/super-size/many-extensions/pom.xml
+++ b/super-size/many-extensions/pom.xml
@@ -194,30 +194,6 @@
     </dependencies>
     <profiles>
         <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>deploy-to-openshift-using-extension</id>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
### Summary

Now that we have https://github.com/quarkus-qe/quarkus-test-framework/pull/864 in TS, we can let FW to decide if the tests can be run or not.

Test classes annotated with `@QuarkusTest` (surefire ones) are disabled on Windows for now, I need to adjust FW bit to handle this as well (meaning so that we can reuse execution condition).

Situation with Docker-build seems to be more difficult as `quarkus-maven-plugin` runs before our FW. I decided to keep it disabled for now as I think `quarkus-container-image-docker` will require some file system sharing and I wanna know I have solution before I enable it on AWS.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)