### PR TITLE
Add datasource type in hibernate reactive application.properties

### DIFF
--- a/sql-db/hibernate-reactive/src/main/resources/application.properties
+++ b/sql-db/hibernate-reactive/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.hibernate-orm.database.charset=utf-8
 quarkus.hibernate-orm.database.generation=drop-and-create
-
+quarkus.datasource.db-kind=postgresql
 
 # HttpClient config
 SomeApi/mp-rest/url=http://localhost:${quarkus.http.port}


### PR DESCRIPTION
### Summary

This should fix daily failure.
 
After https://github.com/quarkusio/quarkus/pull/39005 the Quarkus need specify datasource type in build time. We doing it others modules but missing it here.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)