### PR TITLE
Keycloak fixes and Quarkus FW bump to 1.4.0.Beta5

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HttpAdvancedReactiveIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.http.advanced.reactive;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -12,11 +16,9 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class HttpAdvancedReactiveIT extends BaseHttpAdvancedReactiveIT {
 
-    private static final String REALM_DEFAULT = "test-realm";
-
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication(ssl = true)

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHttpAdvancedReactiveIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.http.advanced.reactive;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -13,11 +17,9 @@ import io.quarkus.test.services.QuarkusApplication;
 @DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x.")
 public class OpenShiftHttpAdvancedReactiveIT extends BaseHttpAdvancedReactiveIT {
 
-    private static final String REALM_DEFAULT = "test-realm";
-
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication(ssl = true)

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/BaseHttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/BaseHttpAdvancedIT.java
@@ -55,7 +55,6 @@ import io.vertx.mutiny.ext.web.client.predicate.ResponsePredicateResult;
 
 public abstract class BaseHttpAdvancedIT {
 
-    protected static final String REALM_DEFAULT = "test-realm";
     private static final String ROOT_PATH = "/api";
     private static final int TIMEOUT_SEC = 3;
     private static final int RETRY = 3;

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.http.advanced;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -13,8 +17,8 @@ import io.quarkus.test.services.QuarkusApplication;
 public class HttpAdvancedIT extends BaseHttpAdvancedIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication(ssl = true)

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHttpAdvancedIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.http.advanced;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -14,8 +18,8 @@ import io.quarkus.test.services.QuarkusApplication;
 public class OpenShiftHttpAdvancedIT extends BaseHttpAdvancedIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication(ssl = true)

--- a/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/BaseMicrometerOidcSecurityIT.java
+++ b/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/BaseMicrometerOidcSecurityIT.java
@@ -1,5 +1,8 @@
 package io.quarkus.ts.micrometer.oidc;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -18,7 +21,6 @@ import io.quarkus.test.services.KeycloakContainer;
 public abstract class BaseMicrometerOidcSecurityIT {
 
     static final String NORMAL_USER = "test-normal-user";
-    static final String REALM_DEFAULT = "test-realm";
     static final String CLIENT_ID_DEFAULT = "test-application-client";
     static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
     static final int ASSERT_SERVICE_TIMEOUT_MINUTES = 1;
@@ -28,8 +30,8 @@ public abstract class BaseMicrometerOidcSecurityIT {
     static final String UNAUTHORIZED_HTTP_CALL_METRIC = HTTP_METRIC + "outcome=\"CLIENT_ERROR\",status=\"401\",uri=\"%s\"}";
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = { "start-dev --import-realm" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     private AuthzClient authzClient;

--- a/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/DevMicrometerOidcSecurityIT.java
+++ b/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/DevMicrometerOidcSecurityIT.java
@@ -9,7 +9,7 @@ public class DevMicrometerOidcSecurityIT extends BaseMicrometerOidcSecurityIT {
 
     @DevModeQuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
             .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
             .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT);
 

--- a/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/ProdMicrometerOidcSecurityIT.java
+++ b/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/ProdMicrometerOidcSecurityIT.java
@@ -9,7 +9,7 @@ public class ProdMicrometerOidcSecurityIT extends BaseMicrometerOidcSecurityIT {
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
             .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
             .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT);
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <quarkus.ide.version>3.6.1</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.4.0.Beta4</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.4.0.Beta5</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.5.0</quarkus-qpid-jms.version>
         <apache-httpclient-fluent.version>4.5.14</apache-httpclient-fluent.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
@@ -57,6 +57,7 @@
         <exclude.quarkus.devmode.tests>no</exclude.quarkus.devmode.tests>
         <!-- Docker images used by both surefire and failsafe plugin -->
         <postgresql.latest.image>docker.io/library/postgres:15</postgresql.latest.image>
+        <rhbk.image>registry.redhat.io/rhbk/keycloak-rhel9:22-6</rhbk.image>
         <wiremock-jre8.version>2.35.1</wiremock-jre8.version>
         <build-reporter-maven-extension.version>3.3.1</build-reporter-maven-extension.version>
     </properties>
@@ -749,7 +750,7 @@
                             <systemPropertyVariables>
                                 <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                 <!-- Product Services -->
-                                <rhsso.image>registry.redhat.io/rh-sso-7/sso76-openshift-rhel8</rhsso.image>
+                                <rhbk.image>${rhbk.image}</rhbk.image>
                                 <postgresql.10.image>registry.redhat.io/rhscl/postgresql-10-rhel7</postgresql.10.image>
                                 <postgresql.latest.image>registry.redhat.io/rhscl/postgresql-13-rhel7</postgresql.latest.image>
                                 <mariadb.103.image>registry.redhat.io/rhscl/mariadb-103-rhel7</mariadb.103.image>
@@ -799,7 +800,7 @@
                                         <ts.arm.missing.services.excludes>true</ts.arm.missing.services.excludes>
                                         <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                         <!-- Product Services -->
-                                        <rhsso.image>registry.redhat.io/rh-sso-7/sso76-openshift-rhel8</rhsso.image>
+                                        <rhbk.image>${rhbk.image}</rhbk.image>
                                         <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10</postgresql.10.image>
                                         <mysql.80.image>registry.redhat.io/rhel8/mysql-80</mysql.80.image>
                                         <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103</mariadb.103.image>
@@ -852,7 +853,7 @@
                                         <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                         <!-- Product Services -->
                                         <amqbroker.image>registry.redhat.io/amq7/amq-broker-rhel8:7.10</amqbroker.image>
-                                        <rhsso.image>registry.redhat.io/rh-sso-7/sso76-openshift-rhel8</rhsso.image>
+                                        <rhbk.image>${rhbk.image}</rhbk.image>
                                         <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10</postgresql.10.image>
                                         <mysql.80.image>registry.redhat.io/rhel8/mysql-80</mysql.80.image>
                                         <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103</mariadb.103.image>

--- a/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/BaseAuthzSecurityIT.java
+++ b/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/BaseAuthzSecurityIT.java
@@ -16,7 +16,6 @@ public abstract class BaseAuthzSecurityIT {
 
     static final String NORMAL_USER = "test-normal-user";
     static final String ADMIN_USER = "test-admin-user";
-    static final String REALM_DEFAULT = "test-realm";
     static final String CLIENT_ID_DEFAULT = "test-application-client";
     static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
 

--- a/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/KeycloakAuthzSecurityIT.java
+++ b/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/KeycloakAuthzSecurityIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.security.keycloak.authz;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -9,11 +13,9 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class KeycloakAuthzSecurityIT extends BaseAuthzSecurityIT {
 
-    static final int KEYCLOAK_PORT = 8080;
-
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication

--- a/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSsoAuthzSecurityIT.java
+++ b/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSsoAuthzSecurityIT.java
@@ -1,12 +1,16 @@
 package io.quarkus.ts.security.keycloak.authz;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
@@ -14,11 +18,8 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoAuthzSecurityIT extends BaseAuthzSecurityIT {
 
-    static final int KEYCLOAK_PORT = 8080;
-
-    @Container(image = "${rhsso.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
-            .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
+    @KeycloakContainer(command = { "start-dev", "--import-realm" }, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/BaseAuthzSecurityReactiveIT.java
+++ b/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/BaseAuthzSecurityReactiveIT.java
@@ -24,7 +24,6 @@ public abstract class BaseAuthzSecurityReactiveIT {
 
     static final String NORMAL_USER = "test-normal-user";
     static final String ADMIN_USER = "test-admin-user";
-    static final String REALM_DEFAULT = "test-realm";
     static final String CLIENT_ID_DEFAULT = "test-application-client";
     static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
 

--- a/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/KeycloakAuthzSecurityReactiveIT.java
+++ b/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/KeycloakAuthzSecurityReactiveIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.security.keycloak.authz.reactive;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -10,8 +14,8 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakAuthzSecurityReactiveIT extends BaseAuthzSecurityReactiveIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication

--- a/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/OpenShiftRhSsoAuthzSecurityReactiveIT.java
+++ b/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/OpenShiftRhSsoAuthzSecurityReactiveIT.java
@@ -1,12 +1,16 @@
 package io.quarkus.ts.security.keycloak.authz.reactive;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
@@ -14,11 +18,8 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoAuthzSecurityReactiveIT extends BaseAuthzSecurityReactiveIT {
 
-    static final int KEYCLOAK_PORT = 8080;
-
-    @Container(image = "${rhsso.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
-            .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
+    @KeycloakContainer(command = { "start-dev", "--import-realm" }, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/BaseOidcJwtSecurityIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/BaseOidcJwtSecurityIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.security.keycloak.jwt;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -22,10 +23,9 @@ import io.quarkus.test.bootstrap.RestService;
 
 public abstract class BaseOidcJwtSecurityIT {
 
-    protected static final String REALM_DEFAULT = "test-realm";
     protected static final String CLIENT_ID_DEFAULT = "test-application-client";
 
-    private static final String LOGIN_REALM_REGEXP = ".*(Sign|Log) in to " + REALM_DEFAULT + ".*";
+    private static final String LOGIN_REALM_REGEXP = ".*(Sign|Log) in to " + DEFAULT_REALM + ".*";
 
     private WebClient webClient;
     private HtmlPage page;

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/KeycloakOidcJwtSecurityIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/KeycloakOidcJwtSecurityIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.security.keycloak.jwt;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -13,8 +17,8 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakOidcJwtSecurityIT extends BaseOidcJwtSecurityIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/OpenShiftRhSsoOidcJwtSecurityIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/OpenShiftRhSsoOidcJwtSecurityIT.java
@@ -1,12 +1,16 @@
 package io.quarkus.ts.security.keycloak.jwt;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
@@ -14,11 +18,8 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcJwtSecurityIT extends BaseOidcJwtSecurityIT {
 
-    static final int KEYCLOAK_PORT = 8080;
-
-    @Container(image = "${rhsso.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
-            .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
+    @KeycloakContainer(command = { "start-dev", "--import-realm" }, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseMultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseMultiTenantSecurityIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.security.keycloak.multitenant;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -27,9 +28,8 @@ import io.quarkus.test.bootstrap.RestService;
 public abstract class BaseMultiTenantSecurityIT {
 
     protected static final String USER = "test-user";
-    protected static final String REALM_DEFAULT = "test-realm";
 
-    private static final String LOGIN_REALM_REGEXP = ".*(Sign|Log) in to " + REALM_DEFAULT + ".*";
+    private static final String LOGIN_REALM_REGEXP = ".*(Sign|Log) in to " + DEFAULT_REALM + ".*";
 
     private WebClient webClient;
 

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/KeycloakMultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/KeycloakMultiTenantSecurityIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.security.keycloak.multitenant;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -13,9 +17,8 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakMultiTenantSecurityIT extends BaseMultiTenantSecurityIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = {
-            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false", "--features=token-exchange" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSsoMultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSsoMultiTenantSecurityIT.java
@@ -1,12 +1,16 @@
 package io.quarkus.ts.security.keycloak.multitenant;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
@@ -14,15 +18,13 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoMultiTenantSecurityIT extends BaseMultiTenantSecurityIT {
 
-    static final int KEYCLOAK_PORT = 8080;
-
-    @Container(image = "${rhsso.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
-            .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false",
+            "--features=token-exchange" }, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl());
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
 
     @Override
     protected KeycloakService getKeycloak() {

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/keycloak/oauth2/BaseOauth2SecurityIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/keycloak/oauth2/BaseOauth2SecurityIT.java
@@ -14,7 +14,6 @@ public abstract class BaseOauth2SecurityIT {
 
     static final String NORMAL_USER = "test-normal-user";
     static final String ADMIN_USER = "test-admin-user";
-    static final String REALM_DEFAULT = "test-realm";
     static final String CLIENT_ID_DEFAULT = "test-application-client";
     static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
 

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/keycloak/oauth2/KeycloakOauth2SecurityIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/keycloak/oauth2/KeycloakOauth2SecurityIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.security.keycloak.oauth2;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -10,8 +14,8 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakOauth2SecurityIT extends BaseOauth2SecurityIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/keycloak/oauth2/OpenShiftRhSsoOauth2SecurityIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/keycloak/oauth2/OpenShiftRhSsoOauth2SecurityIT.java
@@ -1,12 +1,16 @@
 package io.quarkus.ts.security.keycloak.oauth2;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
@@ -14,11 +18,8 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOauth2SecurityIT extends BaseOauth2SecurityIT {
 
-    static final int KEYCLOAK_PORT = 8080;
-
-    @Container(image = "${rhsso.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
-            .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
+    @KeycloakContainer(command = { "start-dev", "--import-realm" }, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/BaseOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/BaseOidcClientSecurityIT.java
@@ -13,8 +13,6 @@ import io.quarkus.test.bootstrap.RestService;
 
 public abstract class BaseOidcClientSecurityIT {
 
-    static final String REALM_DEFAULT = "test-realm";
-
     @Test
     public void clientCredentialsSecuredResource() {
         getApp().given()

--- a/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/KeycloakOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/KeycloakOidcClientSecurityIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.security.keycloak.oidcclient.basic;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -10,9 +14,9 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakOidcClientSecurityIT extends BaseOidcClientSecurityIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = {
-            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict-https=false",
+            "--features=token-exchange" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication

--- a/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/OpenShiftRhSsoOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/OpenShiftRhSsoOidcClientSecurityIT.java
@@ -1,12 +1,16 @@
 package io.quarkus.ts.security.keycloak.oidcclient.basic;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
@@ -14,15 +18,13 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcClientSecurityIT extends BaseOidcClientSecurityIT {
 
-    static final int KEYCLOAK_PORT = 8080;
-
-    @Container(image = "${rhsso.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
-            .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict-https=false",
+            "--features=token-exchange" }, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl());
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
 
     @Override
     protected KeycloakService getKeycloak() {

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseOidcIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseOidcIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.keycloak.authorization.client.AuthzClient;
 
@@ -11,14 +15,13 @@ import io.quarkus.test.services.QuarkusApplication;
 public abstract class BaseOidcIT {
     static final String USER = "test-user";
 
-    static final String REALM_DEFAULT = "test-realm";
     static final String CLIENT_ID_DEFAULT = "test-application-client";
     static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = {
-            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict-https=false",
+            "--features=token-exchange" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/LogoutSinglePageAppFlowIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/LogoutSinglePageAppFlowIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,8 +31,8 @@ public class LogoutSinglePageAppFlowIT {
     static final String REALM_DEFAULT = "quarkus";
 
     @KeycloakContainer(command = {
-            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" })
-    static KeycloakService keycloak = new KeycloakService("/kc-logout-realm.json", REALM_DEFAULT, "/realms")
+            "start-dev", "--import-realm", "--hostname-strict-https=false", })
+    static KeycloakService keycloak = new KeycloakService("/kc-logout-realm.json", REALM_DEFAULT, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication(classes = { LogoutFlow.class, LogoutTenantResolver.class })

--- a/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/BaseOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/BaseOidcClientSecurityIT.java
@@ -13,8 +13,6 @@ import io.quarkus.test.bootstrap.RestService;
 
 public abstract class BaseOidcClientSecurityIT {
 
-    static final String REALM_DEFAULT = "test-realm";
-
     @Test
     public void clientCredentialsSecuredResource() {
         getApp().given()

--- a/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/KeycloakOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/KeycloakOidcClientSecurityIT.java
@@ -1,5 +1,8 @@
 package io.quarkus.ts.security.keycloak.oidcclient.reactive.basic;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 import static io.restassured.RestAssured.given;
 
 import java.util.List;
@@ -20,9 +23,9 @@ import io.restassured.response.Response;
 public class KeycloakOidcClientSecurityIT extends BaseOidcClientSecurityIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = {
-            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict-https=false",
+            "--features=token-exchange" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication

--- a/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/OpenShiftRhSsoOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/OpenShiftRhSsoOidcClientSecurityIT.java
@@ -1,12 +1,16 @@
 package io.quarkus.ts.security.keycloak.oidcclient.reactive.basic;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
@@ -14,11 +18,9 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcClientSecurityIT extends BaseOidcClientSecurityIT {
 
-    static final int KEYCLOAK_PORT = 8080;
-
-    @Container(image = "${rhsso.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
-            .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict-https=false",
+            "--features=token-exchange" }, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/BaseOidcIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/BaseOidcIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.keycloak.authorization.client.AuthzClient;
 
@@ -10,15 +14,13 @@ import io.quarkus.test.services.QuarkusApplication;
 
 public abstract class BaseOidcIT {
     static final String USER = "test-user";
-
-    static final String REALM_DEFAULT = "test-realm";
     static final String CLIENT_ID_DEFAULT = "test-application-client";
     static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = {
-            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict-https=false",
+            "--features=token-exchange" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/LogoutSinglePageAppFlowIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/LogoutSinglePageAppFlowIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -32,9 +33,8 @@ public class LogoutSinglePageAppFlowIT {
 
     static final String REALM_DEFAULT = "quarkus";
 
-    @KeycloakContainer(command = {
-            "start-dev --import-realm --hostname-strict-https=false --features=token-exchange" })
-    static KeycloakService keycloak = new KeycloakService("/kc-logout-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false", "--features=token-exchange" })
+    static KeycloakService keycloak = new KeycloakService("/kc-logout-realm.json", REALM_DEFAULT, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication(classes = { LogoutFlow.class })

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/KeycloakWebappSecurityIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/KeycloakWebappSecurityIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.security.keycloak.webapp;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -10,8 +14,8 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakWebappSecurityIT extends BaseWebappSecurityIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/OpenShiftRhSsoWebappSecurityIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/OpenShiftRhSsoWebappSecurityIT.java
@@ -1,12 +1,16 @@
 package io.quarkus.ts.security.keycloak.webapp;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
@@ -14,11 +18,8 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoWebappSecurityIT extends BaseWebappSecurityIT {
 
-    static final int KEYCLOAK_PORT = 8080;
-
-    @Container(image = "${rhsso.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
-            .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
+    @KeycloakContainer(command = { "start-dev", "--import-realm" }, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/KeycloakOidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/KeycloakOidcSecurityIT.java
@@ -1,5 +1,9 @@
 package io.quarkus.ts.security.keycloak;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -10,8 +14,8 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KeycloakOidcSecurityIT extends BaseOidcSecurityIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = { "start-dev --import-realm" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             .withProperty("JAVA_OPTS", "-Dcom.redhat.fips=false");
 
     @QuarkusApplication

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftRhSsoOidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftRhSsoOidcSecurityIT.java
@@ -1,12 +1,16 @@
 package io.quarkus.ts.security.keycloak;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
@@ -14,11 +18,8 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcSecurityIT extends BaseOidcSecurityIT {
 
-    static final int KEYCLOAK_PORT = 8080;
-
-    @Container(image = "${rhsso.image}", expectedLog = "Http management interface listening", port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = new KeycloakService(REALM_DEFAULT)
-            .withProperty("SSO_IMPORT_FILE", "resource::/keycloak-realm.json");
+    @KeycloakContainer(command = { "start-dev", "--import-realm" }, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/BaseOidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/BaseOidcMtlsIT.java
@@ -21,7 +21,6 @@ import io.restassured.specification.RequestSpecification;
 @Tag("QUARKUS-1676")
 public abstract class BaseOidcMtlsIT {
     protected static final String REALM_DEFAULT = "test-mutual-tls-realm";
-    protected static final String REALM_FILE_PATH = "/keycloak-realm.json";
     protected static final String RESOURCE_PATH = "/ping";
     protected static final String NORMAL_USER = "test-normal-user";
     protected static final String CLIENT_ID_DEFAULT = "test-mutual-tls";

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/IncorrectKsFileTypeOidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/IncorrectKsFileTypeOidcMtlsIT.java
@@ -1,6 +1,6 @@
 package io.quarkus.ts.security.oidcclient.mtls;
 
-import static io.quarkus.ts.security.oidcclient.mtls.MutualTlsKeycloakService.KC_DEV_MODE_JKS_CMD;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 import static io.quarkus.ts.security.oidcclient.mtls.MutualTlsKeycloakService.newKeycloakInstance;
 import static io.restassured.RestAssured.given;
 
@@ -25,8 +25,13 @@ public class IncorrectKsFileTypeOidcMtlsIT extends BaseOidcMtlsIT {
     static final String KEYSTORE_FILE_EXTENSION = "jks";
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = KC_DEV_MODE_JKS_CMD, port = KEYCLOAK_PORT)
-    static KeycloakService keycloak = newKeycloakInstance(REALM_FILE_PATH, REALM_DEFAULT, "realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false",
+            "--hostname-strict-https=false", "--features=token-exchange",
+            "--hostname=localhost", // required by LocalHostKeycloakContainerManagedResourceBuilder
+            "--https-client-auth=required", "--https-key-store-file=/etc/server-keystore.jks",
+            "--https-trust-store-file=/etc/server-truststore.jks",
+            "--https-trust-store-password=password" }, port = KEYCLOAK_PORT)
+    static KeycloakService keycloak = newKeycloakInstance(DEFAULT_REALM_FILE, REALM_DEFAULT, "realms")
             .withRedHatFipsDisabled()
             .withProperty("HTTPS_KEYSTORE", "resource_with_destination::/etc/|server-keystore." + KEYSTORE_FILE_EXTENSION)
             .withProperty("HTTPS_TRUSTSTORE", "resource_with_destination::/etc/|server-truststore." + KEYSTORE_FILE_EXTENSION);

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/JksOidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/JksOidcMtlsIT.java
@@ -1,6 +1,6 @@
 package io.quarkus.ts.security.oidcclient.mtls;
 
-import static io.quarkus.ts.security.oidcclient.mtls.MutualTlsKeycloakService.KC_DEV_MODE_JKS_CMD;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 import static io.quarkus.ts.security.oidcclient.mtls.MutualTlsKeycloakService.newKeycloakInstance;
 
 import org.junit.jupiter.api.Tag;
@@ -16,8 +16,13 @@ import io.quarkus.test.services.QuarkusApplication;
 public class JksOidcMtlsIT extends KeycloakMtlsAuthN {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916
-    @KeycloakContainer(command = KC_DEV_MODE_JKS_CMD, port = KEYCLOAK_PORT, builder = LocalHostKeycloakContainerManagedResourceBuilder.class)
-    static KeycloakService keycloak = newKeycloakInstance(REALM_FILE_PATH, REALM_DEFAULT, "realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false",
+            "--hostname-strict-https=false", "--features=token-exchange",
+            "--hostname=localhost", // required by LocalHostKeycloakContainerManagedResourceBuilder
+            "--https-client-auth=required", "--https-key-store-file=/etc/server-keystore.jks",
+            "--https-trust-store-file=/etc/server-truststore.jks",
+            "--https-trust-store-password=password" }, port = KEYCLOAK_PORT, builder = LocalHostKeycloakContainerManagedResourceBuilder.class)
+    static KeycloakService keycloak = newKeycloakInstance(DEFAULT_REALM_FILE, REALM_DEFAULT, "realms")
             .withRedHatFipsDisabled()
             .withProperty("HTTPS_KEYSTORE", "resource_with_destination::/etc/|server-keystore." + JKS_KEYSTORE_FILE_EXTENSION)
             .withProperty("HTTPS_TRUSTSTORE",

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/MutualTlsKeycloakService.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/MutualTlsKeycloakService.java
@@ -1,10 +1,10 @@
 package io.quarkus.ts.security.oidcclient.mtls;
 
-import static io.quarkus.test.utils.PropertiesUtils.SECRET_PREFIX;
 import static java.lang.String.format;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.utils.TestExecutionProperties;
 
 public class MutualTlsKeycloakService extends KeycloakService {
 
@@ -14,46 +14,20 @@ public class MutualTlsKeycloakService extends KeycloakService {
     private final String realmBasePath;
     private final boolean openshiftScenario;
 
-    // command used by Keycloak 18+ container in order to launch JKS secured Keycloak
-    public static final String KC_DEV_MODE_JKS_CMD = "start-dev " +
-            "--import-realm --hostname-strict=false --hostname-strict-https=false --features=token-exchange " +
-            "--hostname=localhost " + // required by LocalHostKeycloakContainerManagedResourceBuilder
-            "--https-client-auth=required " +
-            "--https-key-store-file=/etc/server-keystore.jks " +
-            "--https-trust-store-file=/etc/server-truststore.jks " +
-            "--https-trust-store-password=password";
-
-    // command used by Keycloak 18+ container in order to launch P12 secured Keycloak
-    public static final String KC_DEV_MODE_P12_CMD = "start-dev " +
-            "--import-realm --hostname-strict=false --hostname-strict-https=false --features=token-exchange " +
-            "--hostname=localhost " + // required by LocalHostKeycloakContainerManagedResourceBuilder
-            "--https-client-auth=required " +
-            "--https-key-store-file=/etc/server-keystore.p12 " +
-            "--https-trust-store-file=/etc/server-truststore.p12 " +
-            "--https-trust-store-password=password";
-
     public static MutualTlsKeycloakService newKeycloakInstance(String realmFile, String realmName, String realmBasePath) {
         return new MutualTlsKeycloakService(realmFile, realmName, realmBasePath);
     }
 
-    public static MutualTlsKeycloakService newRhSsoInstance(String realmFilePath, String realm) {
-        return (MutualTlsKeycloakService) new MutualTlsKeycloakService(realm)
-                .withProperty(X509_CA_BUNDLE, "/var/run/secrets/kubernetes.io/serviceaccount/*.crt")
-                .withProperty("SSO_IMPORT_FILE", SECRET_PREFIX + realmFilePath);
+    public static MutualTlsKeycloakService newRhSsoInstance(String realmFile, String realm) {
+        return (MutualTlsKeycloakService) new MutualTlsKeycloakService(realmFile, realm, DEFAULT_REALM_BASE_PATH)
+                .withProperty(X509_CA_BUNDLE, "/var/run/secrets/kubernetes.io/serviceaccount/*.crt");
     }
 
     private MutualTlsKeycloakService(String realmFile, String realmName, String realmBasePath) {
         super(realmFile, realmName, realmBasePath);
         this.realm = realmName;
         this.realmBasePath = realmBasePath;
-        openshiftScenario = false;
-    }
-
-    private MutualTlsKeycloakService(String realm) {
-        super(realm);
-        openshiftScenario = true;
-        this.realm = realm;
-        this.realmBasePath = "auth/realms";
+        this.openshiftScenario = TestExecutionProperties.isOpenshiftPlatform();
     }
 
     /**

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/OpenShiftRhSsoOidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/OpenShiftRhSsoOidcMtlsIT.java
@@ -5,6 +5,7 @@ import static org.keycloak.representations.idm.CredentialRepresentation.PASSWORD
 
 import java.nio.file.Paths;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
@@ -14,6 +15,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
+@Disabled // TODO mvavrik: fixing this will probably require fixing config map names created for resources
 @OpenShiftScenario
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/Pkcs12OidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/Pkcs12OidcMtlsIT.java
@@ -1,6 +1,6 @@
 package io.quarkus.ts.security.oidcclient.mtls;
 
-import static io.quarkus.ts.security.oidcclient.mtls.MutualTlsKeycloakService.KC_DEV_MODE_P12_CMD;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 import static io.quarkus.ts.security.oidcclient.mtls.MutualTlsKeycloakService.newKeycloakInstance;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -16,8 +16,13 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class Pkcs12OidcMtlsIT extends KeycloakMtlsAuthN {
 
-    @KeycloakContainer(command = KC_DEV_MODE_P12_CMD, port = KEYCLOAK_PORT, builder = LocalHostKeycloakContainerManagedResourceBuilder.class)
-    static KeycloakService keycloak = newKeycloakInstance(REALM_FILE_PATH, REALM_DEFAULT, "realms")
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false",
+            "--hostname-strict-https=false", "--features=token-exchange",
+            "--hostname=localhost", // required by LocalHostKeycloakContainerManagedResourceBuilder
+            "--https-client-auth=required", "--https-key-store-file=/etc/server-keystore.p12",
+            "--https-trust-store-file=/etc/server-truststore.p12",
+            "--https-trust-store-password=password" }, port = KEYCLOAK_PORT, builder = LocalHostKeycloakContainerManagedResourceBuilder.class)
+    static KeycloakService keycloak = newKeycloakInstance(DEFAULT_REALM_FILE, REALM_DEFAULT, "realms")
             .withProperty("HTTPS_KEYSTORE", "resource_with_destination::/etc/|server-keystore." + P12_KEYSTORE_FILE_EXTENSION)
             .withProperty("HTTPS_TRUSTSTORE",
                     "resource_with_destination::/etc/|server-truststore." + P12_KEYSTORE_FILE_EXTENSION);

--- a/security/oidc-client-mutual-tls/src/test/resources/test.properties
+++ b/security/oidc-client-mutual-tls/src/test/resources/test.properties
@@ -1,4 +1,3 @@
 ts.keycloak.log.enable=true
-ts.rhsso.log.enable=true
 ts.app.log.enable=true
-ts.rhsso.openshift.template=/openshift-rh-sso-deployment-template.yml
+ts.keycloak.openshift.template=/openshift-rh-sso-deployment-template.yml


### PR DESCRIPTION
### Summary

Main goal of this PR is to fix OCP failures related to the fact that Keycloak auth server URL has changed in our FW: https://github.com/quarkus-qe/quarkus-test-framework/pull/960

- `OpenShiftRhSsoOidcMtlsIT` will require much more thinkering, at the very least I hit that config map name is created with illegal chars when resource is in nested directory. But I think it will be even more difficult, I'll address it later this week.
- I don't want to address all that repeated stuff of KC commands till  https://github.com/quarkus-qe/quarkus-test-suite/issues/1580 is done
- I also think some of these Keycloak starting commands are unnecessary at some of scenarios (I replaced one accidentally and it still works), let's address it when we get rid of `start-dev` because it all seems like a one big workaround for proper solution to me
- `OidcRestClientIT` failure (both baremetal and OCP) goes down to the https://github.com/quarkusio/quarkus/pull/37788, I hope it's going to be merged today as that reviewer is active in other Quarkus PRs
- new KC image does not accept args joined by space, we need to pass them one by one (which is correct way to do it anyway)

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)