### PR TITLE
Set keystore file type as required due to upstream changes the type can't be inferred anymore

### DIFF
--- a/http/http-advanced-reactive/src/main/resources/application.properties
+++ b/http/http-advanced-reactive/src/main/resources/application.properties
@@ -7,6 +7,7 @@ quarkus.swagger-ui.always-include=true
 quarkus.health.openapi.included=true
 quarkus.http.http2=true
 quarkus.http.ssl.certificate.key-store-file=META-INF/resources/server.keystore
+quarkus.http.ssl.certificate.key-store-file-type=JKS
 quarkus.http.ssl.certificate.key-store-password=password
 # HttpClient config
 HealthClientService/mp-rest/url=http://localhost:${quarkus.http.port}

--- a/http/http-advanced/src/main/resources/application.properties
+++ b/http/http-advanced/src/main/resources/application.properties
@@ -7,6 +7,7 @@ quarkus.swagger-ui.always-include=true
 quarkus.health.openapi.included=true
 quarkus.http.http2=true
 quarkus.http.ssl.certificate.key-store-file=META-INF/resources/server.keystore
+quarkus.http.ssl.certificate.key-store-file-type=JKS
 quarkus.http.ssl.certificate.key-store-password=password
 # HttpClient config
 HealthClientService/mp-rest/url=http://localhost:${quarkus.http.port}


### PR DESCRIPTION
### Summary

Sets keystore file type as tests are now failing. See https://github.com/quarkusio/quarkus/pull/39106 and https://github.com/quarkusio/quarkus/issues/39151 for explanation what changed and why it is okay.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)