### PR TITLE
Increase wait time to 300 seconds for CSVs in SB

### DIFF
--- a/service-binding/postgresql-crunchy-classic/src/test/java/io/quarkus/ts/sb/postgresql/OpenShiftPostgreSqlSbIT.java
+++ b/service-binding/postgresql-crunchy-classic/src/test/java/io/quarkus/ts/sb/postgresql/OpenShiftPostgreSqlSbIT.java
@@ -78,7 +78,7 @@ public class OpenShiftPostgreSqlSbIT {
         AwaitilityUtils
                 .untilIsTrue(OpenShiftPostgreSqlSbIT::areRequiredOperatorsInstalled,
                         AwaitilityUtils.AwaitilitySettings.using(Duration.ofSeconds(5),
-                                Duration.ofSeconds(60)));
+                                Duration.ofSeconds(300)));
         applyCustomResourceDefinition("pg-cluster.yml");
         // sometimes operator takes a while to create an object
         AwaitilityUtils

--- a/service-binding/postgresql-crunchy-reactive/src/test/java/io/quarkus/ts/sb/reactive/OpenShiftPostgreSqlReactiveSbIT.java
+++ b/service-binding/postgresql-crunchy-reactive/src/test/java/io/quarkus/ts/sb/reactive/OpenShiftPostgreSqlReactiveSbIT.java
@@ -82,7 +82,7 @@ public class OpenShiftPostgreSqlReactiveSbIT {
         AwaitilityUtils
                 .untilIsTrue(OpenShiftPostgreSqlReactiveSbIT::areRequiredOperatorsInstalled,
                         AwaitilityUtils.AwaitilitySettings.using(Duration.ofSeconds(10),
-                                Duration.ofSeconds(60)));
+                                Duration.ofSeconds(300)));
         applyCustomResourceDefinition();
         // sometimes operator takes a while to create an object
         AwaitilityUtils


### PR DESCRIPTION
* Increasing the maximum timeout to 300 seconds for CSVs to be injected into the namespace in service binding tests. The reason is that on OSD, there's considerably more operators installed on the cluster and it takes more than a minute quite a lot of times.

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)