### PR TITLE
Fix Snappy tests in native, disable invalid DEV mode test and enable OpenShift native snappy test

### DIFF
--- a/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/DevModeKafkaSnappyIT.java
+++ b/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/DevModeKafkaSnappyIT.java
@@ -1,11 +1,13 @@
 package io.quarkus.ts.messaging.kafka.producer;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
+@Disabled("Needs refactoring to test Snappy in a DEV mode") // TODO: refactor to test snappy a DEV mode, not prod mode
 @QuarkusScenario
 public class DevModeKafkaSnappyIT extends SnappyCompressionIT {
 

--- a/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/OpenShiftKafkaSnappyIT.java
+++ b/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/OpenShiftKafkaSnappyIT.java
@@ -12,7 +12,6 @@ import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
@@ -21,7 +20,6 @@ import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.vertx.mutiny.core.buffer.Buffer;
 
 @OpenShiftScenario
-@DisabledOnNative(reason = "In native mode, Snappy is disabled by default as the use of Snappy requires embedding a native library and unpacking it when the application starts.")
 public class OpenShiftKafkaSnappyIT {
 
     private static final int TIMEOUT_SEC = 5;
@@ -31,7 +29,9 @@ public class OpenShiftKafkaSnappyIT {
     static final KafkaService kafka = new KafkaService().withProperty("auto.create.topics.enable", "false");
 
     @QuarkusApplication
-    static RestService app = new RestService().withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl);
+    static RestService app = new RestService()
+            .withProperty("quarkus.kafka.snappy.enabled", "true")
+            .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl);
 
     @Test
     public void checkCompressCodecSnappy() throws IOException, InterruptedException {


### PR DESCRIPTION
### Summary

- daily build is failing as SnappyCompressionIT is failing in native, Kafka reference https://quarkus.io/version/main/guides/kafka#using-snappy-for-message-compression says use `quarkus.kafka.snappy.enabled=true`
- `OpenShiftKafkaSnappyIT` was disabled in OpenShift in native mode, enabling it
- `KafkaConsumer` was not closed
- `DevModeKafkaSnappyIT` started: dev mode app, redpanda, prod mode app and kafka container (4 things), then tested:
    - exactly same thing as was already tested by `SnappyCompressionIT` also in prod mode, not in the DEV mode!
    - in the DEV mode, it tested that Redpanda was started, nothing else
    - the `DevModeKafkaSnappyIT` is wrong name for test that does one thing related to DEV mode: test `kafkaContainerShouldBeStarted`
    - there is no test plan matched or JIRA ticket matched with https://github.com/quarkus-qe/quarkus-test-suite/pull/1799 so I cannot tell what are requirements on the DEV mode test
    - IMHO this needs to be refactored, therefore disabling it with TODO

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)