### PR TITLE
[3.8] Detect that OpenShift test is run when OpenShift IBM Z/PE and ARM64 profiles are used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -816,6 +816,8 @@
                                 </goals>
                                 <configuration>
                                     <systemPropertyVariables>
+                                        <!-- always set 'OpenShift' property as that's how detect OpenShift tests inside FW -->
+                                        <openshift>true</openshift>
                                         <ts.arm.missing.services.excludes>true</ts.arm.missing.services.excludes>
                                         <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                         <!-- Product Services -->
@@ -869,6 +871,8 @@
                                 </goals>
                                 <configuration>
                                     <systemPropertyVariables>
+                                        <!-- always set 'OpenShift' property as that's how detect OpenShift tests inside FW -->
+                                        <openshift>true</openshift>
                                         <ts.ibm-z-p.missing.services.excludes>true</ts.ibm-z-p.missing.services.excludes>
                                         <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                         <!-- Product Services -->


### PR DESCRIPTION
### Summary

We use `openshift` system property to detect that OpenShift test is run here:

https://github.com/quarkus-qe/quarkus-test-framework/blob/f5c973082d109579fa1df09138ddc6d5fcdd496d/quarkus-test-core/src/main/java/io/quarkus/test/utils/TestExecutionProperties.java#L40

However IBM Z/PE and ARM64 don't have set this property, which means we don't detect OpenShift test execution in some contexts. For example, certificates are not mounted as we don't know about OpenShift.

Later, this needs to be ported to the main branch.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)