### PR TITLE
Only enable native CLI test in native

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateNativeApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateNativeApplicationIT.java
@@ -11,12 +11,12 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.EnabledOnNative;
 
 @Tag("QUARKUS-960")
 @Tag("quarkus-cli")
 @QuarkusScenario
-@DisabledOnNative // Only for JVM verification
+@EnabledOnNative
 public class QuarkusCliCreateNativeApplicationIT {
 
     @Inject


### PR DESCRIPTION
### Summary

The `QuarkusCliCreateNativeApplicationIT` is a native app test but comment says it's only for JVM verification. Technically I added the comment here https://github.com/quarkus-qe/quarkus-test-suite/pull/1230/files#diff-13508bdf64e26bd4341b3f69c458f8ca4a0839cc266ff95fcf11aee3cc181c6a but I only replaced original `@DisabledIfSystemProperty(named = "profile.id", matches = "native", disabledReason = "Only for JVM verification")` so I think it is there for a long time and can't tell why.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)