### PR TITLE
Fix RHBQ version regex as dash was used after Final

### DIFF
--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AnalyticsUtils.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AnalyticsUtils.java
@@ -11,8 +11,8 @@ public class AnalyticsUtils {
     // So for 999-SNAPSHOT, it can look like e.g. 999-20230718.203351-1091
     private static final String QUARKUS_EXTENSION_SNAPSHOT_VERSION_REGEX = "999-.*";
     // RHBQ artifacts may differ in the number suffix from a platform version.
-    // E.g.: 3.2.0.Final-redhat-00002 vs. 3.2.0.Final-redhat-00003
-    private static final String RHBQ_VERSION_REGEX_FORMAT = "%s-redhat-\\d{5}";
+    // E.g.: 3.8.0.redhat-00002 vs. 3.8.5.redhat-00003
+    private static final String RHBQ_VERSION_REGEX_FORMAT = "%s\\.redhat-\\d{5}";
     public static final Pattern QUARKUS_EXTENSION_VERSION_PATTERN = Pattern.compile(getExtensionVersionRegex());
 
     public static final String QUARKUS_ANALYTICS_DISABLED_PROPERTY = "quarkus.analytics.disabled";


### PR DESCRIPTION
### Summary

Fix RHBQ version regex as dash `-` was used after the `Final` word. Now as the `Final` word is droped the delimeter from version and `redhat` keyword is dot `.`.

Tested it localy with `mvn clean validate compile test package verify -V -B -fae -P root-modules -Dmaven.repo.local=/home/jjedlick/work/3.8/rh-quarkus-platform-3.8.5.GA-maven-repository/maven-repository/ -Dinclude.quarkus-cli-tests -Dquarkus-plugin.version=3.8.5.redhat-00002 -Dquarkus.platform.version=3.8.5.redhat-00002 -Dquarkus.platform.artifact-id=quarkus-bom -Dquarkus.platform.group-id=com.redhat.quarkus.platform -pl build-time-analytics -Dit.test="*CliProdModeJvmIT#noExtensions"` which affected test

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)