### PR TITLE
Fix Narayana OTEL operation name in Oracle test used for SELECT query to dual table

### DIFF
--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OracleTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OracleTransactionGeneralUsageIT.java
@@ -34,7 +34,7 @@ public class OracleTransactionGeneralUsageIT extends TransactionCommons {
 
     @Override
     protected String[] getExpectedJdbcOperationNames() {
-        return new String[] { "SELECT mydb", "INSERT mydb.journal", "UPDATE mydb.account" };
+        return new String[] { "SELECT mydb.dual", "INSERT mydb.journal", "UPDATE mydb.account" };
     }
 
     @Override


### PR DESCRIPTION
### Summary

Dailys are failing. I can't connect this change to any concerete PR in Quarkus or TS between 25.11 and 29.11 https://github.com/quarkusio/quarkus/pulls?q=is%3Apr+is%3Aclosed+merged%3A2023-11-25..2023-11-29+base%3Amain+sort%3Aupdated-desc+. I don't want to invest more of my time into it. I suppose this can be also related to Docker image (some change in minor version that caused change of driver interaction). It is possible to find out, but it will cost more time. FWIW it's change for better, thought it would be nice to know what changed.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)