### PR TITLE
Disable OidcRestClientIT due to upstream bug

### DIFF
--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OidcRestClientIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OidcRestClientIT.java
@@ -7,12 +7,14 @@ import static org.hamcrest.CoreMatchers.is;
 import java.util.UUID;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.model.Score;
 import io.restassured.http.ContentType;
 
+@Disabled("https://github.com/quarkusio/quarkus/pull/37788")
 @QuarkusScenario
 public class OidcRestClientIT extends BaseOidcIT {
 


### PR DESCRIPTION
### Summary

I bet with my luck https://github.com/quarkusio/quarkus/pull/37788 will get merged anytime now, but our daily build has been failing for more than a week now and other testing is cancelled as this is failing, we need to run full test coverage. So I suggest to disable the test even though upstream PR can be merged in an hour or so.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)