### PR TITLE
Only use Google Mirror as mirror

### DIFF
--- a/.github/mvn-settings.xml
+++ b/.github/mvn-settings.xml
@@ -1,30 +1,18 @@
-<settings>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
     <servers>
     </servers>
     <profiles>
         <profile>
-            <id>google-mirror-jboss-proxy</id>
+            <id>google-mirror</id>
             <repositories>
                 <repository>
                     <id>google-maven-central</id>
                     <name>GCS Maven Central mirror EU</name>
-                    <url>https://maven-central-eu.storage-download.googleapis.com/repos/central/data/</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-                <repository>
-                    <id>jboss-maven-central-proxy</id>
-                    <name>JBoss Maven Central proxy</name>
-                    <url>https://repository.jboss.org/nexus/content/repositories/central/</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-                <repository>
-                    <id>gradle-official-repository</id>
-                    <name>Gradle Official Repository</name>
-                    <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
+                    <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
                     <snapshots>
                         <enabled>false</enabled>
                     </snapshots>
@@ -34,17 +22,18 @@
                 <pluginRepository>
                     <id>google-maven-central</id>
                     <name>GCS Maven Central mirror EU</name>
-                    <url>https://maven-central-eu.storage-download.googleapis.com/repos/central/data/</url>
-                </pluginRepository>
-                <pluginRepository>
-                    <id>jboss-maven-central-proxy</id>
-                    <name>JBoss Maven Central proxy</name>
-                    <url>https://repository.jboss.org/nexus/content/repositories/central/</url>
+                    <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
                 </pluginRepository>
             </pluginRepositories>
         </profile>
     </profiles>
     <activeProfiles>
-        <activeProfile>google-mirror-jboss-proxy</activeProfile>
+        <activeProfile>google-mirror</activeProfile>
     </activeProfiles>
 </settings>


### PR DESCRIPTION
Only use Google Mirror as mirror

We used to have other repositories but it is counter productive nowadays.
Also switch to the American mirror.
There's a good chance GitHub Actions are run in America.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)