### PR TITLE
Fix some build-time analytics failures on Windows by closing file reader

### DIFF
--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AbstractAnalyticsIT.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AbstractAnalyticsIT.java
@@ -142,8 +142,8 @@ public abstract class AbstractAnalyticsIT {
 
     private List<Dependency> getPomDependencies(QuarkusCliRestService app) {
         MavenXpp3Reader reader = new MavenXpp3Reader();
-        try {
-            Model model = reader.read(new FileReader(getPomFile(app)));
+        try (var fileReader = new FileReader(getPomFile(app))) {
+            Model model = reader.read(fileReader);
             return model.getDependencies().stream()
                     .filter(dependency -> !Objects.equals(dependency.getScope(), "test"))
                     .collect(Collectors.toList());


### PR DESCRIPTION
### Summary

On Windows, any test that runs after `io.quarkus.ts.buildtimeanalytics.AbstractAnalyticsIT#getPomDependencies` failes for `pom.xml` is used by other process. We need to close the reader properly. Tested, for failure please see respective Jenkins job.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)