### PR TITLE
Collect and generate build reports used by AWS Windows instanced to analyze reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <!-- Docker images used by both surefire and failsafe plugin -->
         <postgresql.latest.image>docker.io/library/postgres:15</postgresql.latest.image>
         <wiremock-jre8.version>2.35.1</wiremock-jre8.version>
+        <build-reporter-maven-extension.version>3.2.0</build-reporter-maven-extension.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -170,6 +171,14 @@
         </dependency>
     </dependencies>
     <build>
+        <extensions>
+            <!-- Build Reporter collects and generates build reports analyzed by Jenkins jobs using AWS EC2 Windows-->
+            <extension>
+                <groupId>io.quarkus.bot</groupId>
+                <artifactId>build-reporter-maven-extension</artifactId>
+                <version>${build-reporter-maven-extension.version}</version>
+            </extension>
+        </extensions>
         <pluginManagement>
             <plugins>
                 <plugin>


### PR DESCRIPTION
### Summary

Quarkus Quickstarts are using this extension for their Github actions and I find it very useful to detect which base dirs should contains reports, especially for multiple submodules.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)