### PR TITLE
Fix flaky DevModeOpenTelemetryIT especially on Windows with waiting till live reload has finished

### DIFF
--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/DevModeOpenTelemetryIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/DevModeOpenTelemetryIT.java
@@ -7,14 +7,17 @@ import static io.quarkus.ts.transactions.TransactionCommons.getTracedOperationsF
 import static io.quarkus.ts.transactions.TransactionCommons.retrieveTraces;
 import static io.quarkus.ts.transactions.TransactionCommons.verifyRequestTraces;
 import static io.restassured.RestAssured.given;
+import static java.time.Duration.ofMinutes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.function.Function;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
@@ -29,6 +32,7 @@ public class DevModeOpenTelemetryIT {
     private static final String APPLICATION_PROPERTIES = "src/main/resources/application.properties";
     private static final String INSERT_OPERATION_NAME = "INSERT quarkus.journal";
     private static final String UPDATE_OPERATION_NAME = "UPDATE quarkus.account";
+    private static volatile String previousLiveReloadLogEntry = null;
 
     @JaegerContainer(expectedLog = "\"Health Check state change\",\"status\":\"ready\"")
     static final JaegerService jaeger = new JaegerService();
@@ -51,14 +55,13 @@ public class DevModeOpenTelemetryIT {
         verifyNoTracesForOperation(UPDATE_OPERATION_NAME);
 
         // disable JDBC tracing and expect no traces are recorded
-        app.modifyFile(APPLICATION_PROPERTIES, props -> props + System.lineSeparator() + getOtelEnabledProperty(false));
+        modifyAppPropertiesAndWait(props -> props + System.lineSeparator() + getOtelEnabledProperty(false));
         untilAsserted(TransactionCommons::makeTopUpTransfer);
         verifyNoTracesForOperation(INSERT_OPERATION_NAME);
         verifyNoTracesForOperation(UPDATE_OPERATION_NAME);
 
         // enable JDBC tracing and expect new traces
-        app.modifyFile(APPLICATION_PROPERTIES, props -> props.replace(
-                getOtelEnabledProperty(false), getOtelEnabledProperty(true)));
+        modifyAppPropertiesAndWait(props -> props.replace(getOtelEnabledProperty(false), getOtelEnabledProperty(true)));
         untilAsserted(TransactionCommons::makeTopUpTransfer);
         verifyRequestTraces(INSERT_OPERATION_NAME, jaeger);
         verifyRequestTraces(UPDATE_OPERATION_NAME, jaeger);
@@ -88,7 +91,7 @@ public class DevModeOpenTelemetryIT {
     private static String getTraceIdForSpanOperation() {
         return untilIsNotNull(
                 DevModeOpenTelemetryIT::retrieveTraceIdForSpanOperation,
-                using(Duration.ofSeconds(2), Duration.ofMinutes(1)));
+                using(Duration.ofSeconds(2), ofMinutes(1)));
     }
 
     private static String retrieveTraceIdForSpanOperation() {
@@ -97,6 +100,28 @@ public class DevModeOpenTelemetryIT {
 
     private static String getOtelEnabledProperty(boolean enabled) {
         return "quarkus.datasource.jdbc.telemetry.enabled=" + enabled;
+    }
+
+    private static void modifyAppPropertiesAndWait(Function<String, String> transformProperties) {
+        app.modifyFile(APPLICATION_PROPERTIES, transformProperties);
+
+        // TODO: ideally, the Test Framework should take care about waiting when required
+        untilAsserted(() -> {
+            // just waiting won't do the trick, we need to ping Quarkus as well
+            TransactionCommons.makeTopUpTransfer();
+            String logEntry = app
+                    .getLogs()
+                    .stream()
+                    .filter(entry -> entry.contains("Live reload total time")
+                            && (previousLiveReloadLogEntry == null || !previousLiveReloadLogEntry.equals(entry)))
+                    .findAny()
+                    .orElse(null);
+            if (logEntry != null) {
+                previousLiveReloadLogEntry = logEntry;
+            } else {
+                Assertions.fail();
+            }
+        });
     }
 
 }


### PR DESCRIPTION
### Summary

`DevModeOpenTelemetryIT` always fails on Windows (see respective Jenkins job), strange thing I can reproduce it 6 times of 10 on Linux, while in our CI it doesn't fail. Anyway, the root cause is that we don't wait till live reload is finished. That's what this PR does.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)