### PR TITLE
Spread PR CI workload when "full" CI is run little bit better between work runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
             echo "Running modules: ${MODULES_ARG}"
             echo "MODULES_MAVEN_PARAM=[\" -pl ${MODULES_ARG} -Dall-modules\"]" >> $GITHUB_OUTPUT
           else
-            echo "MODULES_MAVEN_PARAM=[' -P root-modules,cache-modules,spring-modules,http-modules,test-tooling-modules', ' -P security-modules,sql-db-modules,messaging-modules,websockets-modules,monitoring-modules']" >> $GITHUB_OUTPUT
+            echo "MODULES_MAVEN_PARAM=[' -P root-modules,cache-modules,spring-modules,http-modules,test-tooling-modules,messaging-modules,monitoring-modules', ' -P security-modules,sql-db-modules,websockets-modules']" >> $GITHUB_OUTPUT
           fi
     outputs:
       MODULES_MAVEN_PARAM: ${{ steps.prepare-modules-mvn-param.outputs.MODULES_MAVEN_PARAM }}


### PR DESCRIPTION
### Summary

When there are changes outside of specific modules like in the `POM.xml` or `.github` workflow, one run (with security and db modules) run very roughly about 2 hours and the other one about 1 hours. I am talking about times from here https://github.com/quarkus-qe/quarkus-test-suite/pull/1824. I'd like to spread out the load a bit. I'm sure it's not going to be perfect as it's dynamic matter (for example tests are added, I am going to remove some modules etc.).

After this PR (see CI) one run is 1h 15m 6s and the other run is 1h 0m 39s. Please keep in mind that some security modules are disabled, and so is the CLI one.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)