### PR TITLE
Disable failing OCP test using OpenShift extension in Many-extensions project due to upstream bug

### DIFF
--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/OpenShiftUsingExtensionDockerBuildStrategyManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/OpenShiftUsingExtensionDockerBuildStrategyManyExtensionsIT.java
@@ -1,10 +1,12 @@
 package io.quarkus.ts.many.extensions;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/37855")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingExtensionDockerBuildStrategyManyExtensionsIT extends ManyExtensionsIT {

--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/OpenShiftUsingExtensionManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/OpenShiftUsingExtensionManyExtensionsIT.java
@@ -1,10 +1,12 @@
 package io.quarkus.ts.many.extensions;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/37855")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionManyExtensionsIT extends ManyExtensionsIT {

--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionDockerBuildStrategyOpenShiftManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionDockerBuildStrategyOpenShiftManyExtensionsIT.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.many.extensions;
 
 import static io.restassured.RestAssured.given;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -9,6 +10,7 @@ import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/37855")
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1142")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")

--- a/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionOpenShiftManyExtensionsIT.java
+++ b/super-size/many-extensions/src/test/java/io/quarkus/ts/many/extensions/ServerlessExtensionOpenShiftManyExtensionsIT.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.many.extensions;
 
 import static io.restassured.RestAssured.given;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -9,6 +10,7 @@ import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/37855")
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1142")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")


### PR DESCRIPTION
### Summary

See https://github.com/quarkusio/quarkus/issues/37855.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)