### PR TITLE
[3.2] Disable Kafka Streams tests when running on Windows with RHBQ due to QUARKUS-3434

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeKafkaStreamIT.java
@@ -1,12 +1,16 @@
 package io.quarkus.ts.messaging.kafka.reactive.streams;
 
+import static io.quarkus.ts.messaging.kafka.reactive.streams.DisabledOnWindowsWithRhbqCondition.DISABLED_IF_RHBQ_ON_WINDOWS;
+
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
+@DisabledIf(value = DISABLED_IF_RHBQ_ON_WINDOWS, disabledReason = "QUARKUS-3434")
 @Tag("QUARKUS-1026")
 @Tag("QUARKUS-959")
 @QuarkusScenario

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeRedPandaDevServiceUserExperienceIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeRedPandaDevServiceUserExperienceIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.ts.messaging.kafka.reactive.streams;
 
+import static io.quarkus.ts.messaging.kafka.reactive.streams.DisabledOnWindowsWithRhbqCondition.DISABLED_IF_RHBQ_ON_WINDOWS;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import com.github.dockerjava.api.model.Image;
 
@@ -11,6 +14,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.DockerUtils;
 
+@DisabledIf(value = DISABLED_IF_RHBQ_ON_WINDOWS, disabledReason = "QUARKUS-3434")
 @Tag("QUARKUS-959")
 @QuarkusScenario
 public class DevModeRedPandaDevServiceUserExperienceIT {

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeStrimziKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeStrimziKafkaStreamIT.java
@@ -1,13 +1,17 @@
 package io.quarkus.ts.messaging.kafka.reactive.streams;
 
+import static io.quarkus.ts.messaging.kafka.reactive.streams.DisabledOnWindowsWithRhbqCondition.DISABLED_IF_RHBQ_ON_WINDOWS;
+
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
+@DisabledIf(value = DISABLED_IF_RHBQ_ON_WINDOWS, disabledReason = "QUARKUS-3434")
 @Tag("QUARKUS-1026")
 @Tag("QUARKUS-959")
 @QuarkusScenario

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DisabledOnWindowsWithRhbqCondition.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DisabledOnWindowsWithRhbqCondition.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.messaging.kafka.reactive.streams;
+
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+import io.smallrye.common.os.OS;
+
+public class DisabledOnWindowsWithRhbqCondition {
+
+    public static final String DISABLED_IF_RHBQ_ON_WINDOWS = "io.quarkus.ts.messaging.kafka.reactive.streams."
+            + "DisabledOnWindowsWithRhbqCondition#isRunningOnWindowsWithRhbq";
+
+    public static boolean isRunningOnWindowsWithRhbq() {
+        return isRunningOnWindows() && isRhbq();
+    }
+
+    private static boolean isRunningOnWindows() {
+        return OS.current() == OS.WINDOWS;
+    }
+
+    private static boolean isRhbq() {
+        return QuarkusProperties.getVersion().contains("-redhat-");
+    }
+
+}

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/KafkaGratefulShutdownIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/KafkaGratefulShutdownIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.messaging.kafka.reactive.streams;
 
+import static io.quarkus.ts.messaging.kafka.reactive.streams.DisabledOnWindowsWithRhbqCondition.DISABLED_IF_RHBQ_ON_WINDOWS;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -9,6 +10,7 @@ import java.util.function.Predicate;
 
 import org.jboss.logmanager.Level;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
@@ -20,6 +22,7 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 import io.quarkus.ts.messaging.kafka.reactive.streams.shutdown.SlowTopicConsumer;
 import io.quarkus.ts.messaging.kafka.reactive.streams.shutdown.SlowTopicResource;
 
+@DisabledIf(value = DISABLED_IF_RHBQ_ON_WINDOWS, disabledReason = "QUARKUS-3434")
 @QuarkusScenario
 @DisabledOnNative(reason = "Due to high native build execution time")
 public class KafkaGratefulShutdownIT {

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SslAlertMonitorIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SslAlertMonitorIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.messaging.kafka.reactive.streams;
 
+import static io.quarkus.ts.messaging.kafka.reactive.streams.DisabledOnWindowsWithRhbqCondition.DISABLED_IF_RHBQ_ON_WINDOWS;
+
+import org.junit.jupiter.api.condition.DisabledIf;
+
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
@@ -9,6 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaProtocol;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
+@DisabledIf(value = DISABLED_IF_RHBQ_ON_WINDOWS, disabledReason = "QUARKUS-3434")
 @QuarkusScenario
 public class SslAlertMonitorIT extends BaseKafkaStreamTest {
     /**

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/StrimziKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/StrimziKafkaStreamIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.messaging.kafka.reactive.streams;
 
+import static io.quarkus.ts.messaging.kafka.reactive.streams.DisabledOnWindowsWithRhbqCondition.DISABLED_IF_RHBQ_ON_WINDOWS;
+
+import org.junit.jupiter.api.condition.DisabledIf;
+
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
@@ -8,6 +12,7 @@ import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
+@DisabledIf(value = DISABLED_IF_RHBQ_ON_WINDOWS, disabledReason = "QUARKUS-3434")
 @QuarkusScenario
 public class StrimziKafkaStreamIT extends BaseKafkaStreamTest {
 


### PR DESCRIPTION
### Summary

Please see https://issues.redhat.com/browse/QUARKUS-3434.

This commit is not intended for the main branch.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)