### PR TITLE
Fix OperatorOpenShiftInfinispanObjectsIT after upstream change of bean scope from Singleton to ApplicationScoped

### DIFF
--- a/infinispan-client/src/main/java/io/quarkus/ts/infinispan/client/serialized/ShopItemResource.java
+++ b/infinispan-client/src/main/java/io/quarkus/ts/infinispan/client/serialized/ShopItemResource.java
@@ -13,9 +13,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
 import org.infinispan.client.hotrod.RemoteCache;
-import org.infinispan.query.dsl.Query;
-import org.infinispan.query.dsl.QueryFactory;
-import org.infinispan.query.dsl.QueryResult;
+import org.infinispan.commons.api.query.Query;
 
 import io.quarkus.infinispan.client.Remote;
 
@@ -49,15 +47,13 @@ public class ShopItemResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public List<ShopItem> listItems(@QueryParam("query") String query) {
-        QueryFactory qf = org.infinispan.client.hotrod.Search.getQueryFactory(cache_items);
         Query<ShopItem> searchQuery;
         if (query != null) {
-            searchQuery = qf.create(query);
+            searchQuery = cache_items.query(query);
         } else {
-            searchQuery = qf.create("from quarkus_qe.ShopItem");
+            searchQuery = cache_items.query("from quarkus_qe.ShopItem");
         }
-        QueryResult<ShopItem> queryResult = searchQuery.execute();
-        return queryResult.list();
+        return searchQuery.execute().list();
     }
 
     @GET


### PR DESCRIPTION
### Summary

Now `OperatorOpenShiftInfinispanObjectsIT` fails due to https://github.com/quarkusio/quarkus/pull/39302, that PR documents what should be done, just isn't properly marked or noted in a migration guide ATM.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)