### PR TITLE
[3.8] Disable the same testing for IBM ppc64le as IBM s390x

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHttpAdvancedReactiveIT.java
@@ -14,7 +14,7 @@ import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x & ppc64le.")
 public class OpenShiftHttpAdvancedReactiveIT extends BaseHttpAdvancedReactiveIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHttpAdvancedIT.java
@@ -14,7 +14,7 @@ import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x & ppc64le.")
 public class OpenShiftHttpAdvancedIT extends BaseHttpAdvancedIT {
 
     //TODO Remove workaround after Keycloak is fixed https://github.com/keycloak/keycloak/issues/9916

--- a/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftRegistryIT.java
+++ b/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftRegistryIT.java
@@ -6,7 +6,7 @@ import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "Impossible to deploy container built on x86_64 on aarch64.")
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "Impossible to deploy container built on x86_64 on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "Impossible to deploy container built on x86_64 on s390x.")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
 public class OpenShiftRegistryIT extends OpenShiftBaseDeploymentIT {
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftAmqStreamsKafkaStreamIT.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @OpenShiftScenario
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1144")
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTest {
 

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftStrimziKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftStrimziKafkaStreamIT.java
@@ -5,6 +5,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 public class OpenShiftStrimziKafkaStreamIT extends StrimziKafkaStreamIT {
 }

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/OpenShiftAmqStreamsKafkaAvroIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/OpenShiftAmqStreamsKafkaAvroIT.java
@@ -12,7 +12,7 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @OpenShiftScenario
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1144")
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsKafkaAvroIT extends BaseKafkaAvroIT {
 

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/OpenShiftStrimziKafkaAvroIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/OpenShiftStrimziKafkaAvroIT.java
@@ -5,6 +5,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 public class OpenShiftStrimziKafkaAvroIT extends StrimziKafkaAvroIT {
 }

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/StrimziKafkaAvroIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/StrimziKafkaAvroIT.java
@@ -10,7 +10,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @QuarkusScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 public class StrimziKafkaAvroIT extends BaseKafkaAvroIT {
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI, withRegistry = true, registryPath = "/apis/registry/v2")

--- a/monitoring/micrometer-prometheus-kafka-reactive/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/OpenShiftAmqStreamsAlertEventsReactiveIT.java
+++ b/monitoring/micrometer-prometheus-kafka-reactive/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/OpenShiftAmqStreamsAlertEventsReactiveIT.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1144")
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsAlertEventsReactiveIT extends BaseOpenShiftAlertEventsReactiveIT {
 

--- a/monitoring/micrometer-prometheus-kafka-reactive/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/OpenShiftKafkaAlertEventsReactiveIT.java
+++ b/monitoring/micrometer-prometheus-kafka-reactive/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/OpenShiftKafkaAlertEventsReactiveIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 public class OpenShiftKafkaAlertEventsReactiveIT extends BaseOpenShiftAlertEventsReactiveIT {
 
     @KafkaContainer

--- a/monitoring/micrometer-prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftAmqStreamsAlertEventsIT.java
+++ b/monitoring/micrometer-prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftAmqStreamsAlertEventsIT.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1144")
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsAlertEventsIT extends BaseOpenShiftAlertEventsIT {
 

--- a/monitoring/micrometer-prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftKafkaAlertEventsIT.java
+++ b/monitoring/micrometer-prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftKafkaAlertEventsIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 public class OpenShiftKafkaAlertEventsIT extends BaseOpenShiftAlertEventsIT {
 
     @KafkaContainer

--- a/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/reactive/OpenShiftMongoClientReactiveIT.java
+++ b/nosql-db/mongodb-reactive/src/test/java/io/quarkus/ts/nosqldb/mongodb/reactive/OpenShiftMongoClientReactiveIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.nosqldb.mongodb.reactive;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
 import io.quarkus.test.bootstrap.MongoDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -9,7 +7,6 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "bitnami/mongodb container not available on s390x.")
 public class OpenShiftMongoClientReactiveIT extends AbstractMongoClientReactiveIT {
 
     @Container(image = "${mongodb.image}", port = 27017, expectedLog = "Waiting for connections")

--- a/pom.xml
+++ b/pom.xml
@@ -831,10 +831,10 @@
             </build>
         </profile>
         <profile>
-            <id>openshift-s390x</id>
+            <id>openshift-ibm-z-p</id>
             <activation>
                 <property>
-                    <name>openshift-s390x</name>
+                    <name>openshift-ibm-z-p</name>
                 </property>
             </activation>
             <properties>
@@ -843,10 +843,10 @@
             </properties>
         </profile>
         <profile>
-            <id>openshift-s390x-containers</id>
+            <id>openshift-ibm-z-p-containers</id>
             <activation>
                 <property>
-                    <name>openshift-s390x</name>
+                    <name>openshift-ibm-z-p</name>
                 </property>
             </activation>
             <build>
@@ -862,7 +862,7 @@
                                 </goals>
                                 <configuration>
                                     <systemPropertyVariables>
-                                        <ts.s390x.missing.services.excludes>true</ts.s390x.missing.services.excludes>
+                                        <ts.ibm-z-p.missing.services.excludes>true</ts.ibm-z-p.missing.services.excludes>
                                         <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                         <!-- Product Services -->
                                         <amqbroker.image>registry.redhat.io/amq7/amq-broker-rhel8:7.10</amqbroker.image>

--- a/properties/src/test/java/io/quarkus/ts/properties/consul/OpenShiftConsulConfigSourceIT.java
+++ b/properties/src/test/java/io/quarkus/ts/properties/consul/OpenShiftConsulConfigSourceIT.java
@@ -5,6 +5,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "consul container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "consul container not available on s390x & ppc64le.")
 public class OpenShiftConsulConfigSourceIT extends ConsulConfigSourceIT {
 }

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftOidcRestClientIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftOidcRestClientIT.java
@@ -5,6 +5,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x & ppc64le.")
 public class OpenShiftOidcRestClientIT extends OidcRestClientIT {
 }

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftOidcSinglePageAppLogoutFlowIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftOidcSinglePageAppLogoutFlowIT.java
@@ -5,6 +5,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x & ppc64le.")
 public class OpenShiftOidcSinglePageAppLogoutFlowIT extends LogoutSinglePageAppFlowIT {
 }

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenShiftOidcRestClientIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenShiftOidcRestClientIT.java
@@ -5,6 +5,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x & ppc64le.")
 public class OpenShiftOidcRestClientIT extends OidcRestClientIT {
 }

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenShiftOidcSinglePageAppLogoutFlowIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenShiftOidcSinglePageAppLogoutFlowIT.java
@@ -5,6 +5,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x & ppc64le.")
 public class OpenShiftOidcSinglePageAppLogoutFlowIT extends LogoutSinglePageAppFlowIT {
 }

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftMysqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftMysqlMultitenantHibernateSearchIT.java
@@ -12,7 +12,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "elasticsearch container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "elasticsearch container not available on s390x & ppc64le.")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftMysqlMultitenantHibernateSearchIT extends AbstractMultitenantHibernateSearchIT {
     private static final int ELASTIC_PORT = 9200;

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
@@ -12,7 +12,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.s390x.missing.services.excludes", matches = "true", disabledReason = "elasticsearch container not available on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "elasticsearch container not available on s390x & ppc64le.")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftPostgresqlMultitenantHibernateSearchIT extends AbstractMultitenantHibernateSearchIT {
     static final int ELASTIC_PORT = 9200;


### PR DESCRIPTION
### Summary

The previous PR to create a s390x testing profile and exclude some tests should have included Power PC (ppc64le) as both archs are similar. [Link to s390x PR](https://github.com/quarkus-qe/quarkus-test-suite/pull/1431)

These changes should also be cherry picked into main and 3.8 branches.

Latest test runs with new profile:

[Quarkus 3.2.10 JDK17 Run](https://master-jenkins-csb-runtimesppcqe.apps.ocp-c1.prod.psi.redhat.com/job/Cloud-Native-Runtimes/job/Quarkus/job/rhbq-3.x-jdk-11-17/)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [x] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)