### PR TITLE
[2.13] Pin todo-demo-app to quarkus2 branch

### DIFF
--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/TodoDemoIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/TodoDemoIT.java
@@ -12,13 +12,15 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 @QuarkusScenario
 public class TodoDemoIT {
     private static final String TODO_REPO = "https://github.com/quarkusio/todo-demo-app.git";
+    private static final String TODO_BRANCH = "quarkus2";
     private static final String VERSIONS = "-Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} ";
     private static final String DEFAULT_OPTIONS = "-DskipTests=true " + VERSIONS;
 
-    @GitRepositoryQuarkusApplication(repo = TODO_REPO, mavenArgs = "-Dquarkus.package.type=uber-jar " + DEFAULT_OPTIONS)
+    @GitRepositoryQuarkusApplication(repo = TODO_REPO, branch = TODO_BRANCH, mavenArgs = "-Dquarkus.package.type=uber-jar "
+            + DEFAULT_OPTIONS)
     static final RestService app = new RestService();
 
-    @GitRepositoryQuarkusApplication(repo = TODO_REPO, artifact = "todo-backend-1.0-SNAPSHOT.jar", mavenArgs = "-Dquarkus.package.type=uber-jar -Dquarkus.package.add-runner-suffix=false"
+    @GitRepositoryQuarkusApplication(repo = TODO_REPO, branch = TODO_BRANCH, artifact = "todo-backend-1.0-SNAPSHOT.jar", mavenArgs = "-Dquarkus.package.type=uber-jar -Dquarkus.package.add-runner-suffix=false"
             + DEFAULT_OPTIONS)
     static final RestService replaced = new RestService();
 


### PR DESCRIPTION
### Summary

* Testing todo-demo-app has finally been updated to Quarkus 3, so we
  need to pin this branch to use quarkus2 branch of the application.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)