### PR TITLE
Test coverage for records returned in response from REST endpoint

### DIFF
--- a/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/HelloResource.java
+++ b/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/HelloResource.java
@@ -41,4 +41,21 @@ public class HelloResource {
     public Response hello() {
         return Response.ok("hello").header("Transfer-Encoding", "chunked").build();
     }
+
+    public record Data(String data) {
+    }
+
+    @GET
+    @Path("short-record-response")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response shortRecordInResponseClass() {
+        return Response.ok().entity(new Data("ok")).build();
+    }
+
+    @GET
+    @Path("short-record")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Data shortRecordReturnedDirectly() {
+        return new Data("ok");
+    }
 }

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpMinimumReactiveIT.java
@@ -6,6 +6,8 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import jakarta.ws.rs.core.MediaType;
+
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -58,6 +60,22 @@ public class HttpMinimumReactiveIT {
                 .statusCode(HttpStatus.SC_OK)
                 .headers("Transfer-Encoding", is(nullValue()))
                 .headers("Content-Length", is(notNullValue()));
+    }
+
+    @Test
+    public void shortRecordInResponseClass() {
+        givenSpec().get("/api/hello/short-record-response").then()
+                .statusCode(HttpStatus.SC_OK)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("data", is("ok"));
+    }
+
+    @Test
+    public void shortRecordReturnedDirectly() {
+        givenSpec().get("/api/hello/short-record").then()
+                .statusCode(HttpStatus.SC_OK)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("data", is("ok"));
     }
 
     protected RequestSpecification givenSpec() {

--- a/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/HelloResource.java
+++ b/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/HelloResource.java
@@ -39,4 +39,21 @@ public class HelloResource {
     public Response hello() {
         return Response.ok("hello").header("Transfer-Encoding", "chunked").build();
     }
+
+    public record Data(String data) {
+    }
+
+    @GET
+    @Path("short-record-response")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response shortRecordInResponseClass() {
+        return Response.ok().entity(new Data("ok")).build();
+    }
+
+    @GET
+    @Path("short-record")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Data shortRecordReturnedDirectly() {
+        return new Data("ok");
+    }
 }

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/HttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/HttpMinimumIT.java
@@ -5,6 +5,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+import jakarta.ws.rs.core.MediaType;
+
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -43,6 +45,22 @@ public class HttpMinimumIT {
                 .statusCode(HttpStatus.SC_OK)
                 .headers("Transfer-Encoding", is(nullValue()))
                 .headers("Content-Length", is(notNullValue()));
+    }
+
+    @Test
+    public void shortRecordInResponseClass() {
+        givenSpec().get("/api/hello/short-record-response").then()
+                .statusCode(HttpStatus.SC_OK)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("data", is("ok"));
+    }
+
+    @Test
+    public void shortRecordReturnedDirectly() {
+        givenSpec().get("/api/hello/short-record").then()
+                .statusCode(HttpStatus.SC_OK)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("data", is("ok"));
     }
 
     protected RequestSpecification givenSpec() {

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,7 @@
     <name>Quarkus QE TS: Parent</name>
     <properties>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Test coverage for records returned in response from REST endpoint

maven.compiler.release property is required by impsort - https://github.com/revelc/impsort-maven-plugin/issues/60#issuecomment-1136464103

Motivation: Java 17 is base now + I have noticed issues related to records on other products/solutions

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)