### PR TITLE
Disable OracleDatabaseIT because of the issue

### DIFF
--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/OracleDatabaseIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/OracleDatabaseIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.hibernate.reactive;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.bootstrap.OracleService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -7,6 +9,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
+@Disabled("https://github.com/quarkusio/quarkus/issues/38263")
 public class OracleDatabaseIT extends AbstractDatabaseHibernateReactiveIT {
 
     private static final String ORACLE_USER = "quarkus_test";


### PR DESCRIPTION
### Summary

Oracle test is causing entire daily pipeline to fail, disable it because of the known issue: Issue https://github.com/quarkusio/quarkus/issues/38263

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [X] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)