### PR TITLE
Remove okhttp dependency

### DIFF
--- a/http/http-advanced-reactive/pom.xml
+++ b/http/http-advanced-reactive/pom.xml
@@ -48,10 +48,6 @@
             <artifactId>quarkus-keycloak-authorization</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>

--- a/http/http-advanced/pom.xml
+++ b/http/http-advanced/pom.xml
@@ -66,10 +66,6 @@
             <classifier>osx-x86_64</classifier>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-grpc</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
### Summary

Remove okhttp dependency from http-advanced and http-advanced-reactive.
This dependency was recently removed from upstream BOM - https://github.com/quarkusio/quarkus/pull/38066 and it's missing version is causing failures.
It is unclear to me, why was this dependency even added. PR that added it does not provide any clue - https://github.com/quarkus-qe/quarkus-test-suite/pull/715
Both modules seems to work even without it.

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)