### PR TITLE
Add test coverage for openTelemetry management endpoint traces

### DIFF
--- a/monitoring/opentelemetry/pom.xml
+++ b/monitoring/opentelemetry/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>quarkus-grpc</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-jaeger</artifactId>
             <scope>test</scope>

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryManagementIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryManagementIT.java
@@ -1,0 +1,69 @@
+package io.quarkus.ts.opentelemetry;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.containsString;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.JaegerService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.JaegerContainer;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class OpenTelemetryManagementIT {
+    @JaegerContainer
+    static final JaegerService jaeger = new JaegerService();
+
+    @QuarkusApplication
+    static RestService pong = new RestService()
+            .withProperty("quarkus.application.name", "pong")
+            .withProperty("quarkus.management.enabled", "true")
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
+
+    private static final String PONG_ENDPOINT = "/hello";
+    private static final String MANAGEMENT_ENDPOINT = "/q/health/ready";
+
+    /**
+     * Test openTelemetry not sending traces from management endpoints
+     */
+    @Test
+    @Tag("https://github.com/quarkusio/quarkus/pull/37218")
+    public void managementEndpointExcludedFromTracesTest() {
+        // invoke management endpoint, so service is prone to send trace from it
+        // if fix is already in place, it should not send any
+        pong.management().get(MANAGEMENT_ENDPOINT)
+                .then().statusCode(HttpStatus.SC_OK);
+
+        // invoke normal endpoint, so we can check that traces are uploading correctly
+        given()
+                .when().get(PONG_ENDPOINT)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("pong"));
+
+        // wait for pong endpoint to be logged in traces
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> given()
+                .when()
+                .queryParam("service", pong.getName())
+                .get(jaeger.getTraceUrl())
+                .then().statusCode(HttpStatus.SC_OK)
+                .and().body(containsString(PONG_ENDPOINT)));
+
+        String traces = given().when()
+                .queryParam("service", pong.getName())
+                .get(jaeger.getTraceUrl())
+                .thenReturn().body().asString();
+
+        // check that management endpoint is not present in traces, while correct trace is there
+        Assertions.assertTrue(traces.contains(PONG_ENDPOINT), "Pong endpoint should be logged in traces");
+        Assertions.assertFalse(traces.contains(MANAGEMENT_ENDPOINT), "Management endpoint should not be logged in traces");
+    }
+}


### PR DESCRIPTION
### Summary

Adds test coverage for https://github.com/quarkusio/quarkus/pull/37218. PR changes that management endpoints (like endpoints from smallrye-health) should not be stored as traces. Before this PR they were.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [X] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)