### PR TITLE
Add keystore file type as it's now required

### DIFF
--- a/http/management/src/test/java/io/quarkus/qe/LocalOptionsIT.java
+++ b/http/management/src/test/java/io/quarkus/qe/LocalOptionsIT.java
@@ -27,7 +27,8 @@ public class LocalOptionsIT {
     static final RestService tls = new RestService()
             .withProperty("quarkus.management.port", "9003")
             .withProperty("quarkus.management.ssl.certificate.key-store-file", "META-INF/resources/server.keystore")
-            .withProperty("quarkus.management.ssl.certificate.key-store-password", "password");
+            .withProperty("quarkus.management.ssl.certificate.key-store-password", "password")
+            .withProperty("quarkus.management.ssl.certificate.key-store-file-type", "PKCS12");
 
     @QuarkusApplication
     static final RestService unmanaged = new RestService()


### PR DESCRIPTION
### Summary

It's the same problem as https://github.com/quarkus-qe/quarkus-test-suite/pull/1700 

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)