### PR TITLE
Adjust expectations regarding OpenTelemetry JDBC operation names after Hibernate ORM bump to 6.5

### DIFF
--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
@@ -57,8 +57,12 @@ public class MssqlTransactionGeneralUsageIT extends TransactionCommons {
     }
 
     @Override
-    protected String[] getExpectedJdbcOperationNames() {
-        return new String[] { "SELECT msdb.account", "INSERT msdb.journal", "UPDATE msdb.account" };
+    protected Operation[] getExpectedJdbcOperations() {
+        return new Operation[] { new Operation("SELECT msdb.account"), new Operation("INSERT msdb.journal"),
+                // here we are looking for UPDATE msdb.ae1_0 because currently DB statement is
+                // update ae1_0 set amount=?,updatedAt=? from account ae1_0 where ae1_0.accountNumber=?
+                // however we shouldn't rely on alias generation logic, therefore we test the UPDATE statement is there
+                new Operation(actualOperationName -> actualOperationName.startsWith("UPDATE msdb.")) };
     }
 
 }

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OracleTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OracleTransactionGeneralUsageIT.java
@@ -33,8 +33,9 @@ public class OracleTransactionGeneralUsageIT extends TransactionCommons {
     }
 
     @Override
-    protected String[] getExpectedJdbcOperationNames() {
-        return new String[] { "SELECT mydb.dual", "INSERT mydb.journal", "UPDATE mydb.account" };
+    protected Operation[] getExpectedJdbcOperations() {
+        return new Operation[] { new Operation("SELECT mydb.dual"), new Operation("INSERT mydb.journal"),
+                new Operation("UPDATE mydb.account") };
     }
 
     @Override


### PR DESCRIPTION
### Summary

After https://github.com/quarkusio/quarkus/pull/40102 actual DB query changes as now, during the UPDATE with JDBC MSSQL, the alias is used. The DB statement now looks like this: `update ae1_0 set amount=?,updatedAt=? from account ae1_0 where ae1_0.accountNumber=?` which results in alias being used instead of database name.

I could not find anything in OTel specs in this regards, the closes I got is the first link https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7821, but it seems like a grey area and I don't think it's a bug.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)