### PR TITLE
Refactor to check equality using relevant assert

### DIFF
--- a/http/servlet-undertow/src/test/java/io/quarkus/ts/http/undertow/HttpServletWithSessionListenerIT.java
+++ b/http/servlet-undertow/src/test/java/io/quarkus/ts/http/undertow/HttpServletWithSessionListenerIT.java
@@ -2,13 +2,13 @@ package io.quarkus.ts.http.undertow;
 
 import static io.quarkus.ts.http.undertow.listener.SessionListener.GAUGE_ACTIVE_SESSION;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.util.Map;
 import java.util.stream.IntStream;
 
 import org.apache.http.HttpStatus;
-import org.apache.http.util.Asserts;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -79,7 +79,7 @@ public class HttpServletWithSessionListenerIT {
     }
 
     private void thenCheckActiveSessionsEqualTo(int threshold) {
-        Asserts.check(getActiveSessions() == threshold, "Unexpected active sessions amount");
+        assertEquals(threshold, getActiveSessions(), "Unexpected active sessions amount");
     }
 
     private void thenWaitToEvictSessionsAndCheckActiveSessionsEqualTo(int value) {


### PR DESCRIPTION
### Summary

Old code check equality, while checking for "true" value. This provides limited info for investigation in case of failure.
Checking using "assertEquals" logs actual values in case of failure.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [X] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)