### PR TITLE
[3.2] Backport 'Bump quarkus.qe.framework.version from 1.3.0.Beta27 to 1.3.0.Beta28'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.2.6.Final</quarkus.platform.version>
         <quarkus.ide.version>3.2.6.Final</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.3.0.Beta27</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.3.0.Beta28</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.4.0</quarkus-qpid-jms.version>
         <apache-httpclient-fluent.version>4.5.14</apache-httpclient-fluent.version>
         <confluent.kafka-avro-serializer.version>7.3.1</confluent.kafka-avro-serializer.version>


### PR DESCRIPTION
### Summary

Backports https://github.com/quarkus-qe/quarkus-test-suite/pull/1450, I need this for Infinispan fixes that will come after this (but it will only run one module instead of all of them, so quicker). Fixes issue with loading resources to Infinispan container.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)