### PR TITLE
Move cache extensions from root modules to spread load evenly in matrix (especially as way to mitigate native build OOM in dailys)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
             echo "Running modules: ${MODULES_ARG}"
             echo "MODULES_MAVEN_PARAM=[\" -pl ${MODULES_ARG} -Dall-modules\"]" >> $GITHUB_OUTPUT
           else
-            echo "MODULES_MAVEN_PARAM=[' -P root-modules,spring-modules,http-modules,test-tooling-modules', ' -P security-modules,sql-db-modules,messaging-modules,websockets-modules,monitoring-modules']" >> $GITHUB_OUTPUT
+            echo "MODULES_MAVEN_PARAM=[' -P root-modules,cache-modules,spring-modules,http-modules,test-tooling-modules', ' -P security-modules,sql-db-modules,messaging-modules,websockets-modules,monitoring-modules']" >> $GITHUB_OUTPUT
           fi
     outputs:
       MODULES_MAVEN_PARAM: ${{ steps.prepare-modules-mvn-param.outputs.MODULES_MAVEN_PARAM }}

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -43,7 +43,7 @@ jobs:
         java: [ 11, 17 ]
         profiles: [ "root-modules,http-modules,security-modules,spring-modules",
                    "sql-db-modules",
-                   "messaging-modules,websockets-modules,monitoring-modules,test-tooling-modules"]
+                   "messaging-modules,websockets-modules,monitoring-modules,cache-modules,test-tooling-modules"]
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space
@@ -93,7 +93,7 @@ jobs:
         java: [ 11 ]
         image: [ "ubi-quarkus-graalvmce-builder-image:jdk-17", "ubi-quarkus-mandrel-builder-image:23.0-java17" ]
         profiles: [ "root-modules",
-                   "http-modules",
+                   "http-modules,cache-modules",
                    "security-modules,spring-modules",
                     "sql-db-modules -pl env-info,sql-db/hibernate,sql-db/sql-app,sql-db/sql-app-compatibility,sql-db/multiple-pus,sql-db/panache-flyway,sql-db/hibernate-reactive",
                     "sql-db-modules -pl env-info,sql-db/reactive-rest-data-panache,sql-db/vertx-sql,sql-db/reactive-vanilla,sql-db/hibernate-fulltext-search,sql-db/narayana-transactions",

--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         profiles: [ "root-modules-no-qute,monitoring-modules,spring-modules,test-tooling-modules",
                     "http-modules",
-                    "security-modules",
+                    "security-modules,cache-modules",
                     "sql-db-modules",
                     "messaging-modules-no-kafka,websockets-modules"]
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following subsections will introduce how to deploy and run the test suite in
 If you have a look the main `pom.xml` you will notice that there are several profiles or in other words the test suite is a maven monorepo that you can compile and verify at once or by topics. Let's review the main profiles:
 
 * root-modules: talk about Quarkus "core stuff" as configuration or properties. Is a basic stuff that should work as a pre-requisite to other modules.
+* cache-modules: cover Quarkus application data caching
 * http-modules: talk about HTTP extensions and no-application endpoints like `/q/health`
 * security-modules: cover all security stuff like OAuth, JWT, OpenId, Keycloak etc
 * messaging-modules: is focus on brokers as Kafka or Artemis-AMQP

--- a/pom.xml
+++ b/pom.xml
@@ -410,11 +410,9 @@
                 <module>lifecycle-application</module>
                 <module>external-applications</module>
                 <module>scheduling/quartz</module>
-                <module>infinispan-client</module>
                 <module>super-size/many-extensions</module>
                 <module>quarkus-cli</module>
                 <module>logging/jboss</module>
-                <module>cache/caffeine</module>
                 <module>qute/multimodule</module>
                 <module>qute/synchronous</module>
                 <module>qute/reactive</module>
@@ -436,12 +434,24 @@
                 <module>lifecycle-application</module>
                 <module>external-applications</module>
                 <module>scheduling/quartz</module>
-                <module>infinispan-client</module>
                 <module>super-size/many-extensions</module>
                 <module>quarkus-cli</module>
                 <module>logging/jboss</module>
-                <module>cache/caffeine</module>
                 <module>build-time-analytics</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>cache-modules</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>all-modules</name>
+                </property>
+            </activation>
+            <modules>
+                <module>env-info</module>
+                <module>cache/caffeine</module>
+                <module>infinispan-client</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
### Summary

I don't know what to do about dailys - https://github.com/quarkus-qe/quarkus-test-suite/actions/workflows/daily.yaml it seems to me like either we need to introduce some cleaning of resources, or we need to spread load to other runners. I already had 2 experimental attempts #1529 and #1523 without success.

But what is worse, new addition is coming right into root modules where we fight resources: #1524

I propose to separate cache modules as that way we can easily couple them with other profiles in matrix. Native executable build time is very volatile, but building HTTP modules still takes less than root-modules. Sometimes significantly less, see https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/6819612674/job/18547594454 2 hours less.

I'll follow-up with Jenkins updates if this goes in.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)