### PR TITLE
Enable and fix MySQL JDBC-based tests in FIPS-enabled environment and correct FIPS-disabling comment on MySQL reactive tests

### DIFF
--- a/scheduling/quartz/src/test/java/io/quarkus/ts/scheduling/quartz/AnnotationScheduledJobsMySqlQuartzIT.java
+++ b/scheduling/quartz/src/test/java/io/quarkus/ts/scheduling/quartz/AnnotationScheduledJobsMySqlQuartzIT.java
@@ -6,7 +6,6 @@ import java.time.Duration;
 
 import org.apache.http.HttpStatus;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -14,7 +13,6 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.scheduling.quartz.failover.ExecutionEntity;
 
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class AnnotationScheduledJobsMySqlQuartzIT extends BaseMySqlQuartzIT {
 

--- a/scheduling/quartz/src/test/java/io/quarkus/ts/scheduling/quartz/BasicMySqlQuartzIT.java
+++ b/scheduling/quartz/src/test/java/io/quarkus/ts/scheduling/quartz/BasicMySqlQuartzIT.java
@@ -3,14 +3,12 @@ package io.quarkus.ts.scheduling.quartz;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.QuarkusApplication;
 
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class BasicMySqlQuartzIT extends BaseMySqlQuartzIT {
 

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/MysqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/MysqlMultitenantHibernateSearchIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.hibernate.search;
 
-import org.junit.jupiter.api.Tag;
-
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.Protocol;
@@ -10,8 +8,6 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class MysqlMultitenantHibernateSearchIT extends AbstractMultitenantHibernateSearchIT {
     static final int ELASTIC_PORT = 9200;

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MySQLDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MySQLDatabaseHibernateReactiveIT.java
@@ -8,8 +8,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
+@Tag("fips-incompatible") // TODO: enable when the https://github.com/eclipse-vertx/vertx-sql-client/issues/1436 is fixed
 @QuarkusScenario
 public class MySQLDatabaseHibernateReactiveIT extends AbstractDatabaseHibernateReactiveIT {
 

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MysqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MysqlTransactionGeneralUsageIT.java
@@ -4,7 +4,6 @@ import static io.quarkus.test.services.containers.DockerContainerManagedResource
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.Tag;
 import org.testcontainers.containers.GenericContainer;
 
 import io.quarkus.test.bootstrap.MySqlService;
@@ -14,8 +13,6 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class MysqlTransactionGeneralUsageIT extends TransactionCommons {
 

--- a/sql-db/panache-flyway/pom.xml
+++ b/sql-db/panache-flyway/pom.xml
@@ -40,11 +40,6 @@
             <artifactId>quarkus-elytron-security-properties-file</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>mysql</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-database</artifactId>
             <scope>test</scope>

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/CRUDAllInPanacheWithFlywayIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/CRUDAllInPanacheWithFlywayIT.java
@@ -7,13 +7,10 @@ import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 class CRUDAllInPanacheWithFlywayIT extends PanacheWithFlywayBaseIT {
 

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/CRUDPanacheWithFlywayIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/CRUDPanacheWithFlywayIT.java
@@ -16,15 +16,12 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class CRUDPanacheWithFlywayIT extends PanacheWithFlywayBaseIT {
 

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/DataSourceConfigPanacheWithFlywayIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/DataSourceConfigPanacheWithFlywayIT.java
@@ -4,14 +4,11 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.restassured.specification.RequestSpecification;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") //native-mode
 @QuarkusScenario
 public class DataSourceConfigPanacheWithFlywayIT extends PanacheWithFlywayBaseIT {
 

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalPoolTest.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalPoolTest.java
@@ -23,7 +23,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.agroal.api.AgroalDataSource;
@@ -46,7 +45,6 @@ import io.vertx.mutiny.ext.web.client.WebClient;
  * Some of these tests required some extra load, in order to reproduce concurrency issues.
  */
 @EnabledWhenLinuxContainersAvailable
-@Tag("fips-incompatible") // native-mode
 @QuarkusTest
 @TestProfile(AgroalTestProfile.class)
 public class AgroalPoolTest {

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalTestProfile.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/AgroalTestProfile.java
@@ -25,7 +25,7 @@ public class AgroalTestProfile implements QuarkusTestProfile {
     public Map<String, String> getConfigOverrides() {
         Map<String, String> config = new HashMap<>();
         config.put("quarkus.datasource.devservices.enabled", "false");
-        config.put("quarkus.datasource.with-xa.devservices", "false");
+        config.put("quarkus.datasource.with-xa.devservices.enabled", "false");
         return config;
     }
 }

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/MySqlDatabaseTestResource.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/MySqlDatabaseTestResource.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
@@ -20,25 +20,39 @@ public class MySqlDatabaseTestResource implements QuarkusTestResourceLifecycleMa
     private static final String DEFAULT_SCHEMA = "test";
     private static final String MYSQL = "mysql";
     private static final String WITH_XA_PROFILE = ".with-xa";
+    private static final String USER_PROPERTY = "MYSQL_USER";
+    private static final String PASSWORD_PROPERTY = "MYSQL_PASSWORD";
+    private static final String PASSWORD_ROOT_PROPERTY = "MYSQL_ROOT_PASSWORD";
+    private static final String DATABASE_PROPERTY = "MYSQL_DATABASE";
+    private static final String USER = "user";
 
-    private MySQLContainer<?> container;
+    private GenericContainer<?> container;
 
     @Override
     public Map<String, String> start() {
         String image = System.getProperty("mysql.80.image");
 
-        container = new MySQLContainer<>(
+        // we used managed version of 'org.testcontainers:mysql' and version '1.19.7' failed in FIPS-enabled environment
+        // over 'SA/ECB/OAEPWithSHA-1AndMGF1Padding' cipher as SunJCE provider was not available in FIPS
+        // hence for now, we use GenericContainer which allows to override waiting strategy that works in FIPS
+        container = new GenericContainer<>(
                 DockerImageName.parse(image).asCompatibleSubstituteFor(MYSQL));
-        container.withUrlParam("currentSchema", DEFAULT_SCHEMA);
+        container.waitingFor(new LogMessageWaitStrategy().withRegEx(".*Only MySQL server logs after this point.*\\s"));
+        container.withExposedPorts(3306);
+        container.withEnv(USER_PROPERTY, USER);
+        container.withEnv(PASSWORD_PROPERTY, USER);
+        container.withEnv(PASSWORD_ROOT_PROPERTY, USER);
+        container.withEnv(DATABASE_PROPERTY, DEFAULT_SCHEMA);
         container.start();
 
+        var jdbcUrl = "jdbc:mysql://localhost:%d/%s".formatted(container.getMappedPort(3306), DEFAULT_SCHEMA);
         Map<String, String> config = new HashMap<>();
-        config.put(defaultDataSource(QUARKUS_DB_JDBC_URL), container.getJdbcUrl());
-        config.put(defaultDataSource(QUARKUS_DB_USER), container.getUsername());
-        config.put(defaultDataSource(QUARKUS_DB_PASSWORD), container.getPassword());
-        config.put(withXaDataSource(QUARKUS_DB_JDBC_URL), container.getJdbcUrl());
-        config.put(withXaDataSource(QUARKUS_DB_USER), container.getUsername());
-        config.put(withXaDataSource(QUARKUS_DB_PASSWORD), container.getPassword());
+        config.put(defaultDataSource(QUARKUS_DB_JDBC_URL), jdbcUrl);
+        config.put(defaultDataSource(QUARKUS_DB_USER), USER);
+        config.put(defaultDataSource(QUARKUS_DB_PASSWORD), USER);
+        config.put(withXaDataSource(QUARKUS_DB_JDBC_URL), jdbcUrl);
+        config.put(withXaDataSource(QUARKUS_DB_USER), USER);
+        config.put(withXaDataSource(QUARKUS_DB_PASSWORD), USER);
 
         return Collections.unmodifiableMap(config);
     }

--- a/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MySqlPanacheResourceIT.java
+++ b/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MySqlPanacheResourceIT.java
@@ -8,8 +8,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
+@Tag("fips-incompatible") // TODO: enable when the https://github.com/eclipse-vertx/vertx-sql-client/issues/1436 is fixed
 @QuarkusScenario
 public class MySqlPanacheResourceIT extends AbstractPanacheResourceIT {
 

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MySqlDatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MySqlDatabaseIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.sqldb.compatibility;
 
-import org.junit.jupiter.api.Tag;
-
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -9,8 +7,6 @@ import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 @DisabledOnNative(reason = "Compatibility mode check in JVM mode is enough for this DB")
 public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MySqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MySqlDatabaseIT.java
@@ -1,15 +1,11 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
-import org.junit.jupiter.api.Tag;
-
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {
 

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MysqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MysqlHandlerIT.java
@@ -8,8 +8,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-// TODO https://github.com/quarkus-qe/quarkus-test-suite/issues/756
-@Tag("fips-incompatible") // native-mode
+@Tag("fips-incompatible") // TODO: enable when the https://github.com/eclipse-vertx/vertx-sql-client/issues/1436 is fixed
 @QuarkusScenario
 public class MysqlHandlerIT extends CommonTestCases {
     private static final String DATABASE = "amadeus";


### PR DESCRIPTION
### Summary

closes: #756

- enables MySQL JDBC-based tests as they work with the MySQL connector and database used in 3.8.4 and 999-SNAPSHOT
- fixes TODO next to MySQL reactive tests
- `AgroalPoolTest` didn't work over `SA/ECB/OAEPWithSHA-1AndMGF1Padding` error (like in https://github.com/quarkusio/quarkus/issues/32910 but in TC MySQL lib) but that's TC's version of MySQL container, so I switched waiting strategy that works in FIPS-enabled environment as well

I run all enabled tests with RH OpenJDK 17 and Quarkus 999-SNAPSHOT and 3.8.4. The ones with "native" comment I also run in a native mode. The reactive MySQL tests are disabled due to https://github.com/eclipse-vertx/vertx-sql-client/issues/1436. As far as Quarkus goes, we have `QUARKUS-4387`, which is why I didn't create Quarkus issue (3 issues for one bug seems too much).

_CI Failures_: The Hibernate Reactive and Transacitonal module also fails in a daily build and I'm only changing jupiter Tag and comment there, that can't cause any failures. I have opened https://github.com/quarkusio/quarkus/issues/40425 for Hibernate Reactive ones.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)