### PR TITLE
Fix workflow that comments and add flaky test label

### DIFF
--- a/.github/workflows/add-flaky-test-label.yml
+++ b/.github/workflows/add-flaky-test-label.yml
@@ -12,12 +12,12 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}
-      PR_NUMBER: ${{ github.event.number }}
+      PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
     steps:
       - name: 'Download "jobs-with-flaky-tests" artifact'
         env:
           WORKFLOW_ID:  ${{ github.event.workflow_run.id }}
-        run: gh run download $WORKFLOW_ID -n jobs-with-flaky-tests
+        run: gh run download $WORKFLOW_ID -n jobs-with-flaky-tests || true
       - name: 'Add "triage/flaky-test" label'
         if: ${{ hashFiles('**/jobs-with-flaky-tests') != '' }}
         run: |


### PR DESCRIPTION
### Summary

I don't think this CI tests this PR anyway, so no need to wait.

- when expected flaky report artifact is not there, gh command throws error (see https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/7992635005/job/21826584746), sorry, but docs https://cli.github.com/manual/gh_run_download does not say what will happen so I didn't know (if artifact is not there, it is standard state for the workflow, we just don't run other job steps)
- PR_NUMBER environment variable is empty https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/7992439157/job/21825925418 which is hilarious because I copied that line from here https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow Now I am taking advices from https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run 

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)