### PR TITLE
[3.2] Backports 'Use single HTTP server for gRPC services'

### DIFF
--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/CliDevModeIT.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/CliDevModeIT.java
@@ -85,7 +85,8 @@ public class CliDevModeIT extends AbstractAnalyticsIT {
     @Test
     public void extensionSetA() {
         QuarkusCliRestService app = createAppWithExtensions(EXTENSION_SET_A);
-        startDevMode(app);
+        // Extension set has gRPC, use new approach with single HTTP server instance
+        startDevMode(app.withProperty("quarkus.grpc.server.use-separate-server", "false"));
         verifyValidPayloadPresent(app);
     }
 

--- a/http/http-advanced-reactive/src/main/resources/application.properties
+++ b/http/http-advanced-reactive/src/main/resources/application.properties
@@ -25,10 +25,11 @@ HttpVersionClientServiceAsync/mp-rest/trustStore=classpath:/META-INF/resources/s
 HttpVersionClientServiceAsync/mp-rest/trustStorePassword=password
 # gRPC
 quarkus.grpc.clients.hello.host=localhost
-quarkus.grpc.clients.hello.port=${quarkus.grpc.server.port}
+quarkus.grpc.clients.hello.port=${quarkus.http.port}
 quarkus.grpc.server.enable-reflection-service=true
 quarkus.grpc.clients.reflection-service.host=localhost
-quarkus.grpc.clients.reflection-service.port=${quarkus.grpc.server.port}
+quarkus.grpc.clients.reflection-service.port=${quarkus.http.port}
+quarkus.grpc.server.use-separate-server=false
 # authZ
 quarkus.keycloak.policy-enforcer.enable=true
 # Non-application endpoints. Required because we are going to force a redirection, otherwise use `/q/*` instead

--- a/http/http-advanced/src/main/resources/application.properties
+++ b/http/http-advanced/src/main/resources/application.properties
@@ -25,7 +25,8 @@ HttpVersionClientServiceAsync/mp-rest/trustStore=classpath:/META-INF/resources/s
 HttpVersionClientServiceAsync/mp-rest/trustStorePassword=password
 # gRPC
 quarkus.grpc.clients.hello.host=localhost
-quarkus.grpc.clients.hello.port=${quarkus.grpc.server.port}
+quarkus.grpc.clients.hello.port=${quarkus.http.port}
+quarkus.grpc.server.use-separate-server=false
 # authZ
 quarkus.keycloak.policy-enforcer.enable=true
 # Non-application endpoints. Required because we are going to force a redirection, otherwise use `/q/*` instead

--- a/monitoring/opentelemetry-reactive/src/main/resources/application.properties
+++ b/monitoring/opentelemetry-reactive/src/main/resources/application.properties
@@ -6,5 +6,7 @@ io.quarkus.ts.opentelemetry.reactive.sse.ServerSentEventsPongClient/mp-rest/scop
 
 # gRPC
 quarkus.grpc.clients.pong.host=localhost
+quarkus.grpc.clients.pong.port=${quarkus.http.port}
+quarkus.grpc.server.use-separate-server=false
 
 quarkus.application.name=pingpong

--- a/monitoring/opentelemetry/src/main/resources/application.properties
+++ b/monitoring/opentelemetry/src/main/resources/application.properties
@@ -6,5 +6,7 @@ io.quarkus.ts.opentelemetry.sse.ServerSentEventsPongClient/mp-rest/scope=jakarta
 
 # gRPC
 quarkus.grpc.clients.pong.host=localhost
+quarkus.grpc.clients.pong.port=${quarkus.http.port}
+quarkus.grpc.server.use-separate-server=false
 
 quarkus.application.name=pingpong

--- a/monitoring/opentracing-reactive-grpc/src/main/resources/application.properties
+++ b/monitoring/opentracing-reactive-grpc/src/main/resources/application.properties
@@ -16,3 +16,5 @@ io.quarkus.ts.monitoring.opentracing.reactive.grpc.ping.clients.ServerSentEvents
 
 # gRPC
 quarkus.grpc.clients.pong.host=localhost
+quarkus.grpc.clients.pong.port=${quarkus.http.port}
+quarkus.grpc.server.use-separate-server=false


### PR DESCRIPTION
### Summary

backports https://github.com/quarkus-qe/quarkus-test-suite/pull/1472

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)