### PR TITLE
Update deprecated URL and Runtime methods

### DIFF
--- a/env-info/src/main/java/io/quarkus/ts/envinfo/OsJvmEnvInfoLogger.java
+++ b/env-info/src/main/java/io/quarkus/ts/envinfo/OsJvmEnvInfoLogger.java
@@ -35,6 +35,8 @@ public class OsJvmEnvInfoLogger {
             + "  </ul>\n"
             + "</li>\n";
 
+    private static final String VERSION_COMMAND = "--version";
+
     public static void main(String[] args) throws IOException, InterruptedException {
         final String os = getOs();
         final String architecture = System.getProperty("os.arch");
@@ -57,7 +59,8 @@ public class OsJvmEnvInfoLogger {
     }
 
     private static String getJavaVersionCmdOutput() throws InterruptedException, IOException {
-        final String cmd = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java --version";
+        final String javaExecutablePath = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+        final String[] cmd = new String[] { javaExecutablePath, VERSION_COMMAND };
         Process pr = Runtime.getRuntime().exec(cmd);
         pr.waitFor(1, TimeUnit.MINUTES);
         return new BufferedReader(new InputStreamReader(pr.getInputStream())).lines().reduce((first, second) -> second)
@@ -65,7 +68,8 @@ public class OsJvmEnvInfoLogger {
     }
 
     private static List<String> getMvnVersionCmdOutput() {
-        final String cmd = System.getProperty("maven.home") + File.separator + "bin" + File.separator + "mvn --version";
+        String mavenExecutablePath = System.getProperty("maven.home") + File.separator + "bin" + File.separator + "mvn";
+        final String[] cmd = new String[] { mavenExecutablePath, VERSION_COMMAND };
         try {
             Process pr = Runtime.getRuntime().exec(cmd);
             pr.waitFor(1, TimeUnit.MINUTES);

--- a/http/http-static/src/test/java/io/quarkus/ts/httpstatic/LargeStaticResourceIT.java
+++ b/http/http-static/src/test/java/io/quarkus/ts/httpstatic/LargeStaticResourceIT.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -27,8 +27,8 @@ public class LargeStaticResourceIT {
 
     @Test
     public void testBigFileAvailability() throws IOException {
-        URL bigFileURL = new URL(RestAssured.baseURI + ":" + RestAssured.port + "/big-file");
-        HttpURLConnection connection = (HttpURLConnection) bigFileURL.openConnection();
+        URI bigFileURL = URI.create(RestAssured.baseURI + ":" + RestAssured.port + "/big-file");
+        HttpURLConnection connection = (HttpURLConnection) bigFileURL.toURL().openConnection();
         connection.setRequestMethod("HEAD");
         connection.setConnectTimeout(TWO_SECONDS);
         connection.connect();

--- a/qute/reactive/src/main/java/io/quarkus/ts/qute/Application.java
+++ b/qute/reactive/src/main/java/io/quarkus/ts/qute/Application.java
@@ -1,9 +1,7 @@
 package io.quarkus.ts.qute;
 
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -222,8 +220,8 @@ public class Application {
         final String host = system.getValue("quarkus.http.host", String.class);
         final Integer port = system.getValue("quarkus.http.port", Integer.class);
         try {
-            return new URL("http", host, port, path).toURI();
-        } catch (URISyntaxException | MalformedURLException e) {
+            return new URI("http", null, host, port, path, null, null);
+        } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }

--- a/qute/synchronous/src/main/java/io/quarkus/ts/qute/Application.java
+++ b/qute/synchronous/src/main/java/io/quarkus/ts/qute/Application.java
@@ -1,9 +1,7 @@
 package io.quarkus.ts.qute;
 
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -216,8 +214,8 @@ public class Application {
         final String host = system.getValue("quarkus.http.host", String.class);
         final Integer port = system.getValue("quarkus.http.port", Integer.class);
         try {
-            return new URL("http", host, port, path).toURI();
-        } catch (URISyntaxException | MalformedURLException e) {
+            return new URI("http", null, host, port, path, null, null);
+        } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
### Summary

Hi, this PR updating some deprecated method. To be prepared to JDK 21.

URL constructors was deprecated in JDK 20. Now is possible to create URL from URI.

`Runtime.getRuntime().exec(String)` was deprecated in JDK 18 and is recommended to use `Runtime.getRuntime().exec(String[])`.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)