### PR TITLE
Disable failing Hiberante Reactive Oracle and PostgreSQL tests after bump to 2.3

### DIFF
--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/OracleDatabaseIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/OracleDatabaseIT.java
@@ -1,5 +1,8 @@
 package io.quarkus.ts.hibernate.reactive;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 import io.quarkus.test.bootstrap.OracleService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -27,5 +30,29 @@ public class OracleDatabaseIT extends AbstractDatabaseHibernateReactiveIT {
     @Override
     protected RestService getApp() {
         return app;
+    }
+
+    // TODO: drop is overridden method when #40425 is fixed
+    @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/40425")
+    @Override
+    public void createBookWithGeneratedId() {
+        super.createBookWithGeneratedId();
+    }
+
+    // TODO: drop is overridden method when #40425 is fixed
+    @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/40425")
+    @Override
+    public void useTransaction() {
+        super.useTransaction();
+    }
+
+    // TODO: drop is overridden method when #40425 is fixed
+    @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/40425")
+    @Override
+    public void ensureSessionIsPropagatedOnReactiveTransactions() {
+        super.ensureSessionIsPropagatedOnReactiveTransactions();
     }
 }

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/PostgresqlDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/PostgresqlDatabaseHibernateReactiveIT.java
@@ -1,5 +1,8 @@
 package io.quarkus.ts.hibernate.reactive;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 import io.quarkus.test.bootstrap.PostgresqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -30,5 +33,29 @@ public class PostgresqlDatabaseHibernateReactiveIT extends AbstractDatabaseHiber
     @Override
     protected RestService getApp() {
         return app;
+    }
+
+    // TODO: drop is overridden method when #40425 is fixed
+    @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/40425")
+    @Override
+    public void createBookWithGeneratedId() {
+        super.createBookWithGeneratedId();
+    }
+
+    // TODO: drop is overridden method when #40425 is fixed
+    @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/40425")
+    @Override
+    public void useTransaction() {
+        super.useTransaction();
+    }
+
+    // TODO: drop is overridden method when #40425 is fixed
+    @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/40425")
+    @Override
+    public void ensureSessionIsPropagatedOnReactiveTransactions() {
+        super.ensureSessionIsPropagatedOnReactiveTransactions();
     }
 }


### PR DESCRIPTION
### Summary

Right now, it doesn't seem like we will get quick fix of the https://github.com/quarkusio/quarkus/issues/40425.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)