### PR TITLE
Fix Flaky workflow by getting PR from downloaded artifact instead of empty event object

### DIFF
--- a/.github/workflows/add-flaky-test-label.yml
+++ b/.github/workflows/add-flaky-test-label.yml
@@ -12,7 +12,6 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}
-      PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
       WORKFLOW_ID:  ${{ github.event.workflow_run.id }}
     steps:
       - name: 'Download "jobs-with-flaky-tests" artifact'
@@ -23,8 +22,8 @@ jobs:
       - name: 'Add "triage/flaky-test" label'
         if: ${{ hashFiles('**/pr-number') != '' }}
         run: |
-          gh pr edit "$PR_NUMBER" --add-label 'triage/flaky-test'
+          gh pr edit "$(cat pr-number)" --add-label 'triage/flaky-test'
       - name: 'Comment on PR about flaky tests'
         if: ${{ hashFiles('**/pr-number') != '' }}
         run: |
-          gh pr comment "$PR_NUMBER" --body "Following jobs contain at least one flaky test: $(cat jobs-with-flaky-tests)"
+          gh pr comment "$(cat pr-number)" --body "Following jobs contain at least one flaky test: $(cat jobs-with-flaky-tests)"


### PR DESCRIPTION
### Summary

Explained in https://github.com/quarkus-qe/quarkus-test-suite/pull/1684, third time is the charm.

Please select the relevant options.

- [x Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)