### PR TITLE
Verify, that VertX pool metrics are being collected

### DIFF
--- a/http/vertx/src/main/java/io/quarkus/ts/vertx/GreetingService.java
+++ b/http/vertx/src/main/java/io/quarkus/ts/vertx/GreetingService.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.vertx;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.vertx.ConsumeEvent;
+
+@ApplicationScoped
+public class GreetingService {
+
+    @ConsumeEvent("greetings")
+    public String greet(String name) {
+        return "Greetings, " + name;
+    }
+}

--- a/http/vertx/src/main/java/io/quarkus/ts/vertx/HelloResource.java
+++ b/http/vertx/src/main/java/io/quarkus/ts/vertx/HelloResource.java
@@ -30,4 +30,13 @@ public class HelloResource {
                 .map(string -> String.format(string, name).trim())
                 .map(Hello::new);
     }
+
+    @GET
+    @Path("bus")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Uni<Hello> getFromBus(@QueryParam("name") @DefaultValue("World") String name) {
+        return vertx.eventBus().<String> request("greetings", name)
+                .onItem()
+                .transform(response -> new Hello(response.body()));
+    }
 }

--- a/http/vertx/src/main/java/io/quarkus/ts/vertx/SecondGreetingService.java
+++ b/http/vertx/src/main/java/io/quarkus/ts/vertx/SecondGreetingService.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.vertx;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.vertx.ConsumeEvent;
+
+@ApplicationScoped
+public class SecondGreetingService {
+
+    @ConsumeEvent("greetings")
+    public String greet(String name) {
+        return "Greetings, " + name;
+    }
+}

--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/Metric.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/Metric.java
@@ -1,0 +1,97 @@
+package io.quarkus.ts.vertx;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import io.smallrye.mutiny.tuples.Tuple2;
+
+class Metric {
+    private final String name;
+    private final String value;
+    private final Map<String, String> tags;
+
+    /**
+     * @param source metric from the file, eg:
+     *        worker_pool_queue_size{pool_name="vert.x-internal-blocking",pool_type="worker"} 0.0
+     *        since we do not care about values, we store them as strings, and ignore duplicated keys.
+     */
+    public Metric(String source) {
+        try {
+            final int DEFAULT = -1;
+            int space = DEFAULT;
+            int closing = DEFAULT;
+            int opening = DEFAULT;
+            byte[] bytes = source.getBytes(StandardCharsets.UTF_8);
+            for (int i = bytes.length - 1; i >= 0; i--) {
+                byte current = bytes[i];
+                if (current == ' ' && space == DEFAULT) {
+                    space = i;
+                }
+                if (current == '}' && closing == DEFAULT) {
+                    closing = i;
+                }
+                if (current == '{' && opening == DEFAULT) {
+                    opening = i;
+                }
+            }
+            String key;
+            if (space > 0) {
+                value = source.substring(space + 1);
+                key = source.substring(0, space);
+            } else {
+                throw new IllegalArgumentException("Metric " + source + " doesn't contain a value");
+            }
+            boolean withBrackets = closing < space && opening < closing && opening > 0;
+            if (withBrackets) {
+                name = source.substring(0, opening);
+            } else {
+                name = key;
+            }
+            if (withBrackets) {
+                String params = source.substring(opening + 1, closing);
+                tags = Arrays.stream(params.split("\","))
+                        .map(pair -> {
+                            return pair.split("=");
+                        })
+                        .map(pair -> Tuple2.of(pair[0], pair[1]))
+                        .map(tuple -> tuple.mapItem2(value -> value.replace('"', '\0').trim())) // "value"->value
+                        .collect(Collectors.toMap(Tuple2::getItem1, Tuple2::getItem2));
+            } else {
+                tags = Collections.emptyMap();
+            }
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Unable to parse metric " + source, ex);
+        }
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Metric metric = (Metric) o;
+        return Objects.equals(name, metric.name) && Objects.equals(value, metric.value) && Objects.equals(tags, metric.tags);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, value, tags);
+    }
+}

--- a/monitoring/opentelemetry-reactive/pom.xml
+++ b/monitoring/opentelemetry-reactive/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>quarkus-scheduler</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-jaeger</artifactId>
             <scope>test</scope>

--- a/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpenTelemetryGrpcIT.java
+++ b/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpenTelemetryGrpcIT.java
@@ -5,8 +5,13 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
@@ -16,6 +21,7 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.JaegerContainer;
 import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.response.Response;
 
 @QuarkusScenario
 public class OpenTelemetryGrpcIT {
@@ -33,7 +39,7 @@ public class OpenTelemetryGrpcIT {
     private static final String SAY_PONG_PROTO = "SayPong";
 
     @Test
-    public void testServerClientTrace() throws InterruptedException {
+    public void testServerClientTrace() {
         // When calling ping, the rest will invoke also the pong rest endpoint.
         given()
                 .when().get(PING_ENDPOINT)
@@ -54,6 +60,52 @@ public class OpenTelemetryGrpcIT {
                 .and().body(allOf(containsString(PING_ENDPOINT), containsString(SAY_PONG_PROTO))));
     }
 
+    @Test
+    void metrics() {
+        Response response = given().get("q/metrics");
+        assertEquals(200, response.statusCode());
+        String body = response.body().asString();
+        Map<String, String> metrics = Arrays.stream(body.split("\n"))
+                .filter(line -> !line.startsWith("#"))
+                .filter(line -> line.contains("grpc"))
+                .map(line -> line.split(" "))
+                .collect(Collectors.toMap(line -> line[0], line -> line[1]));
+        String wrongValueMessage = "Unexpected value of a metric in the list: " + metrics;
+        assertEquals("1.0", metrics.get(
+                "grpc_server_requests_received_messages_total{method=\"SayPong\",methodType=\"UNARY\",service=\"io.quarkus.example.PongService\"}"),
+                wrongValueMessage);
+        assertEquals("1.0", metrics.get(
+                "grpc_server_requests_received_messages_total{method=\"ReturnLastTraceId\",methodType=\"UNARY\",service=\"io.quarkus.example.PongService\"}"),
+                wrongValueMessage);
+        assertEquals("1.0", metrics.get(
+                "grpc_server_responses_sent_messages_total{method=\"SayPong\",methodType=\"UNARY\",service=\"io.quarkus.example.PongService\"}"),
+                wrongValueMessage);
+        assertEquals("1.0", metrics.get(
+                "grpc_server_responses_sent_messages_total{method=\"ReturnLastTraceId\",methodType=\"UNARY\",service=\"io.quarkus.example.PongService\"}"),
+                wrongValueMessage);
+        assertEquals("1.0", metrics.get(
+                "grpc_client_responses_received_messages_total{method=\"SayPong\",methodType=\"UNARY\",service=\"io.quarkus.example.PongService\"}"),
+                wrongValueMessage);
+        assertEquals("1.0", metrics.get(
+                "grpc_client_responses_received_messages_total{method=\"ReturnLastTraceId\",methodType=\"UNARY\",service=\"io.quarkus.example.PongService\"}"),
+                wrongValueMessage);
+        assertEquals("1.0", metrics.get(
+                "grpc_client_requests_sent_messages_total{method=\"SayPong\",methodType=\"UNARY\",service=\"io.quarkus.example.PongService\"}"),
+                wrongValueMessage);
+        assertEquals("1.0", metrics.get(
+                "grpc_client_requests_sent_messages_total{method=\"ReturnLastTraceId\",methodType=\"UNARY\",service=\"io.quarkus.example.PongService\"}"),
+                wrongValueMessage);
+        Set<String> metricNames = metrics.keySet().stream()
+                .map(name -> name.split("\\{")[0])
+                .collect(Collectors.toSet());
+        assertTrue(metricNames.contains("grpc_server_processing_duration_seconds_count"));
+        assertTrue(metricNames.contains("grpc_server_processing_duration_seconds_sum"));
+        assertTrue(metricNames.contains("grpc_server_processing_duration_seconds_max"));
+        assertTrue(metricNames.contains("grpc_client_processing_duration_seconds_count"));
+        assertTrue(metricNames.contains("grpc_client_processing_duration_seconds_sum"));
+        assertTrue(metricNames.contains("grpc_client_processing_duration_seconds_max"));
+    }
+
     protected void assertTraceIdWithPongService(String expected) {
         String pongTraceId = given()
                 .when().get(PONG_ENDPOINT + "/lastTraceId")
@@ -61,5 +113,4 @@ public class OpenTelemetryGrpcIT {
 
         assertEquals(expected, pongTraceId);
     }
-
 }

--- a/sql-db/vertx-sql/pom.xml
+++ b/sql-db/vertx-sql/pom.xml
@@ -72,6 +72,10 @@
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-database</artifactId>
             <scope>test</scope>

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/CommonTestCases.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/CommonTestCases.java
@@ -1,5 +1,13 @@
 package io.quarkus.ts.vertx.sql.handlers;
 
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.ts.vertx.sql.handlers.spec.AirlineHandlerSpec;
@@ -7,6 +15,7 @@ import io.quarkus.ts.vertx.sql.handlers.spec.AirportHandlerSpec;
 import io.quarkus.ts.vertx.sql.handlers.spec.BasketHandlerSpec;
 import io.quarkus.ts.vertx.sql.handlers.spec.FlightsHandlerSpec;
 import io.quarkus.ts.vertx.sql.handlers.spec.PricingRulesSpec;
+import io.restassured.response.Response;
 
 public abstract class CommonTestCases implements
         PricingRulesSpec, FlightsHandlerSpec, BasketHandlerSpec, AirportHandlerSpec,
@@ -44,4 +53,32 @@ public abstract class CommonTestCases implements
     public void airlineScenario() {
         retrieveAllAirlines();
     }
+
+    @Test
+    void metrics() {
+        Response response = given().get("q/metrics");
+        assertEquals(200, response.statusCode());
+        String body = response.body().asString();
+        Set<String> metrics = Arrays.stream(body.split("\n"))
+                .filter(line -> !line.startsWith("#"))
+                .filter(line -> line.contains(getDBName()))
+                .map(line -> line.split(" ")[0])
+                .collect(Collectors.toSet());
+        assertEquals(10, metrics.size(),
+                String.format("There is an unexpected number of %s metrics in metrics: %s", getDBName(), body));
+        assertTrue(metrics.contains(getMetricKey("processing_seconds_max")), "No processing_seconds_max in " + metrics);
+        assertTrue(metrics.contains(getMetricKey("processing_seconds_count")), "No processing_seconds_count in " + metrics);
+        assertTrue(metrics.contains(getMetricKey("processing_seconds_sum")), "No processing_seconds_sum in " + metrics);
+        assertTrue(metrics.contains(getMetricKey("queue_size")), "No queue_size in " + metrics);
+        assertTrue(metrics.contains(getMetricKey("reset_total")), "No reset_total in " + metrics);
+        assertTrue(metrics.contains(getMetricKey("completed_total")), "No completed_total in " + metrics);
+        assertTrue(metrics.contains(getMetricKey("queue_delay_seconds_count")), "No queue_delay_seconds_count in " + metrics);
+        assertTrue(metrics.contains(getMetricKey("queue_delay_seconds_sum")), "No queue_delay_seconds_sum in " + metrics);
+        assertTrue(metrics.contains(getMetricKey("queue_delay_seconds_max")), "No queue_delay_seconds_max in " + metrics);
+        assertTrue(metrics.contains(getMetricKey("current")), "No current in " + metrics);
+    }
+
+    protected abstract CharSequence getDBName();
+
+    protected abstract String getMetricKey(String metricName);
 }

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MssqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MssqlHandlerIT.java
@@ -23,4 +23,14 @@ public class MssqlHandlerIT extends CommonTestCases {
             .withProperty("app.selected.db", "mssql")
             // Enable Flyway for MySQL
             .withProperty("quarkus.flyway.mssql.migrate-at-start", "true");
+
+    @Override
+    public String getDBName() {
+        return "mssql";
+    }
+
+    @Override
+    protected String getMetricKey(String metricName) {
+        return "mssql_" + metricName + "{clientName=\"mssql\",clientType=\"sql\"}";
+    }
 }

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MysqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MysqlHandlerIT.java
@@ -27,4 +27,14 @@ public class MysqlHandlerIT extends CommonTestCases {
             .withProperty("app.selected.db", "mysql")
             // Enable Flyway for MySQL
             .withProperty("quarkus.flyway.mysql.migrate-at-start", "true");
+
+    @Override
+    public String getDBName() {
+        return "mysql";
+    }
+
+    @Override
+    protected String getMetricKey(String metricName) {
+        return "mysql_" + metricName + "{clientName=\"mysql\",clientType=\"sql\"}";
+    }
 }

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/OracleHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/OracleHandlerIT.java
@@ -29,4 +29,14 @@ public class OracleHandlerIT extends CommonTestCases {
     public void wrongBasketFormatCheckout() {
         // FIXME: drop this method when https://github.com/eclipse-vertx/vertx-sql-client/issues/1343 is fixed
     }
+
+    @Override
+    public String getDBName() {
+        return "oracle";
+    }
+
+    @Override
+    protected String getMetricKey(String metricName) {
+        return "oracle_" + metricName + "{clientName=\"oracle\",clientType=\"sql\"}";
+    }
 }

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/PostgresqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/PostgresqlHandlerIT.java
@@ -23,4 +23,14 @@ public class PostgresqlHandlerIT extends CommonTestCases {
             .withProperty("app.selected.db", "postgresql")
             // Enable Flyway for Postgresql
             .withProperty("quarkus.flyway.migrate-at-start", "true");
+
+    @Override
+    public String getDBName() {
+        return "postgresql";
+    }
+
+    @Override
+    protected String getMetricKey(String metricName) {
+        return "postgresql_" + metricName + "{clientName=\"<default>\",clientType=\"sql\"}";
+    }
 }


### PR DESCRIPTION
### Summary

Coverage for Full support of Vertx metrics, see https://issues.redhat.com/browse/QUARKUS-2830 for details.
Test plan: https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-2830.md

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)