### PR TITLE
Add test coverage for issue in PR 37268.

### DIFF
--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/HeaderClient.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/HeaderClient.java
@@ -1,0 +1,15 @@
+package io.quarkus.ts.http.restclient.reactive;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+@Path("/headersReflection")
+public interface HeaderClient {
+
+    @GET
+    @Path("/client")
+    String getClientHeader();
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/filter/VersionHeaderFilter.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/filter/VersionHeaderFilter.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.http.restclient.reactive.filter;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * Used to reproduce issue in https://github.com/quarkusio/quarkus/pull/37268
+ * Needs to implement both ContainerResponseFilter and ClientRequestFilter to reproduce the issue,
+ * although ContainerResponseFilter is ignored
+ */
+@Provider
+public class VersionHeaderFilter implements ContainerResponseFilter, ClientRequestFilter {
+    public VersionHeaderFilter() {
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        // do nothing. implements this method just because ContainerResponseFilter requires it
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        requestContext.getHeaders().add("clientFilter", "clientFilterInvoked");
+    }
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/HeadersReflectionResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/HeadersReflectionResource.java
@@ -1,0 +1,15 @@
+package io.quarkus.ts.http.restclient.reactive.resources;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.resteasy.reactive.RestHeader;
+
+@Path("/headersReflection")
+public class HeadersReflectionResource {
+    @GET
+    @Path("/client")
+    public String returnHeaders(@RestHeader("clientFilter") String header) {
+        return header;
+    }
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/HeadersResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/HeadersResource.java
@@ -1,0 +1,32 @@
+package io.quarkus.ts.http.restclient.reactive.resources;
+
+import java.net.URI;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+import io.quarkus.ts.http.restclient.reactive.HeaderClient;
+
+@Path("/headers")
+public class HeadersResource {
+
+    private final URI baseUri;
+
+    public HeadersResource(@ConfigProperty(name = "quarkus.http.port") int httpPort) {
+        this.baseUri = URI.create("http://localhost:" + httpPort);
+    }
+
+    @GET
+    @Path("/")
+    public String getClientHeader() {
+        HeaderClient client = RestClientBuilder
+                .newBuilder()
+                .baseUri(baseUri)
+                .build(HeaderClient.class);
+
+        return client.getClientHeader();
+    }
+}

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
@@ -267,6 +267,14 @@ public class ReactiveRestClientIT {
                 .body(containsString("random SSE data"));
     }
 
+    @Test
+    @Tag("https://github.com/quarkusio/quarkus/pull/37268")
+    public void clientHeaderInjectionTest() {
+        app.given().get("/headers")
+                .then()
+                .body(containsString("clientFilterInvoked"));
+    }
+
     @AfterAll
     static void afterAll() {
         mockServer.stop();


### PR DESCRIPTION
### Summary

Add test coverage for https://github.com/quarkusio/quarkus/pull/37268 and issue described in it.
Issue is that ClientRequestFilter is not applied, if ContainerResponseFilter is also present in the same class, because of https://github.com/quarkusio/quarkus/pull/37006.

This PR is similar to https://github.com/quarkus-qe/quarkus-test-suite/pull/1616 but this test requires the restClient to actually do a request for the client filter to be invoked. For that reason, this new tests is in `rest-client-reactive` module, where is can do actual requests.


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [X] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)