### PR TITLE
Change waiting rules for operators

### DIFF
--- a/service-binding/postgresql-crunchy-classic/src/test/java/io/quarkus/ts/sb/postgresql/OpenShiftPostgreSqlSbIT.java
+++ b/service-binding/postgresql-crunchy-classic/src/test/java/io/quarkus/ts/sb/postgresql/OpenShiftPostgreSqlSbIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.sb.postgresql;
 
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -10,7 +11,6 @@ import jakarta.inject.Inject;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -18,6 +18,7 @@ import io.quarkus.test.bootstrap.inject.OpenShiftClient;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.utils.AwaitilityUtils;
 import io.quarkus.test.utils.Command;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
@@ -50,9 +51,6 @@ public class OpenShiftPostgreSqlSbIT {
     private static boolean areRequiredOperatorsInstalled() {
         List<String> output = new ArrayList<>();
         try {
-            // TODO: figure out a better way to wait for this - this wait is necessary as it takes some time for API to
-            //       populate new namespace with objects
-            Thread.sleep(2000);
             new Command("oc", "get", "csv").outputToLines(output).runAndWait();
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
@@ -61,13 +59,30 @@ public class OpenShiftPostgreSqlSbIT {
         return (outputString.contains("postgresoperator") && outputString.contains("service-binding-operator"));
     }
 
-    private static void createPostgresCluster() {
-        Assumptions.assumeTrue(areRequiredOperatorsInstalled());
-        applyCustomResourceDefinition("pg-cluster.yml");
+    private static boolean arePodsInstalled() {
         try {
-            // TODO: figure out a better way to wait for this - sometimes operator takes a while to create object
-            //       maybe condition of the generated postgres object would help, but this is not a documented API
-            Thread.sleep(2000);
+            List<String> output = new ArrayList<>();
+            new Command("oc", "get", "pods").outputToLines(output).runAndWait();
+            return output.stream()
+                    .anyMatch(line -> line.contains("hippo"));
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    private static void createPostgresCluster() {
+        // this wait is necessary as it takes some time for API to populate new namespace with objects
+        AwaitilityUtils
+                .untilIsTrue(OpenShiftPostgreSqlSbIT::areRequiredOperatorsInstalled,
+                        AwaitilityUtils.AwaitilitySettings.using(Duration.ofSeconds(5),
+                                Duration.ofSeconds(60)));
+        applyCustomResourceDefinition("pg-cluster.yml");
+        // sometimes operator takes a while to create an object
+        AwaitilityUtils
+                .untilIsTrue(OpenShiftPostgreSqlSbIT::arePodsInstalled,
+                        AwaitilityUtils.AwaitilitySettings.using(Duration.ofSeconds(2),
+                                Duration.ofSeconds(30)));
+        try {
             new Command("oc", "-n", ocClient.project(), "wait", "--for", "condition=Ready", "--timeout=300s",
                     "pods", "--all").runAndWait();
         } catch (Exception e) {

--- a/service-binding/postgresql-crunchy-reactive/src/test/java/io/quarkus/ts/sb/reactive/OpenShiftPostgreSqlReactiveSbIT.java
+++ b/service-binding/postgresql-crunchy-reactive/src/test/java/io/quarkus/ts/sb/reactive/OpenShiftPostgreSqlReactiveSbIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.sb.reactive;
 
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -11,7 +12,6 @@ import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -19,6 +19,7 @@ import io.quarkus.test.bootstrap.inject.OpenShiftClient;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.utils.AwaitilityUtils;
 import io.quarkus.test.utils.Command;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
@@ -54,9 +55,6 @@ public class OpenShiftPostgreSqlReactiveSbIT {
     private static boolean areRequiredOperatorsInstalled() {
         List<String> output = new ArrayList<>();
         try {
-            // TODO: figure out a better way to wait for this - this wait is necessary as it takes some time for API to
-            //       populate new namespace with objects
-            Thread.sleep(2000);
             new Command("oc", "get", "csv").outputToLines(output).runAndWait();
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
@@ -65,13 +63,30 @@ public class OpenShiftPostgreSqlReactiveSbIT {
         return (outputString.contains("postgresoperator") && outputString.contains("service-binding-operator"));
     }
 
-    private static void createPostgresCluster() {
-        Assumptions.assumeTrue(areRequiredOperatorsInstalled());
-        applyCustomResourceDefinition();
+    private static boolean arePodsInstalled() {
         try {
-            // TODO: figure out a better way to wait for this - sometimes operator takes a while to create object
-            //       maybe condition of the generated postgres object would help, but this is not a documented API
-            Thread.sleep(2000);
+            List<String> output = new ArrayList<>();
+            new Command("oc", "get", "pods").outputToLines(output).runAndWait();
+            return output.stream()
+                    .anyMatch(line -> line.contains("hippo"));
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    private static void createPostgresCluster() {
+        // this wait is necessary as it takes some time for API to populate new namespace with objects
+        AwaitilityUtils
+                .untilIsTrue(OpenShiftPostgreSqlReactiveSbIT::areRequiredOperatorsInstalled,
+                        AwaitilityUtils.AwaitilitySettings.using(Duration.ofSeconds(10),
+                                Duration.ofSeconds(60)));
+        applyCustomResourceDefinition();
+        // sometimes operator takes a while to create an object
+        AwaitilityUtils
+                .untilIsTrue(OpenShiftPostgreSqlReactiveSbIT::arePodsInstalled,
+                        AwaitilityUtils.AwaitilitySettings.using(Duration.ofSeconds(2),
+                                Duration.ofSeconds(30)));
+        try {
             new Command("oc", "-n", ocClient.project(), "wait", "--for", "condition=Ready", "--timeout=300s",
                     "pods", "--all").runAndWait();
         } catch (Exception e) {


### PR DESCRIPTION
### Summary
These tests wait for operators to be ready.
Earlier, they used Thread.sleep, which sometimes was not enough. These tests fail several times on OCP 4-15, so now they use awaitility

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)