### PR TITLE
[3.2] Disabling registry tests on OCP on aarch64

### DIFF
--- a/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftRegistryIT.java
+++ b/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftRegistryIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.qe.extension;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "Impossible to deploy container built on x86_64 on aarch64.")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
 public class OpenShiftRegistryIT extends OpenShiftBaseDeploymentIT {
 }


### PR DESCRIPTION
### Summary

* It is currently impossible to run registry tests on aarch64. The test builds the application container on machine where the test is ran, pushes it to quay.io and deploys the container to OpenShift. So, in in our case it means the container is built for x86_64 arch, but we need aarch64.

Backport of #1390 

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)