### PR TITLE
Fix External apps module execution on Windows

### DIFF
--- a/external-applications/pom.xml
+++ b/external-applications/pom.xml
@@ -17,19 +17,8 @@
     <artifactId>external-applications</artifactId>
     <packaging>jar</packaging>
     <name>Quarkus QE TS: External Applications</name>
-    <build>
-        <plugins>
-            <!-- Skip Quarkus Maven plugin build on JVM and Native since we're going to deploy external apps -->
-            <plugin>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>build</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+    <properties>
+        <!-- Skip Quarkus Maven plugin build on JVM and Native since we're going to deploy external apps -->
+        <quarkus.build.skip>true</quarkus.build.skip>
+    </properties>
 </project>


### PR DESCRIPTION
### Summary

This change fixes execution of External app module on Windows, I still can see maven plugin skipped

```
[INFO] --- quarkus:3.2.6.Final-redhat-00001:build (build) @ external-applications ---
[INFO] Skipping Quarkus build
```

However I won't see it failed as before:

```
Failed to execute goal org.apache.maven.plugins:maven-jar-plugin:3.3.0:jar (default-jar) on project external-applications: You have to use a classifier to attach supplemental artifacts to the project instead of replacing them.
```

Previously, if you run command like this 

```
mvn clean validate compile test package verify -V -B -fae -Dlog.nocolor=true -P root-modules -Dquarkus-plugin.version=3.2.6.Final-redhat-00001 -Dquarkus.platform.version=3.2.6.Final-redhat-00001 -Dquarkus.platform.artifact-id="quarkus-bom" -Dquarkus.platform.group-id="com.redhat.quarkus.platform" -Dinclude.quarkus-cli-tests -Dmaven.repo.local=C:\Users\hudson\maven-repository -pl external-applications
```

Test wouldn't be executed and build would fail.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)