### PR TITLE
Disable MySQL WebAuth test in FIPS-enabled environment due to upstream bug

### DIFF
--- a/security/webauthn/src/test/java/io/quarkus/ts/security/webauthn/MySqlWebAuthnIT.java
+++ b/security/webauthn/src/test/java/io/quarkus/ts/security/webauthn/MySqlWebAuthnIT.java
@@ -1,11 +1,14 @@
 package io.quarkus.ts.security.webauthn;
 
+import org.junit.jupiter.api.Tag;
+
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
+@Tag("fips-incompatible") // TODO: enable when the https://github.com/eclipse-vertx/vertx-sql-client/issues/1436 is fixed
 @QuarkusScenario
 public class MySqlWebAuthnIT extends AbstractWebAuthnTest {
 


### PR DESCRIPTION
### Summary

I have created both RHBQ JIRA QUARKUS-4387 and upstream https://github.com/eclipse-vertx/vertx-sql-client/issues/1436. We need to disable this as our FIPS tests are failing.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)