### PR TITLE
Disable OpenTracing modules due to unreleased extensions in Quarkiverse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -550,8 +550,9 @@
                 <module>monitoring/micrometer-prometheus-oidc</module>
                 <module>monitoring/opentelemetry</module>
                 <module>monitoring/opentelemetry-reactive</module>
-                <module>monitoring/microprofile-opentracing</module>
-                <module>monitoring/opentracing-reactive-grpc</module>
+                <!-- TODO: enable when Quarkiverse extensions are released: https://github.com/quarkusio/quarkus/pull/36602 -->
+                <!-- <module>monitoring/microprofile-opentracing</module> -->
+                <!-- <module>monitoring/opentracing-reactive-grpc</module> -->
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
### Summary

Extensions are moved https://github.com/quarkusio/quarkus/pull/36602 but as for now, not released: 

- https://github.com/quarkiverse/quarkus-jaeger
- https://github.com/quarkiverse/quarkus-smallrye-opentracing

Usage in Build Time Analytics won't cause compilation failure for whole TS and I'll handle it in a separate PR - https://github.com/quarkus-qe/quarkus-test-suite/blob/main/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AnalyticsUtils.java#L95 as there it will be replacement with OTEL.

See: https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.6

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)