### PR TITLE
[3.2] Verify Hibernate ORM config mapping for named persistence units

### DIFF
--- a/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/analyze/AnalyzeResource.java
+++ b/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/analyze/AnalyzeResource.java
@@ -8,11 +8,14 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 
+import io.quarkus.hibernate.orm.PersistenceUnit;
+
 @Path("/analyze")
 public class AnalyzeResource {
 
     public static final String AUTHOR = "Churchill";
 
+    @PersistenceUnit("named")
     @Inject
     EntityManager entityManager;
 

--- a/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/ItemsResource.java
+++ b/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/ItemsResource.java
@@ -9,10 +9,13 @@ import jakarta.transaction.Transactional;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
+import io.quarkus.hibernate.orm.PersistenceUnit;
+
 @Path("/items")
 @Transactional
 public class ItemsResource {
 
+    @PersistenceUnit("named")
     @Inject
     EntityManager em;
 

--- a/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/validator/JakartaPersistenceAndHibernateValidatorResource.java
+++ b/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/validator/JakartaPersistenceAndHibernateValidatorResource.java
@@ -13,6 +13,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+import io.quarkus.hibernate.orm.PersistenceUnit;
+
 @Path("/hello")
 public class JakartaPersistenceAndHibernateValidatorResource {
     // reproducer for https://github.com/quarkusio/quarkus/issues/8323
@@ -20,6 +22,7 @@ public class JakartaPersistenceAndHibernateValidatorResource {
     @Inject
     Validator validator;
 
+    @PersistenceUnit("named")
     @Inject
     EntityManager em;
 

--- a/sql-db/hibernate/src/main/resources/application.properties
+++ b/sql-db/hibernate/src/main/resources/application.properties
@@ -1,5 +1,8 @@
-quarkus.hibernate-orm.database.generation=drop-and-create
-quarkus.hibernate-orm.sql-load-script=import.sql
+# using named config persistence unit to verify https://github.com/quarkusio/quarkus/issues/35631
+quarkus.hibernate-orm.named.datasource=<default>
+quarkus.hibernate-orm.named.packages=io.quarkus.qe.hibernate.analyze,io.quarkus.qe.hibernate.items,io.quarkus.qe.hibernate.validator
+quarkus.hibernate-orm.named.database.generation=drop-and-create
+quarkus.hibernate-orm.named.sql-load-script=import.sql
 
 # verify https://github.com/quarkusio/quarkus/issues/28593 by using quote identifiers strategy
-quarkus.hibernate-orm.quote-identifiers.strategy=all-except-column-definitions
+quarkus.hibernate-orm.named.quote-identifiers.strategy=all-except-column-definitions

--- a/sql-db/hibernate/src/test/java/io/quarkus/qe/hibernate/BaseHibernateIT.java
+++ b/sql-db/hibernate/src/test/java/io/quarkus/qe/hibernate/BaseHibernateIT.java
@@ -10,8 +10,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag("QUARKUS-3731")
 public abstract class BaseHibernateIT {
 
     private static final String TRANSACTION_SCOPE_BASE_PATH = "/transaction-scope";


### PR DESCRIPTION
### Summary

verifies: https://github.com/quarkusio/quarkus/pull/35635

Plenty of other modules still uses default Hibernate persistence unit (sql-app, sql-app-compatibility; almost all others uses it as well together named pu)

`mvn clean verify` => pass
`mvn clean verify -Dquarkus.platform.version=3.2.7.Final` => fail

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)