### PR TITLE
Fix cookie sameSite tests as quarkus change the handling

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/CookiesIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/CookiesIT.java
@@ -105,9 +105,8 @@ public class CookiesIT {
             response.statusCode(204)
                     .cookie(TEST_COOKIE, detailedCookie().sameSite((String) null));
         } else {
-            sameSite = sameSite.toUpperCase();
             response.statusCode(200)
-                    .body(is(sameSite))
+                    .body(is(sameSite.toUpperCase()))
                     .cookie(TEST_COOKIE, detailedCookie().sameSite(sameSite));
         }
     }


### PR DESCRIPTION
### Summary

As https://github.com/quarkusio/quarkus/pull/38466 change how the cookies are handled this PR update it as well.

JFYI this should be correct form (at least the standard define it as "Lax" etc.) and not all uppercase as the RestEasy do it. That's the reason why the `toUpperCase` is remaining when the body is checked.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)