### PR TITLE
Use thread safe collection in servlet-undertow

### DIFF
--- a/http/servlet-undertow/src/main/java/io/quarkus/ts/http/undertow/listener/SessionListener.java
+++ b/http/servlet-undertow/src/main/java/io/quarkus/ts/http/undertow/listener/SessionListener.java
@@ -1,6 +1,6 @@
 package io.quarkus.ts.http.undertow.listener;
 
-import java.util.LinkedList;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.servlet.http.HttpSession;
@@ -19,7 +19,11 @@ import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 public final class SessionListener implements HttpSessionListener {
 
     public static final String GAUGE_ACTIVE_SESSION = "io_quarkus_ts_active_sessions_amount";
-    private LinkedList<String> sessionsBucket = new LinkedList<>();
+    /*
+     * Needs to use thread-safe collection.
+     * When multiple sessions gets created or destroyed at once, it might create inconsistencies otherwise.
+     */
+    private final ConcurrentLinkedDeque<String> sessionsBucket = new ConcurrentLinkedDeque<>();
 
     SessionListener(MeterRegistry registry) {
         registry.gaugeCollectionSize(GAUGE_ACTIVE_SESSION, Tags.empty(), sessionsBucket);


### PR DESCRIPTION
### Summary

servlet-undertow test is failing for a long time in github daily. Issue is, that sessions are stored in a LinkedList, which is not thread safe. Sessions are inserted into it, remain active for some time and then get evicted, all at about a same time. Although all sessions are actually deleted/ended, theye are not correctly removed from the collection and collection turns into inconsistent state (some sessions remain in it, even though were destroyed), which results in test failures.

This PR changes it to using thread safe collection, which correctly removes all sessions, even if they are destroyed all at once.


Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)