### PR TITLE
Use public Red Hat registry images for non OC scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,14 +519,14 @@ Container images used in the tests are:
   - version 10: `registry.redhat.io/rhel8/postgresql-10` (only if `ts.redhat.registry.enabled` is set)
 - MySQL:
   - version 5.7: `mysql:5.7`
-  - version 8.0: `registry.redhat.io/rhel8/mysql-80`
+  - version 8.0: `registry.access.redhat.com/rhscl/mysql-80-rhel7`
 - MariaDB:
   - version 10.11: `mariadb:10.11`
   - version 10.3: `registry.redhat.io/rhel8/mariadb-103`
   - version 10.5: `registry.redhat.io/rhel8/mariadb-105`
 - MSSQL: `mcr.microsoft.com/mssql/rhel/server`
 - Oracle
-  - version 21 XE: `gvenzl/oracle-free:23-slim-faststart`
+  - version 23: `gvenzl/oracle-free:23-slim-faststart`
 
 ### `sql-db/sql-app-oracle`
 Functionally identical to `sql-db/sql-app`, but using only `quarkus-jdbc-oracle` driver. This is a workaround for the missing native Oracle coverage in `sql-db/sql-app`.

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <exclude.quarkus.devmode.tests>no</exclude.quarkus.devmode.tests>
         <!-- Docker images used by both surefire and failsafe plugin -->
         <postgresql.latest.image>docker.io/postgres:16.1</postgresql.latest.image>
-        <mysql.80.image>registry.redhat.io/rhel9/mysql-80</mysql.80.image>
+        <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7</mysql.80.image>
         <rhbk.image>registry.redhat.io/rhbk/keycloak-rhel9:22-8</rhbk.image>
         <wiremock-jre8.version>2.35.1</wiremock-jre8.version>
         <build-reporter-maven-extension.version>3.4.4</build-reporter-maven-extension.version>
@@ -265,7 +265,7 @@
                                 <quarkus.s2i.base-native-image>${quarkus.s2i.base-native-image}</quarkus.s2i.base-native-image>
                                 <!-- Services used in test suite -->
                                 <nginx.image>docker.io/library/nginx:1-alpine</nginx.image>
-                                <amqbroker.image>registry.redhat.io/amq7/amq-broker-rhel8:7.11</amqbroker.image>
+                                <amqbroker.image>registry.access.redhat.com/amq-broker-7/amq-broker-72-openshift:latest</amqbroker.image>
                                 <amqbroker.1.0x.image>quay.io/artemiscloud/activemq-artemis-broker:1.0.25</amqbroker.1.0x.image>
                                 <redpanda.image>redpandadata/redpanda:v23.3.4</redpanda.image>
                                 <postgresql.latest.image>${postgresql.latest.image}</postgresql.latest.image>


### PR DESCRIPTION
### Summary

Fixes my fault from [images bump PR](https://github.com/quarkus-qe/quarkus-test-suite/pull/1651)
Images from `registry.redhat.io` cannot be pushed without access token, that we have only in OC tests jobs in Jenkins
Should fix daily build failures

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)