### PR TITLE
[3.2] Bump QE Test Framework to 1.3.0.Beta32 and workaround Quarkus CLI issues

### DIFF
--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AbstractAnalyticsIT.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AbstractAnalyticsIT.java
@@ -60,6 +60,7 @@ public abstract class AbstractAnalyticsIT {
     private QuarkusCliRestService createApp(String appName, String... extensions) {
         String gav = QuarkusProperties.PLATFORM_GROUP_ID.get() + ":quarkus-bom:" + QuarkusProperties.getVersion();
         QuarkusCliClient.CreateApplicationRequest createApplicationRequest = defaults()
+                .withStream(null) // HOTFIX: combination of --stream and --platform-bom exits without generating app
                 .withPlatformBom(gav)
                 .withExtraArgs("--no-code", "--no-wrapper")
                 .withExtensions(extensions);

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.2.9.Final</quarkus.platform.version>
         <quarkus.ide.version>3.2.9.Final</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.3.0.Beta28</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.3.0.Beta32</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.4.0</quarkus-qpid-jms.version>
         <apache-httpclient-fluent.version>4.5.14</apache-httpclient-fluent.version>
         <confluent.kafka-avro-serializer.version>7.3.1</confluent.kafka-avro-serializer.version>

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -242,7 +242,10 @@ public class QuarkusCliCreateJvmApplicationIT {
     public void shouldAddAndRemoveExtensions() {
         // Create application
         String gav = QuarkusProperties.PLATFORM_GROUP_ID.get() + ":quarkus-bom:" + QuarkusProperties.getVersion();
-        QuarkusCliRestService app = cliClient.createApplication("app", defaults().withPlatformBom(gav));
+        QuarkusCliRestService app = cliClient.createApplication("app", defaults()
+                // HOTFIX: combination of --stream and --platform-bom exits without generating app
+                .withStream(null)
+                .withPlatformBom(gav));
 
         // By default, it installs only "quarkus-resteasy"
         assertInstalledExtensions(app, RESTEASY_REACTIVE_EXTENSION);
@@ -273,6 +276,8 @@ public class QuarkusCliCreateJvmApplicationIT {
     public void shouldKeepUsingTheSameQuarkusVersionAfterReload() {
         // Generate application using old community version
         QuarkusCliRestService app = cliClient.createApplication("app", defaults()
+                // HOTFIX: combination of --stream and --platform-bom exits without generating app
+                .withStream(null)
                 .withPlatformBom("io.quarkus:quarkus-bom:3.0.0.Alpha4")
                 .withExtensions(SMALLRYE_HEALTH_EXTENSION, RESTEASY_REACTIVE_EXTENSION));
 


### PR DESCRIPTION
### Summary

- Bumps test framework to 1.3.0.Beta32.
- Works around https://github.com/quarkusio/quarkus/issues/37307 as now we have fixed version https://github.com/quarkus-qe/quarkus-test-framework/commit/f0cdc1f4d76489171fce234685b59bc05e64ddb5

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)