### PR TITLE
Use Arm64 specific MongoDB image for OSD ARM

### DIFF
--- a/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/reactive/OpenShiftMongoClientReactiveIT.java
+++ b/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/reactive/OpenShiftMongoClientReactiveIT.java
@@ -9,7 +9,6 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1146")
 @DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "bitnami/mongodb container not available on s390x.")
 public class OpenShiftMongoClientReactiveIT extends AbstractMongoClientReactiveIT {
 

--- a/nosql-db/mongodb/src/test/java/io/quarkus/ts/nosqldb/mongodb/OpenShiftMongoClientIT.java
+++ b/nosql-db/mongodb/src/test/java/io/quarkus/ts/nosqldb/mongodb/OpenShiftMongoClientIT.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1146")
 @DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "bitnami/mongodb container not available on s390x.")
 public class OpenShiftMongoClientIT extends MongoClientIT {
 }

--- a/pom.xml
+++ b/pom.xml
@@ -789,6 +789,8 @@
                                         <mariadb.105.image>registry.redhat.io/rhel8/mariadb-105</mariadb.105.image>
                                         <amq-streams.image>registry.redhat.io/amq7/amq-streams-kafka-27-rhel7</amq-streams.image>
                                         <amq-streams.version>1.7.0</amq-streams.version>
+                                        <!-- run 'docker manifest inspect mongo:5.0' and use digest for architecture 'arm64', variant '8', os 'linux' -->
+                                        <mongodb.image>docker.io/library/mongo@sha256:6f851e31a1b317c6fa681b7dad5f94c622f1c3588477f3b769579dc5462ee659</mongodb.image>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
### Summary

closes: #1146

OSD ARM64 should use MongoDB image for platform ARM64, OS Linux and variant v8. I didn't find a way to specify platform in Pod object definition https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container and even though OSD is running on ARM64, I checked digest from `oc describe pod ...` and inspected it with 
 `docker inspect manifest docker.io/library/mongo@sha256:0d8482aef8d58e787fcf8e5e4aa81440f0ff1d9017c63958584b22312da10937` - it was still amd64. Stuff like `docker pull arm64v8/mongo` suggested here https://hub.docker.com/r/arm64v8/mongo doesn't even work for me locally, let alone in OCP (you need to specify --platform).

Fun fact, it works on AMD64 architecture image anyway, but requirement is to use ARM64 specific image.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)