### PR TITLE
Raise maximum Java heap used in Daily native image generation

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -129,7 +129,7 @@ jobs:
         run: |
           mvn -fae -V -B -s .github/mvn-settings.xml -P ${{ matrix.profiles }} -fae clean verify -Dnative \
             -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }} \
-            -Dquarkus.native.native-image-xmx=4g \
+            -Dquarkus.native.native-image-xmx=7g \
             -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
         if: failure()


### PR DESCRIPTION
### Summary

I thought the best way to mitigate Daily native image workflow running out of memory was to limit maximum Java heap used during the native image generation, but you can see that it didn't really help and I'm thinking GC just needs more. In both cases, we saw that we only allow GC small part of system memory. So either something else is using the memory (in which case we need to find it, like purge Docker images), or we simply don't use all that is at our disposal. The minimum memory suggested by Quarkus guide is 4 GB, so we can't go any lower.

See #1523

```
2023-11-19T03:40:09.2040280Z  - 3.56GB of memory (22.8% of 15.61GB system memory, set via '-Xmx4g')
2023-11-19T03:40:09.2040567Z  - 4 thread(s) (100.0% of 4 available processor(s), determined at start)
2023-11-19T03:40:09.2040833Z Terminating due to java.lang.OutOfMemoryError: GC overhead limit exceeded
```

Either this will work, or we need to clean resources, or build less of extensions. As daily build is already failing over this anyway, there is no risk at trying it.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)