### PR TITLE
Run OIDC client mTLS tests in FIPS-enabled environment

### DIFF
--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/IncorrectKsFileTypeOidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/IncorrectKsFileTypeOidcMtlsIT.java
@@ -5,7 +5,6 @@ import static io.quarkus.ts.security.oidcclient.mtls.MutualTlsKeycloakService.ne
 import static io.restassured.RestAssured.given;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -18,7 +17,6 @@ import io.quarkus.test.services.QuarkusApplication;
  * If keystore/truststore file type does not match declared one, communication between OIDC server
  * and client should fail.
  */
-@Tag("fips-incompatible")
 @QuarkusScenario
 public class IncorrectKsFileTypeOidcMtlsIT extends BaseOidcMtlsIT {
 

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/JksOidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/JksOidcMtlsIT.java
@@ -12,7 +12,6 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
-@Tag("fips-incompatible")
 @QuarkusScenario
 public class JksOidcMtlsIT extends KeycloakMtlsAuthN {
 


### PR DESCRIPTION
### Summary

I run all the tests in native and JVM with RH OpenJDK 17 & 21 and they work.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)