### PR TITLE
Enable BouncyCastleFipsJsseTest in FIPS-enabled environment as upstream issue got fixed

### DIFF
--- a/security/bouncycastle-fips/bcFipsJsse/src/test/java/io/quarkus/ts/security/bouncycastle/fips/jsse/BouncyCastleFipsJsseTest.java
+++ b/security/bouncycastle-fips/bcFipsJsse/src/test/java/io/quarkus/ts/security/bouncycastle/fips/jsse/BouncyCastleFipsJsseTest.java
@@ -25,7 +25,6 @@ import io.vertx.core.net.KeyStoreOptions;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.mutiny.ext.web.client.WebClient;
 
-@Tag("fips-incompatible") // disabled due to the https://github.com/quarkusio/quarkus/issues/40659
 @QuarkusTest
 public class BouncyCastleFipsJsseTest {
 


### PR DESCRIPTION
### Summary

https://github.com/quarkusio/quarkus/issues/40659 is fixed, therefore we can run BouncyCastleFipsJsseTest in FIPS-enabled environment. This PR is not backportable to 3.8 as the upstream fix wasn't backported.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)