### PR TITLE
Test coverage for elasticsearch-rest-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1111,6 +1111,10 @@ Reactive equivalent of `nosql-db/mongodb`. Uses reactive ReactiveMongoClient (wi
 
 Provides some coverage similar to `infinispan-client` module, but with focus on connecting to local cluster and Dev mode and not on working with OpenShift
 
+### `nosql-db/elasticsearch`
+
+Provides coverage for quarkus-elasticsearch-rest-client
+
 ### `websockets/quarkus-websockets`
 Coverage for sending messages over websockets
 

--- a/nosql-db/elasticsearch/pom.xml
+++ b/nosql-db/elasticsearch/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>elasticsearch</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: NoSQL Database: Elasticsearch</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elasticsearch-rest-client</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/DataTypes.java
+++ b/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/DataTypes.java
@@ -1,0 +1,43 @@
+package io.quarkus.ts.elasticsearch;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
+public class DataTypes {
+    public String id;
+    public String name;
+    public List<Fruit> fruits;
+    public Date date;
+    public float floatNum;
+    public double doubleNum;
+
+    @Override
+    public String toString() {
+        return "DataTypes{" +
+                "id='" + id + '\'' +
+                ", name='" + name + '\'' +
+                ", fruits=" + fruits +
+                ", date=" + date +
+                ", floatNum=" + floatNum +
+                ", doubleNum=" + doubleNum +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        DataTypes dataTypes = (DataTypes) o;
+        return Float.compare(floatNum, dataTypes.floatNum) == 0 && Double.compare(doubleNum, dataTypes.doubleNum) == 0
+                && Objects.equals(id, dataTypes.id) && Objects.equals(name, dataTypes.name)
+                && Objects.equals(fruits, dataTypes.fruits) && Objects.equals(date, dataTypes.date);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, fruits, date, floatNum, doubleNum);
+    }
+}

--- a/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/DataTypesResource.java
+++ b/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/DataTypesResource.java
@@ -1,0 +1,19 @@
+package io.quarkus.ts.elasticsearch;
+
+import java.io.IOException;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+@Path("/data-types")
+public class DataTypesResource {
+
+    @Inject
+    DataTypesService dataTypesService;
+
+    @POST
+    public DataTypes indexAndGet(DataTypes dataTypes) throws IOException {
+        return dataTypesService.indexAndGet(dataTypes);
+    }
+}

--- a/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/DataTypesService.java
+++ b/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/DataTypesService.java
@@ -1,0 +1,37 @@
+package io.quarkus.ts.elasticsearch;
+
+import java.io.IOException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+
+import io.vertx.core.json.JsonObject;
+
+@ApplicationScoped
+public class DataTypesService {
+    @Inject
+    RestClient restClient;
+
+    public DataTypes indexAndGet(DataTypes dataTypes) throws IOException {
+        Request request = new Request(
+                "PUT",
+                "/foos/_doc/" + dataTypes.id);
+        request.setJsonEntity(JsonObject.mapFrom(dataTypes).toString());
+        restClient.performRequest(request);
+
+        request = new Request(
+                "GET",
+                "/foos/_doc/" + dataTypes.id);
+        Response response = restClient.performRequest(request);
+        String responseBody = EntityUtils.toString(response.getEntity());
+
+        JsonObject json = new JsonObject(responseBody);
+        DataTypes dataTypesRet = json.getJsonObject("_source").mapTo(DataTypes.class);
+        return dataTypesRet;
+    }
+}

--- a/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/Fruit.java
+++ b/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/Fruit.java
@@ -1,0 +1,40 @@
+package io.quarkus.ts.elasticsearch;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class Fruit {
+    public String id;
+    public String name;
+    public String color;
+
+    public Fruit(String name, String color) {
+        this.id = UUID.randomUUID().toString();
+        this.name = name;
+        this.color = color;
+    }
+
+    @Override
+    public String toString() {
+        return "Fruit{" +
+                "id='" + id + '\'' +
+                ", name='" + name + '\'' +
+                ", color='" + color + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Fruit fruit = (Fruit) o;
+        return Objects.equals(id, fruit.id) && Objects.equals(name, fruit.name) && Objects.equals(color, fruit.color);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, color);
+    }
+}

--- a/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/FruitResource.java
+++ b/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/FruitResource.java
@@ -1,0 +1,56 @@
+package io.quarkus.ts.elasticsearch;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.RestQuery;
+
+@Path("/fruits")
+public class FruitResource {
+
+    @Inject
+    FruitService fruitService;
+
+    @POST
+    public Response index(Fruit fruit) throws IOException {
+        if (fruit.id == null) {
+            fruit.id = UUID.randomUUID().toString();
+        }
+        fruitService.index(fruit);
+        return Response.created(URI.create("/fruits/" + fruit.id)).build();
+    }
+
+    @GET
+    @Path("/{id}")
+    public Fruit get(String id) throws IOException {
+        return fruitService.get(id);
+    }
+
+    @DELETE
+    @Path("/{id}")
+    public void delete(String id) throws IOException {
+        fruitService.delete(id);
+    }
+
+    @GET
+    @Path("/search")
+    public List<Fruit> search(@RestQuery String name, @RestQuery String color) throws IOException {
+        if (name != null) {
+            return fruitService.searchByName(name);
+        } else if (color != null) {
+            return fruitService.searchByColor(color);
+        } else {
+            throw new BadRequestException("Should provide name or color query parameter");
+        }
+    }
+}

--- a/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/FruitService.java
+++ b/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/FruitService.java
@@ -1,0 +1,78 @@
+package io.quarkus.ts.elasticsearch;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+@ApplicationScoped
+public class FruitService {
+    @Inject
+    RestClient restClient;
+
+    public void index(Fruit fruit) throws IOException {
+        Request request = new Request(
+                "PUT",
+                "/fruits/_doc/" + fruit.id);
+        request.setJsonEntity(JsonObject.mapFrom(fruit).toString());
+        restClient.performRequest(request);
+    }
+
+    public Fruit get(String id) throws IOException {
+        Request request = new Request(
+                "GET",
+                "/fruits/_doc/" + id);
+        Response response = restClient.performRequest(request);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        JsonObject json = new JsonObject(responseBody);
+        return json.getJsonObject("_source").mapTo(Fruit.class);
+    }
+
+    public void delete(String id) throws IOException {
+        Request request = new Request(
+                "DELETE",
+                "/fruits/_doc/" + id);
+        restClient.performRequest(request);
+    }
+
+    public List<Fruit> searchByColor(String color) throws IOException {
+        return search("color", color);
+    }
+
+    public List<Fruit> searchByName(String name) throws IOException {
+        return search("name", name);
+    }
+
+    private List<Fruit> search(String term, String match) throws IOException {
+        Request request = new Request(
+                "GET",
+                "/fruits/_search");
+        //construct a JSON query like {"query": {"match": {"<term>": "<match"}}
+        JsonObject termJson = new JsonObject().put(term, match);
+        JsonObject matchJson = new JsonObject().put("match", termJson);
+        JsonObject queryJson = new JsonObject().put("query", matchJson);
+        request.setJsonEntity(queryJson.encode());
+        Response response = restClient.performRequest(request);
+        String responseBody = EntityUtils.toString(response.getEntity());
+
+        JsonObject json = new JsonObject(responseBody);
+        JsonArray hits = json.getJsonObject("hits").getJsonArray("hits");
+        List<Fruit> results = new ArrayList<>(hits.size());
+        for (int i = 0; i < hits.size(); i++) {
+            JsonObject hit = hits.getJsonObject(i);
+            Fruit fruit = hit.getJsonObject("_source").mapTo(Fruit.class);
+            results.add(fruit);
+        }
+        return results;
+    }
+}

--- a/nosql-db/elasticsearch/src/test/java/io/quarkus/ts/elasticsearch/DevModeElasticsearchIT.java
+++ b/nosql-db/elasticsearch/src/test/java/io/quarkus/ts/elasticsearch/DevModeElasticsearchIT.java
@@ -1,0 +1,42 @@
+package io.quarkus.ts.elasticsearch;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.containsString;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.restassured.http.ContentType;
+
+@QuarkusScenario
+public class DevModeElasticsearchIT {
+
+    @DevModeQuarkusApplication()
+    static RestService devModeApp = new RestService();
+
+    @Test
+    void dataCreatedAndAccessible() {
+        devModeApp.given()
+                .contentType(ContentType.JSON)
+                .body("{\"name\": \"banány\", \"color\": \"žlutá\"}")
+                .when()
+                .post("fruits")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED);
+
+        await().ignoreExceptions().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            devModeApp.given()
+                    .when()
+                    .get("fruits/search?color=žlutá")
+                    .then()
+                    .statusCode(HttpStatus.SC_OK)
+                    .body(containsString("banány"));
+        });
+    }
+}

--- a/nosql-db/elasticsearch/src/test/java/io/quarkus/ts/elasticsearch/ElasticsearchIT.java
+++ b/nosql-db/elasticsearch/src/test/java/io/quarkus/ts/elasticsearch/ElasticsearchIT.java
@@ -1,0 +1,121 @@
+package io.quarkus.ts.elasticsearch;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.HttpStatus;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.DefaultService;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.vertx.core.json.JsonObject;
+
+@QuarkusScenario
+public class ElasticsearchIT {
+
+    static final int ELASTIC_PORT = 9200;
+
+    @Container(image = "${elastic.7x.image}", port = ELASTIC_PORT, expectedLog = "started")
+    static DefaultService elastic = new DefaultService()
+            .withProperty("discovery.type", "single-node")
+            .withProperty("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
+            .withProperty("cluster.routing.allocation.disk.threshold_enabled", "false")
+            .withProperty("xpack.security.enabled", "false");
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.elasticsearch.hosts", () -> elastic.getURI(Protocol.NONE).toString());
+
+    protected RestService getApp() {
+        return app;
+    }
+
+    @Test
+    void dataCreatedAndAccessible() {
+        // CREATE content
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"name\": \"apples\", \"color\": \"green\"}")
+                .when()
+                .post("fruits")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED);
+
+        // SEARCH content
+        final StringBuilder sb = new StringBuilder();
+        // Elasticsearch is creating index and mapping, thus await loop
+        await().pollInterval(500, TimeUnit.MILLISECONDS).atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            String id = given()
+                    .when()
+                    .get("fruits/search?color=green")
+                    .then()
+                    .statusCode(HttpStatus.SC_OK)
+                    .body(containsString("apples"))
+                    .extract().path("[0].id");
+            sb.append(id);
+        });
+
+        // DELETE content
+        given()
+                .when()
+                .delete("fruits/" + sb)
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+        // wait for Elasticsearch to finish the work
+        await().pollInterval(500, TimeUnit.MILLISECONDS).atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            given()
+                    .when()
+                    .get("fruits/search?color=green")
+                    .then()
+                    .statusCode(HttpStatus.SC_OK)
+                    .body("isEmpty()", is(true));
+        });
+    }
+
+    @Test
+    void dataTypesCheck() {
+        DataTypes fooDataTypes = new DataTypes();
+        fooDataTypes.id = UUID.randomUUID().toString();
+        fooDataTypes.name = "Foo name ěščřžýáíéůú ťďň";
+        fooDataTypes.fruits = List.of(new Fruit("Fruit #1", "Red"), new Fruit("Fruit #2", "Yellow"));
+        fooDataTypes.date = new Date();
+        fooDataTypes.floatNum = 0.2353f;
+        fooDataTypes.doubleNum = 15.698d;
+
+        Response response = given()
+                .contentType(ContentType.JSON)
+                .body(JsonObject.mapFrom(fooDataTypes).toString())
+                .when()
+                .post("data-types");
+
+        response.then()
+                .statusCode(HttpStatus.SC_OK);
+
+        DataTypes returnedFooDataTypes = response.getBody().as(DataTypes.class);
+        Assert.assertEquals(fooDataTypes, returnedFooDataTypes);
+    }
+
+    @Test
+    void healthCheckAvailable() {
+        given()
+                .when()
+                .get("q/health")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("Elasticsearch cluster health check"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
                                 <quarkus.s2i.base-native-image>${quarkus.s2i.base-native-image}</quarkus.s2i.base-native-image>
                                 <!-- Services used in test suite -->
                                 <postgresql.latest.image>${postgresql.latest.image}</postgresql.latest.image>
-                                <elastic.71.image>docker.io/library/elasticsearch:7.17.10</elastic.71.image>
+                                <elastic.7x.image>docker.io/library/elasticsearch:7.17.12</elastic.7x.image>
                                 <mysql.57.image>docker.io/library/mysql:5.7.42</mysql.57.image>
                                 <mysql.upstream.80.image>docker.io/library/mysql:8.0</mysql.upstream.80.image>
                                 <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7</mysql.80.image>
@@ -578,6 +578,7 @@
                 <module>nosql-db/mongodb</module>
                 <module>nosql-db/mongodb-reactive</module>
                 <module>nosql-db/infinispan</module>
+                <module>nosql-db/elasticsearch</module>
             </modules>
         </profile>
         <profile>

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/MysqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/MysqlMultitenantHibernateSearchIT.java
@@ -26,7 +26,7 @@ public class MysqlMultitenantHibernateSearchIT extends AbstractMultitenantHibern
     @Container(image = "${mysql.upstream.80.image}", port = MYSQL_PORT, expectedLog = "ready for connections")
     static MySqlService company2 = new MySqlService().withDatabase("company2");;
 
-    @Container(image = "${elastic.71.image}", port = ELASTIC_PORT, expectedLog = "started")
+    @Container(image = "${elastic.7x.image}", port = ELASTIC_PORT, expectedLog = "started")
     static DefaultService elastic = new DefaultService()
             .withProperty("discovery.type", "single-node")
             // Limit resources as Elasticsearch official docker image use half of available RAM

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftMysqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftMysqlMultitenantHibernateSearchIT.java
@@ -34,7 +34,7 @@ public class OpenShiftMysqlMultitenantHibernateSearchIT extends AbstractMultiten
             .withDatabase("company2")
             .withProperty(MAX_ALLOWED_PACKET_KEY, MAX_ALLOWED_PACKET_VALUE);
 
-    @Container(image = "${elastic.71.image}", port = ELASTIC_PORT, expectedLog = "started")
+    @Container(image = "${elastic.7x.image}", port = ELASTIC_PORT, expectedLog = "started")
     static DefaultService elastic = new DefaultService()
             .withProperty("discovery.type", "single-node")
             // Limit resources as Elasticsearch official docker image use half of available RAM

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
@@ -16,7 +16,7 @@ public class OpenShiftPostgresqlMultitenantHibernateSearchIT extends AbstractMul
     static final int ELASTIC_PORT = 9200;
     static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "${elastic.71.image}", port = ELASTIC_PORT, expectedLog = "started")
+    @Container(image = "${elastic.7x.image}", port = ELASTIC_PORT, expectedLog = "started")
     static DefaultService elastic = new DefaultService()
             .withProperty("discovery.type", "single-node")
             // Limit resources as Elasticsearch official docker image use half of available RAM

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/PostgresqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/PostgresqlMultitenantHibernateSearchIT.java
@@ -14,7 +14,7 @@ public class PostgresqlMultitenantHibernateSearchIT extends AbstractMultitenantH
     static final int ELASTIC_PORT = 9200;
     static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "${elastic.71.image}", port = ELASTIC_PORT, expectedLog = "started")
+    @Container(image = "${elastic.7x.image}", port = ELASTIC_PORT, expectedLog = "started")
     static DefaultService elastic = new DefaultService()
             .withProperty("discovery.type", "single-node")
             // Limit resources as Elasticsearch official docker image use half of available RAM


### PR DESCRIPTION
### Summary

 - Test coverage for elasticsearch-rest-client (https://issues.redhat.com/browse/QUARKUS-3260)
 - Rename elastic.71.image property to elastic.7x.image, use the latest 7.x version

`DevModeElasticsearchIT` uses devservices with Elasticsearch 8, `ElasticsearchIT` uses `elastic.7x.image`

Future AIs (tracked in GH issue https://github.com/quarkus-qe/quarkus-test-suite/issues/1402):
 - Move to Elasticsearch 8, focus on `sql-db/hibernate-fulltext-search`
 - Introduce quarkus-test-service-elasticsearch in https://github.com/quarkus-qe/quarkus-test-framework and use it here

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)