### PR TITLE
Add encrypted communication between Quarkus app and SQL Server 2022 and disable SQL Server tests when run in FIPS-enabled environment with OpenJDK 17

### DIFF
--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MsSQLDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MsSQLDatabaseHibernateReactiveIT.java
@@ -3,15 +3,15 @@ package io.quarkus.ts.hibernate.reactive;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.SqlServerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.SqlServerContainer;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @QuarkusScenario
 public class MsSQLDatabaseHibernateReactiveIT extends AbstractDatabaseHibernateReactiveIT {
 
-    private static final int MSSQL_PORT = 1433;
-
-    @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
+    @SqlServerContainer
     static SqlServerService database = new SqlServerService();
 
     @QuarkusApplication

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
@@ -9,16 +9,16 @@ import org.testcontainers.containers.GenericContainer;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.SqlServerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.SqlServerContainer;
 import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @QuarkusScenario
 public class MssqlTransactionGeneralUsageIT extends TransactionCommons {
 
-    private static final int MSSQL_PORT = 1433;
-
-    @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
+    @SqlServerContainer
     static SqlServerService database = new SqlServerService().onPostStart(service -> {
         // enable XA transactions
         var self = (SqlServerService) service;

--- a/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MssqlPanacheResourceIT.java
+++ b/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MssqlPanacheResourceIT.java
@@ -3,15 +3,15 @@ package io.quarkus.ts.reactive.rest.data.panache;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.SqlServerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.SqlServerContainer;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @QuarkusScenario
 public class MssqlPanacheResourceIT extends AbstractPanacheResourceIT {
 
-    private static final int MSSQL_PORT = 1433;
-
-    @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
+    @SqlServerContainer
     static SqlServerService database = new SqlServerService();
 
     @QuarkusApplication

--- a/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeReactiveMssqlDevServiceUserExperienceIT.java
+++ b/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeReactiveMssqlDevServiceUserExperienceIT.java
@@ -11,9 +11,11 @@ import com.github.dockerjava.api.model.Image;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.DockerUtils;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @Tag("QUARKUS-1408")
 @QuarkusScenario
 public class DevModeReactiveMssqlDevServiceUserExperienceIT {

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MssqlDatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MssqlDatabaseIT.java
@@ -3,15 +3,15 @@ package io.quarkus.ts.sqldb.compatibility;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.SqlServerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.SqlServerContainer;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @QuarkusScenario
 public class MssqlDatabaseIT extends AbstractSqlDatabaseIT {
 
-    private static final int MSSQL_PORT = 1433;
-
-    @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
+    @SqlServerContainer
     static SqlServerService database = new SqlServerService();
 
     @QuarkusApplication

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMssqlDevServicesUserExperienceIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMssqlDevServicesUserExperienceIT.java
@@ -12,10 +12,12 @@ import com.github.dockerjava.api.model.Image;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.DockerUtils;
 import io.quarkus.test.utils.SocketUtils;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @Tag("QUARKUS-959")
 @QuarkusScenario
 public class DevModeMssqlDevServicesUserExperienceIT {

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MssqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MssqlDatabaseIT.java
@@ -3,19 +3,20 @@ package io.quarkus.ts.sqldb.sqlapp;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.SqlServerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.SqlServerContainer;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @QuarkusScenario
 public class MssqlDatabaseIT extends AbstractSqlDatabaseIT {
 
-    private static final int MSSQL_PORT = 1433;
-
-    @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
+    @SqlServerContainer(tlsEnabled = true)
     static SqlServerService database = new SqlServerService();
 
     @QuarkusApplication
     static final RestService app = new RestService()
+            .withProperties(database::getTlsProperties)
             .withProperties("mssql.properties")
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())

--- a/sql-db/sql-app/src/test/resources/mssql.properties
+++ b/sql-db/sql-app/src/test/resources/mssql.properties
@@ -2,4 +2,3 @@ quarkus.datasource.db-kind=mssql
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServer2012Dialect
 quarkus.hibernate-orm.sql-load-script=mssql_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
-quarkus.datasource.jdbc.additional-jdbc-properties.trustservercertificate=true

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MssqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MssqlHandlerIT.java
@@ -3,14 +3,15 @@ package io.quarkus.ts.vertx.sql.handlers;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.SqlServerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.SqlServerContainer;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @QuarkusScenario
 public class MssqlHandlerIT extends CommonTestCases {
-    private static final int MSSQL_PORT = 1433;
 
-    @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
+    @SqlServerContainer
     static SqlServerService database = new SqlServerService();
 
     @QuarkusApplication


### PR DESCRIPTION
### Summary

- run at least one of JDBC MSSQL extension tests with encrypted communication without trusting server certs as documented in Microsoft SQL Server 2022 documentation: https://learn.microsoft.com/en-us/sql/connect/jdbc/fips-mode?view=sql-server-ver16
- do not run MSSQL tests with OpenJDK 17 in FIPS-enabled environment due to the https://github.com/quarkusio/quarkus/issues/40813 (that works with our Jenkins jobs as they expect `FIPS=fips` exported environment variable)

All the SQL Server tests are disabled in OpenShift, so running only GitHub CI.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)