### PR TITLE
Use OpenTelemetry extension in Build-tiime Analytics module as OpenTracing is deprecated and not released yet

### DIFF
--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AnalyticsUtils.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AnalyticsUtils.java
@@ -92,7 +92,7 @@ public class AnalyticsUtils {
             "quarkus-smallrye-jwt-build",
             "quarkus-smallrye-metrics",
             "quarkus-smallrye-openapi",
-            "quarkus-smallrye-opentracing",
+            "quarkus-opentelemetry",
             "quarkus-smallrye-reactive-messaging",
             "quarkus-smallrye-reactive-messaging-kafka",
             "quarkus-spring-cache",


### PR DESCRIPTION
### Summary

Fixes CI. https://github.com/quarkus-qe/quarkus-test-suite/pull/1519 follow-up

https://docs.quarkiverse.io/quarkus-smallrye-opentracing/dev/index.html says we should use OpenTelemetry. There is no deeper logic why this module used OpenTracing extension (like product requirement or RH ticket etc.), so here we can safely replace it with preferred version.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)