### PR TITLE
Fix gRPC Infinispan tests by setting SNI as it is required when SSL is used after the latest Infinispan bump

### DIFF
--- a/messaging/infinispan-grpc-kafka/src/main/resources/application.properties
+++ b/messaging/infinispan-grpc-kafka/src/main/resources/application.properties
@@ -7,6 +7,8 @@ quarkus.infinispan-client.trust-store-type=jks
 quarkus.infinispan-client.hosts=localhost:11222
 quarkus.infinispan-client.use-auth=true
 
+quarkus.infinispan-client.sni-host-name=localhost
+
 # gRPC
 quarkus.grpc.clients.hello.host=localhost
 %test.quarkus.grpc.clients.hello.port=9001


### PR DESCRIPTION
### Summary

SNI is now required by default when SSL is used, see https://github.com/quarkusio/quarkus/pull/36445. Fixes one daily failure.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)