### PR TITLE
Add Redis cache tests and bump Redis version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,15 @@ It covers different usages:
 3. from a blocking endpoint
 4. from a reactive endpoint
 
+### `cache/redis`
+
+Verifies the `quarkus-redis-cache` extension using `@CacheResult`, `@CacheInvalidate`, `@CacheInvalidateAll` and `@CacheKey`.
+It covers different usages:
+1. from an application scoped service
+2. from a request scoped service
+
+Also verify that Qute correctly indicate that does not work with remote cache.
+
 ### `cache/spring`
 
 Verifies the `quarkus-spring-cache` extension using `@Cacheable`, `@CacheEvict` and `@CachePut`.

--- a/cache/redis/pom.xml
+++ b/cache/redis/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>cache-redis</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: Cache: Redis</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-redis-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-qute</artifactId>
+        </dependency>
+        <!--> Added dependency to check https://github.com/quarkusio/quarkus/issues/35680 <-->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mailer</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/cache/redis/src/main/java/io/quarkus/ts/cache/redis/ApplicationScopeService.java
+++ b/cache/redis/src/main/java/io/quarkus/ts/cache/redis/ApplicationScopeService.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.cache.caffeine;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ApplicationScopeService extends BaseServiceWithCache {
+}

--- a/cache/redis/src/main/java/io/quarkus/ts/cache/redis/BaseServiceWithCache.java
+++ b/cache/redis/src/main/java/io/quarkus/ts/cache/redis/BaseServiceWithCache.java
@@ -1,0 +1,38 @@
+package io.quarkus.ts.cache.caffeine;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.CacheKey;
+import io.quarkus.cache.CacheResult;
+
+public abstract class BaseServiceWithCache {
+
+    private static final String CACHE_NAME = "service-cache";
+
+    private static int counter = 0;
+
+    @CacheResult(cacheName = CACHE_NAME)
+    public String getValue() {
+        return "Value: " + counter++;
+    }
+
+    @CacheInvalidate(cacheName = CACHE_NAME)
+    public void invalidate() {
+        // do nothing
+    }
+
+    @CacheResult(cacheName = CACHE_NAME)
+    public String getValueWithPrefix(@CacheKey String prefix) {
+        return prefix + ": " + counter++;
+    }
+
+    @CacheInvalidate(cacheName = CACHE_NAME)
+    public void invalidateWithPrefix(@CacheKey String prefix) {
+        // do nothing
+    }
+
+    @CacheInvalidateAll(cacheName = CACHE_NAME)
+    public void invalidateAll() {
+        // do nothing
+    }
+}

--- a/cache/redis/src/main/java/io/quarkus/ts/cache/redis/RequestScopeService.java
+++ b/cache/redis/src/main/java/io/quarkus/ts/cache/redis/RequestScopeService.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.cache.caffeine;
+
+import jakarta.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class RequestScopeService extends BaseServiceWithCache {
+}

--- a/cache/redis/src/main/java/io/quarkus/ts/cache/redis/ServiceWithCacheResource.java
+++ b/cache/redis/src/main/java/io/quarkus/ts/cache/redis/ServiceWithCacheResource.java
@@ -1,0 +1,65 @@
+package io.quarkus.ts.cache.caffeine;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/services")
+public class ServiceWithCacheResource {
+
+    public static final String APPLICATION_SCOPE_SERVICE_PATH = "application-scope";
+    public static final String REQUEST_SCOPE_SERVICE_PATH = "request-scope";
+
+    @Inject
+    ApplicationScopeService applicationScopeService;
+
+    @Inject
+    RequestScopeService requestScopeService;
+
+    @GET
+    @Path("/{service}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getValueFromService(@PathParam("service") String service) {
+        return lookupServiceByPathParam(service).getValue();
+    }
+
+    @POST
+    @Path("/{service}/invalidate-cache")
+    public void invalidateCacheFromService(@PathParam("service") String service) {
+        lookupServiceByPathParam(service).invalidate();
+    }
+
+    @POST
+    @Path("/{service}/invalidate-cache-all")
+    public void invalidateCacheAllFromService(@PathParam("service") String service) {
+        lookupServiceByPathParam(service).invalidateAll();
+    }
+
+    @GET
+    @Path("/{service}/using-prefix/{prefix}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getValueUsingPrefixFromService(@PathParam("service") String service, @PathParam("prefix") String prefix) {
+        return lookupServiceByPathParam(service).getValueWithPrefix(prefix);
+    }
+
+    @POST
+    @Path("/{service}/using-prefix/{prefix}/invalidate-cache")
+    public void invalidateCacheUsingPrefixFromService(@PathParam("service") String service,
+            @PathParam("prefix") String prefix) {
+        lookupServiceByPathParam(service).invalidateWithPrefix(prefix);
+    }
+
+    private BaseServiceWithCache lookupServiceByPathParam(String service) {
+        if (APPLICATION_SCOPE_SERVICE_PATH.equals(service)) {
+            return applicationScopeService;
+        } else if (REQUEST_SCOPE_SERVICE_PATH.equals(service)) {
+            return requestScopeService;
+        }
+
+        throw new IllegalArgumentException("Service " + service + " is not recognised");
+    }
+}

--- a/cache/redis/src/main/java/io/quarkus/ts/cache/redis/TemplateCacheResource.java
+++ b/cache/redis/src/main/java/io/quarkus/ts/cache/redis/TemplateCacheResource.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.cache.caffeine;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.quarkus.qute.Template;
+
+@Path("template")
+public class TemplateCacheResource {
+
+    @Inject
+    Template cached;
+
+    /**
+     * Check for remote cache with Qute template. Qute should not use remote cache.
+     * See https://github.com/quarkusio/quarkus/issues/35680#issuecomment-1711153725
+     *
+     * @return Should return error contains `not supported for remote caches`
+     */
+    @GET
+    @Path("error")
+    public String getQuteTemplate() {
+        try {
+            return cached.render();
+        } catch (IllegalStateException e) {
+            return e.getMessage();
+        }
+    }
+
+}

--- a/cache/redis/src/main/resources/templates/cached.html
+++ b/cache/redis/src/main/resources/templates/cached.html
@@ -1,0 +1,1 @@
+{#cached}This cached template won't be working with remote cache like redis.{/cached}

--- a/cache/redis/src/test/java/io/quarkus/ts/cache/redis/OpenShiftRedisCacheIT.java
+++ b/cache/redis/src/test/java/io/quarkus/ts/cache/redis/OpenShiftRedisCacheIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.cache.redis;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftRedisCacheIT extends RedisCacheIT {
+}

--- a/cache/redis/src/test/java/io/quarkus/ts/cache/redis/RedisCacheIT.java
+++ b/cache/redis/src/test/java/io/quarkus/ts/cache/redis/RedisCacheIT.java
@@ -1,0 +1,185 @@
+package io.quarkus.ts.cache.redis;
+
+import static io.quarkus.ts.cache.caffeine.ServiceWithCacheResource.APPLICATION_SCOPE_SERVICE_PATH;
+import static io.quarkus.ts.cache.caffeine.ServiceWithCacheResource.REQUEST_SCOPE_SERVICE_PATH;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.quarkus.test.bootstrap.DefaultService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class RedisCacheIT {
+
+    private static final String SERVICE_APPLICATION_SCOPE_PATH = "/services/" + APPLICATION_SCOPE_SERVICE_PATH;
+    private static final String SERVICE_REQUEST_SCOPE_PATH = "/services/" + REQUEST_SCOPE_SERVICE_PATH;
+
+    private static final String PREFIX_ONE = "prefix1";
+    private static final String PREFIX_TWO = "prefix2";
+
+    private static final int REDIS_PORT = 6379;
+
+    @Container(image = "${redis.image}", port = REDIS_PORT, expectedLog = "Ready to accept connections")
+    static DefaultService redis = new DefaultService().withProperty("ALLOW_EMPTY_PASSWORD", "YES");
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.redis.hosts",
+                    () -> {
+                        String redisHost = redis.getURI().withScheme("redis").getRestAssuredStyleUri();
+                        return String.format("%s:%d", redisHost, redis.getURI().getPort());
+                    });
+
+    /**
+     * Check whether the `@CacheResult` annotation works when used in a service.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { SERVICE_APPLICATION_SCOPE_PATH, SERVICE_REQUEST_SCOPE_PATH })
+    public void shouldGetTheSameValueAlwaysWhenGettingValueFromPath(String path) {
+        // We call the service endpoint
+        String value = getFromPath(path);
+
+        // At this point, the cache is populated and we should get the same value from the cache
+        assertEquals(value, getFromPath(path), "Value was different which means cache is not working");
+    }
+
+    /**
+     * Check whether the `@CacheInvalidate` annotation invalidates the cache when used in a service.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { SERVICE_APPLICATION_SCOPE_PATH, SERVICE_REQUEST_SCOPE_PATH })
+    public void shouldGetDifferentValueWhenInvalidateCacheFromPath(String path) {
+        // We call the service endpoint
+        String value = getFromPath(path);
+
+        // invalidate the cache
+        invalidateCacheFromPath(path);
+
+        // Then the value should be different as we have invalidated the cache.
+        assertNotEquals(value, getFromPath(path), "Value was equal which means cache invalidate didn't work");
+    }
+
+    /**
+     * Check whether the `@CacheResult` annotation works when used in a service.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { SERVICE_APPLICATION_SCOPE_PATH, SERVICE_REQUEST_SCOPE_PATH })
+    public void shouldGetTheSameValueForSamePrefixesWhenGettingValueFromPath(String path) {
+        // We call the service endpoint
+        String value = getValueFromPathUsingPrefix(path, PREFIX_ONE);
+
+        // At this point, the cache is populated and we should get the same value from the cache
+        assertEquals(value, getValueFromPathUsingPrefix(path, PREFIX_ONE),
+                "Value was different which means cache is not working");
+        // But different value using another prefix
+        assertNotEquals(value, getValueFromPathUsingPrefix(path, PREFIX_TWO),
+                "Value was equal which means @CacheKey didn't work");
+    }
+
+    /**
+     * Check whether the `@CacheInvalidate` annotation does not invalidate all the caches
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { SERVICE_APPLICATION_SCOPE_PATH, SERVICE_REQUEST_SCOPE_PATH })
+    public void shouldGetTheSameValuesEvenAfterCallingToCacheInvalidateFromPath(String path) {
+        // We call the service endpoints
+        String valueOfPrefix1 = getValueFromPathUsingPrefix(path, PREFIX_ONE);
+        String valueOfPrefix2 = getValueFromPathUsingPrefix(path, PREFIX_TWO);
+
+        // invalidate the cache: this should not invalidate all the keys
+        invalidateCacheFromPath(path);
+
+        // At this point, the cache is populated and we should get the same value for both prefixes
+        assertEquals(valueOfPrefix1, getValueFromPathUsingPrefix(path, PREFIX_ONE));
+        assertEquals(valueOfPrefix2, getValueFromPathUsingPrefix(path, PREFIX_TWO));
+    }
+
+    /**
+     * Check whether the `@CacheInvalidate` and `@CacheKey` annotations work as expected.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { SERVICE_APPLICATION_SCOPE_PATH, SERVICE_REQUEST_SCOPE_PATH })
+    public void shouldGetDifferentValueWhenInvalidateCacheOnlyForOnePrefixFromPath(String path) {
+        // We call the service endpoints
+        String valueOfPrefix1 = getValueFromPathUsingPrefix(path, PREFIX_ONE);
+        String valueOfPrefix2 = getValueFromPathUsingPrefix(path, PREFIX_TWO);
+
+        // invalidate the cache: this should not invalidate all the keys
+        invalidateCacheWithPrefixFromPath(path, PREFIX_ONE);
+
+        // The cache was invalidated only for prefix1, so the value should be different
+        assertNotEquals(valueOfPrefix1, getValueFromPathUsingPrefix(path, PREFIX_ONE));
+        // The cache was not invalidated for prefix2, so the value should be the same
+        assertEquals(valueOfPrefix2, getValueFromPathUsingPrefix(path, PREFIX_TWO));
+    }
+
+    /**
+     * Check whether the `@CacheInvalidateAll` annotation works as expected.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { SERVICE_APPLICATION_SCOPE_PATH, SERVICE_REQUEST_SCOPE_PATH })
+    public void shouldGetDifferentValueWhenInvalidateAllTheCacheFromPath(String path) {
+        // We call the service endpoints
+        String value = getFromPath(path);
+        String valueOfPrefix1 = getValueFromPathUsingPrefix(path, PREFIX_ONE);
+        String valueOfPrefix2 = getValueFromPathUsingPrefix(path, PREFIX_TWO);
+
+        // invalidate all the cache
+        invalidateCacheAllFromPath(path);
+
+        // Then, all the values should be different:
+        assertNotEquals(value, getFromPath(path));
+        assertNotEquals(valueOfPrefix1, getValueFromPathUsingPrefix(path, PREFIX_ONE));
+        assertNotEquals(valueOfPrefix2, getValueFromPathUsingPrefix(path, PREFIX_TWO));
+    }
+
+    /**
+     * Check if the usage of Qute and redis throw expected error
+     */
+    @Test
+    public void quteShouldThrowError() {
+        assertThat(getFromPath("/template/error"), containsString("not supported for remote caches"));
+    }
+
+    private void invalidateCacheAllFromPath(String path) {
+        postFromPath(path + "/invalidate-cache-all");
+    }
+
+    private void invalidateCacheWithPrefixFromPath(String path, String prefix) {
+        postFromPath(path + "/using-prefix/" + prefix + "/invalidate-cache");
+    }
+
+    private void invalidateCacheFromPath(String path) {
+        postFromPath(path + "/invalidate-cache");
+    }
+
+    private String getValueFromPathUsingPrefix(String path, String prefix) {
+        return getFromPath(path + "/using-prefix/" + prefix);
+    }
+
+    private String getFromPath(String path) {
+        return app.given()
+                .when().get(path)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().asString();
+    }
+
+    private void postFromPath(String path) {
+        app.given()
+                .when().post(path)
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+}

--- a/cache/redis/src/test/resources/test.properties
+++ b/cache/redis/src/test/resources/test.properties
@@ -1,0 +1,1 @@
+ts.redis.openshift.use-internal-service-as-url=true

--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
                                 <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
                                 <db2.image>quay.io/quarkusqeteam/db2:11.5.7.0</db2.image>
                                 <mongodb.image>docker.io/library/mongo:5.0</mongodb.image>
-                                <redis.image>docker.io/library/redis:6.0</redis.image>
+                                <redis.image>docker.io/library/redis:7.2</redis.image>
                                 <wiremock.image>quay.io/ocpmetal/wiremock</wiremock.image>
                                 <!-- TODO use official image when/if this fixed https://github.com/hashicorp/docker-consul/issues/184 -->
                                 <consul.image>docker.io/bitnami/consul:1.15.2</consul.image>

--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,7 @@
             <modules>
                 <module>env-info</module>
                 <module>cache/caffeine</module>
+                <module>cache/redis</module>
                 <module>infinispan-client</module>
             </modules>
         </profile>


### PR DESCRIPTION
### Summary

Hi, this PR main objective was cover https://github.com/quarkusio/quarkus/issues/35680. As it was need standalone module I added some test which was overlapping between caffeine cache and spring cache.  Test to cover 35680 is `quteShouldThrowError`. Tested manually the redis cache with rest of the api and I saw it cached in Redis (used `redis-cli keys "*"`).

In standalone commit is update of Redis version (Quarkus dev mode using latest).  

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)