### PR TITLE
Enable HelloMainTest on Windows as we dont use Cygwin

### DIFF
--- a/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/HelloMainTest.java
+++ b/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/HelloMainTest.java
@@ -4,15 +4,12 @@ import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 import io.quarkus.test.junit.main.QuarkusMainTest;
 
 @QuarkusMainTest
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "https://github.com/quarkusio/quarkus/issues/31765")
 public class HelloMainTest {
 
     @Test


### PR DESCRIPTION
### Summary

AFAICT this is only issue with Cygwin - https://github.com/quarkusio/quarkus/issues/31765, which we are not using anymore to run TS.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)