### PR TITLE
bug-fix : Closed Vert.x to Prevent Resource Leaks

### DIFF
--- a/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/PureVertxHttpClientTest.java
+++ b/http/vertx-web-client/src/test/java/io/quarkus/ts/http/vertx/webclient/PureVertxHttpClientTest.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -25,12 +26,14 @@ public class PureVertxHttpClientTest {
     URL url;
 
     WebClient httpClient;
+    Vertx vertx;
     static final int EXPECTED_EVENTS = 25000;
     private static final int TIMEOUT_SEC = 10;
 
     @BeforeEach
     public void setup() {
-        httpClient = WebClient.create(Vertx.vertx(), new WebClientOptions());
+        vertx = Vertx.vertx();
+        httpClient = WebClient.create(vertx, new WebClientOptions());
     }
 
     @Test
@@ -45,5 +48,14 @@ public class PureVertxHttpClientTest {
 
         done.await(TIMEOUT_SEC, TimeUnit.SECONDS);
         assertEquals(0, done.getCount(), String.format("Missing %d events.", EXPECTED_EVENTS - done.getCount()));
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        if (httpClient != null)
+            httpClient.close();
+
+        if (vertx != null)
+            vertx.close();
     }
 }

--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/AbstractVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/AbstractVertxIT.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.vertx;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.testcontainers.shaded.org.hamcrest.MatcherAssert.assertThat;
 import static org.testcontainers.shaded.org.hamcrest.Matchers.containsString;
@@ -56,7 +57,11 @@ public abstract class AbstractVertxIT {
 
     @Test
     public void vertxHttpClient() {
-        HttpClient httpClient = Vertx.vertx().createHttpClient();
+        Vertx vertx = Vertx.vertx();
+        assertNotNull(vertx);
+        HttpClient httpClient = vertx.createHttpClient();
+        assertNotNull(httpClient);
+
         httpClient.request(HttpMethod.GET, service.getPort(), service.getURI(Protocol.NONE).getHost(), "/hello")
                 .compose(request -> request.send()
                         .compose(httpClientResponse -> {
@@ -66,12 +71,19 @@ public abstract class AbstractVertxIT {
                 .onSuccess(body -> {
                     assertThat("Body response", body.toString().contains("Hello, World!"));
                 }).onFailure(Throwable::printStackTrace);
+
+        httpClient.close();
+        vertx.close();
     }
 
     @Test
     public void vertxHttpClientProtocolHttp2() {
         HttpClientOptions httpClientOptions = new HttpClientOptions().setProtocolVersion(HttpVersion.HTTP_2);
-        HttpClient httpClient = Vertx.vertx().createHttpClient(httpClientOptions);
+        Vertx vertx = Vertx.vertx();
+        assertNotNull(vertx);
+        HttpClient httpClient = vertx.createHttpClient(httpClientOptions);
+        assertNotNull(httpClient);
+
         httpClient.request(HttpMethod.GET, service.getPort(), service.getURI(Protocol.NONE).getHost(), "/hello")
                 .compose(httpClientRequest -> httpClientRequest.send()
                         .compose(httpClientResponse -> {
@@ -81,12 +93,19 @@ public abstract class AbstractVertxIT {
                 .onSuccess(body -> {
                     assertThat("Body response", body.toString().contains("Hello, World!"));
                 }).onFailure(Throwable::printStackTrace);
+
+        httpClient.close();
+        vertx.close();
     }
 
     @Test
     public void vertxHttpClientWithNameParameter() {
         JsonObject jsonObject = new JsonObject().put("name", "Bender");
-        HttpClient httpClient = Vertx.vertx().createHttpClient();
+        Vertx vertx = Vertx.vertx();
+        assertNotNull(vertx);
+        HttpClient httpClient = vertx.createHttpClient();
+        assertNotNull(httpClient);
+
         httpClient.request(HttpMethod.GET, service.getPort(), service.getURI(Protocol.NONE).getHost(),
                 "/hello?name=" + jsonObject.getString("name"))
                 .compose(request -> request.send())
@@ -95,6 +114,9 @@ public abstract class AbstractVertxIT {
                     assertThat("Body response", body.toString().contains("Hello, Bender!"));
                 })
                 .onFailure(Throwable::printStackTrace);
+
+        httpClient.close();
+        vertx.close();
     }
 
     public abstract RequestSpecification requests();

--- a/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/AbstractCommonIT.java
+++ b/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/AbstractCommonIT.java
@@ -80,6 +80,8 @@ public abstract class AbstractCommonIT {
                 .delete("/replicant/" + replicant.getId())
                 .then()
                 .statusCode(anyOf(is(204), is(404)));
+
+        vertx.close();
     }
 
     protected enum Invalidity {


### PR DESCRIPTION
### Summary

closes : [Leaking Vertx and HttpClient](https://github.com/quarkus-qe/quarkus-test-suite/issues/1408)

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)