### PR TITLE
Disable special chars CLI test on Windows due to upstream bug

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
@@ -14,6 +14,7 @@ import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.condition.OS;
 
@@ -50,6 +51,7 @@ public class QuarkusCliSpecialCharsIT {
         assertCreateJavaApplicationAtFolder(FOLDER_WITH_SPACES);
     }
 
+    @DisabledOnOs(OS.WINDOWS) // TODO: enable me when https://github.com/quarkusio/quarkus/issues/35913 gets fixed
     @Test
     public void shouldCreateApplicationOnJvmWithSpecialChars() {
         assertCreateJavaApplicationAtFolder(FOLDER_WITH_SPECIAL_CHARS);


### PR DESCRIPTION
### Summary

Disabling the `QuarkusCliSpecialCharsIT#shouldCreateApplicationOnJvmWithSpecialChars` test on Windows due to upstream issue https://github.com/quarkusio/quarkus/issues/35913.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)