### PR TITLE
[3.2] Enable disabled test for gradle building app by Quarkus cli

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -115,7 +115,6 @@ public class QuarkusCliCreateJvmApplicationIT {
         assertDockerJavaVersion(getFileFromApplication(app, DOCKER_FOLDER, DOCKERFILE_JVM), JDK_17);
     }
 
-    @Disabled("https://issues.redhat.com/browse/QUARKUS-3439")
     @Tag("QUARKUS-1071")
     @Test
     public void shouldCreateApplicationWithGradleOnJvm() {


### PR DESCRIPTION
### Summary

[QUARKUS-3439](https://issues.redhat.com/browse/QUARKUS-3439) was resolved, so this PR enable the test for gradle with Quarkus cli. 

Tested it locally with RHBQ. The test are passing.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)