### PR TITLE
Move Java baseline to 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space
@@ -38,7 +38,7 @@ jobs:
     needs: build-dependencies
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v4
       - name: Install JDK {{ matrix.java }}
@@ -69,7 +69,8 @@ jobs:
         continue-on-error: true
       - id: detect-changes
         run: |
-          MODULES=$(find -name pom.xml | sed -e 's|pom.xml| |' | sed -e 's|./| |' | grep -v " quarkus/")
+          # FIXME: remove helm filter from following line when helm module is enabled
+          MODULES=$(find -name pom.xml | sed -e 's|pom.xml| |' | sed -e 's|./| |' | grep -v " quarkus/" | grep -v " helm/helm-minimum")
           CHANGED=""
           MODULES_ARG=""
 
@@ -111,7 +112,7 @@ jobs:
     needs: prepare-jvm-latest-modules-mvn-param
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
         module-mvn-args: ${{ fromJSON(needs.prepare-jvm-latest-modules-mvn-param.outputs.MODULES_MAVEN_PARAM) }}
     steps:
       - uses: actions/checkout@v4
@@ -161,7 +162,7 @@ jobs:
       MODULES_ARG: ${{ needs.detect-test-suite-modules.outputs.MODULES_ARG }}
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space
@@ -216,7 +217,7 @@ jobs:
       MODULES_ARG: ${{ needs.detect-test-suite-modules.outputs.MODULES_ARG }}
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v4
       - name: Install JDK {{ matrix.java }}

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space
@@ -40,7 +40,7 @@ jobs:
     needs: build-dependencies
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 17, 21 ]
         profiles: [ "root-modules,http-modules,security-modules,spring-modules",
                    "sql-db-modules",
                    "messaging-modules,websockets-modules,monitoring-modules,cache-modules,test-tooling-modules"]
@@ -90,8 +90,8 @@ jobs:
     needs: build-dependencies
     strategy:
       matrix:
-        java: [ 11 ]
-        image: [ "ubi-quarkus-graalvmce-builder-image:jdk-17", "ubi-quarkus-mandrel-builder-image:23.0-java17" ]
+        java: [ 17 ]
+        image: [ "ubi-quarkus-graalvmce-builder-image:jdk-21", "ubi-quarkus-mandrel-builder-image:jdk-21" ]
         profiles: [ "root-modules",
                    "http-modules,cache-modules",
                    "security-modules,spring-modules",
@@ -147,7 +147,7 @@ jobs:
     needs: build-dependencies
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 17, 21 ]
     steps:
       - uses: actions/checkout@v4
       - name: Install JDK {{ matrix.java }}
@@ -187,9 +187,9 @@ jobs:
     needs: build-dependencies
     strategy:
       matrix:
-        java: [ 11 ]
-        graalvm-version: [ "mandrel-23.0.1.2-Final" ]
-        graalvm-java-version: [ "17" ]
+        java: [ 17 ]
+        graalvm-version: [ "mandrel-latest" ]
+        graalvm-java-version: [ "21" ]
     steps:
       - uses: actions/checkout@v4
       - name: Install JDK {{ matrix.java }}

--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -9,7 +9,7 @@ on:
 env:
   ECOSYSTEM_CI_REPO: quarkusio/quarkus-ecosystem-ci
   ECOSYSTEM_CI_REPO_FILE: context.yaml
-  JAVA_VERSION: 11
+  JAVA_VERSION: 17
 
   #########################
   # Repo specific setting #

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The test suite includes:
 
 ## How-to run Quarkus test suite
 
-Docker, JDK 11+, and Apache Maven 3.8 are the base requirements to run the test suite using the following command:
+Docker, JDK 17+, and Apache Maven 3.8 are the base requirements to run the test suite using the following command:
 
 `mvn clean verify`
 
@@ -134,7 +134,7 @@ More info about how to generate native images could be found in Quarkus [buildin
 User: `Deploy in OpenShift the module http-minimum compiled with a custom GraalVM Docker image and 5GB of memory`
 
 ```shell
-mvn clean verify -Dall-modules -Dnative -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17 -Dquarkus.native.native-image-xmx=5g -Dopenshift -pl http/http-minimum
+mvn clean verify -Dall-modules -Dnative -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21 -Dquarkus.native.native-image-xmx=5g -Dopenshift -pl http/http-minimum
 ```
 
 #### OpenShift & Native via local GraalVM

--- a/docker-build/src/main/docker/Dockerfile.jvm
+++ b/docker-build/src/main/docker/Dockerfile.jvm
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/getting-started-jvm
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.14
+FROM registry.access.redhat.com/ubi8/openjdk-17:latest
 
 ENV LANGUAGE='en_US:en'
 

--- a/helm/helm-minimum/src/main/docker/Dockerfile.jvm
+++ b/helm/helm-minimum/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.14
+FROM registry.access.redhat.com/ubi8/openjdk-17:latest
 
 ENV LANGUAGE='en_US:en'
 

--- a/http/vertx-web-client/README.md
+++ b/http/vertx-web-client/README.md
@@ -8,7 +8,7 @@
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 
 ## Scope of the testing
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
     <name>Quarkus QE TS: Parent</name>
     <properties>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -704,7 +704,7 @@
                 <quarkus.package.type>native</quarkus.package.type>
                 <quarkus.native.container-build>true</quarkus.native.container-build>
                 <quarkus.native.native-image-xmx>4g</quarkus.native.native-image-xmx>
-                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:23.0-java17</quarkus.native.builder-image>
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21</quarkus.native.builder-image>
                 <exclude.quarkus.devmode.tests>**/*DevMode*IT.java</exclude.quarkus.devmode.tests>
             </properties>
         </profile>

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -57,7 +57,7 @@ public class QuarkusCliCreateJvmApplicationIT {
     static final String RESTEASY_REACTIVE_JACKSON_EXTENSION = "quarkus-resteasy-reactive-jackson";
     static final String ROOT_FOLDER = "";
     static final String DOCKER_FOLDER = "/src/main/docker";
-    static final String JDK_11 = "11";
+    static final String JDK_21 = "21";
     static final String JDK_17 = "17";
     static final String JDK_18 = "18";
     static final String DOCKERFILE_JVM = "Dockerfile.jvm";
@@ -91,11 +91,11 @@ public class QuarkusCliCreateJvmApplicationIT {
 
     @Tag("QUARKUS-1472")
     @Test
-    public void shouldCreateAnApplicationForcingJavaVersion11() {
-        CreateApplicationRequest args = defaultWithFixedStream().withExtraArgs("--java=" + JDK_11);
+    public void shouldCreateAnApplicationForcingJavaVersion21() {
+        CreateApplicationRequest args = defaultWithFixedStream().withExtraArgs("--java=" + JDK_21);
         QuarkusCliRestService app = cliClient.createApplication("app", args);
-        assertExpectedJavaVersion(getFileFromApplication(app, ROOT_FOLDER, "pom.xml"), JDK_11);
-        assertDockerJavaVersion(getFileFromApplication(app, DOCKER_FOLDER, DOCKERFILE_JVM), JDK_11);
+        assertExpectedJavaVersion(getFileFromApplication(app, ROOT_FOLDER, "pom.xml"), JDK_21);
+        assertDockerJavaVersion(getFileFromApplication(app, DOCKER_FOLDER, DOCKERFILE_JVM), JDK_21);
     }
 
     @Tag("QUARKUS-1472")

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/Pkcs12OidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/Pkcs12OidcMtlsIT.java
@@ -3,25 +3,16 @@ package io.quarkus.ts.security.oidcclient.mtls;
 import static io.quarkus.ts.security.oidcclient.mtls.MutualTlsKeycloakService.KC_DEV_MODE_P12_CMD;
 import static io.quarkus.ts.security.oidcclient.mtls.MutualTlsKeycloakService.newKeycloakInstance;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.jupiter.api.condition.DisabledIf;
-
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.test.utils.Command;
 
 /**
  * Keystore file type is automatically detected in following tests by its extension in quarkus-oidc.
  * Extension declared here is used by tests only.
  */
-@DisabledIf(value = "cannotRunOnFIPS", disabledReason = "PKCS12 keystore is not FIPS compliant on Red Hat OpenJDK 11")
 @QuarkusScenario
 public class Pkcs12OidcMtlsIT extends KeycloakMtlsAuthN {
 
@@ -49,24 +40,4 @@ public class Pkcs12OidcMtlsIT extends KeycloakMtlsAuthN {
         return P12_KEYSTORE_FILE_EXTENSION;
     }
 
-    private static boolean cannotRunOnFIPS() {
-        String javaVersion = new PropertyLookup("java.version").get();
-        String javaVMVendor = new PropertyLookup("java.vm.vendor").get();
-
-        if (javaVersion.matches("11.*") && javaVMVendor.matches(".*Red.*Hat.*")) {
-            List<String> commandOutputLines = new ArrayList<>();
-
-            try {
-                new Command("sysctl", "crypto.fips_enabled").outputToLines(commandOutputLines).runAndWait();
-            } catch (IOException | InterruptedException e) {
-                return false;
-            }
-
-            boolean isFipsEnabled = commandOutputLines.get(0).matches(".*1");
-
-            return javaVersion.matches("11.*") && javaVMVendor.matches(".*Red.*Hat.*") && isFipsEnabled;
-        }
-
-        return false;
-    }
 }

--- a/spring/spring-web-reactive/README.md
+++ b/spring/spring-web-reactive/README.md
@@ -18,7 +18,7 @@ Verify correct content types in OpenAPI endpoint output using Mutiny method sign
 - Verify content types in the schema. The types should correspond to the definitions in Spring annotations.
 
 ## Requirements
-- JDK 11+
+- JDK 17+
 - GraalVM
 
 # Quarkus Spring Web Reactive - Spring Boot Bootstrap application
@@ -39,5 +39,5 @@ Test CRUD resource `BookController`:
 Test home page HTML response and value injection in `SimpleController`.
 
 ## Requirements
-- JDK 11+
+- JDK 17+
 - GraalVM

--- a/sql-db/vertx-sql/README.md
+++ b/sql-db/vertx-sql/README.md
@@ -6,7 +6,7 @@
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - Docker
 - PostgreSQL
 - MySQL


### PR DESCRIPTION
### Summary

- Both Quarkus and QE FW are moving to Java 17 - https://github.com/quarkus-qe/quarkus-test-framework/pull/970
- Builder images are mirroring Quarkus upstream defaults as these are most likely to be used by users - https://github.com/quarkusio/quarkus/blob/main/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java#L23

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)