### PR TITLE
Detect and report flaky tests

### DIFF
--- a/.github/workflows/add-flaky-test-label.yml
+++ b/.github/workflows/add-flaky-test-label.yml
@@ -1,0 +1,28 @@
+name: Add 'triage/flaky-test' label and inform if PR CI run contained flaky tests
+on:
+  workflow_run:
+    workflows: ["Pull Request CI"]
+    types:
+      - completed
+jobs:
+  handle-flaky-tests-in-pr-ci:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.number }}
+    steps:
+      - name: 'Download "jobs-with-flaky-tests" artifact'
+        env:
+          WORKFLOW_ID:  ${{ github.event.workflow_run.id }}
+        run: gh run download $WORKFLOW_ID -n jobs-with-flaky-tests
+      - name: 'Add "triage/flaky-test" label'
+        if: ${{ hashFiles('**/jobs-with-flaky-tests') != '' }}
+        run: |
+          gh pr edit "$PR_NUMBER" --add-label 'triage/flaky-test'
+      - name: 'Comment on PR about flaky tests'
+        if: ${{ hashFiles('**/jobs-with-flaky-tests') != '' }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "Following jobs contain at least one flaky test: $(cat jobs-with-flaky-tests)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,8 @@ jobs:
       matrix:
         java: [ 17 ]
         module-mvn-args: ${{ fromJSON(needs.prepare-jvm-latest-modules-mvn-param.outputs.MODULES_MAVEN_PARAM) }}
+    outputs:
+      has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space
@@ -145,6 +147,10 @@ jobs:
       - name: Build with Maven
         run: |
           mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"${{ matrix.module-mvn-args }} -am
+      - name: Detect flaky tests
+        id: flaky-test-detector
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -163,6 +169,8 @@ jobs:
     strategy:
       matrix:
         java: [ 17 ]
+    outputs:
+      has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space
@@ -200,6 +208,10 @@ jobs:
                         -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" \
                         -pl $MODULES_ARG clean verify -Dnative -am
           fi
+      - name: Detect flaky tests
+        id: flaky-test-detector
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -218,6 +230,8 @@ jobs:
     strategy:
       matrix:
         java: [ 17 ]
+    outputs:
+      has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
     steps:
       - uses: actions/checkout@v4
       - name: Install JDK {{ matrix.java }}
@@ -245,6 +259,10 @@ jobs:
           fi
 
           mvn -B -fae -s .github/mvn-settings.xml clean verify -Dall-modules $MODULES_MAVEN_PARAM -am
+      - name: Detect flaky tests
+        id: flaky-test-detector
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
       - name: Zip Artifacts
         shell: bash
         if: failure()
@@ -257,3 +275,35 @@ jobs:
         with:
           name: artifacts-latest-windows-jvm${{ matrix.java }}
           path: artifacts-latest-windows-jvm${{ matrix.java }}.tar
+  detect-flaky-tests:
+    name: Detect flaky tests
+    runs-on: ubuntu-latest
+    needs: [linux-build-jvm-latest, linux-build-native-latest, windows-build-jvm-latest]
+    steps:
+      - name: Create file with information about job with flaky test
+        if: needs.linux-build-jvm-latest.outputs.has-flaky-tests == 'true' || needs.linux-build-native-latest.outputs.has-flaky-tests == 'true' || needs.windows-build-jvm-latest.outputs.has-flaky-tests == 'true'
+        run: |
+          job_name=""
+          if $IS_LINUX_JVM
+          then
+          job_name+=", 'PR - Linux - JVM build - Latest Version'"
+          fi
+          if $IS_LINUX_NATIVE
+          then
+          job_name+=", 'PR - Linux - Native build - Latest Version'"
+          fi
+          if $IS_WINDOWS_JVM
+          then
+          job_name+=", 'PR - Windows - JVM build - Latest Version'"
+          fi
+          echo "${job_name:2}" > jobs-with-flaky-tests
+        env:
+          IS_LINUX_JVM: ${{ needs.linux-build-jvm-latest.outputs.has-flaky-tests == 'true' }}
+          IS_LINUX_NATIVE: ${{ needs.linux-build-native-latest.outputs.has-flaky-tests == 'true' }}
+          IS_WINDOWS_JVM: ${{ needs.windows-build-jvm-latest.outputs.has-flaky-tests == 'true' }}
+      - name: Archive 'jobs-with-flaky-tests' artifact
+        if: ${{ hashFiles('**/jobs-with-flaky-tests') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: jobs-with-flaky-tests
+          path: jobs-with-flaky-tests

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <build-reporter-maven-extension.version>3.4.4</build-reporter-maven-extension.version>
         <reruns>2</reruns>
         <oc.reruns>1</oc.reruns>
+        <flaky-run-reporter.version>0.1.2.Beta1</flaky-run-reporter.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -186,6 +187,12 @@
                 <groupId>io.quarkus.bot</groupId>
                 <artifactId>build-reporter-maven-extension</artifactId>
                 <version>${build-reporter-maven-extension.version}</version>
+            </extension>
+            <!--Creates report about detected flaky tests during SureFire and FailSafe test runs -->
+            <extension>
+                <groupId>io.quarkus.qe</groupId>
+                <artifactId>flaky-run-reporter</artifactId>
+                <version>${flaky-run-reporter.version}</version>
             </extension>
         </extensions>
         <pluginManagement>


### PR DESCRIPTION
### Summary

- Generate flaky run report when flaky tests are detected during SureFire and FailSafe test runs (by Maven extension https://github.com/quarkus-qe/flaky-run-reporter); this report is going to be consumed by our Jenkins jobs and GitHub application and the report will be visualized
- I've tested it here https://github.com/quarkus-qe/quarkus-test-suite/pull/1678 with flaky test and artifact were generated; I don't think it is possible to test listening workflow from PR, it probably needs to be merged and if there is an issue then adjusted...

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)