### PR TITLE
Disable tests on aarch64 due to no CrunchyDB there

### DIFF
--- a/service-binding/postgresql-crunchy-classic/src/test/java/io/quarkus/ts/sb/postgresql/OpenShiftPostgreSqlSbIT.java
+++ b/service-binding/postgresql-crunchy-classic/src/test/java/io/quarkus/ts/sb/postgresql/OpenShiftPostgreSqlSbIT.java
@@ -24,6 +24,7 @@ import io.quarkus.test.utils.Command;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 @DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "Crunchy Postgres operator not available on s390x & ppc64le.")
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1755")
 public class OpenShiftPostgreSqlSbIT {
 
     @Inject

--- a/service-binding/postgresql-crunchy-reactive/src/test/java/io/quarkus/ts/sb/reactive/OpenShiftPostgreSqlReactiveSbIT.java
+++ b/service-binding/postgresql-crunchy-reactive/src/test/java/io/quarkus/ts/sb/reactive/OpenShiftPostgreSqlReactiveSbIT.java
@@ -25,6 +25,7 @@ import io.quarkus.test.utils.Command;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 @DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "Crunchy Postgres operator not available on s390x & ppc64le.")
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1755")
 public class OpenShiftPostgreSqlReactiveSbIT {
 
     private static final String PG_CLUSTER_YML = "pg-cluster.yml";


### PR DESCRIPTION
* Disabling service binding tests on aarch64 as the CrunchyDB operator is not yet supported there.

Tracking issue: https://github.com/quarkus-qe/quarkus-test-suite/issues/1755

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)