### PR TITLE
Fix PR CI workflow flaky detection step shell on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,7 @@ jobs:
       - name: Detect flaky tests
         id: flaky-test-detector
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        shell: bash
         run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
       - name: Zip Artifacts
         shell: bash


### PR DESCRIPTION
### Summary

Setting explicitly `bash` as shell used in this Windows step that stores workflow output, because I didn't find what is default value and on Windows it could be a problem.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)