### PR TITLE
Disable shouldCreateApplicationWithJbangOnJvm

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -173,6 +173,7 @@ public class QuarkusCliCreateJvmApplicationIT {
         }
     }
 
+    @Disabled("https://issues.redhat.com/browse/QUARKUS-3371")
     @Tag("QUARKUS-1071")
     @Test
     public void shouldCreateApplicationWithJbangOnJvm() {


### PR DESCRIPTION
### Summary

Disable the test in 3.2 because of [QUARKUS-3371](https://issues.redhat.com/browse/QUARKUS-3371)

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)