### PR TITLE
Test Suite part of the QuarkusCliSpecialCharsIT fixes for Windows - ensure proper folder name escaping

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
@@ -4,6 +4,7 @@ import static io.quarkus.ts.quarkus.cli.QuarkusCliUtils.getCurrentStreamVersion;
 import static io.quarkus.ts.quarkus.cli.QuarkusCliUtils.isUpstream;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,6 +15,7 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -125,16 +127,19 @@ public class QuarkusCliSpecialCharsIT {
     }
 
     private void whenBuildOnNativeAppAt(String folder) {
-        result = cliClient.run(TARGET.resolve(folder + "/" + ARTIFACT_ID), "build", "--native");
+        result = cliClient.run(TARGET.resolve(folder + File.separator + ARTIFACT_ID), "build", "--native");
     }
 
     private void whenBuildOnJvmAppAt(String folder) {
-        result = cliClient.run(TARGET.resolve(folder + "/" + ARTIFACT_ID), "build");
+        result = cliClient.run(TARGET.resolve(folder + File.separator + ARTIFACT_ID), "build");
     }
 
     private void whenCreateAppAt(String folder) {
         List<String> args = getDefaultAppArgs("create", "app");
-        args.addAll(List.of("--output-directory=" + folder, ARTIFACT_ID));
+        if (OS.current() == OS.WINDOWS) {
+            folder = String.format("\"%s\"", folder);
+        }
+        args.addAll(List.of("--output-directory", folder, ARTIFACT_ID));
         result = cliClient.run(args.toArray(new String[args.size()]));
     }
 


### PR DESCRIPTION
### Summary

- Separating `--output-directory` and `folder` fixes `shouldCreateApplicationOnJvmWithSpaces`
- Enclosing folder name inside double quotes helped to get further in `shouldCreateApplicationOnJvmWithSpecialChars`, but it later fails on `whenBuildOnJvmAppAt` (unrelated to changes here). I guess it needs fixing in FW, but won't know until I understand what is causing it.
  - `[ERROR]   QuarkusCliSpecialCharsIT.shouldCreateApplicationOnJvmWithSpecialChars:55->assertCreateJavaApplicationAtFolder:123->thenBuildOutputIsSuccessful:151->thenResultIsSuccessful:147 Something failed, output: 'C:\Users\hudson\quarkus-test-suite\quarkus-cli\target\' is not recognized as an internal or external command,`

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)