### PR TITLE
Add tests for QuarkusSecurityTestExtension callbacks

### DIFF
--- a/security/basic/src/test/java/io/quarkus/ts/openshift/security/basic/callback/AbstractSecurityCallbackTest.java
+++ b/security/basic/src/test/java/io/quarkus/ts/openshift/security/basic/callback/AbstractSecurityCallbackTest.java
@@ -1,0 +1,102 @@
+package io.quarkus.ts.openshift.security.basic.callback;
+
+import java.security.Permission;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+
+import io.quarkus.security.credential.Credential;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.security.TestIdentityAssociation;
+import io.smallrye.mutiny.Uni;
+
+@DisabledOnNative
+@Tag("https://github.com/quarkusio/quarkus/issues/36601")
+/*
+ * This set of tests are testing QuarkusSecurityTestExtension callbacks @BeforeEach and @AfterEach
+ * These should not interfere with CDI in when tests are not annotated with @TestSecurity
+ * Way to measure if these callbacks are doing something is by testing TestIdentity in
+ * CDI.current().select(TestIdentityAssociation.class)
+ * This should be set to value in BeforeEach and then set to null in AfterEach in case, @TestSecurity is present
+ * and not touched otherwise.
+ * To properly test handling in these methods, this test package uses a testClass for every testCase,
+ * to isolate calls of *Each methods
+ */
+abstract public class AbstractSecurityCallbackTest {
+    protected static final SecurityIdentity MOCK_SECURITY_IDENTITY = new SecurityIdentity() {
+        @Override
+        public Principal getPrincipal() {
+            return new Principal() {
+                @Override
+                public String getName() {
+                    return "";
+                }
+            };
+        }
+
+        @Override
+        public boolean isAnonymous() {
+            return true;
+        }
+
+        @Override
+        public Set<String> getRoles() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public boolean hasRole(String role) {
+            return false;
+        }
+
+        @Override
+        public <T extends Credential> T getCredential(Class<T> credentialType) {
+            return null;
+        }
+
+        @Override
+        public Set<Credential> getCredentials() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public <T> T getAttribute(String name) {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> getAttributes() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public Uni<Boolean> checkPermission(Permission permission) {
+            return Uni.createFrom().item(false);
+        }
+    };
+
+    protected static void assertTestIdentityIsNull() {
+        Assertions.assertNull(CDI.current().select(TestIdentityAssociation.class).get().getTestIdentity(),
+                "TestIdentity should be null");
+    }
+
+    protected static void assertTestIdentityIsNotNull() {
+        Assertions.assertNotNull(CDI.current().select(TestIdentityAssociation.class).get().getTestIdentity(),
+                "TestIdentity should have value");
+    }
+
+    protected static void setTestIdentityToValue() {
+        CDI.current().select(TestIdentityAssociation.class).get().setTestIdentity(MOCK_SECURITY_IDENTITY);
+    }
+
+    protected static void setTestIdentityToNull() {
+        CDI.current().select(TestIdentityAssociation.class).get().setTestIdentity(null);
+    }
+}

--- a/security/basic/src/test/java/io/quarkus/ts/openshift/security/basic/callback/TestSecurityDisabledTest.java
+++ b/security/basic/src/test/java/io/quarkus/ts/openshift/security/basic/callback/TestSecurityDisabledTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.ts.openshift.security.basic.callback;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class TestSecurityDisabledTest extends AbstractSecurityCallbackTest {
+
+    @BeforeAll
+    public static void checkBeforeAll() {
+        // this is called before QuarkusSecurityTestExtension.beforeEach, so testIdentity should still be null
+        assertTestIdentityIsNull();
+    }
+
+    @BeforeEach
+    public void checkBeforeEach() {
+        // this is called after QuarkusSecurityTestExtension.beforeEach, with no @TestSecurity, this should be still null
+        assertTestIdentityIsNull();
+    }
+
+    @Test
+    public void checkTest() {
+        // QuarkusSecurityTestExtension.beforeEach should not set test identity
+        assertTestIdentityIsNull();
+
+        // set testIdentity, so we can later check, if it is set to null or not
+        setTestIdentityToValue();
+    }
+
+    @AfterEach
+    public void checkAfterEach() {
+        // testIdentity was set in test, it should be still set
+        assertTestIdentityIsNotNull();
+    }
+
+    @AfterAll
+    public static void checkAfterAll() {
+        // testIdentity was set in test, it should be still set
+        assertTestIdentityIsNotNull();
+
+        // reset testIdentity to null, so it won't break other tests
+        setTestIdentityToNull();
+    }
+}

--- a/security/basic/src/test/java/io/quarkus/ts/openshift/security/basic/callback/TestSecurityEnabledTest.java
+++ b/security/basic/src/test/java/io/quarkus/ts/openshift/security/basic/callback/TestSecurityEnabledTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.ts.openshift.security.basic.callback;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+
+@QuarkusTest
+public class TestSecurityEnabledTest extends AbstractSecurityCallbackTest {
+    @BeforeAll
+    public static void checkBeforeAll() {
+        // this is called before QuarkusSecurityTestExtension.beforeEach, so testIdentity should still be null
+        assertTestIdentityIsNull();
+    }
+
+    @BeforeEach
+    public void checkBeforeEach() {
+        // this is called after QuarkusSecurityTestExtension.beforeEach, so testIdentity should be set
+        assertTestIdentityIsNotNull();
+    }
+
+    @Test
+    @TestSecurity(user = "myUser")
+    public void checkTestItself() {
+        // QuarkusSecurityTestExtension.beforeEach should set test identity
+        assertTestIdentityIsNotNull();
+    }
+
+    @AfterAll
+    public static void checkAfterAll() {
+        // this is called after QuarkusSecurityTestExtension.afterEach, so testIdentity should be set to null again
+        assertTestIdentityIsNull();
+    }
+}


### PR DESCRIPTION
Related to issue https://github.com/quarkusio/quarkus/issues/36601.

### Summary

Create test that tests when QuarkusSecurityTestExtension.beforeEach and afterEach executes `@TestSecurity` related behaviour.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [X] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)