### PR TITLE
Fix Brotli4JHttpIT.checkTextPlainDefaultWithoutBrotli4JEncoding test

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/Brotli4JHttpIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/Brotli4JHttpIT.java
@@ -3,7 +3,6 @@ package io.quarkus.ts.http.advanced.reactive;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -43,14 +42,16 @@ public class Brotli4JHttpIT {
 
     @Test
     public void checkTextPlainDefaultWithoutBrotli4JEncoding() {
-        app.given()
+        // As we are using quarkus.http.enable-compression=true then gzip compression is used by default
+        Response response = app.given()
                 .get("/compression/default/text")
                 .then()
                 .statusCode(200)
                 .and()
-                .header(HttpHeaders.CONTENT_LENGTH, String.valueOf(CONTENT_LENGTH_DEFAULT_TEXT_PLAIN))
-                .header(HttpHeaders.CONTENT_ENCODING, nullValue())
-                .body(is(DEFAULT_TEXT_PLAIN)).log().all();
+                .header(HttpHeaders.CONTENT_ENCODING, "gzip")
+                .body(is(DEFAULT_TEXT_PLAIN)).extract().response();
+        int contentLength = Integer.parseInt(response.getHeader(HttpHeaders.CONTENT_LENGTH));
+        assertTrue(CONTENT_LENGTH_DEFAULT_TEXT_PLAIN > contentLength);
     }
 
     @Test


### PR DESCRIPTION
### Summary
I realized that our quarkus test suite was failing on our CI because the test Brotli4JHttpIT failure :
https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/9509280971
After investigate a bit what had changed (because previosly our tests worked properly) I discovered that these changes https://github.com/quarkusio/quarkus/pull/40750/files affected our test failing.

 In shorts, currently gzip compression works by default if we have set `quarkus.http.enable-compression=true` and we are not specifying any encoding in the request.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)