### PR TITLE
Workaround Keycloak Authoriz Client network connection issues in OpenShift

### DIFF
--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseOidcIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BaseOidcIT.java
@@ -4,8 +4,8 @@ import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.keycloak.authorization.client.AuthzClient;
+import org.apache.http.NoHttpResponseException;
+import org.jboss.logging.Logger;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
@@ -13,6 +13,7 @@ import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 public abstract class BaseOidcIT {
+    private static final Logger LOG = Logger.getLogger(BaseOidcIT.class);
     static final String USER = "test-user";
 
     static final String CLIENT_ID_DEFAULT = "test-application-client";
@@ -28,14 +29,23 @@ public abstract class BaseOidcIT {
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
 
-    private AuthzClient authzClient;
-
-    @BeforeEach
-    public void setup() {
-        authzClient = keycloak.createAuthzClient(CLIENT_ID_DEFAULT, CLIENT_SECRET_DEFAULT);
+    protected String createToken() {
+        // we retry and create AuthzClient as we experienced following exception in the past: 'Caused by:
+        // org.apache.http.NoHttpResponseException: keycloak-ts-juwpkvyduk.apps.ocp4-15.dynamic.quarkus:80 failed to respond'
+        return createToken(1);
     }
 
-    protected String createToken() {
-        return authzClient.obtainAccessToken(USER, USER).getToken();
+    private static String createToken(int attemptCount) {
+        try {
+            return keycloak.createAuthzClient(CLIENT_ID_DEFAULT, CLIENT_SECRET_DEFAULT).obtainAccessToken(USER, USER)
+                    .getToken();
+        } catch (RuntimeException e) {
+            LOG.error("Attempt #%d to create token failed with exception:".formatted(attemptCount), e);
+            if (e.getCause() instanceof org.apache.http.NoHttpResponseException && attemptCount < 3) {
+                LOG.info("Retrying to create token.");
+                return createToken(attemptCount + 1);
+            }
+            throw e;
+        }
     }
 }


### PR DESCRIPTION
### Summary

Our `OidcRestClientIT`s tests in OpenShift are randomly failing. It's not reproducible, but it happens for some time now and re-run doesn't seem to help (not flaky :-/), exception looks like this:

```
java.lang.RuntimeException: Error executing http method [POST]. Response : null
	at org.keycloak.authorization.client.util.HttpMethod.execute(HttpMethod.java:114)
	at org.keycloak.authorization.client.util.HttpMethodResponse$2.execute(HttpMethodResponse.java:50)
	at org.keycloak.authorization.client.AuthzClient.obtainAccessToken(AuthzClient.java:213)
	at io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.BaseOidcIT.createToken(BaseOidcIT.java:39)
	at io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.OidcRestClientIT.assertPingPongWithPathParam(OidcRestClientIT.java:127)
	at io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.OidcRestClientIT.assertPingEndpoints(OidcRestClientIT.java:58)
	at io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.OidcRestClientIT.testTokenPropagation(OidcRestClientIT.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: org.apache.http.NoHttpResponseException: keycloak-ts-bynxmqtmez.apps.<<restricted>>:<<restricted>> failed to respond
	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:141)
	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:56)
	at org.apache.http.impl.io.AbstractMessageParser.parse(AbstractMessageParser.java:259)
	at org.apache.http.impl.DefaultBHttpClientConnection.receiveResponseHeader(DefaultBHttpClientConnection.java:163)
	at org.apache.http.impl.conn.CPoolProxy.receiveResponseHeader(CPoolProxy.java:157)
	at org.apache.http.protocol.HttpRequestExecutor.doReceiveResponse(HttpRequestExecutor.java:273)
	at org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:125)
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:272)
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)
	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)
	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:108)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:56)
	at org.keycloak.authorization.client.util.HttpMethod.execute(HttpMethod.java:88)
	... 9 more
```

I don't think is is a bug, maybe it goes down to the configuration, but we do not configure anything and I saw the same issue in the `OpenShiftHttpAdvancedReactiveIT` where the client is used and configured by the Quarkus itself. My suggestion is that we need more information - will it keep failing if we don't hold connection open for a long time (re-create client) and if we retry when HTTP request to a Keycloak fails?

If we keep seeing issues, we can revisit taken measures. I'm only adjusting tests that I know that failed in past, in other places we still use `AuthzClient` in the fashion as before this PR.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)