### PR TITLE
[3.2] Fix service binding PostgreSQL tests on OpenShift 4.14 as cluster service versions are loaded lazily

### DIFF
--- a/service-binding/postgresql-crunchy-classic/src/test/java/io/quarkus/ts/sb/postgresql/OpenShiftPostgreSqlSbIT.java
+++ b/service-binding/postgresql-crunchy-classic/src/test/java/io/quarkus/ts/sb/postgresql/OpenShiftPostgreSqlSbIT.java
@@ -1,16 +1,19 @@
 package io.quarkus.ts.sb.postgresql;
 
+import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
+import static io.quarkus.test.utils.AwaitilityUtils.AwaitilitySettings.using;
+import static java.time.Duration.ofSeconds;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -47,22 +50,23 @@ public class OpenShiftPostgreSqlSbIT {
                 .statusCode(HttpStatus.SC_OK);
     }
 
-    private static boolean areRequiredOperatorsInstalled() {
-        List<String> output = new ArrayList<>();
-        try {
-            // TODO: figure out a better way to wait for this - this wait is necessary as it takes some time for API to
-            //       populate new namespace with objects
-            Thread.sleep(2000);
-            new Command("oc", "get", "csv").outputToLines(output).runAndWait();
-        } catch (Exception e) {
-            throw new RuntimeException(e.getMessage(), e);
-        }
-        String outputString = output.stream().collect(Collectors.joining(System.lineSeparator()));
-        return (outputString.contains("postgresoperator") && outputString.contains("service-binding-operator"));
+    private static void assertRequiredOperatorsInstalled() {
+        untilAsserted(() -> {
+            List<String> output = new ArrayList<>();
+            try {
+                // TODO: figure out a better way to wait for this - this wait is necessary as it takes some
+                //  time for API to populate new namespace with objects
+                new Command("oc", "get", "csv").outputToLines(output).runAndWait();
+            } catch (Exception e) {
+                throw new RuntimeException(e.getMessage(), e);
+            }
+            assertTrue(output.stream().anyMatch(str -> str.contains("postgresoperator")));
+            assertTrue(output.stream().anyMatch(str -> str.contains("service-binding-operator")));
+        }, using(ofSeconds(2), ofSeconds(60)));
     }
 
     private static void createPostgresCluster() {
-        Assumptions.assumeTrue(areRequiredOperatorsInstalled());
+        assertRequiredOperatorsInstalled();
         applyCustomResourceDefinition("pg-cluster.yml");
         try {
             // TODO: figure out a better way to wait for this - sometimes operator takes a while to create object


### PR DESCRIPTION
### Summary

Behavior between OCP 4.11 and OCP 4.14 differs in that cluster service versions are added to newly created project one by one (not at once) and it takes longer.

**Native OCP failure is very much as what I see on main (but there even in JVM mode), I'll get back to it, but it is not related to changes here.**

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)