### PR TITLE
Close FileReader when we are done in OpenAPI tests

### DIFF
--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenApiStoreSchemaIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenApiStoreSchemaIT.java
@@ -66,8 +66,10 @@ public class OpenApiStoreSchemaIT extends BaseOidcIT {
     }
 
     private JsonObject fromJson(URI openApiJson) throws IOException {
-        String jsonStr = IOUtils.toString(new FileReader(openApiJson.getPath()));
-        return new JsonObject(jsonStr);
+        try (var reader = new FileReader(openApiJson.getPath())) {
+            String jsonStr = IOUtils.toString(reader);
+            return new JsonObject(jsonStr);
+        }
     }
 
     private String fileExtension(String uri) {

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenApiStoreSchemaIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenApiStoreSchemaIT.java
@@ -66,8 +66,10 @@ public class OpenApiStoreSchemaIT extends BaseOidcIT {
     }
 
     private JsonObject fromJson(URI openApiJson) throws IOException {
-        String jsonStr = IOUtils.toString(new FileReader(openApiJson.getPath()));
-        return new JsonObject(jsonStr);
+        try (var reader = new FileReader(openApiJson.getPath())) {
+            String jsonStr = IOUtils.toString(reader);
+            return new JsonObject(jsonStr);
+        }
     }
 
     private String fileExtension(String uri) {


### PR DESCRIPTION
### Summary

I didn't see failing test for this, but we should close closeable and `IOUtils` are not doing it.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)