### PR TITLE
Use "library" version of postgresql image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <exclude.quarkus.cli.tests>**/QuarkusCli*IT.java</exclude.quarkus.cli.tests>
         <exclude.quarkus.devmode.tests>no</exclude.quarkus.devmode.tests>
         <!-- Docker images used by both surefire and failsafe plugin -->
-        <postgresql.latest.image>docker.io/postgres:16.1</postgresql.latest.image>
+        <postgresql.latest.image>docker.io/library/postgres:16.1</postgresql.latest.image>
         <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7</mysql.80.image>
         <rhbk.image>registry.redhat.io/rhbk/keycloak-rhel9:22-8</rhbk.image>
         <wiremock-jre8.version>2.35.1</wiremock-jre8.version>


### PR DESCRIPTION
### Summary

I'm reverting postgres image to use "library" version as it back with the version 15.

Problem is, that postgres has different tags on docker and podman. On docker image "docker.io/postgres" works OK. On podman it does not.

In current version (prior to this PR):
Docker pulls the image and tags it as "postgres:16.1-bullseye". When our TS is searching for this image, it searches for "docker.io/postgres:16.1" and finds it.
Podman pulls the very same image (same hash sum) and tags it as "docker.io/library/postgres:16.1-bullseye". And then, when searching for "docker.io/postgres:16.1" it fails to find it, even though image is there.

Changing the image name to "docker.io/library/postgres:16.1-bullseye" makes both docker and podman able of pulling it and then successfully searching for it.


Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)