### PR TITLE
Fix Vert.X SQL module compilation after ProfileManager removal from Quarkus

### DIFF
--- a/sql-db/vertx-sql/src/main/java/io/quarkus/ts/vertx/sql/Application.java
+++ b/sql-db/vertx-sql/src/main/java/io/quarkus/ts/vertx/sql/Application.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.arc.profile.IfBuildProfile;
 import io.quarkus.runtime.StartupEvent;
-import io.quarkus.runtime.configuration.ProfileManager;
+import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.ts.vertx.sql.services.DbPoolService;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
@@ -61,7 +61,7 @@ public class Application {
     OraclePool oracle;
 
     void onStart(@Observes StartupEvent ev) {
-        LOGGER.info("The application is starting with profile " + ProfileManager.getActiveProfile());
+        LOGGER.info("The application is starting with profiles " + ConfigUtils.getProfiles());
 
         ObjectMapper mapper = DatabindCodec.mapper();
         mapper.setSerializationInclusion(Include.NON_NULL);


### PR DESCRIPTION
### Summary

The module compilation fails due to https://github.com/quarkusio/quarkus/pull/39194.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)