### PR TITLE
[3.8] Backports for 3.8.5+Update to 3.8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         java: [ 17 ]
-        cli: [ 3.8.4 ]
+        cli: [ 3.8.5 ]
         module-mvn-args: ${{ fromJSON(needs.prepare-jvm-latest-modules-mvn-param.outputs.MODULES_MAVEN_PARAM) }}
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
@@ -121,7 +121,7 @@ jobs:
     strategy:
       matrix:
         java: [ 17 ]
-        cli: [ 3.8.4 ]
+        cli: [ 3.8.5 ]
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
     steps:

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/BaseHttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/BaseHttpAdvancedReactiveIT.java
@@ -23,6 +23,7 @@ import static jakarta.ws.rs.core.MediaType.TEXT_XML;
 import static org.apache.http.HttpHeaders.ACCEPT_ENCODING;
 import static org.apache.http.HttpHeaders.ACCEPT_LANGUAGE;
 import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,7 +36,6 @@ import static org.htmlunit.util.MimeType.IMAGE_JPEG;
 import static org.htmlunit.util.MimeType.IMAGE_PNG;
 import static org.htmlunit.util.MimeType.TEXT_CSS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -180,6 +180,46 @@ public abstract class BaseHttpAdvancedReactiveIT {
                 .then().statusCode(SC_OK)
                 .body(FILE, is("File content"))
                 .body(TEXT, is(TEXT));
+    }
+
+    @Test
+    @DisplayName("RESTEasy Reactive Multipart Max Parameters test")
+    public void multiPartFormDataMaxParametersAllowed() {
+        // We are going to reach the MAX_PARAMETERS_ALLOWED in Quarkus Multipart that it's 1000
+        final int PARAMETERS_TO_ADD = 998;
+        // The file itself it's one parameter to add also
+        var request = getApp().given().multiPart(FILE, Paths.get("src", "test", "resources", "file.txt").toFile());
+
+        for (int i = 0; i < PARAMETERS_TO_ADD; i++) {
+            request = request.multiPart("param" + i, "value" + i);
+        }
+        //  now we add the parameter TEXT with formParam, so we will get the max limit 1000
+        request.formParam(TEXT, TEXT);
+        request
+                .post(ROOT_PATH + MULTIPART_FORM_PATH)
+                .then()
+                .statusCode(SC_OK)
+                .body(FILE, is("File content"))
+                .body(TEXT, is(TEXT));
+
+    }
+
+    @DisplayName("RESTEasy Reactive Multipart Over the Max Parameters limit test")
+    @Test
+    public void exceedMultiPartParamsMaxLimit() {
+        // The file itself it's one parameter to add also
+        var request = getApp().given().multiPart(FILE, Paths.get("src", "test", "resources", "file.txt").toFile());
+        // We test the over the max limit of parameters defined by Quarkus that is 1000.
+        final int PARAMETERS_TO_ADD = 999;
+        for (int i = 0; i < PARAMETERS_TO_ADD; i++) {
+            request = request.multiPart("param" + i, "value" + i);
+        }
+        // we add the parameter TEXT with formParam so the total parameters will be 1000 + 1 so we are sending 1001
+        request.formParam(TEXT, TEXT);
+        request
+                .post(ROOT_PATH + MULTIPART_FORM_PATH)
+                .then()
+                .statusCode(SC_INTERNAL_SERVER_ERROR);
     }
 
     @DisplayName("Jakarta REST RouterFilter and Vert.x Web Routes integration")

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/failures/FailingClientResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/failures/FailingClientResource.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.http.restclient.reactive.failures;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/client/failing")
+public class FailingClientResource {
+    @RestClient
+    FailureClient client;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("/straight")
+    public String getStraightResult() {
+        return client.getVisitor();
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("/reactive")
+    public Uni<String> getReactiveResult() {
+        return client.getVisitorReactively()
+                .onFailure().retry().atMost(5);
+    }
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/failures/FailingResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/failures/FailingResource.java
@@ -1,0 +1,28 @@
+package io.quarkus.ts.http.restclient.reactive.failures;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/fail")
+public class FailingResource {
+    private static final AtomicInteger counter = new AtomicInteger(0);
+    private static final boolean[] fail = { true, true, true, true, false };
+    // in earlier versions, connection was closed after three errors. We need to ensure, that this is not the case.
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("/cyclic")
+    public String fail() {
+        int visit = counter.getAndIncrement();
+        int index = visit % fail.length;
+        if (fail[index]) {
+            throw new RuntimeException("Whoops, we encountered a problem!");
+        } else {
+            return "You're the " + (visit + 1) + "th visitor of this page";
+        }
+    }
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/failures/FailureClient.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/failures/FailureClient.java
@@ -1,0 +1,25 @@
+package io.quarkus.ts.http.restclient.reactive.failures;
+
+import java.time.temporal.ChronoUnit;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.smallrye.mutiny.Uni;
+
+@RegisterRestClient(baseUri = "http://localhost:8080/")
+@Path("/fail")
+public interface FailureClient {
+
+    @GET
+    @Retry(delay = 1, delayUnit = ChronoUnit.SECONDS, maxRetries = 5)
+    @Path("/cyclic")
+    String getVisitor();
+
+    @GET
+    @Path("/cyclic")
+    Uni<String> getVisitorReactively();
+}

--- a/http/rest-client-reactive/src/main/resources/modern.properties
+++ b/http/rest-client-reactive/src/main/resources/modern.properties
@@ -5,6 +5,7 @@ quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.BookClient".url=http
 quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.BookClient.AuthorClient".url=http://localhost:${quarkus.http.port}
 quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.ResourceAndSubResourcesClient".url=http://localhost:${quarkus.http.port}
 quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.MalformedClient".url=http://localhost:${quarkus.http.port}
+quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.failures.FailureClient".url=http://localhost:${quarkus.http.port}
 
 quarkus.rest-client.logging.scope=request-response
 quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
@@ -46,6 +46,7 @@ public class ReactiveRestClientIT {
     }
 
     static final String MALFORMED_URL = "quarkus.rest-client.\"io.quarkus.ts.http.restclient.reactive.MalformedClient\".url";
+
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperties("modern.properties")
@@ -273,6 +274,24 @@ public class ReactiveRestClientIT {
         app.given().get("/headers")
                 .then()
                 .body(containsString("clientFilterInvoked"));
+    }
+
+    @Test
+    @Tag("https://github.com/quarkusio/quarkus/issues/37323")
+    public void clientRetry() {
+        app.given().get("/client/failing/straight")
+                .then()
+                .statusCode(200)
+                .body(containsString("visitor of this page"));
+    }
+
+    @Test
+    @Tag("https://github.com/quarkusio/quarkus/issues/37323")
+    public void clientReactiveRetry() {
+        app.given().get("/client/failing/reactive")
+                .then()
+                .statusCode(200)
+                .body(containsString("visitor of this page"));
     }
 
     @AfterAll

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
         <failsafe-plugin.version>3.2.5</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.8.4</quarkus.platform.version>
-        <quarkus.ide.version>3.8.4</quarkus.ide.version>
+        <quarkus.platform.version>3.8.5</quarkus.platform.version>
+        <quarkus.ide.version>3.8.5</quarkus.ide.version>
         <quarkus.qe.framework.version>1.4.6</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.5.0</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>

--- a/security/basic/pom.xml
+++ b/security/basic/pom.xml
@@ -13,11 +13,16 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
+            <!-- Only reactive dependency can cause https://github.com/quarkusio/quarkus/issues/40307-->
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-elytron-security-properties-file</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-routes</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/security/basic/src/main/java/io/quarkus/ts/openshift/security/basic/SecurityFilter.java
+++ b/security/basic/src/main/java/io/quarkus/ts/openshift/security/basic/SecurityFilter.java
@@ -1,0 +1,16 @@
+package io.quarkus.ts.openshift.security.basic;
+
+import jakarta.inject.Singleton;
+
+import io.quarkus.vertx.web.RouteFilter;
+import io.vertx.ext.web.RoutingContext;
+
+@Singleton
+// if https://github.com/quarkusio/quarkus/issues/40307 is not fixed, then presence of a filter leads to 500 error
+public class SecurityFilter {
+
+    @RouteFilter(401)
+    void filter(RoutingContext routingContext) {
+        routingContext.next();
+    }
+}

--- a/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/principal/JsonTokenResource.java
+++ b/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/principal/JsonTokenResource.java
@@ -1,0 +1,22 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.principal;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.principal.clients.JsonTokenClient;
+
+@Path("/json-propagation-filter")
+public class JsonTokenResource {
+
+    @Inject
+    @RestClient
+    JsonTokenClient jsonClient;
+
+    @GET
+    public String getUserNameThroughJson() {
+        return jsonClient.getUserName();
+    }
+}

--- a/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/principal/clients/JsonTokenClient.java
+++ b/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/principal/clients/JsonTokenClient.java
@@ -1,0 +1,20 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.principal.clients;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.oidc.token.propagation.JsonWebTokenRequestFilter;
+
+@RegisterRestClient
+@RegisterClientHeaders
+@Path("/principal")
+@RegisterProvider(JsonWebTokenRequestFilter.class)
+public interface JsonTokenClient {
+
+    @GET
+    String getUserName();
+}

--- a/security/keycloak-oidc-client-extended/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client-extended/src/main/resources/application.properties
@@ -46,6 +46,7 @@ io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.ping.clients.Auto
 io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.ping.clients.TokenPropagationPongClient/mp-rest/url=http://localhost:${quarkus.http.port}
 
 io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.principal.clients.TokenPropagationFilteredClient/mp-rest/url=http://localhost:${quarkus.http.port}
+io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.principal.clients.JsonTokenClient/mp-rest/url=http://localhost:${quarkus.http.port}
 
 #OpenAPI
 quarkus.smallrye-openapi.store-schema-directory=target/generated/jakarta-rest/

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/TokenPropagationFilterIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/TokenPropagationFilterIT.java
@@ -4,10 +4,12 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.restassured.response.Response;
 
 @Tag("QUARKUS-3680")
 @QuarkusScenario
@@ -20,5 +22,14 @@ public class TokenPropagationFilterIT extends BaseOidcIT {
                 .when().get("/token-propagation-filter")
                 .then().statusCode(HttpStatus.SC_OK)
                 .body(containsString(USER));
+    }
+
+    @Test
+    public void jsonUsernameTest() {
+        Response response = given()
+                .auth().oauth2(createToken())
+                .when().get("/json-propagation-filter");
+        Assertions.assertEquals(HttpStatus.SC_OK, response.statusCode());
+        Assertions.assertEquals(USER, response.body().asString());
     }
 }


### PR DESCRIPTION
### Summary
Backports:
- https://github.com/quarkus-qe/quarkus-test-suite/pull/1813
- https://github.com/quarkus-qe/quarkus-test-suite/pull/1802 (only max parameters part)
- https://github.com/quarkus-qe/quarkus-test-suite/pull/1818

Also updates Quarkus version to 3.8.5 in POM and CI

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)