### PR TITLE
`QuarkusCliCreateJvmApplicationIT#shouldAddAndRemoveExtensions` needs to wait till app is ready after restart

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -262,7 +262,7 @@ public class QuarkusCliCreateJvmApplicationIT {
         assertTrue(result.isSuccessful(), SMALLRYE_HEALTH_EXTENSION + " was not uninstalled. Output: " + result.getOutput());
 
         // The health endpoint should be now gone
-        app.restart();
+        app.restartAndWaitUntilServiceIsStarted();
         untilAsserted(() -> app.given().get("/q/health").then().statusCode(HttpStatus.SC_NOT_FOUND));
     }
 


### PR DESCRIPTION
### Summary

Things are slower on Windows, I can see logged `Caused by: java.net.ConnectException: Connection refused: connect` right after restart before app is ready, I think it also has implication as it is never stopped even though tests already finished.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)