### PR TITLE
Disable modules affected by issue 38054

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -541,8 +541,9 @@
                 <module>messaging/amqp-reactive</module>
                 <module>messaging/qpid</module>
                 <module>messaging/kafka-streams-reactive-messaging</module>
-                <module>messaging/kafka-confluent-avro-reactive-messaging</module>
-                <module>messaging/kafka-strimzi-avro-reactive-messaging</module>
+                <!-- TODO: enable these modules once https://github.com/quarkusio/quarkus/issues/38054 is fixed-->
+                <!-- <module>messaging/kafka-confluent-avro-reactive-messaging</module>-->
+                <!-- <module>messaging/kafka-strimzi-avro-reactive-messaging</module>-->
                 <module>messaging/kafka-producer</module>
                 <module>messaging/kafkaSSL</module>
                 <module>messaging/infinispan-grpc-kafka</module>


### PR DESCRIPTION
### Summary
Issue https://github.com/quarkusio/quarkus/issues/38054 makes two kafka modules fail. Disable them, before the bug is fixed, so it doesn't fail our test pipeline.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)