### PR TITLE
[3.8] Bump quarkus-test-framework to 1.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.8.4</quarkus.platform.version>
         <quarkus.ide.version>3.8.4</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.4.2.Beta8</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.4.4</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.5.0</quarkus-qpid-jms.version>
         <apache-httpclient-fluent.version>4.5.14</apache-httpclient-fluent.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>


### PR DESCRIPTION
### Summary

* Bumping version of quarkus-test-framework to first stable release of 1.4 stream meant for Quarkus 3.8.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)