### PR TITLE
Bump kafka-avro-serializer to 7.5.1, add jackson-dataformat-csv dependency

### DIFF
--- a/messaging/kafka-confluent-avro-reactive-messaging/pom.xml
+++ b/messaging/kafka-confluent-avro-reactive-messaging/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>kafka-avro-serializer</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-csv</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-scheduler</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <quarkus.qe.framework.version>1.3.0.Beta28</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.4.0</quarkus-qpid-jms.version>
         <apache-httpclient-fluent.version>4.5.14</apache-httpclient-fluent.version>
-        <confluent.kafka-avro-serializer.version>7.3.1</confluent.kafka-avro-serializer.version>
+        <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>
         <xml-format-maven-plugin.version>3.2.2</xml-format-maven-plugin.version>


### PR DESCRIPTION
Bump kafka-avro-serializer to 7.5.1, add jackson-dataformat-csv dependency

See https://github.com/quarkusio/quarkus/issues/36372 for details

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)