### PR TITLE
Reeneable test affected by issue 1034

### DIFF
--- a/http/jakarta-rest-reactive/src/test/java/io/quarkus/ts/http/jakartarest/reactive/OpenShiftExecutionModelIT.java
+++ b/http/jakarta-rest-reactive/src/test/java/io/quarkus/ts/http/jakartarest/reactive/OpenShiftExecutionModelIT.java
@@ -3,13 +3,11 @@ package io.quarkus.ts.http.jakartarest.reactive;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@Disabled("https://github.com/quarkus-qe/quarkus-test-framework/issues/1034")
 public class OpenShiftExecutionModelIT extends ExecutionModelIT {
     //TODO https://github.com/quarkusio/quarkus/issues/29642
     // investigate: when FILE_SIZE is set to 99999999, we are getting a


### PR DESCRIPTION
### Summary

Enable test that was disabled due to https://github.com/quarkus-qe/quarkus-test-framework/issues/1034.
Merge this, once https://github.com/quarkus-qe/quarkus-test-framework/pull/1047 is effective (change is released and framework version bumped).

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)