### PR TITLE
[3.8] Do not expect index page in DEV mode on Windows

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -79,7 +79,13 @@ public class QuarkusCliCreateJvmApplicationIT {
 
         // Start using DEV mode
         app.start();
-        app.given().get().then().statusCode(HttpStatus.SC_OK);
+        if (OS.WINDOWS.isCurrentOs()) {
+            // there is empty page on Windows as we don't use registry prepared by prod team
+            // related to https://github.com/quarkusio/quarkus/issues/39909
+            app.given().get("/hello").then().statusCode(HttpStatus.SC_OK);
+        } else {
+            app.given().get().then().statusCode(HttpStatus.SC_OK);
+        }
     }
 
     @Tag("QUARKUS-1472")


### PR DESCRIPTION
### Summary

The check in question returns 404 on Windows due to https://github.com/quarkusio/quarkus/issues/39909#issuecomment-2070739091. It seems like it's related to the CLI version installed on our Windows runners with a Docker. I didn't look further into cause of this behavior because I do not consider this very important as long as there is opened known issue marked as won't f i x https://github.com/quarkusio/quarkus/issues/39909.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)