### PR TITLE
Fix Narayana transaction recovery tests for Postgres and MariaDB in OpenShift

### DIFF
--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMariaDbTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMariaDbTransactionGeneralUsageIT.java
@@ -35,8 +35,4 @@ public class OpenShiftMariaDbTransactionGeneralUsageIT extends TransactionCommon
         return TransactionExecutor.STATIC_TRANSACTION_MANAGER;
     }
 
-    @Override
-    protected void testTransactionRecoveryInternal() {
-        // disabled on OpenShift as there are required changes in Test Framework in container restart
-    }
 }

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMysqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMysqlTransactionGeneralUsageIT.java
@@ -36,6 +36,6 @@ public class OpenShiftMysqlTransactionGeneralUsageIT extends TransactionCommons 
 
     @Override
     protected void testTransactionRecoveryInternal() {
-        // disabled on OpenShift as there are required changes in Test Framework in container restart
+        // FIXME: enable when https://github.com/quarkus-qe/quarkus-test-suite/issues/1397 gets fixed
     }
 }

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftPostgresqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftPostgresqlTransactionGeneralUsageIT.java
@@ -5,8 +5,4 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 @OpenShiftScenario
 public class OpenShiftPostgresqlTransactionGeneralUsageIT extends PostgresqlTransactionGeneralUsageIT {
 
-    @Override
-    protected void testTransactionRecoveryInternal() {
-        // disabled on OpenShift as there are required changes in Test Framework in container restart
-    }
 }


### PR DESCRIPTION
### Summary

Fixes Postgres and MariaDB OpenShift test coverage for transaction recovery. MySQL doesn't work and I'm perplexed why. As for Oracle & MsSQL, I'm working on baremetal fixes, but it's either not as trivial as it is described here https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.1/html/configuration_guide/datasource_management#vendor_specific_xa_recovery or I'm making some mistakes. Shall see.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)