### PR TITLE
Disable OCP tests using OpenShift extension due to upstream bug

### DIFF
--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumReactiveIT.java
@@ -1,10 +1,12 @@
 package io.quarkus.ts.http.minimum.reactive;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/38018")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumReactiveIT extends HttpMinimumReactiveIT {

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionHttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/OpenShiftUsingExtensionHttpMinimumReactiveIT.java
@@ -1,10 +1,12 @@
 package io.quarkus.ts.http.minimum.reactive;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/38018")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionHttpMinimumReactiveIT extends HttpMinimumReactiveIT {

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumIT.java
@@ -1,10 +1,12 @@
 package io.quarkus.ts.http.minimum;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/38018")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingExtensionDockerBuildStrategyHttpMinimumIT extends HttpMinimumIT {

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionHttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftUsingExtensionHttpMinimumIT.java
@@ -1,10 +1,12 @@
 package io.quarkus.ts.http.minimum;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/38018")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionHttpMinimumIT extends HttpMinimumIT {

--- a/http/jakarta-rest-reactive/src/test/java/io/quarkus/ts/http/jakartarest/reactive/OpenShiftCompressionHandlerIT.java
+++ b/http/jakarta-rest-reactive/src/test/java/io/quarkus/ts/http/jakartarest/reactive/OpenShiftCompressionHandlerIT.java
@@ -1,11 +1,13 @@
 package io.quarkus.ts.http.jakartarest.reactive;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/38018")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 // OCP Native coverage is not required (Test plan QUARKUS-2487), due to a lack of resources and the ROI.

--- a/http/jakarta-rest-reactive/src/test/java/io/quarkus/ts/http/jakartarest/reactive/OpenShiftHttpCachingIT.java
+++ b/http/jakarta-rest-reactive/src/test/java/io/quarkus/ts/http/jakartarest/reactive/OpenShiftHttpCachingIT.java
@@ -1,10 +1,12 @@
 package io.quarkus.ts.http.jakartarest.reactive;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/38018")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftHttpCachingIT extends HttpCachingIT {

--- a/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftDockerBuildIT.java
+++ b/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftDockerBuildIT.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Disabled;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/38018")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftDockerBuildIT extends OpenShiftBaseDeploymentIT {
     @Override

--- a/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftExtensionIT.java
+++ b/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftExtensionIT.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Disabled;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/38018")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftExtensionIT extends OpenShiftBaseDeploymentIT {
     @Override

--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/OpenShiftUsingExtensionDockerBuildStrategyVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/OpenShiftUsingExtensionDockerBuildStrategyVertxIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.vertx;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -8,6 +9,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/38018")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingExtensionDockerBuildStrategyVertxIT extends AbstractVertxIT {

--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/OpenShiftUsingExtensionVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/OpenShiftUsingExtensionVertxIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.vertx;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -8,6 +9,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/38018")
 @Tag("use-quarkus-openshift-extension")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionVertxIT extends AbstractVertxIT {

--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionDockerBuildStrategyOpenShiftVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionDockerBuildStrategyOpenShiftVertxIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.vertx;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -9,6 +10,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/38018")
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1142")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")

--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionOpenShiftVertxIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/ServerlessExtensionOpenShiftVertxIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.vertx;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -9,6 +10,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.specification.RequestSpecification;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/38018")
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1142")
 @Tag("use-quarkus-openshift-extension")
 @Tag("serverless")


### PR DESCRIPTION
### Summary

Disabling tests that fail due to https://github.com/quarkusio/quarkus/issues/38018. Same was done last week for FW https://github.com/quarkus-qe/quarkus-test-framework/pull/1007. See weekly runs for examples, I can reproduce it from my workstation.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)