### PR TITLE
Set minimum database version to inform Hibernate our RH images are older than defaults which will fix failing OpenShift tests

### DIFF
--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/OpenShiftSpringWebQuteIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/OpenShiftSpringWebQuteIT.java
@@ -20,7 +20,9 @@ public class OpenShiftSpringWebQuteIT extends AbstractSpringWebQuteIT {
     private static final RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
+            // set DB version as we use older version than default version configured at the build time
+            .withProperty("quarkus.datasource.db-version", "10.5");
 
     @Override
     public RestService getApp() {

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/OpenShiftSpringWebRestIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/OpenShiftSpringWebRestIT.java
@@ -23,7 +23,9 @@ public class OpenShiftSpringWebRestIT extends AbstractSpringWebRestIT {
     private static final RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
+            // set DB version as we use older version than default version configured at the build time
+            .withProperty("quarkus.datasource.db-version", "10.5");
 
     @Override
     public RestService getApp() {

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/openapi/OpenShiftSpringWebOpenApiIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/openapi/OpenShiftSpringWebOpenApiIT.java
@@ -26,7 +26,9 @@ public class OpenShiftSpringWebOpenApiIT extends AbstractSpringWebOpenApiIT {
     private static final RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
+            // set DB version as we use older version than default version configured at the build time
+            .withProperty("quarkus.datasource.db-version", "10.5");
 
     @Override
     public RestService getApp() {

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
@@ -34,7 +34,9 @@ public class OpenShiftPostgresqlMultitenantHibernateSearchIT extends AbstractMul
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
             .withProperty("quarkus.hibernate-search-orm.elasticsearch.hosts",
-                    () -> getElasticSearchConnectionChain(elastic.getURI(Protocol.HTTP)));
+                    () -> getElasticSearchConnectionChain(elastic.getURI(Protocol.HTTP)))
+            // set DB version as we use older version than default version configured at the build time
+            .withProperty("quarkus.datasource.db-version", "10");
 
     @Override
     protected RestService getApp() {

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
@@ -31,7 +31,9 @@ public class OpenShiftMultiplePersistenceIT extends AbstractMultiplePersistenceI
             .withProperty("MARIA_DB_JDBC_URL", mariadb::getJdbcUrl)
             .withProperty("POSTGRESQL_USERNAME", postgresql.getUser())
             .withProperty("POSTGRESQL_PASSWORD", postgresql.getPassword())
-            .withProperty("POSTGRESQL_JDBC_URL", postgresql::getJdbcUrl);
+            .withProperty("POSTGRESQL_JDBC_URL", postgresql::getJdbcUrl)
+            // set DB version as we use older version than default version configured at the build time
+            .withProperty("quarkus.datasource.\"fruits\".db-version", "10.3");
 
     @Override
     RestService getApp() {

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMariaDbTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMariaDbTransactionGeneralUsageIT.java
@@ -23,7 +23,9 @@ public class OpenShiftMariaDbTransactionGeneralUsageIT extends TransactionCommon
             .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
+            // set DB version as we use older version than default version configured at the build time
+            .withProperty("quarkus.datasource.db-version", "10.5");
 
     @Override
     protected RestService getApp() {

--- a/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/OpenShiftMariaDBPanacheResourceIT.java
+++ b/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/OpenShiftMariaDBPanacheResourceIT.java
@@ -20,5 +20,7 @@ public class OpenShiftMariaDBPanacheResourceIT extends AbstractPanacheResourceIT
     static RestService app = new RestService().withProperties("mariadb_app.properties")
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
+            // set DB version as we use older version than default version configured at the build time
+            .withProperty("quarkus.datasource.db-version", "10.5");
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMariaDB103DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMariaDB103DatabaseIT.java
@@ -20,5 +20,7 @@ public class OpenShiftMariaDB103DatabaseIT extends AbstractSqlDatabaseIT {
     static RestService app = new RestService().withProperties("mariadb_app.properties")
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
+            // set DB version as we use older version than default version configured at the build time
+            .withProperty("quarkus.datasource.db-version", "10.3");
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMariaDBDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMariaDBDatabaseIT.java
@@ -20,5 +20,7 @@ public class OpenShiftMariaDBDatabaseIT extends AbstractSqlDatabaseIT {
     static RestService app = new RestService().withProperties("mariadb_app.properties")
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
+            // set DB version as we use older version than default version configured at the build time
+            .withProperty("quarkus.datasource.db-version", "10.5");
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresql10DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresql10DatabaseIT.java
@@ -20,5 +20,7 @@ public class OpenShiftPostgresql10DatabaseIT extends AbstractSqlDatabaseIT {
     static RestService app = new RestService().withProperties("postgresql.properties")
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
+            // set DB version as we use older version than default version configured at the build time
+            .withProperty("quarkus.datasource.db-version", "10");
 }


### PR DESCRIPTION
### Summary

OpenShift tests are failing as Red Hat MariaDB and PostgreSQL images are using older versions than defaults configured at the build time. This is expected failure as it is explained in the migration guide https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.12#hibernate-orm.

We use:

- MariaDB 10.5 and 10.3
- PostgreSQL 10.23.0 (but image is `registry.redhat.io/rhel8/postgresql-10` so it's 10)

While defaults are:

- MariaDB 10.6.0
- PostgreSQL 12.0.0

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)