### PR TITLE
Enable and refactor TodoDemoIT on baremetal and OpenShift as TODO Application with Quarkus is now based on Quarkus 3

### DIFF
--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftTodoDemoIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftTodoDemoIT.java
@@ -1,14 +1,8 @@
 package io.quarkus.ts.external.applications;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
-// TODO: enable when Quarkus TODO application migrates to Quarkus 3
-@Disabled("Disabled until TODO application migrates to Quarkus 3")
-@DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @DisabledOnNative(reason = "Native + s2i not supported")
 @OpenShiftScenario
 public class OpenShiftTodoDemoIT extends TodoDemoIT {

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/TodoDemoIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/TodoDemoIT.java
@@ -1,43 +1,61 @@
 package io.quarkus.ts.external.applications;
 
+import static org.hamcrest.Matchers.is;
+
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.bootstrap.PostgresqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Container;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
+import io.restassured.http.ContentType;
 
-// TODO: enable when Quarkus TODO application migrates to Quarkus 3
-@Disabled("Disabled until TODO application migrates to Quarkus 3")
 @DisabledOnNative(reason = "This scenario is using uber-jar, so it's incompatible with Native")
 @QuarkusScenario
 public class TodoDemoIT {
     private static final String TODO_REPO = "https://github.com/quarkusio/todo-demo-app.git";
     private static final String VERSIONS = "-Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} ";
-    private static final String DEFAULT_OPTIONS = "-DskipTests=true " + VERSIONS;
+    private static final String DEFAULT_OPTIONS = " -DskipTests=true " + VERSIONS;
 
-    @GitRepositoryQuarkusApplication(repo = TODO_REPO, mavenArgs = "-Dquarkus.package.type=uber-jar " + DEFAULT_OPTIONS)
-    static final RestService app = new RestService();
+    @Container(image = "${postgresql.latest.image}", port = 5432, expectedLog = "listening on IPv4 address")
+    static PostgresqlService database = new PostgresqlService()
+            // store data in /tmp/psql as in OpenShift we don't have permissions to /var/lib/postgresql/data
+            .withProperty("PGDATA", "/tmp/psql");
+
+    @GitRepositoryQuarkusApplication(repo = TODO_REPO, mavenArgs = "-Dquarkus.package.type=uber-jar" + DEFAULT_OPTIONS)
+    static final RestService app = new RestService()
+            .withProperty("quarkus.datasource.username", database.getUser())
+            .withProperty("quarkus.datasource.password", database.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
 
     @GitRepositoryQuarkusApplication(repo = TODO_REPO, artifact = "todo-backend-1.0-SNAPSHOT.jar", mavenArgs = "-Dquarkus.package.type=uber-jar -Dquarkus.package.add-runner-suffix=false"
             + DEFAULT_OPTIONS)
-    static final RestService replaced = new RestService();
+    static final RestService replaced = new RestService()
+            .withProperty("quarkus.datasource.username", database.getUser())
+            .withProperty("quarkus.datasource.password", database.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
 
     @Test
     public void startsSuccessfully() {
         app.given()
-                .get()
+                .contentType(ContentType.JSON)
+                .body("{\"title\": \"Use Quarkus\", \"order\": 1, \"url\": \"https://quarkus.io\"}")
+                .post("/api")
                 .then()
-                .statusCode(HttpStatus.SC_OK);
+                .statusCode(HttpStatus.SC_CREATED);
     }
 
     @Test
     public void replacedStartsSuccessfully() {
         replaced.given()
-                .get()
+                .accept(ContentType.JSON)
+                .get("/api")
                 .then()
-                .statusCode(HttpStatus.SC_OK);
+                .statusCode(HttpStatus.SC_OK)
+                .body("$.size()", is(1))
+                .body("title[0]", is("Use Quarkus"));
     }
 }


### PR DESCRIPTION
### Summary

- TODO Application with Quarkus is now based on Quarkus 3 - https://github.com/quarkusio/todo-demo-app/pull/32
- we already support running git repository OpenShift tests with 999-SNAPSHOT
- TODO Application is now using database. I refactored test so that we use it and don't start database for nothing.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)