### PR TITLE
Fully disable service discovery test

### DIFF
--- a/service-discovery/stork/src/test/java/io/quarkus/ts/stork/OpenShiftStorkServiceDiscoveryIT.java
+++ b/service-discovery/stork/src/test/java/io/quarkus/ts/stork/OpenShiftStorkServiceDiscoveryIT.java
@@ -15,19 +15,17 @@ import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.inject.OpenShiftClient;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.utils.FileUtils;
 
 @OpenShiftScenario
-@DisabledOnQuarkusVersion(version = "2\\..*", reason = "QE OCP user need more privilege in order to be able to create the required ClusterRole")
-@DisabledOnQuarkusSnapshot(reason = "QE OCP user need more privilege in order to be able to create the required ClusterRole")
+@Disabled("QE OCP user need more privilege in order to be able to create the required ClusterRole")
 public class OpenShiftStorkServiceDiscoveryIT extends AbstractCommonTestCases {
 
     private static final String CLUSTER_ROLE_FILE_NAME = "cluster-role.yaml";


### PR DESCRIPTION
### Summary

It is disabled for 2.x, 999-SNAPSHOT and on 3.2 branch already
Required for https://github.com/quarkus-qe/quarkus-test-suite/pull/1668

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)