### PR TITLE
Adapt OpenShift MongoDB tests to work with official Docker image

### DIFF
--- a/nosql-db/mongodb-reactive/src/test/resources/mongo-openshift-deployment-template.yml
+++ b/nosql-db/mongodb-reactive/src/test/resources/mongo-openshift-deployment-template.yml
@@ -1,0 +1,46 @@
+---
+apiVersion: "v1"
+kind: "List"
+items:
+- apiVersion: "v1"
+  kind: "Service"
+  metadata:
+    name: "${SERVICE_NAME}"
+  spec:
+    ports:
+    - name: "http"
+      port: ${INTERNAL_PORT}
+      targetPort: ${INTERNAL_PORT}
+    selector:
+      deploymentconfig: "${SERVICE_NAME}"
+    type: "ClusterIP"
+- apiVersion: "apps.openshift.io/v1"
+  kind: "DeploymentConfig"
+  metadata:
+    name: "${SERVICE_NAME}"
+  spec:
+    replicas: 1
+    selector:
+      deploymentconfig: "${SERVICE_NAME}"
+    template:
+      metadata:
+        labels:
+          deploymentconfig: "${SERVICE_NAME}"
+      spec:
+        volumes:
+          - name: mongo-db-data-volume
+            emptyDir: { }
+        containers:
+        - image: "${IMAGE}"
+          args: [${ARGS}]
+          imagePullPolicy: "IfNotPresent"
+          name: "${SERVICE_NAME}"
+          ports:
+          - containerPort: ${INTERNAL_PORT}
+            name: "http"
+            protocol: "TCP"
+          volumeMounts:
+            - name: mongo-db-data-volume
+              mountPath: /data/db
+    triggers:
+    - type: "ConfigChange"

--- a/nosql-db/mongodb-reactive/src/test/resources/test.properties
+++ b/nosql-db/mongodb-reactive/src/test/resources/test.properties
@@ -1,3 +1,5 @@
 ts.app.log.enable=true
 ts.database.log.enable=true
 ts.database.openshift.use-internal-service-as-url=true
+# store MongoDB data in 'emptyDir' volume to work-around write permission issue
+ts.database.openshift.template=/mongo-openshift-deployment-template.yml

--- a/nosql-db/mongodb/src/test/resources/mongo-openshift-deployment-template.yml
+++ b/nosql-db/mongodb/src/test/resources/mongo-openshift-deployment-template.yml
@@ -1,0 +1,46 @@
+---
+apiVersion: "v1"
+kind: "List"
+items:
+- apiVersion: "v1"
+  kind: "Service"
+  metadata:
+    name: "${SERVICE_NAME}"
+  spec:
+    ports:
+    - name: "http"
+      port: ${INTERNAL_PORT}
+      targetPort: ${INTERNAL_PORT}
+    selector:
+      deploymentconfig: "${SERVICE_NAME}"
+    type: "ClusterIP"
+- apiVersion: "apps.openshift.io/v1"
+  kind: "DeploymentConfig"
+  metadata:
+    name: "${SERVICE_NAME}"
+  spec:
+    replicas: 1
+    selector:
+      deploymentconfig: "${SERVICE_NAME}"
+    template:
+      metadata:
+        labels:
+          deploymentconfig: "${SERVICE_NAME}"
+      spec:
+        volumes:
+          - name: mongo-db-data-volume
+            emptyDir: { }
+        containers:
+        - image: "${IMAGE}"
+          args: [${ARGS}]
+          imagePullPolicy: "IfNotPresent"
+          name: "${SERVICE_NAME}"
+          ports:
+          - containerPort: ${INTERNAL_PORT}
+            name: "http"
+            protocol: "TCP"
+          volumeMounts:
+            - name: mongo-db-data-volume
+              mountPath: /data/db
+    triggers:
+    - type: "ConfigChange"

--- a/nosql-db/mongodb/src/test/resources/test.properties
+++ b/nosql-db/mongodb/src/test/resources/test.properties
@@ -1,3 +1,5 @@
 ts.app.log.enable=true
 ts.database.log.enable=true
 ts.database.openshift.use-internal-service-as-url=true
+# store MongoDB data in 'emptyDir' volume to work-around write permission issue
+ts.database.openshift.template=/mongo-openshift-deployment-template.yml

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
                                 <!-- Oracle image - we aim to use same version as Dev Services for Oracle so that we only download one image -->
                                 <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
                                 <db2.image>quay.io/quarkusqeteam/db2:11.5.7.0</db2.image>
-                                <mongodb.image>docker.io/bitnami/mongodb:5.0</mongodb.image>
+                                <mongodb.image>docker.io/library/mongo:5.0</mongodb.image>
                                 <redis.image>docker.io/library/redis:6.0</redis.image>
                                 <wiremock.image>quay.io/ocpmetal/wiremock</wiremock.image>
                                 <!-- TODO use official image when/if this fixed https://github.com/hashicorp/docker-consul/issues/184 -->


### PR DESCRIPTION
### Summary

Official MongoDB Docker image requires read / write on `/data/db` directory and because it is not adapted to work with random user ID, this user doesn't have permission to edit `/data/db` by default and startup in OCP fails with `"DBException in initAndListen, terminating","attr":{"error":"IllegalOperation: Attempted to create a lock file on a read-only directory: /data/db"}}`.

I've considered using `pre` lifecycle hook to grant permissions to this file, but it also means to handle `entrypoint` ourselves. This PR proposes to use `emptyDir` volume to store `/data/db`. Storing this data on mounted volume is legit strategy explained https://hub.docker.com/_/mongo in the _Where to Store Data_ section.

Please note that in next PR I'll allow run MongoDB tests on Aarch64, I didn't forget about it, but it's a separate issue that needs to be tested differently.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)