### PR TITLE
Fix Infinispan client operator tests - disable hostname SNI validation and ensure cluster deleted on error

### DIFF
--- a/infinispan-client/src/main/resources/application.properties
+++ b/infinispan-client/src/main/resources/application.properties
@@ -5,6 +5,7 @@ quarkus.infinispan-client.username=qe
 quarkus.infinispan-client.password=qe
 quarkus.infinispan-client.sasl-mechanism=PLAIN
 quarkus.infinispan-client.client-intelligence=BASIC
+quarkus.infinispan-client.ssl-host-name-validation=false
 
 # Where the app can read the trust store from when it runs
 quarkus.openshift.app-secret=clientcerts

--- a/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanCountersIT.java
+++ b/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanCountersIT.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
@@ -27,9 +28,16 @@ import io.restassured.response.Response;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class OperatorOpenShiftInfinispanCountersIT extends BaseOpenShiftInfinispanIT {
 
+    private static final AtomicBoolean CLUSTER_CREATED = new AtomicBoolean(false);
+
     @QuarkusApplication
     static RestService one = new RestService()
-            .onPreStart(s -> createInfinispanCluster());
+            .onPreStart(s -> {
+                // prevent attempting to create cluster on restart
+                if (CLUSTER_CREATED.compareAndSet(false, true)) {
+                    createInfinispanCluster();
+                }
+            });
 
     @QuarkusApplication
     static RestService two = new RestService();

--- a/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanErrorSvcListener.java
+++ b/infinispan-client/src/test/java/io/quarkus/ts/infinispan/client/OperatorOpenShiftInfinispanErrorSvcListener.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.infinispan.client;
+
+import java.util.Set;
+
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.bootstrap.ServiceListener;
+import io.vertx.core.impl.ConcurrentHashSet;
+
+/**
+ * Makes sure Infinispan cluster is deleted even when there is error and {@link org.junit.jupiter.api.AfterAll}
+ * is not called.
+ */
+public class OperatorOpenShiftInfinispanErrorSvcListener implements ServiceListener {
+
+    private static final Set<String> TEST_CLASS_CACHE = new ConcurrentHashSet<>();
+
+    @Override
+    public void onServiceError(ServiceContext service, Throwable throwable) {
+        if (TEST_CLASS_CACHE.add(service.getScenarioContext().getRunningTestClassName())) {
+            BaseOpenShiftInfinispanIT.deleteInfinispanCluster();
+        }
+    }
+}

--- a/infinispan-client/src/test/resources/META-INF/services/io.quarkus.test.bootstrap.ServiceListener
+++ b/infinispan-client/src/test/resources/META-INF/services/io.quarkus.test.bootstrap.ServiceListener
@@ -1,0 +1,1 @@
+io.quarkus.ts.infinispan.client.OperatorOpenShiftInfinispanErrorSvcListener


### PR DESCRIPTION
### Summary

- disables Infinispan client SNI host name validation as I didn't manage from test host to find out correct hostname that will be resolved inside cluster. Test with Infinispan client runs in different namespace then where operator is installed. We already test validation here https://github.com/quarkus-qe/quarkus-test-suite/pull/1473. I'm happy to try again if there are suggestions (or time)
- we had problem that when service failed to start as when validation is enabled, cluster is never deleted, now I'm adding listener that will take care of it together with https://github.com/quarkus-qe/quarkus-test-framework/pull/936
- service `one` is restarted and yamls that create cluster are re-applied again. AFAICT it is not causing issue, but at least it is whole lot of unnecessary commands.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)