### PR TITLE
Fix daily native build by limiting Java heap used and spread load in matrix

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -92,9 +92,9 @@ jobs:
       matrix:
         java: [ 11 ]
         image: [ "ubi-quarkus-graalvmce-builder-image:jdk-17", "ubi-quarkus-mandrel-builder-image:23.0-java17" ]
-        profiles: [ "root-modules,spring-modules",
+        profiles: [ "root-modules",
                    "http-modules",
-                   "security-modules",
+                   "security-modules,spring-modules",
                     "sql-db-modules -pl env-info,sql-db/hibernate,sql-db/sql-app,sql-db/sql-app-compatibility,sql-db/multiple-pus,sql-db/panache-flyway,sql-db/hibernate-reactive",
                     "sql-db-modules -pl env-info,sql-db/reactive-rest-data-panache,sql-db/vertx-sql,sql-db/reactive-vanilla,sql-db/hibernate-fulltext-search,sql-db/narayana-transactions",
                    "messaging-modules,websockets-modules,monitoring-modules,test-tooling-modules,nosql-db-modules"]
@@ -129,7 +129,7 @@ jobs:
         run: |
           mvn -fae -V -B -s .github/mvn-settings.xml -P ${{ matrix.profiles }} -fae clean verify -Dnative \
             -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }} \
-            -Dquarkus.native.native-image-xmx=5g \
+            -Dquarkus.native.native-image-xmx=4g \
             -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
         if: failure()


### PR DESCRIPTION
### Summary

- Currently native analytics daily build fails over OOM during native executable build, it started to happen after #1520 but I don't expect there is something wrong about OpenTelemetry, it might be larger than OpenTracing extension, but we definitely had problemw with memory in this module before: https://github.com/quarkus-qe/quarkus-test-suite/pull/1349
- I checked and Security profile takes least on average (~ 1 h 20 min) and root modules with spring takes up to for 4 h https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/6765196692/job/18392571155 but it jumps heavily with hours in difference). IMO we should spread load by moving Spring modules to Security modules

```
2023-11-16T03:28:34.0733613Z 03:28:34,030 INFO   - 4.44GB of memory (28.5% of 15.61GB system memory, set via '-Xmx5g')
2023-11-16T03:28:34.0734917Z 03:28:34,030 INFO   - 4 thread(s) (100.0% of 4 available processor(s), determined at start)
2023-11-16T03:35:32.9806773Z 03:35:32,969 INFO  Terminating due to java.lang.OutOfMemoryError: GC overhead limit exceeded
```

IIUC https://www.graalvm.org/latest/reference-manual/native-image/optimizations-and-performance/MemoryManagement/ it says that GC also needs 2x of the maximum heap size is the worst case and https://quarkus.io/guides/native-reference says minimum allowed is 4 GB.

So this PR might slower down native CI execution, but GH runners seems weak, I suggest to try it and optimize based on results.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)