### PR TITLE
Updating CORS policy for app in oidc reactive

### DIFF
--- a/security/keycloak-oidc-client-reactive-extended/src/test/resources/logout.properties
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/resources/logout.properties
@@ -14,7 +14,7 @@ quarkus.http.auth.permission.unsecured.policy=permit
 quarkus.http.auth.permission.unsecured.methods=GET
 
 quarkus.http.cors=true
-quarkus.http.cors.origins=${keycloak.origin}
+quarkus.http.cors.origins=*
 quarkus.http.auth.permission.logout.paths=/code-flow/logout
 quarkus.http.auth.permission.logout.policy=authenticated
 


### PR DESCRIPTION
* Updating CORS policy for app in keycloak-oidc-client-reactive-extended module. Currently, the policy in test app only allows for access from the same domain where the test Keycloak is setup. This setup will not work in scenarios where the test is ran on domain different than that (e.g. our Aarch64 testing).

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)