### PR TITLE
Disable QuarkusCLIVersionIT on Windows when tested with Quarkus snapshot as we don't have snapshot CLI on Windows

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliVersionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliVersionIT.java
@@ -1,11 +1,14 @@
 package io.quarkus.ts.quarkus.cli;
 
+import static io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshotCondition.isQuarkusSnapshotVersion;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.builder.Version;
 import io.quarkus.test.bootstrap.QuarkusCliClient;
@@ -13,6 +16,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 
+@DisabledIf(value = "isQuarkusSnapshotRunOnWindows", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1464")
 @Tag("QUARKUS-960")
 @Tag("quarkus-cli")
 @QuarkusScenario
@@ -30,5 +34,9 @@ public class QuarkusCliVersionIT {
 
         // Using shortcut
         assertEquals(Version.getVersion(), cliClient.run("-v").getOutput());
+    }
+
+    static boolean isQuarkusSnapshotRunOnWindows() {
+        return isQuarkusSnapshotVersion() && OS.current() == OS.WINDOWS;
     }
 }


### PR DESCRIPTION
### Summary

Not sure how to create 999-SNAPSHOT CLI on Windows and I don't want to investigate it now. Let's disable failing test and work on opened issue when priorities decide so.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)