### PR TITLE
[2.13] Disable special chars CLI test on Windows due to upstream bug

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
@@ -14,7 +14,9 @@ import javax.inject.Inject;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -48,6 +50,7 @@ public class QuarkusCliSpecialCharsIT {
         assertCreateJavaApplicationAtFolder(FOLDER_WITH_SPACES);
     }
 
+    @DisabledOnOs(OS.WINDOWS) // TODO: enable me when https://github.com/quarkusio/quarkus/issues/35913 gets fixed
     @Test
     public void shouldCreateApplicationOnJvmWithSpecialChars() {
         assertCreateJavaApplicationAtFolder(FOLDER_WITH_SPECIAL_CHARS);


### PR DESCRIPTION
### Summary

backports https://github.com/quarkus-qe/quarkus-test-suite/pull/1414

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)