### PR TITLE
Properly disable Env info and Qute API modules native build as native build is failing over this

### DIFF
--- a/env-info/pom.xml
+++ b/env-info/pom.xml
@@ -43,7 +43,7 @@
             </activation>
             <properties>
                 <!-- To not build the module on Native -->
-                <quarkus.package.type>fast-jar</quarkus.package.type>
+                <quarkus.build.skip>true</quarkus.build.skip>
             </properties>
         </profile>
     </profiles>

--- a/qute/multimodule/qute-api/pom.xml
+++ b/qute/multimodule/qute-api/pom.xml
@@ -21,7 +21,7 @@
             </activation>
             <properties>
                 <!-- To not build the module on Native -->
-                <quarkus.package.type>fast-jar</quarkus.package.type>
+                <quarkus.build.skip>true</quarkus.build.skip>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
### Summary

Native build now fails https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/8371702125/job/22922072961. See https://github.com/quarkusio/quarkus/pull/39295#issuecomment-2011857784 for explanation why.

The `quarkus.native.enabled=true` disabled native executable build, however there is no point to even start, therefore this PR is disabling build on Plugin level, which is sooner, therefore less processing.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)