### PR TITLE
Fix most of QuarkusCliCreateJvmApplicationIT file handling (but not all) on Windows

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -320,8 +320,8 @@ public class QuarkusCliCreateJvmApplicationIT {
 
     private void assertExpectedJavaVersion(File pomFile, String expectedJavaVersion) {
         MavenXpp3Reader reader = new MavenXpp3Reader();
-        try {
-            Model model = reader.read(new FileReader(pomFile));
+        try (FileReader fileReader = new FileReader(pomFile)) {
+            Model model = reader.read(fileReader);
             Assertions.assertEquals(model.getProperties().get("maven.compiler.release"), expectedJavaVersion,
                     "Unexpected Java version defined in maven.compiler.release property of pom.xml. " +
                             "Java support tool should detect host Java version or use " +
@@ -332,8 +332,7 @@ public class QuarkusCliCreateJvmApplicationIT {
     }
 
     private void assertDockerJavaVersion(File dockerFile, String expectedVersion) {
-        try {
-            Scanner sc = new Scanner(dockerFile);
+        try (Scanner sc = new Scanner(dockerFile)) {
             String line = "";
             while (sc.hasNextLine()) {
                 line = sc.nextLine();


### PR DESCRIPTION
### Summary

`QuarkusCliCreateJvmApplicationIT` is failing on Windows for we try to delete service folder while still working with pom and other files. This fixed issue.

There is remaining issue with deleting `quarkus-cli-command.out`, but it can't be fixed only from here. I'm also not sure how to fix it at all.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)