### PR TITLE
Change mandrel version in CI

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -188,7 +188,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: [ "mandrel-latest" ]
+        graalvm-version: [ "mandrel-23.0.1.2-Final" ]
         graalvm-java-version: [ "17" ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Summary

Change CI definition from latest mandrel version to specific version (23.0.1.2-Final) as the newest one was built only by JDK 21.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)