### PR TITLE
[3.8] QUARKUS-4321 Disabling Kafka Streams test on native product 

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DisabledOnRHBQAarch64Native.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DisabledOnRHBQAarch64Native.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.messaging.kafka.reactive.streams;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Inherited
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledOnRHBQAarch64NativeConditions.class)
+public @interface DisabledOnRHBQAarch64Native {
+
+    /**
+     * Why is the annotated test class or test method disabled.
+     */
+    String reason();
+}

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DisabledOnRHBQAarch64NativeConditions.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DisabledOnRHBQAarch64NativeConditions.java
@@ -1,0 +1,22 @@
+package io.quarkus.ts.messaging.kafka.reactive.streams;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+
+public class DisabledOnRHBQAarch64NativeConditions implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        boolean isRHBQ = QuarkusProperties.getVersion().contains("redhat");
+        boolean isNative = QuarkusProperties.isNativePackageType();
+        boolean isAarch64 = "true".equals(System.getProperty("ts.arm.missing.services.excludes"));
+        if (isRHBQ && isAarch64 && isNative) {
+            return ConditionEvaluationResult.disabled("It is RHBQ running on aarch64 in native mode.");
+        } else {
+            return ConditionEvaluationResult.enabled("It is not RHBQ running on aarch64 in native mode.");
+        }
+    }
+}

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftStrimziKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftStrimziKafkaStreamIT.java
@@ -6,5 +6,6 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
 @DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
+@DisabledOnRHBQAarch64Native(reason = "https://issues.redhat.com/browse/QUARKUS-4321")
 public class OpenShiftStrimziKafkaStreamIT extends StrimziKafkaStreamIT {
 }


### PR DESCRIPTION
### Summary

* Disabling Kafka Streams test on native product due to https://issues.redhat.com/browse/QUARKUS-4321.

Test run: https://main-jenkins-csb-quarkusqe.apps.ocp-c1.prod.psi.redhat.com/job/rhbq-3.8-rhel8-jdk21-openshift-ts-native-ocp-4-stable-aarch64-mj/label=RHEL8_aarch64%20&&%20xlarge%20&&%20docker,scenario=messaging-modules/9/

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)