### PR TITLE
[3.8] Bump Quarkus QE Test Framework to 1.4.6 and backport SQL Server FIPS fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.8.4</quarkus.platform.version>
         <quarkus.ide.version>3.8.4</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.4.5</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.4.6</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.5.0</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MsSQLDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MsSQLDatabaseHibernateReactiveIT.java
@@ -3,15 +3,15 @@ package io.quarkus.ts.hibernate.reactive;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.SqlServerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.SqlServerContainer;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @QuarkusScenario
 public class MsSQLDatabaseHibernateReactiveIT extends AbstractDatabaseHibernateReactiveIT {
 
-    private static final int MSSQL_PORT = 1433;
-
-    @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
+    @SqlServerContainer
     static SqlServerService database = new SqlServerService();
 
     @QuarkusApplication

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
@@ -9,16 +9,16 @@ import org.testcontainers.containers.GenericContainer;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.SqlServerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.SqlServerContainer;
 import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @QuarkusScenario
 public class MssqlTransactionGeneralUsageIT extends TransactionCommons {
 
-    private static final int MSSQL_PORT = 1433;
-
-    @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
+    @SqlServerContainer
     static SqlServerService database = new SqlServerService().onPostStart(service -> {
         // enable XA transactions
         var self = (SqlServerService) service;

--- a/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MssqlPanacheResourceIT.java
+++ b/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MssqlPanacheResourceIT.java
@@ -3,15 +3,15 @@ package io.quarkus.ts.reactive.rest.data.panache;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.SqlServerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.SqlServerContainer;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @QuarkusScenario
 public class MssqlPanacheResourceIT extends AbstractPanacheResourceIT {
 
-    private static final int MSSQL_PORT = 1433;
-
-    @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
+    @SqlServerContainer
     static SqlServerService database = new SqlServerService();
 
     @QuarkusApplication

--- a/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeReactiveMssqlDevServiceUserExperienceIT.java
+++ b/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeReactiveMssqlDevServiceUserExperienceIT.java
@@ -11,9 +11,11 @@ import com.github.dockerjava.api.model.Image;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.DockerUtils;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @Tag("QUARKUS-1408")
 @QuarkusScenario
 public class DevModeReactiveMssqlDevServiceUserExperienceIT {

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MssqlDatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MssqlDatabaseIT.java
@@ -3,15 +3,15 @@ package io.quarkus.ts.sqldb.compatibility;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.SqlServerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.SqlServerContainer;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @QuarkusScenario
 public class MssqlDatabaseIT extends AbstractSqlDatabaseIT {
 
-    private static final int MSSQL_PORT = 1433;
-
-    @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
+    @SqlServerContainer
     static SqlServerService database = new SqlServerService();
 
     @QuarkusApplication

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMssqlDevServicesUserExperienceIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMssqlDevServicesUserExperienceIT.java
@@ -12,10 +12,12 @@ import com.github.dockerjava.api.model.Image;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.DockerUtils;
 import io.quarkus.test.utils.SocketUtils;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @Tag("QUARKUS-959")
 @QuarkusScenario
 public class DevModeMssqlDevServicesUserExperienceIT {

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MssqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MssqlDatabaseIT.java
@@ -3,19 +3,20 @@ package io.quarkus.ts.sqldb.sqlapp;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.SqlServerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.SqlServerContainer;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @QuarkusScenario
 public class MssqlDatabaseIT extends AbstractSqlDatabaseIT {
 
-    private static final int MSSQL_PORT = 1433;
-
-    @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
+    @SqlServerContainer(tlsEnabled = true)
     static SqlServerService database = new SqlServerService();
 
     @QuarkusApplication
     static final RestService app = new RestService()
+            .withProperties(database::getTlsProperties)
             .withProperties("mssql.properties")
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())

--- a/sql-db/sql-app/src/test/resources/mssql.properties
+++ b/sql-db/sql-app/src/test/resources/mssql.properties
@@ -2,4 +2,3 @@ quarkus.datasource.db-kind=mssql
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServer2012Dialect
 quarkus.hibernate-orm.sql-load-script=mssql_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
-quarkus.datasource.jdbc.additional-jdbc-properties.trustservercertificate=true

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MssqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MssqlHandlerIT.java
@@ -3,14 +3,15 @@ package io.quarkus.ts.vertx.sql.handlers;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.bootstrap.SqlServerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndJava17;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.SqlServerContainer;
 
+@DisabledOnFipsAndJava17(reason = "https://github.com/quarkusio/quarkus/issues/40813")
 @QuarkusScenario
 public class MssqlHandlerIT extends CommonTestCases {
-    private static final int MSSQL_PORT = 1433;
 
-    @Container(image = "${mssql.image}", port = MSSQL_PORT, expectedLog = "Service Broker manager has started")
+    @SqlServerContainer
     static SqlServerService database = new SqlServerService();
 
     @QuarkusApplication


### PR DESCRIPTION
### Summary

- bump QE Test Framework to 1.4.6 (required for MSSQL changes)
- backport https://github.com/quarkus-qe/quarkus-test-suite/pull/1807

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)