### PR TITLE
Removing OpenShiftQpidIT from arm profile

### DIFF
--- a/messaging/qpid/src/test/java/io/quarkus/ts/messaging/qpid/OpenShiftQpidIT.java
+++ b/messaging/qpid/src/test/java/io/quarkus/ts/messaging/qpid/OpenShiftQpidIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.ts.messaging.qpid;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1144")
 public class OpenShiftQpidIT extends QpidIT {
 }


### PR DESCRIPTION
### Summary

* AMQ Streams Kafka is not supported on aarch64.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)