### PR TITLE
QQE-673 | Cover max-length option for syslog logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,13 @@ Module that covers the logging functionality using JBoss Logging Manager. The fo
 - Inject a `Logger` instance using a custom category
 - Setting up the log level property for logger instances
 - Check default `quarkus.log.min-level` value
+- 
+### `logging/thirdparty`
+
+Module that covers, that logging works with various third-party solutions. The following scenarios are covered:
+- Check default `quarkus.log.min-level` value
+- Syslog-type log (syslog-ng is used)
+- Option `quarkus.log.syslog.max-length` filters messages, which are too big
 
 ### `sql-db/hibernate`
 

--- a/logging/thirdparty/pom.xml
+++ b/logging/thirdparty/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>logging-thridparty</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: Logging: Third party</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/logging/thirdparty/src/main/java/io/quarkus/ts/logging/jboss/LogResource.java
+++ b/logging/thirdparty/src/main/java/io/quarkus/ts/logging/jboss/LogResource.java
@@ -1,0 +1,59 @@
+package io.quarkus.ts.logging.jboss;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.log.LoggerName;
+
+@Path("/log")
+public class LogResource {
+
+    public static final String CUSTOM_CATEGORY = "FOO";
+
+    private static final Logger LOG = Logger.getLogger(LogResource.class);
+
+    @Inject
+    Logger log;
+
+    @LoggerName(CUSTOM_CATEGORY)
+    Logger customCategoryLog;
+
+    @POST
+    @Path("/static/{level}")
+    public void addLogMessageInStaticLogger(@PathParam("level") String level, @QueryParam("message") String message) {
+        addLogMessage(LOG, level, message);
+    }
+
+    @POST
+    @Path("/field/{level}")
+    public void addLogMessageInFieldLogger(@PathParam("level") String level, @QueryParam("message") String message) {
+        addLogMessage(log, level, message);
+    }
+
+    @POST
+    @Path("/field-with-custom-category/{level}")
+    public void addLogMessageInFieldWithCustomCategoryLogger(@PathParam("level") String level,
+            @QueryParam("message") String message) {
+        addLogMessage(customCategoryLog, level, message);
+    }
+
+    @GET
+    public void logExample() {
+        LOG.fatal("Fatal log example");
+        LOG.error("Error log example");
+        LOG.warn("Warn log example");
+        LOG.info("Info log example");
+        LOG.debug("Debug log example");
+        LOG.trace("Trace log example");
+    }
+
+    private void addLogMessage(Logger logger, String level, String message) {
+        logger.log(Logger.Level.valueOf(level.toUpperCase()), message);
+    }
+}

--- a/logging/thirdparty/src/main/resources/application.properties
+++ b/logging/thirdparty/src/main/resources/application.properties
@@ -1,0 +1,18 @@
+#When you set the logging level below the minimum logging level, you must adjust the minimum logging level as well.
+#Otherwise, the value of minimum logging level overrides the logging level.
+# DOC:
+# https://access.redhat.com/documentation/en-us/red_hat_build_of_quarkus/1.11/html-single/configuring_logging_with_quarkus/index#ref-example-logging-configuration_quarkus-configuring-logging
+# https://quarkus.io/guides/logging
+# https://quarkus.io/guides/all-config#quarkus-core_quarkus.log.min-level
+
+# By default min-level is set to DEBUG
+#quarkus.log.min-level=DEBUG
+quarkus.log.level=INFO
+
+%syslog.quarkus.log.syslog.enable=true
+%syslog.quarkus.log.syslog.app-name=quarkus
+%syslog.quarkus.log.syslog.format=%-5p %s%n
+%syslog.quarkus.log.syslog.syslog-type=rfc3164
+%syslog.quarkus.log.syslog.protocol=tcp
+# the option below is overriden in @QuarkusScenario tests
+%syslog.quarkus.log.syslog.endpoint=localhost:1514

--- a/logging/thirdparty/src/test/java/io/quarkus/ts/logging/jboss/SyslogIT.java
+++ b/logging/thirdparty/src/test/java/io/quarkus/ts/logging/jboss/SyslogIT.java
@@ -1,0 +1,66 @@
+package io.quarkus.ts.logging.jboss;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class SyslogIT {
+
+    /*
+     * For manual testing:
+     * podman run -p 8514:514 \
+     * -v $(pwd)/src/test/resources/syslog-ng.conf:/etc/syslog-ng/syslog-ng.conf:z --rm -it balabit/syslog-ng
+     */
+    @Container(image = "balabit/syslog-ng", port = 514, expectedLog = "syslog-ng")
+    static RestService syslog = new RestService()
+            .withProperty("_ignored", "resource_with_destination::/etc/syslog-ng/|syslog-ng.conf");
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.profile", "syslog")
+            .withProperty("quarkus.log.syslog.max-length", "64")
+            .withProperty("quarkus.log.syslog.endpoint", () -> syslog.getURI().toString());
+
+    @Test
+    public void checkDefaultLogMinLevel() {
+        app.given().when().get("/log").then().statusCode(204);
+
+        syslog.logs().assertContains("Fatal log example");
+
+        syslog.logs().assertContains("Error log example");
+        syslog.logs().assertContains("Warn log example");
+        syslog.logs().assertContains("Info log example");
+
+        // the value of minimum logging level overrides the logging level
+        syslog.logs().assertDoesNotContain("Debug log example");
+        syslog.logs().assertDoesNotContain("Trace log example");
+    }
+
+    @Test
+    @Tag("https://issues.redhat.com/browse/QUARKUS-4531")
+    public void logBigMessage() {
+        String shorterMessage = "Relatively long message";
+        app.given().when()
+                .post("/log/static/info?message={message}", shorterMessage)
+                .then().statusCode(204);
+        syslog.logs().assertContains(shorterMessage);
+    }
+
+    @Test
+    @Tag("https://issues.redhat.com/browse/QUARKUS-4531")
+    public void filterBigMessage() {
+        String longerMessage = "Message, which is very long and is not expected to fit into 64 bytes";
+        app.given().when()
+                .post("/log/static/info?message={message}",
+                        longerMessage)
+                .then().statusCode(204);
+
+        syslog.logs().assertDoesNotContain(longerMessage);
+    }
+
+}

--- a/logging/thirdparty/src/test/resources/syslog-ng.conf
+++ b/logging/thirdparty/src/test/resources/syslog-ng.conf
@@ -1,0 +1,11 @@
+@version: 4.4
+@include "scl.conf"
+
+log {
+	source {
+		#network();
+		tcp(ip(0.0.0.0) port(514));
+	};
+	#destination { file("/var/log/syslog"); };
+	destination {stdout();};
+};

--- a/pom.xml
+++ b/pom.xml
@@ -418,6 +418,7 @@
                 <module>super-size/many-extensions</module>
                 <module>quarkus-cli</module>
                 <module>logging/jboss</module>
+                <module>logging/thirdparty</module>
                 <module>qute/multimodule</module>
                 <module>qute/synchronous</module>
                 <module>qute/reactive</module>


### PR DESCRIPTION
Adds new module for working with syslogs, since jboss uses json logs which have less predictable size.
Uses official image of sylog-ng. Syslog-ng was chose over rsyslog and logstash because it supports syslog input and stdout output out of the box, without additional plugins.

Required for https://issues.redhat.com/browse/QUARKUS-4531

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)