### PR TITLE
Add test coverage for improvement multipart encoded mode in rest-client

### DIFF
--- a/http/rest-client-reactive/pom.xml
+++ b/http/rest-client-reactive/pom.xml
@@ -41,5 +41,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/EncoderModeRestClient.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/EncoderModeRestClient.java
@@ -1,0 +1,26 @@
+package io.quarkus.ts.http.restclient.reactive.multipart;
+
+import static jakarta.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+
+@Path("/encoder-mode")
+public interface EncoderModeRestClient {
+
+    @POST
+    @Consumes(MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    MyMultipartDTO doAPostRequestToThisResource(
+            @PartType(MediaType.TEXT_PLAIN) @FormParam("file1") java.nio.file.Path file1,
+            @PartType(MediaType.TEXT_PLAIN) @FormParam("file2") java.nio.file.Path file2,
+            @RestForm String otherField);
+
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/Html5EncoderModeRestClient.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/Html5EncoderModeRestClient.java
@@ -1,0 +1,8 @@
+package io.quarkus.ts.http.restclient.reactive.multipart;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey = "encoder-mode-html5")
+public interface Html5EncoderModeRestClient extends EncoderModeRestClient {
+
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/Item.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/Item.java
@@ -1,0 +1,56 @@
+package io.quarkus.ts.http.restclient.reactive.multipart;
+
+import java.util.List;
+import java.util.Map;
+
+public class Item {
+    public final String name;
+    public final long size;
+    public final String charset;
+    public final String fileContent;
+
+    public String getFileContent() {
+        return fileContent;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public String getCharset() {
+        return charset;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public boolean isFileItem() {
+        return isFileItem;
+    }
+
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    public final String fileName;
+    public final boolean isFileItem;
+    public final Map<String, List<String>> headers;
+    public boolean fileItem;
+
+    public Item(String name, long size, String charset, String fileName, boolean isFileItem,
+            Map<String, List<String>> headers, boolean fileItem, String fileContent) {
+        this.name = name;
+        this.size = size;
+        this.charset = charset;
+        this.fileName = fileName;
+        this.isFileItem = isFileItem;
+        this.headers = headers;
+        this.fileItem = fileItem;
+        this.fileContent = fileContent;
+    }
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/MyMultipartDTO.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/MyMultipartDTO.java
@@ -1,0 +1,22 @@
+package io.quarkus.ts.http.restclient.reactive.multipart;
+
+import java.util.List;
+
+public class MyMultipartDTO {
+    private List<Item> items;
+
+    public MyMultipartDTO() {
+    }
+
+    public MyMultipartDTO(List<Item> items) {
+        this.items = items;
+    }
+
+    public List<Item> getItems() {
+        return items;
+    }
+
+    public void setItems(List<Item> items) {
+        this.items = items;
+    }
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/Rfc1738EncoderModeRestClient.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/Rfc1738EncoderModeRestClient.java
@@ -1,0 +1,8 @@
+package io.quarkus.ts.http.restclient.reactive.multipart;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey = "encoder-mode-rfc1738")
+public interface Rfc1738EncoderModeRestClient extends EncoderModeRestClient {
+
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/Rfc3986EncoderModeRestClient.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/Rfc3986EncoderModeRestClient.java
@@ -1,0 +1,8 @@
+package io.quarkus.ts.http.restclient.reactive.multipart;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey = "encoder-mode-rfc3986")
+public interface Rfc3986EncoderModeRestClient extends EncoderModeRestClient {
+
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/MultipartPostEncoderModeResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/MultipartPostEncoderModeResource.java
@@ -1,0 +1,67 @@
+package io.quarkus.ts.http.restclient.reactive.resources;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.reactive.server.multipart.FormValue;
+import org.jboss.resteasy.reactive.server.multipart.MultipartFormDataInput;
+
+import io.quarkus.ts.http.restclient.reactive.multipart.EncoderModeRestClient;
+import io.quarkus.ts.http.restclient.reactive.multipart.Html5EncoderModeRestClient;
+import io.quarkus.ts.http.restclient.reactive.multipart.Item;
+import io.quarkus.ts.http.restclient.reactive.multipart.MyMultipartDTO;
+import io.quarkus.ts.http.restclient.reactive.multipart.Rfc1738EncoderModeRestClient;
+import io.quarkus.ts.http.restclient.reactive.multipart.Rfc3986EncoderModeRestClient;
+
+@Path("/encode")
+public class MultipartPostEncoderModeResource {
+
+    private final Map<String, EncoderModeRestClient> modeToRestClient;
+
+    public MultipartPostEncoderModeResource(@RestClient Html5EncoderModeRestClient html5Client,
+            @RestClient Rfc1738EncoderModeRestClient rfc1738Client,
+            @RestClient Rfc3986EncoderModeRestClient rfc3986Client) {
+        this.modeToRestClient = Map.of("HTML5", html5Client, "RFC1738", rfc1738Client, "RFC3986", rfc3986Client);
+    }
+
+    @Path("{encoder-mode}")
+    @POST
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    public MyMultipartDTO doAPostRequestToSimpleEncodeResource(MultipartFormDataInput input,
+            @PathParam("encoder-mode") String encoderMode) {
+
+        EncoderModeRestClient client = modeToRestClient.get(encoderMode);
+        if (!modeToRestClient.containsKey(encoderMode)) {
+            throw new WebApplicationException("Unsupported encoder mode" + encoderMode, Response.Status.BAD_REQUEST);
+        }
+
+        Map<String, Collection<FormValue>> formValues = input.getValues();
+
+        if (!formValues.containsKey("file1") || !formValues.containsKey("file2") || !formValues.containsKey("otherField")) {
+            throw new IllegalArgumentException("Missing mandatory fields!");
+        }
+
+        java.nio.file.Path file1 = formValues.get("file1").stream().findFirst().get().getFileItem().getFile();
+        java.nio.file.Path file2 = formValues.get("file2").stream().findFirst().get().getFileItem().getFile();
+        String otherField = formValues.get("otherField").stream().findFirst().get().getValue();
+
+        MyMultipartDTO response = client.doAPostRequestToThisResource(file1, file2, otherField);
+
+        List<Item> items = response.getItems();
+
+        return new MyMultipartDTO(items);
+    }
+
+}

--- a/http/rest-client-reactive/src/main/resources/application.properties
+++ b/http/rest-client-reactive/src/main/resources/application.properties
@@ -1,3 +1,10 @@
 quarkus.tls.trust-all=true
 quarkus.http.ssl.certificate.key-store-file=META-INF/keystore.jks
 quarkus.http.ssl.certificate.key-store-password=password
+vertx-server-url=http://${quarkus.http.host:localhost}:${vertx-server-port}/
+quarkus.rest-client.encoder-mode-html5.url=${vertx-server-url}
+quarkus.rest-client.encoder-mode-html5.multipart-post-encoder-mode=HTML5
+quarkus.rest-client.encoder-mode-rfc1738.url=${vertx-server-url}
+quarkus.rest-client.encoder-mode-rfc1738.multipart-post-encoder-mode=RFC1738
+quarkus.rest-client.encoder-mode-rfc3986.url=${vertx-server-url}
+quarkus.rest-client.encoder-mode-rfc3986.multipart-post-encoder-mode=RFC3986

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/HttpMultipartEncodeModeAndContentIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/HttpMultipartEncodeModeAndContentIT.java
@@ -1,0 +1,225 @@
+package io.quarkus.ts.http.restclient.reactive;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.ws.rs.core.MediaType;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.http.restclient.reactive.multipart.Item;
+import io.quarkus.ts.http.restclient.reactive.multipart.MyMultipartDTO;
+import io.restassured.response.Response;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.junit5.VertxExtension;
+
+/**
+ * Integration test for multipart encoder mode handling in the REST client.
+ *
+ * This test verifies:
+ * - Multipart requests are correctly encoded using HTML5, RFC1738, and RFC3986 modes.
+ * - A Vert.x server successfully parses and interprets the encoded data.
+ * - File contents and additional form fields are transmitted without corruption.
+ *
+ * Note: Although the exact encoder mode used in transmission cannot be directly verified,
+ * test ensure content is correctly parsed and interpreted by the server, providing confidence that the appropriate encoder mode
+ * was applied.
+ */
+
+@ExtendWith(VertxExtension.class)
+@QuarkusScenario
+public class HttpMultipartEncodeModeAndContentIT {
+
+    private static final int VERTX_SERVER_PORT = 8081;
+    private static HttpServer httpServer;
+    private static final File FILE1;
+    private static final File FILE2;
+    static {
+        FILE1 = Paths.get("src", "test", "resources", "sample.txt").toFile();
+        FILE2 = Paths.get("src", "test", "resources", "sampl'eñ.txt").toFile();
+    }
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("vertx-server-port", String.valueOf(VERTX_SERVER_PORT));
+
+    @BeforeAll
+    public static void setUpVertxServer(Vertx vertx) {
+        final var mapper = new ObjectMapper();
+        vertx.createHttpServer(new HttpServerOptions().setPort(VERTX_SERVER_PORT))
+                .requestHandler(httpServerRequest -> {
+                    if (!httpServerRequest.path().contains("/encoder-mode")) {
+                        httpServerRequest.response().setStatusCode(500).end();
+                        return;
+                    }
+
+                    httpServerRequest.setExpectMultipart(true);
+                    AtomicInteger fileCount = new AtomicInteger(0);
+                    List<Item> items = new ArrayList<>();
+
+                    httpServerRequest.uploadHandler(upload -> {
+                        upload.handler(buffer -> {
+                            Map<String, List<String>> headers = new HashMap<>();
+
+                            headers.put("Content-Type", List.of(upload.contentType()));
+                            if (upload.contentTransferEncoding() != null) {
+                                headers.put("Content-Transfer-Encoding", List.of(upload.contentTransferEncoding()));
+                            }
+                            headers.put("Content-Disposition", List.of(
+                                    "form-data; name=\"" + upload.name() + "\"; filename=\"" + upload.filename() + "\""));
+
+                            items.add(new Item(
+                                    upload.name(),
+                                    buffer.length(),
+                                    upload.charset(),
+                                    upload.filename(),
+                                    true,
+                                    headers,
+                                    true,
+                                    buffer.toString()));
+                        });
+
+                        upload.endHandler(v -> {
+                            if (fileCount.incrementAndGet() == 2) {
+                                try {
+                                    httpServerRequest.response()
+                                            .setStatusCode(200)
+                                            .putHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                                            .end(mapper.writeValueAsString(new MyMultipartDTO(items)));
+                                } catch (JsonProcessingException e) {
+                                    httpServerRequest.response().setStatusCode(500).end(e.getMessage());
+                                }
+                            }
+                        });
+                    });
+
+                })
+
+                .listen()
+                .onSuccess(server -> HttpMultipartEncodeModeAndContentIT.httpServer = server);
+    }
+
+    @ParameterizedTest
+    @EnumSource(EncoderMode.class)
+    public void testMultipartEncodeMode(EncoderMode encoderMode) throws IOException {
+
+        Response response = app.given()
+                .multiPart("file1", FILE1, "text/plain")
+                .multiPart("file2", FILE2, "text/plain")
+                .multiPart("otherField", "other field")
+                .header("Content-Type", MediaType.MULTIPART_FORM_DATA)
+                .pathParam("encoder-mode", encoderMode)
+                .when()
+                .post("/encode/{encoder-mode}")
+                .then()
+                .statusCode(200)
+                .extract().response();
+
+        Assertions.assertNotNull(response.getBody(), "Response body should not be null");
+
+        MyMultipartDTO responseDto = response.as(MyMultipartDTO.class);
+        Assertions.assertNotNull(responseDto, "Response DTO should not be null");
+
+        for (Item item : responseDto.getItems()) {
+            if (item.isFileItem()) {
+                Map<String, List<String>> headers = item.getHeaders();
+
+                // Content-Disposition
+                List<String> contentDispositionList = headers.get("Content-Disposition");
+                Assertions.assertNotNull(contentDispositionList,
+                        "Content-Disposition header should not be null for file item: " + item.getName());
+                Assertions.assertFalse(contentDispositionList.isEmpty(),
+                        "Content-Disposition header should not be empty for file item: " + item.getName());
+                String contentDisposition = contentDispositionList.get(0);
+                Assertions.assertTrue(contentDisposition.contains("name=\"" + item.getName() + "\""));
+                Assertions.assertTrue(contentDisposition.contains("filename=\"" + item.getFileName() + "\""));
+
+                // Content-Transfer-Encoding
+                List<String> contentTransferEncodingList = headers.get("Content-Transfer-Encoding");
+                Assertions.assertNotNull(contentTransferEncodingList,
+                        "Content-Transfer-Encoding header should not be null for file item: " + item.getName());
+                Assertions.assertFalse(contentTransferEncodingList.isEmpty(),
+                        "Content-Transfer-Encoding header should not be empty for file item: " + item.getName());
+                String contentTransferEncoding = contentTransferEncodingList.get(0);
+                Assertions.assertEquals("binary", contentTransferEncoding);
+
+                // Content-Type
+                List<String> contentTypeList = headers.get("Content-Type");
+                Assertions.assertNotNull(contentTypeList,
+                        "Content-Type header should not be null for file item: " + item.getName());
+                Assertions.assertFalse(contentTypeList.isEmpty(),
+                        "Content-Type header should not be empty for file item: " + item.getName());
+                String contentType = contentTypeList.get(0);
+                Assertions.assertEquals("application/octet-stream", contentType);
+
+                // File content verification
+                File expectedFile = null;
+                if (item.getName().equals("file1")) {
+                    expectedFile = FILE1;
+                } else if (item.getName().equals("file2")) {
+                    expectedFile = FILE2;
+                } else {
+                    Assertions.fail("Unexpected file item name: " + item.getName());
+                }
+                String expectedFileContent = Files.readString(expectedFile.toPath());
+                Assertions.assertEquals(expectedFileContent, item.getFileContent(),
+                        "File content mismatch for " + item.getName());
+
+            }
+
+        }
+        Assertions.assertEquals(2, responseDto.getItems().size(), "Expected exactly 2 file items in response");
+    }
+
+    @Test
+    public void testIncorrectMultipartEncoderMode() {
+        String incorrectEncodeMode = "XXHTML3";
+        app.given()
+                .multiPart("file1", FILE1, "text/plain")
+                .multiPart("file2", FILE2, "text/plain")
+                .multiPart("otherField", "other field")
+                .header("Content-Type", MediaType.MULTIPART_FORM_DATA)
+                .pathParam("encoder-mode", incorrectEncodeMode) // Client mode in the path
+                .when()
+                .post("/encode/{encoder-mode}")
+                .then()
+                .statusCode(400);
+
+    }
+
+    @AfterAll
+    public static void stopServer() {
+        if (httpServer != null) {
+            httpServer.close();
+        }
+    }
+
+    private enum EncoderMode {
+        HTML5,
+        RFC1738,
+        RFC3986
+    }
+
+}

--- a/http/rest-client-reactive/src/test/resources/sampl'eñ.txt
+++ b/http/rest-client-reactive/src/test/resources/sampl'eñ.txt
@@ -1,0 +1,1 @@
+sdfsdfsdñ´'dsf

--- a/http/rest-client-reactive/src/test/resources/sample.txt
+++ b/http/rest-client-reactive/src/test/resources/sample.txt
@@ -1,0 +1,1 @@
+This is an example's text.


### PR DESCRIPTION
### Summary

Adding TD for the next backport:
[Improve the multipart encoded mode handling in the rest client](https://github.com/quarkusio/quarkus/pull/39770)

This PR adds test coverage for the improved multipart encoder mode handling in the REST client. 
The tests cover the encoder modes (HTML5, RFC1738, RFC3986), verifying the correct encoding of multipart requests and successful parsing by a Vert.x server. Data integrity checks, including file content verification via size and headers, are performed.

Note: Direct verification of the specific encoder mode used during the transmission is not directly feasible, but 
the tests ensure that the resulting content is correctly parsed and interpreted by the server, providing confidence that the appropriate encoder mode was applied.



Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)