### PR TITLE
Enable some disabled tests

### DIFF
--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/OpenShiftUsingExtensionDockerBuildStrategyVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/OpenShiftUsingExtensionDockerBuildStrategyVertxIT.java
@@ -1,6 +1,5 @@
 package io.quarkus.ts.vertx;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -9,7 +8,6 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
-@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingExtensionDockerBuildStrategyVertxIT extends AbstractVertxIT {

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/AbstractDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/AbstractDatabaseHibernateReactiveIT.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.restassured.http.ContentType;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.Response;
@@ -156,7 +155,6 @@ public abstract class AbstractDatabaseHibernateReactiveIT {
         assertTrue(result.contains("Thinking fast and slow"));
     }
 
-    @DisabledOnNative(reason = "https://github.com/quarkusio/quarkus/issues/32114")
     @Test
     public void searchWithLimit() {
         String result = getApp().given()
@@ -244,7 +242,6 @@ public abstract class AbstractDatabaseHibernateReactiveIT {
                 .body("$", hasItem("Ubik"));
     }
 
-    @DisabledOnNative(reason = "https://github.com/quarkusio/quarkus/issues/32114")
     @Test
     public void convertValue() {
         Response response = getApp().given().get("/library/isbn/2");
@@ -263,7 +260,6 @@ public abstract class AbstractDatabaseHibernateReactiveIT {
         assertEquals("0", response.body().asString());
     }
 
-    @DisabledOnNative(reason = "https://github.com/quarkusio/quarkus/issues/32114")
     @Test
     public void setConvertedValue() {
         Response change = getApp().given().put("/library/isbn/1/5170261586");


### PR DESCRIPTION
### Summary

As Quarkus QuickStarts migrated to Quarkus 3 I see no problem to enable them.

For the databases, issue is not closed but apparently it solved by itself or somebody forget to link issue in PR. Didn't dig deeper to look when this was solved.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)