### PR TITLE
remove 'native-image' component from daily pipeline

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -213,7 +213,6 @@ jobs:
         with:
           version: ${{ matrix.graalvm-version }}
           java-version: ${{ matrix.graalvm-java-version }}
-          components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure Pagefile
         # Increased the page-file size due to memory-consumption of native-image command


### PR DESCRIPTION
### Summary

Removing component: 'native_image' from windows daily pipeline, as it is no longer required. Pipeline itself throws a warning about this:
https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/7455477415/job/20284865839#step:6:20

I checked that this pipeline works without this.



Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [X] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)