### PR TITLE
[3.2] Re-enable mongodb tests on s390x

### DIFF
--- a/nosql-db/mongodb/src/test/java/io/quarkus/ts/nosqldb/mongodb/OpenShiftMongoClientIT.java
+++ b/nosql-db/mongodb/src/test/java/io/quarkus/ts/nosqldb/mongodb/OpenShiftMongoClientIT.java
@@ -1,10 +1,7 @@
 package io.quarkus.ts.nosqldb.mongodb;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "bitnami/mongodb container not available on s390x.")
 public class OpenShiftMongoClientIT extends MongoClientIT {
 }

--- a/pom.xml
+++ b/pom.xml
@@ -851,6 +851,7 @@
                                         <mariadb.105.image>registry.redhat.io/rhel8/mariadb-105</mariadb.105.image>
                                         <amq-streams.image>registry.redhat.io/amq7/amq-streams-kafka-33-rhel8</amq-streams.image>
                                         <amq-streams.version>2.3.0</amq-streams.version>
+                                        <mongodb.image>docker.io/library/mongo:4.4.6</mongodb.image>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
### Summary

Due to the test suite no longer using `bitnami/mongodb`, we can use the community version of MongoDB from DockerHub that is available on s390x. The test is passing now instead of being previously skipped. I will cherry-pick this into `main` after.

https://master-jenkins-csb-runtimes-ibmzqe.apps.ocp-c1.prod.psi.redhat.com/view/RHOAR/job/rhbq-3.x-ocp4-rhel8-jdk11/lastCompletedBuild/jdk=openjdk11,label=quarkus,scenario=databases-modules/testReport/io.quarkus.ts.nosqldb.mongodb/

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)