### PR TITLE
Bump htmlunit to 3.5.0

### DIFF
--- a/http/http-advanced-reactive/pom.xml
+++ b/http/http-advanced-reactive/pom.xml
@@ -81,7 +81,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
+            <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
             <scope>test</scope>
         </dependency>

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/AbstractDevModeIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/AbstractDevModeIT.java
@@ -8,15 +8,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.htmlunit.WebClient;
+import org.htmlunit.html.DomElement;
+import org.htmlunit.html.HtmlPage;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.DomElement;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.services.URILike;

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/BaseHttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/BaseHttpAdvancedReactiveIT.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.http.advanced.reactive;
 
-import static com.gargoylesoftware.htmlunit.util.MimeType.IMAGE_JPEG;
-import static com.gargoylesoftware.htmlunit.util.MimeType.IMAGE_PNG;
-import static com.gargoylesoftware.htmlunit.util.MimeType.TEXT_CSS;
 import static io.quarkus.ts.http.advanced.reactive.MediaTypeResource.ANY_ENCODING;
 import static io.quarkus.ts.http.advanced.reactive.MediaTypeResource.APPLICATION_YAML;
 import static io.quarkus.ts.http.advanced.reactive.MediaTypeResource.ENGLISH;
@@ -33,6 +30,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.htmlunit.util.MimeType.IMAGE_JPEG;
+import static org.htmlunit.util.MimeType.IMAGE_PNG;
+import static org.htmlunit.util.MimeType.TEXT_CSS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/http/http-advanced-reactive/src/test/resources/test.properties
+++ b/http/http-advanced-reactive/src/test/resources/test.properties
@@ -1,3 +1,3 @@
 ts.keycloak.log.enable=true
 ts.app.log.enable=true
-com.gargoylesoftware.htmlunit.level=OFF
+org.htmlunit.level=OFF

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <smallrye-stork.version>2.3.2</smallrye-stork.version>
         <assertj.version>3.24.2</assertj.version>
         <profile.id>jvm</profile.id>
-        <htmlunit.version>2.70.0</htmlunit.version>
+        <htmlunit.version>3.5.0</htmlunit.version>
         <!-- Faster build when using -DskipTests -->
         <quarkus.build.skip>${skipTests}</quarkus.build.skip>
         <!-- S2i configuration -->
@@ -116,7 +116,7 @@
                 <version>${assertj.version}</version>
             </dependency>
             <dependency>
-                <groupId>net.sourceforge.htmlunit</groupId>
+                <groupId>org.htmlunit</groupId>
                 <artifactId>htmlunit</artifactId>
                 <version>${htmlunit.version}</version>
                 <scope>test</scope>

--- a/security/keycloak-jwt/pom.xml
+++ b/security/keycloak-jwt/pom.xml
@@ -20,7 +20,7 @@
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
+            <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
             <scope>test</scope>
         </dependency>

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/BaseOidcJwtSecurityIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/BaseOidcJwtSecurityIT.java
@@ -7,15 +7,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Optional;
 
 import org.apache.http.HttpStatus;
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
-import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.Protocol;
@@ -83,8 +82,8 @@ public abstract class BaseOidcJwtSecurityIT {
     private void whenLoginAs(String user) throws Exception {
         HtmlForm loginForm = page.getForms().get(0);
 
-        loginForm.getInputByName("username").setValueAttribute(user);
-        loginForm.getInputByName("password").setValueAttribute(user);
+        loginForm.getInputByName("username").setValue(user);
+        loginForm.getInputByName("password").setValue(user);
 
         page = loginForm.getInputByName("login").click();
     }

--- a/security/keycloak-jwt/src/test/resources/test.properties
+++ b/security/keycloak-jwt/src/test/resources/test.properties
@@ -1,3 +1,3 @@
 ts.keycloak.log.enable=true
 ts.app.log.enable=true
-com.gargoylesoftware.htmlunit.level=OFF
+org.htmlunit.level=OFF

--- a/security/keycloak-multitenant/pom.xml
+++ b/security/keycloak-multitenant/pom.xml
@@ -20,7 +20,7 @@
             <artifactId>quarkus-oidc</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
+            <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
             <scope>test</scope>
         </dependency>

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseMultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseMultiTenantSecurityIT.java
@@ -8,18 +8,17 @@ import java.net.URI;
 import java.util.Optional;
 
 import org.apache.http.HttpStatus;
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.WebRequest;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-
-import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.WebRequest;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.Protocol;
@@ -107,8 +106,8 @@ public abstract class BaseMultiTenantSecurityIT {
     private TextPage whenLogin(HtmlPage loginPage, String user) throws Exception {
         HtmlForm loginForm = loginPage.getForms().get(0);
 
-        loginForm.getInputByName("username").setValueAttribute(USER);
-        loginForm.getInputByName("password").setValueAttribute(USER);
+        loginForm.getInputByName("username").setValue(USER);
+        loginForm.getInputByName("password").setValue(USER);
         return loginForm.getInputByName("login").click();
     }
 

--- a/security/keycloak-multitenant/src/test/resources/test.properties
+++ b/security/keycloak-multitenant/src/test/resources/test.properties
@@ -1,3 +1,3 @@
 ts.keycloak.log.enable=true
 ts.app.log.enable=true
-com.gargoylesoftware.htmlunit.level=OFF
+org.htmlunit.level=OFF

--- a/security/keycloak-oidc-client-extended/pom.xml
+++ b/security/keycloak-oidc-client-extended/pom.xml
@@ -49,7 +49,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
+            <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
             <scope>test</scope>
             <exclusions>

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/LogoutSinglePageAppFlowIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/LogoutSinglePageAppFlowIT.java
@@ -8,13 +8,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.util.Cookie;
 import org.junit.jupiter.api.Test;
-
-import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.util.Cookie;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.Protocol;

--- a/security/keycloak-oidc-client-extended/src/test/resources/test.properties
+++ b/security/keycloak-oidc-client-extended/src/test/resources/test.properties
@@ -1,1 +1,1 @@
-com.gargoylesoftware.htmlunit.level=OFF
+org.htmlunit.level=OFF

--- a/security/keycloak-oidc-client-reactive-extended/pom.xml
+++ b/security/keycloak-oidc-client-reactive-extended/pom.xml
@@ -45,7 +45,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
+            <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
             <scope>test</scope>
             <exclusions>

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/LogoutSinglePageAppFlowIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/LogoutSinglePageAppFlowIT.java
@@ -9,15 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.Objects;
 
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.WebClient;
+import org.htmlunit.WebResponse;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.util.Cookie;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-
-import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.WebResponse;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.util.Cookie;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.Protocol;

--- a/security/keycloak-oidc-client-reactive-extended/src/test/resources/test.properties
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/resources/test.properties
@@ -1,1 +1,1 @@
-com.gargoylesoftware.htmlunit.level=OFF
+org.htmlunit.level=OFF

--- a/security/keycloak-webapp/pom.xml
+++ b/security/keycloak-webapp/pom.xml
@@ -20,7 +20,7 @@
             <artifactId>quarkus-oidc</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
+            <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
             <scope>test</scope>
         </dependency>

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/BaseWebappSecurityIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/BaseWebappSecurityIT.java
@@ -10,18 +10,17 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpStatus;
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.Page;
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.WebRequest;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
-import com.gargoylesoftware.htmlunit.Page;
-import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.WebRequest;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.Protocol;
@@ -144,8 +143,8 @@ public abstract class BaseWebappSecurityIT {
         assertTrue(page instanceof HtmlPage, "Should be in an HTML page");
         HtmlForm loginForm = ((HtmlPage) page).getForms().get(0);
 
-        loginForm.getInputByName("username").setValueAttribute(user);
-        loginForm.getInputByName("password").setValueAttribute(user);
+        loginForm.getInputByName("username").setValue(user);
+        loginForm.getInputByName("password").setValue(user);
 
         page = loginForm.getInputByName("login").click();
     }

--- a/security/keycloak-webapp/src/test/resources/test.properties
+++ b/security/keycloak-webapp/src/test/resources/test.properties
@@ -1,3 +1,3 @@
 ts.keycloak.log.enable=true
 ts.app.log.enable=true
-com.gargoylesoftware.htmlunit.level=OFF
+org.htmlunit.level=OFF


### PR DESCRIPTION
### Summary

* Updating htmlunit to 3.5.0, along with relocations required by the htmlunit migration guide (https://www.htmlunit.org/migration.html).

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)