### PR TITLE
Increase Opentelemetry test coverage

### DIFF
--- a/messaging/amqp-reactive/pom.xml
+++ b/messaging/amqp-reactive/pom.xml
@@ -20,8 +20,17 @@
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-amq</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-jaeger</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/messaging/amqp-reactive/src/test/java/io/quarkus/ts/messaging/amqpreactive/ProdAmqpReactiveIT.java
+++ b/messaging/amqp-reactive/src/test/java/io/quarkus/ts/messaging/amqpreactive/ProdAmqpReactiveIT.java
@@ -1,14 +1,29 @@
 package io.quarkus.ts.messaging.amqpreactive;
 
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
+
 import io.quarkus.test.bootstrap.AmqService;
+import io.quarkus.test.bootstrap.JaegerService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.AmqContainer;
+import io.quarkus.test.services.JaegerContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.AmqProtocol;
+import io.restassured.response.Response;
 
 @QuarkusScenario
 public class ProdAmqpReactiveIT extends BaseAmqpReactiveIT {
+
+    @JaegerContainer(expectedLog = "\"Health Check state change\",\"status\":\"ready\"")
+    static final JaegerService jaeger = new JaegerService();
 
     @AmqContainer(image = "${amqbroker.image}", protocol = AmqProtocol.AMQP)
     static AmqService amq = new AmqService();
@@ -16,5 +31,51 @@ public class ProdAmqpReactiveIT extends BaseAmqpReactiveIT {
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("amqp-host", amq::getAmqpHost)
-            .withProperty("amqp-port", () -> "" + amq.getPort());
+            .withProperty("amqp-port", () -> "" + amq.getPort())
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
+
+    private Response resp;
+
+    @Test
+    public void testContextPropagation() {
+        int pageLimit = 10;
+        String operationName = "GET /price";
+        String lookback = "1h";
+        String serviceName = "messaging-amqp-reactive";
+        await().atMost(5, TimeUnit.SECONDS).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
+            thenRetrieveTraces(operationName, lookback, pageLimit, serviceName);
+            thenTraceSpanSizeMustBe(is(1));
+            verifyStandardSourceCodeAttributesArePresent(operationName);
+
+        });
+    }
+
+    private void thenRetrieveTraces(String operationName, String lookback, int pageLimit, String serviceName) {
+        resp = app.given().when()
+                .queryParam("operation", operationName)
+                .queryParam("lookback", lookback)
+                .queryParam("limit", pageLimit)
+                .queryParam("service", serviceName)
+                .get(jaeger.getTraceUrl())
+                .then().log().all().extract().response();
+    }
+
+    private void thenTraceSpanSizeMustBe(Matcher<?> matcher) {
+        resp.then().body("data[0].spans.size()", matcher);
+    }
+
+    private void verifyStandardSourceCodeAttributesArePresent(String operationName) {
+        verifyAttributeValue(operationName, "code.namespace", PriceResource.class.getName());
+        verifyAttributeValue(operationName, "code.function", "price");
+    }
+
+    private void verifyAttributeValue(String operationName, String attributeName, String attributeValue) {
+        resp.then().body(getGPathForOperationAndAttribute(operationName, attributeName), is(attributeValue));
+    }
+
+    private static String getGPathForOperationAndAttribute(String operationName, String attribute) {
+        return String.format("data[0].spans.find { it.operationName == '%s' }.tags.find { it.key == '%s' }.value",
+                operationName, attribute);
+    }
+
 }

--- a/monitoring/opentelemetry-reactive/pom.xml
+++ b/monitoring/opentelemetry-reactive/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>quarkus-scheduler</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-jaeger</artifactId>
             <scope>test</scope>

--- a/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/AdminResource.java
+++ b/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/AdminResource.java
@@ -1,0 +1,17 @@
+package io.quarkus.ts.opentelemetry.reactive;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.SecurityContext;
+
+@Path("/admin")
+@RolesAllowed("admin")
+public class AdminResource {
+
+    @GET
+    public String get(@Context SecurityContext security) {
+        return "Hello, admin " + security.getUserPrincipal().getName();
+    }
+}

--- a/monitoring/opentelemetry-reactive/src/main/resources/application.properties
+++ b/monitoring/opentelemetry-reactive/src/main/resources/application.properties
@@ -10,3 +10,13 @@ quarkus.grpc.clients.pong.port=${quarkus.http.port}
 quarkus.grpc.server.use-separate-server=false
 
 quarkus.application.name=pingpong
+
+# basic authentication
+quarkus.http.auth.basic=true
+quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.plain-text=true
+quarkus.security.users.embedded.users.alice=alice
+quarkus.security.users.embedded.roles.alice=admin
+
+# Export security events
+quarkus.otel.security-events.enabled=true

--- a/monitoring/opentelemetry/src/main/resources/application.properties
+++ b/monitoring/opentelemetry/src/main/resources/application.properties
@@ -10,3 +10,5 @@ quarkus.grpc.clients.pong.port=${quarkus.http.port}
 quarkus.grpc.server.use-separate-server=false
 
 quarkus.application.name=pingpong
+quarkus.otel.traces.enabled=true
+quarkus.log.level=INFO

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/DevModeOpenTelemetryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/DevModeOpenTelemetryIT.java
@@ -1,0 +1,119 @@
+package io.quarkus.ts.opentelemetry;
+
+import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.apache.http.HttpStatus;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.DevModeQuarkusService;
+import io.quarkus.test.bootstrap.JaegerService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.test.services.JaegerContainer;
+import io.restassured.response.Response;
+
+@QuarkusScenario
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class DevModeOpenTelemetryIT {
+
+    private static final Logger LOG = Logger.getLogger(DevModeOpenTelemetryIT.class);
+    private static final String APPLICATION_PROPERTIES = Paths.get("src", "main", "resources", "application.properties")
+            .toFile()
+            .getPath();
+    private static final String TRACES_ENABLE_PROPERTY = "quarkus.otel.traces.enabled=";
+
+    private static final int PAGE_LIMIT = 10;
+    private static volatile String previousLiveReloadLogEntry = null;
+
+    @JaegerContainer(expectedLog = "\"Health Check state change\",\"status\":\"ready\"")
+    static final JaegerService jaeger = new JaegerService();
+
+    @DevModeQuarkusApplication(classes = { PingPongService.class, PingResource.class,
+            PongResource.class })
+    static DevModeQuarkusService otel = (DevModeQuarkusService) new DevModeQuarkusService()
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
+
+    @Test
+    @Order(2)
+    void checkTraces() {
+        String operationName = "GET /hello";
+        modifyAppPropertiesAndWait(props -> props.replace(getOtelEnabledProperty(false), getOtelEnabledProperty(true)));
+        await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            doRequest();
+            Response response = thenRetrieveTraces(PAGE_LIMIT, "1h", "pingpong", operationName);
+            response.then()
+                    .body("data.size()", greaterThan(0));
+        });
+    }
+
+    @Test
+    @Order(1)
+    void checkThereIsNoTracesAfterRestart() {
+        String operationName = "GET /hello";
+        modifyAppPropertiesAndWait(props -> props.replace(getOtelEnabledProperty(true), getOtelEnabledProperty(false)));
+
+        await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            doRequest();
+            Response response = thenRetrieveTraces(PAGE_LIMIT, "1h", "pingpong", operationName);
+            response.then()
+                    .body("data", empty());
+        });
+    }
+
+    private Response thenRetrieveTraces(int pageLimit, String lookBack, String serviceName, String operationName) {
+        Response response = otel.given()
+                .when()
+                .queryParam("operation", operationName)
+                .queryParam("lookback", lookBack)
+                .queryParam("limit", pageLimit)
+                .queryParam("service", serviceName)
+                .get(jaeger.getTraceUrl());
+        LOG.info("Traces  -->  " + response.asPrettyString());
+        return response;
+    }
+
+    private static void doRequest() {
+        otel.given()
+                .get("/hello")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is("pong"));
+    }
+
+    private static String getOtelEnabledProperty(boolean enabled) {
+        return TRACES_ENABLE_PROPERTY + enabled;
+    }
+
+    private static void modifyAppPropertiesAndWait(Function<String, String> transformProperties) {
+        otel.modifyFile(APPLICATION_PROPERTIES, transformProperties);
+        untilAsserted(() -> {
+            // just waiting won't do the trick, we need to ping Quarkus as well
+            doRequest();
+            String logEntry = otel
+                    .getLogs()
+                    .stream()
+                    .filter(entry -> entry.contains("Live reload total time")
+                            && (previousLiveReloadLogEntry == null || !previousLiveReloadLogEntry.equals(entry)))
+                    .findAny()
+                    .orElse(null);
+            if (logEntry != null) {
+                previousLiveReloadLogEntry = logEntry;
+            } else {
+                Assertions.fail();
+            }
+        });
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <quarkus.ide.version>3.10.0</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.4.2.Beta10</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.4.2.Beta11</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.6.1</quarkus-qpid-jms.version>
         <apache-httpclient-fluent.version>4.5.14</apache-httpclient-fluent.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>


### PR DESCRIPTION

### Summary
As was described in the Jira task : [QUARKUS-2391 Promote the OpenTelemetry extension from TP to full support](https://issues.redhat.com/browse/QQE-540), the OpenTelemetry extension will be fully supported then the plan is to increase the test coverage for Quarkus Opentelemetry, according with the test plan created here:
[OpenTelemetry extension test plan](https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-2391.md)


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)