### PR TITLE
Fix Kafka Reactive Streams tests on Windows

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/LocalHostKafkaContainerManagedResourceBuilder.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/LocalHostKafkaContainerManagedResourceBuilder.java
@@ -1,0 +1,121 @@
+package io.quarkus.ts.messaging.kafka.reactive.streams;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.ManagedResource;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.services.URILike;
+import io.quarkus.test.services.containers.KafkaContainerManagedResourceBuilder;
+import io.quarkus.test.utils.Command;
+
+/**
+ * Forward Docker ports from localhost to Docker host on Windows. This works around issue when
+ * certificates are only generated for localhost.
+ */
+public class LocalHostKafkaContainerManagedResourceBuilder extends KafkaContainerManagedResourceBuilder {
+
+    /**
+     * Our Linux bare-metal instances use Docker on localhost.
+     */
+    private static final boolean forwardPort = OS.current() == OS.WINDOWS;
+
+    @Override
+    public ManagedResource build(ServiceContext context) {
+        final ManagedResource delegate = super.build(context);
+        return new ManagedResource() {
+
+            @Override
+            public String getDisplayName() {
+                return delegate.getDisplayName();
+            }
+
+            @Override
+            public void stop() {
+                if (forwardPort) {
+                    try {
+                        // stop port proxy
+                        new Command("netsh", "interface", "portproxy", "delete", "v4tov4",
+                                "listenport=" + getExposedPort(), "listenaddress=127.0.0.1").runAndWait();
+                    } catch (IOException | InterruptedException e) {
+                        throw new RuntimeException(
+                                "Failed delete port proxy for Kafka container port " + getExposedPort(), e);
+                    }
+                }
+                delegate.stop();
+            }
+
+            @Override
+            public void start() {
+                delegate.start();
+                if (forwardPort) {
+                    try {
+                        // forward localhost:somePort to dockerIp:somePort
+                        new Command("netsh", "interface", "portproxy", "add", "v4tov4", "listenport=" + getExposedPort(),
+                                "listenaddress=127.0.0.1", "connectport=" + getExposedPort(),
+                                "connectaddress=" + getDockerHost()).runAndWait();
+                    } catch (IOException | InterruptedException e) {
+                        throw new RuntimeException(
+                                "Failed to setup forwarding for Kafka container port " + getExposedPort(), e);
+                    }
+                }
+            }
+
+            @Override
+            public URILike getURI(Protocol protocol) {
+                var uriLike = delegate.getURI(protocol);
+                if (forwardPort) {
+                    // replace Docker IP with local host
+                    uriLike = new URILike(uriLike.getScheme(), "localhost", uriLike.getPort(), uriLike.getPath());
+                }
+                return uriLike;
+            }
+
+            private String getDockerHost() {
+                return delegate.getURI(Protocol.NONE).getHost();
+            }
+
+            private int getExposedPort() {
+                return delegate.getURI(Protocol.NONE).getPort();
+            }
+
+            @Override
+            public boolean isRunning() {
+                return delegate.isRunning();
+            }
+
+            @Override
+            public boolean isFailed() {
+                return delegate.isFailed();
+            }
+
+            @Override
+            public List<String> logs() {
+                return delegate.logs();
+            }
+
+            @Override
+            public void restart() {
+                delegate.restart();
+            }
+
+            @Override
+            public void validate() {
+                delegate.validate();
+            }
+
+            @Override
+            public void afterStart() {
+                delegate.afterStart();
+            }
+
+            @Override
+            public URILike createURI(String scheme, String host, int port) {
+                return delegate.createURI(scheme, host, port);
+            }
+        };
+    }
+}

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SslAlertMonitorIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SslAlertMonitorIT.java
@@ -16,7 +16,7 @@ public class SslAlertMonitorIT extends BaseKafkaStreamTest {
      */
     private static final String TRUSTSTORE_FILE = "strimzi-server-ssl-truststore.p12";
 
-    @KafkaContainer(vendor = KafkaVendor.STRIMZI, protocol = KafkaProtocol.SSL, kafkaConfigResources = TRUSTSTORE_FILE)
+    @KafkaContainer(vendor = KafkaVendor.STRIMZI, protocol = KafkaProtocol.SSL, kafkaConfigResources = TRUSTSTORE_FILE, builder = LocalHostKafkaContainerManagedResourceBuilder.class)
     static final KafkaService kafka = new KafkaService();
 
     @QuarkusApplication

--- a/messaging/kafka-streams-reactive-messaging/src/test/resources/kafka.grateful.shutdown.application.properties
+++ b/messaging/kafka-streams-reactive-messaging/src/test/resources/kafka.grateful.shutdown.application.properties
@@ -21,3 +21,5 @@ kafka-streams.consumer.heartbeat.interval.ms=80
 
 # Native
 quarkus.native.enable-all-security-services=true
+
+mp.messaging.incoming.slow.graceful-shutdown=true


### PR DESCRIPTION
### Summary

Fixes failing tests on Windows. 

- Kafka SSL fix is of same sort as we did in other modules (certificate issue).

- Processing of incoming topics during graceful shutdown just seems slower on Windows, I can't explain it. I've refactored it to avoid restart before testing graceful shutdown because amount of time needed to wait before app was accepting incoming topics was enormous. I spent hours trying to findout some timeout or other reasons (tried readyness checks calling etc.) and I can't find a reason why is it slower.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)