### PR TITLE
Forward OIDC mTLS container on Windows to localhost as certificates are generated for localhost

### DIFF
--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/JksOidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/JksOidcMtlsIT.java
@@ -16,7 +16,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class JksOidcMtlsIT extends KeycloakMtlsAuthN {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = KC_DEV_MODE_JKS_CMD, port = KEYCLOAK_PORT)
+    @KeycloakContainer(command = KC_DEV_MODE_JKS_CMD, port = KEYCLOAK_PORT, builder = LocalHostKeycloakContainerManagedResourceBuilder.class)
     static KeycloakService keycloak = newKeycloakInstance(REALM_FILE_PATH, REALM_DEFAULT, "realms")
             .withRedHatFipsDisabled()
             .withProperty("HTTPS_KEYSTORE", "resource_with_destination::/etc/|server-keystore." + JKS_KEYSTORE_FILE_EXTENSION)

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/LocalHostKeycloakContainerManagedResourceBuilder.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/LocalHostKeycloakContainerManagedResourceBuilder.java
@@ -1,0 +1,123 @@
+package io.quarkus.ts.security.oidcclient.mtls;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.ManagedResource;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.services.URILike;
+import io.quarkus.test.services.containers.KeycloakContainerManagedResourceBuilder;
+import io.quarkus.test.utils.Command;
+
+/**
+ * Forward Docker ports from localhost to Docker host on Windows. This works around issue when
+ * certificates are only generated for localhost. Ideally, we would regenerate certificates
+ * on Windows as there, host is changing every time we run tests, but that's for future improvements.
+ */
+public class LocalHostKeycloakContainerManagedResourceBuilder extends KeycloakContainerManagedResourceBuilder {
+
+    /**
+     * Our Linux bare-metal instances use Docker on localhost.
+     */
+    private static final boolean forwardPort = OS.current() == OS.WINDOWS;
+
+    @Override
+    public ManagedResource build(ServiceContext context) {
+        return new ManagedResource() {
+
+            private final ManagedResource delegate = LocalHostKeycloakContainerManagedResourceBuilder.super.build(context);
+
+            @Override
+            public String getDisplayName() {
+                return delegate.getDisplayName();
+            }
+
+            @Override
+            public void stop() {
+                if (forwardPort) {
+                    try {
+                        // stop port proxy
+                        new Command("netsh", "interface", "portproxy", "delete", "v4tov4",
+                                "listenport=" + getExposedPort(), "listenaddress=127.0.0.1").runAndWait();
+                    } catch (IOException | InterruptedException e) {
+                        throw new RuntimeException(
+                                "Failed delete port proxy for Keycloak container port " + getExposedPort(), e);
+                    }
+                }
+                delegate.stop();
+            }
+
+            @Override
+            public void start() {
+                delegate.start();
+                if (forwardPort) {
+                    try {
+                        // forward localhost:somePort to dockerIp:somePort
+                        new Command("netsh", "interface", "portproxy", "add", "v4tov4", "listenport=" + getExposedPort(),
+                                "listenaddress=127.0.0.1", "connectport=" + getExposedPort(),
+                                "connectaddress=" + getDockerHost()).runAndWait();
+                    } catch (IOException | InterruptedException e) {
+                        throw new RuntimeException(
+                                "Failed to setup forwarding for Keycloak container port " + getExposedPort(), e);
+                    }
+                }
+            }
+
+            @Override
+            public URILike getURI(Protocol protocol) {
+                var uriLike = delegate.getURI(protocol);
+                if (forwardPort) {
+                    // replace Docker IP with local host
+                    uriLike = new URILike(uriLike.getScheme(), "localhost", uriLike.getPort(), uriLike.getPath());
+                }
+                return uriLike;
+            }
+
+            private String getDockerHost() {
+                return delegate.getURI(Protocol.NONE).getHost();
+            }
+
+            private int getExposedPort() {
+                return delegate.getURI(Protocol.NONE).getPort();
+            }
+
+            @Override
+            public boolean isRunning() {
+                return delegate.isRunning();
+            }
+
+            @Override
+            public boolean isFailed() {
+                return delegate.isFailed();
+            }
+
+            @Override
+            public List<String> logs() {
+                return delegate.logs();
+            }
+
+            @Override
+            public void restart() {
+                delegate.restart();
+            }
+
+            @Override
+            public void validate() {
+                delegate.validate();
+            }
+
+            @Override
+            public void afterStart() {
+                delegate.afterStart();
+            }
+
+            @Override
+            public URILike createURI(String scheme, String host, int port) {
+                return delegate.createURI(scheme, host, port);
+            }
+        };
+    }
+}

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/MutualTlsKeycloakService.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/MutualTlsKeycloakService.java
@@ -17,6 +17,7 @@ public class MutualTlsKeycloakService extends KeycloakService {
     // command used by Keycloak 18+ container in order to launch JKS secured Keycloak
     public static final String KC_DEV_MODE_JKS_CMD = "start-dev " +
             "--import-realm --hostname-strict=false --hostname-strict-https=false --features=token-exchange " +
+            "--hostname=localhost " + // required by LocalHostKeycloakContainerManagedResourceBuilder
             "--https-client-auth=required " +
             "--https-key-store-file=/etc/server-keystore.jks " +
             "--https-trust-store-file=/etc/server-truststore.jks " +
@@ -25,6 +26,7 @@ public class MutualTlsKeycloakService extends KeycloakService {
     // command used by Keycloak 18+ container in order to launch P12 secured Keycloak
     public static final String KC_DEV_MODE_P12_CMD = "start-dev " +
             "--import-realm --hostname-strict=false --hostname-strict-https=false --features=token-exchange " +
+            "--hostname=localhost " + // required by LocalHostKeycloakContainerManagedResourceBuilder
             "--https-client-auth=required " +
             "--https-key-store-file=/etc/server-keystore.p12 " +
             "--https-trust-store-file=/etc/server-truststore.p12 " +

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/Pkcs12OidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/Pkcs12OidcMtlsIT.java
@@ -25,7 +25,7 @@ import io.quarkus.test.utils.Command;
 @QuarkusScenario
 public class Pkcs12OidcMtlsIT extends KeycloakMtlsAuthN {
 
-    @KeycloakContainer(command = KC_DEV_MODE_P12_CMD, port = KEYCLOAK_PORT)
+    @KeycloakContainer(command = KC_DEV_MODE_P12_CMD, port = KEYCLOAK_PORT, builder = LocalHostKeycloakContainerManagedResourceBuilder.class)
     static KeycloakService keycloak = newKeycloakInstance(REALM_FILE_PATH, REALM_DEFAULT, "realms")
             .withProperty("HTTPS_KEYSTORE", "resource_with_destination::/etc/|server-keystore." + P12_KEYSTORE_FILE_EXTENSION)
             .withProperty("HTTPS_TRUSTSTORE",


### PR DESCRIPTION
### Summary

I wrote README how to re-generated these certificates, but I am not sure how good one, as couldn't automate it precisely yet. It will take little effort to every time regenerate all the certificates, while this port forwarding is quick and straightforward. Let's take it as a hotfix and come back if we have a time in the future.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)