### PR TITLE
Change REST service properties names for OpenTelemetry tests

### DIFF
--- a/monitoring/opentelemetry-reactive/src/main/resources/application.properties
+++ b/monitoring/opentelemetry-reactive/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-io.quarkus.ts.opentelemetry.reactive.PingPongService/mp-rest/url=${pongservice_url}:${pongservice_port}
+io.quarkus.ts.opentelemetry.reactive.PingPongService/mp-rest/url=${pongservice.url}:${pongservice.port}
 io.quarkus.ts.opentelemetry.reactive.PingPongService/mp-rest/scope=jakarta.inject.Singleton
 
 io.quarkus.ts.opentelemetry.reactive.sse.ServerSentEventsPongClient/mp-rest/url=http://localhost:${quarkus.http.port}

--- a/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpentelemetryReactiveIT.java
+++ b/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpentelemetryReactiveIT.java
@@ -48,8 +48,8 @@ public class OpentelemetryReactiveIT {
 
     @QuarkusApplication(classes = { PingResource.class, PingPongService.class, AdminResource.class })
     static final RestService pingservice = new RestService()
-            .withProperty("pongservice_url", () -> pongservice.getURI(HTTP).getRestAssuredStyleUri())
-            .withProperty("pongservice_port", () -> Integer.toString(pongservice.getURI(HTTP).getPort()))
+            .withProperty("pongservice.url", () -> pongservice.getURI(HTTP).getRestAssuredStyleUri())
+            .withProperty("pongservice.port", () -> Integer.toString(pongservice.getURI(HTTP).getPort()))
             .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
             // verify OTEL service name has priority over default Quarkus application name
             .withProperty("quarkus.otel.service.name", OTEL_PING_SERVICE_NAME)

--- a/monitoring/opentelemetry/src/main/resources/application.properties
+++ b/monitoring/opentelemetry/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-io.quarkus.ts.opentelemetry.PingPongService/mp-rest/url=${pongservice_url}:${pongservice_port}
+io.quarkus.ts.opentelemetry.PingPongService/mp-rest/url=${pongservice.url}:${pongservice.port}
 io.quarkus.ts.opentelemetry.PingPongService/mp-rest/scope=jakarta.inject.Singleton
 
 io.quarkus.ts.opentelemetry.sse.ServerSentEventsPongClient/mp-rest/url=http://localhost:${quarkus.http.port}

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryIT.java
@@ -51,8 +51,8 @@ public class OpenTelemetryIT {
     @QuarkusApplication(classes = { PingResource.class, PingPongService.class })
     static final RestService pingservice = new RestService()
             .withProperty("quarkus.application.name", "pingservice")
-            .withProperty("pongservice_url", () -> pongservice.getURI(HTTP).getRestAssuredStyleUri())
-            .withProperty("pongservice_port", () -> Integer.toString(pongservice.getURI(HTTP).getPort()))
+            .withProperty("pongservice.url", () -> pongservice.getURI(HTTP).getRestAssuredStyleUri())
+            .withProperty("pongservice.port", () -> Integer.toString(pongservice.getURI(HTTP).getPort()))
             .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
 
     @Order(1)


### PR DESCRIPTION
### Summary

Workaround after merging https://github.com/quarkus-qe/quarkus-test-framework/pull/1117. 
`pongservice_url` and `pongservice_port` were not put to env vars, because non Quarkus properties in undotted format are only put to `quarkus-application-configuration-file` config map. That caused problem with creating REST URL

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)