### PR TITLE
Add test for check SSE reactive empty response data

### DIFF
--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/SseEventUpdateResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/SseEventUpdateResource.java
@@ -1,0 +1,71 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.sse.OutboundSseEvent;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.SseEventSink;
+import jakarta.ws.rs.sse.SseEventSource;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+@Path("sse")
+public class SseEventUpdateResource {
+    public static final String DATA_VALUE = "random data value";
+
+    @Context
+    Sse sse;
+
+    @GET
+    @Path("client-update")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response clientUpdate() throws InterruptedException {
+        String host = ConfigProvider.getConfig().getValue("quarkus.http.host", String.class);
+        int port = ConfigProvider.getConfig().getValue("quarkus.http.port", Integer.class);
+        List<String> receivedData = new CopyOnWriteArrayList<>();
+
+        WebTarget target = ClientBuilder.newClient().target("http://" + host + ":" + port + "/api/sse/server-update");
+        try (SseEventSource eventSource = SseEventSource.target(target).build()) {
+            eventSource.register(ev -> {
+                String event = "event: name=" + ev.getName() + " data={" + ev.readData() + "} and is empty: " + ev.isEmpty()
+                        + "\n";
+                receivedData.add(event);
+            }, thr -> {
+                String event = "Error: " + thr.getMessage() + "\n" + Arrays.toString(thr.getStackTrace());
+                receivedData.add(event);
+            });
+
+            CountDownLatch latch = new CountDownLatch(2);
+            eventSource.open();
+            latch.await(1, TimeUnit.SECONDS);
+        }
+        return Response.ok(String.join("\n", receivedData)).build();
+    }
+
+    @GET
+    @Path("server-update")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    public void updates(@Context SseEventSink eventSink) {
+        eventSink.send(createEvent("NON EMPTY", DATA_VALUE));
+        eventSink.send(createEvent("EMPTY", ""));
+    }
+
+    private OutboundSseEvent createEvent(String name, String data) {
+        return sse.newEventBuilder()
+                .name(name)
+                .data(data)
+                .build();
+    }
+}

--- a/http/http-advanced-reactive/src/main/resources/application.properties
+++ b/http/http-advanced-reactive/src/main/resources/application.properties
@@ -62,6 +62,8 @@ quarkus.keycloak.policy-enforcer.paths.client.path=/api/client/*
 quarkus.keycloak.policy-enforcer.paths.client.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.intercepted.path=/api/intercepted*
 quarkus.keycloak.policy-enforcer.paths.intercepted.enforcement-mode=DISABLED
+quarkus.keycloak.policy-enforcer.paths.sse.path=/api/sse/*
+quarkus.keycloak.policy-enforcer.paths.sse.enforcement-mode=DISABLED
 quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 # tolerate 1 minute of clock skew between the Keycloak server and the application

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/BaseHttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/BaseHttpAdvancedReactiveIT.java
@@ -12,6 +12,7 @@ import static io.quarkus.ts.http.advanced.reactive.MultipleResponseSerializersRe
 import static io.quarkus.ts.http.advanced.reactive.MultipleResponseSerializersResource.MULTIPLE_RESPONSE_SERIALIZERS_PATH;
 import static io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource.QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3;
 import static io.quarkus.ts.http.advanced.reactive.NinetyNineBottlesOfBeerResource.QUARKUS_PLATFORM_VERSION_LESS_THAN_2_8_3_VAL;
+import static io.quarkus.ts.http.advanced.reactive.SseEventUpdateResource.DATA_VALUE;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
@@ -71,6 +72,7 @@ import io.quarkus.example.HelloWorldProto;
 import io.quarkus.example.StreamingGrpc;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.scenarios.annotations.EnabledOnQuarkusVersion;
 import io.quarkus.ts.http.advanced.reactive.clients.HttpVersionClientService;
 import io.quarkus.ts.http.advanced.reactive.clients.HttpVersionClientServiceAsync;
@@ -443,6 +445,17 @@ public abstract class BaseHttpAdvancedReactiveIT {
         Assertions.assertTrue(response.contains("Unconstrained"), "Unconstrained interceptor should be invoked");
         Assertions.assertTrue(response.contains("Server"), "Server interceptor should be invoked");
         Assertions.assertFalse(response.contains("Client"), "Client interceptor should not be invoked");
+    }
+
+    @DisplayName("SSE check for event responses values containing empty data")
+    @Test
+    @DisabledOnNative(reason = "https://github.com/quarkusio/quarkus/issues/36986")
+    void testSseResponseForEmptyData() {
+        getApp().given()
+                .get(ROOT_PATH + "/sse/client-update")
+                .then().statusCode(SC_OK)
+                .body(containsString(String.format("event: name=NON EMPTY data={%s} and is empty: false", DATA_VALUE)),
+                        containsString("event: name=EMPTY data={} and is empty: true"));
     }
 
     private void assertAcceptedMediaTypeEqualsResponseBody(String acceptedMediaType) {


### PR DESCRIPTION
### Summary

Adding the test based on scenario from https://github.com/quarkusio/quarkus/issues/35966. When developing it there are some issues so for now it's disabled (https://github.com/quarkusio/quarkus/issues/37033 and https://github.com/quarkusio/quarkus/issues/36986). 

Test should run on ocp as well but as it it disable I don't see much point to run it now.

Maybe it would be nice to add this scenario (with empty request) to http-advanced (non-reactive)? There is recent test for SSE but with this there will need be some small adjustment to it. WDYT?

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)