### PR TITLE
Fix Vert.x JWT tests in FIPS-enabled environment

### DIFF
--- a/security/vertx-jwt/src/main/java/io/quarkus/ts/security/vertx/auth/AuthN.java
+++ b/security/vertx-jwt/src/main/java/io/quarkus/ts/security/vertx/auth/AuthN.java
@@ -6,6 +6,7 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 
 import io.quarkus.ts.security.vertx.config.AuthNConfig;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.JWTOptions;
 import io.vertx.ext.auth.PubSecKeyOptions;
@@ -29,9 +30,9 @@ public class AuthN {
 
     private PubSecKeyOptions getPubSecKeyOptions() {
         JsonObject authConfig = new JsonObject()
-                .put("symmetric", true)
+                .put("symmetric", false)
                 .put("algorithm", authNConf.alg())
-                .put("publicKey", authNConf.secret());
+                .put("publicKey", Buffer.buffer(CertUtils.loadKey(authNConf.certPath())));
 
         return new PubSecKeyOptions(authConfig).setBuffer(authConfig.getBuffer("publicKey"));
     }

--- a/security/vertx-jwt/src/main/java/io/quarkus/ts/security/vertx/auth/CertUtils.java
+++ b/security/vertx-jwt/src/main/java/io/quarkus/ts/security/vertx/auth/CertUtils.java
@@ -1,0 +1,20 @@
+package io.quarkus.ts.security.vertx.auth;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class CertUtils {
+
+    private CertUtils() {
+        // UTIL CLASS
+    }
+
+    public static String loadKey(String path) {
+        try {
+            return Files.readString(Path.of(path));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to extract key from path %s".formatted(path), e);
+        }
+    }
+}

--- a/security/vertx-jwt/src/main/java/io/quarkus/ts/security/vertx/config/AuthNConfig.java
+++ b/security/vertx-jwt/src/main/java/io/quarkus/ts/security/vertx/config/AuthNConfig.java
@@ -7,7 +7,7 @@ import io.smallrye.config.WithName;
 public interface AuthNConfig {
     String alg();
 
-    String secret();
+    String certPath();
 
     @WithName("token-live-span-min")
     int liveSpan();

--- a/security/vertx-jwt/src/main/resources/application.properties
+++ b/security/vertx-jwt/src/main/resources/application.properties
@@ -2,8 +2,7 @@
 
 app.name=Vertx-jwt
 
-authN.alg=HS256
-authN.secret=keepSecret
+authN.alg=RS256
 authN.token-live-span-min=10
 authN.jwt.claims.aud=third_party
 authN.jwt.claims.iss=vertxJWT@redhat.com

--- a/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/BladeRunnerHandlerIT.java
+++ b/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/BladeRunnerHandlerIT.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.restassured.http.ContentType;
 
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class BladeRunnerHandlerIT extends AbstractCommonIT {
     @Test

--- a/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/NoSecuredResourceIT.java
+++ b/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/NoSecuredResourceIT.java
@@ -1,11 +1,9 @@
 package io.quarkus.ts.security.vertx;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class NoSecuredResourceIT extends AbstractCommonIT {
     @Test

--- a/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/ReplicantHandlerIT.java
+++ b/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/ReplicantHandlerIT.java
@@ -2,13 +2,11 @@ package io.quarkus.ts.security.vertx;
 
 import static org.hamcrest.Matchers.is;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.restassured.http.ContentType;
 
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class ReplicantHandlerIT extends AbstractCommonIT {
     @Test

--- a/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/SecuredResourceIT.java
+++ b/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/SecuredResourceIT.java
@@ -1,15 +1,14 @@
 package io.quarkus.ts.security.vertx;
 
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.restassured.http.ContentType;
 
-@Tag("fips-incompatible") // native-mode
 @QuarkusScenario
 public class SecuredResourceIT extends AbstractCommonIT {
+
     @Test
     @DisplayName("secured resource. Valid Token")
     public void validJwtToken() {

--- a/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/jwt/JwtTest.java
+++ b/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/jwt/JwtTest.java
@@ -4,18 +4,14 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.scenarios.QuarkusScenario;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.impl.jose.JWK;
 import io.vertx.ext.auth.impl.jose.JWT;
 
-@Tag("fips-incompatible") // native-mode
-@QuarkusScenario
-public class JwtIT {
+public class JwtTest {
 
     @Test
     void x5cCertificateChainTest() throws Exception {


### PR DESCRIPTION
### Summary

- algorithm `HS256` doesn't work in FIPS-enabled environment, so I replaced it with `RS256`
- `JwtIT` started Quarkus application for no reason, because it didn't test it, so I made it a plain unit test

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)