### PR TITLE
[3.2] Skip Kafka test on IBM Z/Power due to missing image

### DIFF
--- a/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftRegistryIT.java
+++ b/http/management/src/test/java/io/quarkus/qe/extension/OpenShiftRegistryIT.java
@@ -6,7 +6,7 @@ import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "Impossible to deploy container built on x86_64 on aarch64.")
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "Impossible to deploy container built on x86_64 on s390x.")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "Impossible to deploy container built on x86_64 on s390x & ppc64le.")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
 public class OpenShiftRegistryIT extends OpenShiftBaseDeploymentIT {
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
@@ -11,6 +11,7 @@ import io.quarkus.test.services.operator.KafkaInstance;
 
 @OpenShiftScenario
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1147")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 public class OperatorOpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTest {
     @Operator(name = "amq-streams", source = "redhat-operators")
     static KafkaInstance kafka = new KafkaInstance();


### PR DESCRIPTION
### Summary

Skipping an additional Kafka test on both IBM Z/Power due to specific image not being available on these platforms.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [x] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)