### PR TITLE
Switch MySQL 5.7 to 8 as 5.7 is EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,6 @@ Container images used in the tests are:
   - version 16: `postgres:16.1`
   - version 10: `registry.redhat.io/rhel8/postgresql-10` (only if `ts.redhat.registry.enabled` is set)
 - MySQL:
-  - version 5.7: `mysql:5.7`
   - version 8.0: `registry.access.redhat.com/rhscl/mysql-80-rhel7`
 - MariaDB:
   - version 10.11: `mariadb:10.11`

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,6 @@
                                 <redpanda.image>redpandadata/redpanda:v23.3.4</redpanda.image>
                                 <postgresql.latest.image>${postgresql.latest.image}</postgresql.latest.image>
                                 <elastic.7x.image>docker.io/library/elasticsearch:7.17.17</elastic.7x.image>
-                                <mysql.57.image>docker.io/library/mysql:5.7.44</mysql.57.image>
                                 <mysql.upstream.80.image>docker.io/library/mysql:8.0</mysql.upstream.80.image>
                                 <mysql.80.image>${mysql.80.image}</mysql.80.image>
                                 <mariadb.10.image>docker.io/library/mariadb:10.11</mariadb.10.image>

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MysqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MysqlTransactionGeneralUsageIT.java
@@ -1,6 +1,11 @@
 package io.quarkus.ts.transactions;
 
+import static io.quarkus.test.services.containers.DockerContainerManagedResource.DOCKER_INNER_CONTAINER;
+
+import java.io.IOException;
+
 import org.junit.jupiter.api.Tag;
+import org.testcontainers.containers.GenericContainer;
 
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
@@ -15,9 +20,22 @@ import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 public class MysqlTransactionGeneralUsageIT extends TransactionCommons {
 
     static final int MYSQL_PORT = 3306;
-
     @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
-    static final MySqlService database = new MySqlService();
+    static final MySqlService database = new MySqlService().onPostStart(service -> {
+        // enable transactions recovery for user
+        var self = (MySqlService) service;
+        // RH MySQL image allow login root user locally without using password and ignoring set root password
+        String passwordString = System.getProperty("mysql.80.image").contains("redhat") ? "" : "-p" + self.getPassword();
+        try {
+            self
+                    .<GenericContainer<?>> getPropertyFromContext(DOCKER_INNER_CONTAINER)
+                    .execInContainer(
+                            "/bin/mysql", "-u", "root", passwordString, "-e",
+                            "grant XA_RECOVER_ADMIN on *.* to '" + self.getUser() + "'@'%';");
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    });
 
     @QuarkusApplication
     static RestService app = new RestService().withProperties("mysql.properties")

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MysqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MysqlTransactionGeneralUsageIT.java
@@ -16,7 +16,7 @@ public class MysqlTransactionGeneralUsageIT extends TransactionCommons {
 
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.57.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
+    @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
     static final MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/TransactionCommons.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/TransactionCommons.java
@@ -20,7 +20,6 @@ import java.util.function.Predicate;
 import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -213,7 +212,6 @@ public abstract class TransactionCommons {
     @Order(8)
     @Tag("QUARKUS-2739")
     @Test
-    @Disabled("https://github.com/quarkus-qe/quarkus-test-suite/issues/1397")
     public void testTransactionRecovery() {
         // make it possible to disable transaction recovery tests for certain databases
         testTransactionRecoveryInternal();

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/TransactionCommons.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/TransactionCommons.java
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -212,6 +213,7 @@ public abstract class TransactionCommons {
     @Order(8)
     @Tag("QUARKUS-2739")
     @Test
+    @Disabled("https://github.com/quarkus-qe/quarkus-test-suite/issues/1397")
     public void testTransactionRecovery() {
         // make it possible to disable transaction recovery tests for certain databases
         testTransactionRecoveryInternal();

--- a/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MySqlPanacheResourceIT.java
+++ b/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MySqlPanacheResourceIT.java
@@ -15,7 +15,7 @@ public class MySqlPanacheResourceIT extends AbstractPanacheResourceIT {
 
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.57.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
+    @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MySqlDatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MySqlDatabaseIT.java
@@ -17,7 +17,7 @@ public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {
 
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.57.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
+    @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/sql-db/sql-app-compatibility/src/test/resources/mysql.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/mysql.properties
@@ -1,6 +1,6 @@
 quarkus.datasource.db-kind=mysql
-quarkus.hibernate-orm.dialect=org.hibernate.community.dialect.MariaDBLegacyDialect
-quarkus.datasource.db-version=5.7
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.MySQLDialect
+quarkus.datasource.db-version=8.0
 quarkus.hibernate-orm.sql-load-script=mariadb_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
 

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MySqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MySqlDatabaseIT.java
@@ -15,7 +15,7 @@ public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {
 
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.57.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
+    @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication


### PR DESCRIPTION
### Summary

Update docker image of MySQL as 5.7 reach EOL in October

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)