### PR TITLE
[3.8] Bump Framework + keycloak

### DIFF
--- a/http/http-advanced-reactive/src/test/resources/keycloak-realm.json
+++ b/http/http-advanced-reactive/src/test/resources/keycloak-realm.json
@@ -22,6 +22,9 @@
   "users": [
     {
       "username": "test-normal-user",
+      "email": "test-normal-user@localhost",
+      "firstName": "test-normal-user",
+      "lastName": "test-normal-user",
       "enabled": true,
       "credentials": [
         {

--- a/http/http-advanced/src/test/resources/keycloak-realm.json
+++ b/http/http-advanced/src/test/resources/keycloak-realm.json
@@ -22,6 +22,9 @@
   "users": [
     {
       "username": "test-normal-user",
+      "email": "test-normal-user@localhost",
+      "firstName": "test-normal-user",
+      "lastName": "test-normal-user",
       "enabled": true,
       "credentials": [
         {

--- a/monitoring/micrometer-prometheus-oidc/src/test/resources/keycloak-realm.json
+++ b/monitoring/micrometer-prometheus-oidc/src/test/resources/keycloak-realm.json
@@ -13,6 +13,9 @@
   "users": [
     {
       "username": "test-normal-user",
+      "email": "test-normal-user@localhost",
+      "firstName": "test-normal-user",
+      "lastName": "test-normal-user",
       "enabled": true,
       "credentials": [
         {

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <!-- Docker images used by both surefire and failsafe plugin -->
         <postgresql.latest.image>docker.io/postgres:16.1</postgresql.latest.image>
         <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7</mysql.80.image>
-        <rhbk.image>registry.redhat.io/rhbk/keycloak-rhel9:22-8</rhbk.image>
+        <rhbk.image>registry.redhat.io/rhbk/keycloak-rhel9:24</rhbk.image>
         <wiremock-jre8.version>2.35.1</wiremock-jre8.version>
         <build-reporter-maven-extension.version>3.4.4</build-reporter-maven-extension.version>
         <reruns>2</reruns>
@@ -289,7 +289,7 @@
                                 <infinispan.image>quay.io/infinispan/server:14.0</infinispan.image>
                                 <infinispan.expected-log>Infinispan Server.*started in</infinispan.expected-log>
                                 <spring.cloud.server.image>quay.io/quarkusqeteam/spring-cloud-config-server:3.0</spring.cloud.server.image>
-                                <keycloak.image>quay.io/keycloak/keycloak:23.0.6</keycloak.image>
+                                <keycloak.image>quay.io/keycloak/keycloak:24.0</keycloak.image>
                                 <bouncycastle.bctls-fips.version>1.0.12.2</bouncycastle.bctls-fips.version>
                                 <rhbk.image>${rhbk.image}</rhbk.image>
                             </systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.8.5</quarkus.platform.version>
         <quarkus.ide.version>3.8.5</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.4.6</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.4.7</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.5.0</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>

--- a/security/keycloak-authz-classic/src/test/resources/keycloak-realm.json
+++ b/security/keycloak-authz-classic/src/test/resources/keycloak-realm.json
@@ -25,6 +25,9 @@
   "users": [
     {
       "username": "test-normal-user",
+      "email": "test-normal-user@localhost",
+      "firstName": "test-normal-user",
+      "lastName": "test-normal-user",
       "enabled": true,
       "credentials": [
         {
@@ -44,6 +47,9 @@
     },
     {
       "username": "test-admin-user",
+      "email": "test-admin-user@localhost",
+      "firstName": "test-admin-user",
+      "lastName": "test-admin-user",
       "enabled": true,
       "credentials": [
         {

--- a/security/keycloak-authz-reactive/src/test/resources/keycloak-realm.json
+++ b/security/keycloak-authz-reactive/src/test/resources/keycloak-realm.json
@@ -25,6 +25,9 @@
   "users": [
     {
       "username": "test-normal-user",
+      "email": "test-normal-user@localhost",
+      "firstName": "test-normal-user",
+      "lastName": "test-normal-user",
       "enabled": true,
       "credentials": [
         {
@@ -44,6 +47,9 @@
     },
     {
       "username": "test-admin-user",
+      "email": "test-admin-user@localhost",
+      "firstName": "test-admin-user",
+      "lastName": "test-admin-user",
       "enabled": true,
       "credentials": [
         {

--- a/security/keycloak-jwt/src/test/resources/keycloak-realm.json
+++ b/security/keycloak-jwt/src/test/resources/keycloak-realm.json
@@ -15,6 +15,9 @@
   "users": [
     {
       "username": "test-user",
+      "email": "test-user@localhost",
+      "firstName": "test-user",
+      "lastName": "test-user",
       "enabled": true,
       "credentials": [
         {
@@ -28,6 +31,9 @@
     },
     {
       "username": "test-admin",
+      "email": "test-admin@localhost",
+      "firstName": "test-admin",
+      "lastName": "test-admin",
       "enabled": true,
       "credentials": [
         {

--- a/security/keycloak-multitenant/src/test/resources/keycloak-realm.json
+++ b/security/keycloak-multitenant/src/test/resources/keycloak-realm.json
@@ -12,6 +12,9 @@
   "users": [
     {
       "username": "test-user",
+      "email": "test-user@localhost",
+      "firstName": "test-user",
+      "lastName": "test-user",
       "enabled": true,
       "credentials": [
         {

--- a/security/keycloak-oauth2/src/test/resources/keycloak-realm.json
+++ b/security/keycloak-oauth2/src/test/resources/keycloak-realm.json
@@ -15,6 +15,9 @@
   "users": [
     {
       "username": "test-normal-user",
+      "email": "test-normal-user@localhost",
+      "firstName": "test-normal-user",
+      "lastName": "test-normal-user",
       "enabled": true,
       "credentials": [
         {
@@ -28,6 +31,9 @@
     },
     {
       "username": "test-admin-user",
+      "email": "test-admin-user@localhost",
+      "firstName": "test-admin-user",
+      "lastName": "test-admin-user",
       "enabled": true,
       "credentials": [
         {

--- a/security/keycloak-oidc-client-basic/src/test/resources/keycloak-realm.json
+++ b/security/keycloak-oidc-client-basic/src/test/resources/keycloak-realm.json
@@ -15,6 +15,9 @@
   "users": [
     {
       "username": "test-normal-user",
+      "email": "test-normal-user@localhost",
+      "firstName": "test-normal-user",
+      "lastName": "test-normal-user",
       "enabled": true,
       "credentials": [
         {
@@ -34,6 +37,9 @@
     },
     {
       "username": "test-admin-user",
+      "email": "test-admin-user@localhost",
+      "firstName": "test-admin-user",
+      "lastName": "test-admin-user",
       "enabled": true,
       "credentials": [
         {

--- a/security/keycloak-oidc-client-extended/src/test/resources/keycloak-realm.json
+++ b/security/keycloak-oidc-client-extended/src/test/resources/keycloak-realm.json
@@ -12,6 +12,9 @@
   "users": [
     {
       "username": "test-user",
+      "email": "test-user@localhost",
+      "firstName": "test-user",
+      "lastName": "test-user",
       "enabled": true,
       "credentials": [
         {

--- a/security/keycloak-oidc-client-reactive-basic/src/test/resources/keycloak-realm.json
+++ b/security/keycloak-oidc-client-reactive-basic/src/test/resources/keycloak-realm.json
@@ -15,6 +15,9 @@
   "users": [
     {
       "username": "test-normal-user",
+      "email": "test-normal-user@localhost",
+      "firstName": "test-normal-user",
+      "lastName": "test-normal-user",
       "enabled": true,
       "credentials": [
         {
@@ -34,6 +37,9 @@
     },
     {
       "username": "test-admin-user",
+      "email": "test-admin-user@localhost",
+      "firstName": "test-admin-user",
+      "lastName": "test-admin-user",
       "enabled": true,
       "credentials": [
         {

--- a/security/keycloak-oidc-client-reactive-extended/src/test/resources/keycloak-realm.json
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/resources/keycloak-realm.json
@@ -12,6 +12,9 @@
   "users": [
     {
       "username": "test-user",
+      "email": "test-user@localhost",
+      "firstName": "test-user",
+      "lastName": "test-user",
       "enabled": true,
       "credentials": [
         {

--- a/security/keycloak-webapp/src/test/resources/keycloak-realm.json
+++ b/security/keycloak-webapp/src/test/resources/keycloak-realm.json
@@ -16,6 +16,9 @@
   "users": [
     {
       "username": "test-user",
+      "email": "test-user@localhost",
+      "firstName": "test-user",
+      "lastName": "test-user",
       "enabled": true,
       "credentials": [
         {
@@ -29,6 +32,9 @@
     },
     {
       "username": "test-admin",
+      "email": "test-admin@localhost",
+      "firstName": "test-admin",
+      "lastName": "test-admin",
       "enabled": true,
       "credentials": [
         {

--- a/security/keycloak/src/test/resources/keycloak-realm.json
+++ b/security/keycloak/src/test/resources/keycloak-realm.json
@@ -16,6 +16,9 @@
   "users": [
     {
       "username": "test-normal-user",
+      "email": "test-normal-user@localhost",
+      "firstName": "test-normal-user",
+      "lastName": "test-normal-user",
       "enabled": true,
       "credentials": [
         {
@@ -35,6 +38,9 @@
     },
     {
       "username": "test-admin-user",
+      "email": "test-admin-user@localhost",
+      "firstName": "test-admin-user",
+      "lastName": "test-admin-user",
       "enabled": true,
       "credentials": [
         {

--- a/security/oidc-client-mutual-tls/src/test/resources/keycloak-realm.json
+++ b/security/oidc-client-mutual-tls/src/test/resources/keycloak-realm.json
@@ -14,8 +14,10 @@
   "users": [
     {
       "username": "test-normal-user",
-      "enabled": true,
       "email": "test-normal-user@gmail.com",
+      "firstName": "test-normal-user",
+      "lastName": "test-normal-user",
+      "enabled": true,
       "credentials": [
         {
           "type": "password",


### PR DESCRIPTION
### Summary

Bumping framework as it contains image for Keycloak 24.

With this bump the fix for Keycloak 24 is backported (commit 29b0ee12f517a9fe5705d4080202a2de6fa55ca5 from https://github.com/quarkus-qe/quarkus-test-suite/pull/1829) 

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)