### PR TITLE
Detect that OpenShift test is run when OpenShift IBM Z/PE and ARM64 profiles are used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -797,6 +797,8 @@
                                 </goals>
                                 <configuration>
                                     <systemPropertyVariables>
+                                        <!-- always set 'OpenShift' property as that's how detect OpenShift tests inside FW -->
+                                        <openshift>true</openshift>
                                         <ts.arm.missing.services.excludes>true</ts.arm.missing.services.excludes>
                                         <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                         <!-- Product Services -->
@@ -850,6 +852,8 @@
                                 </goals>
                                 <configuration>
                                     <systemPropertyVariables>
+                                        <!-- always set 'OpenShift' property as that's how detect OpenShift tests inside FW -->
+                                        <openshift>true</openshift>
                                         <ts.ibm-z-p.missing.services.excludes>true</ts.ibm-z-p.missing.services.excludes>
                                         <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                         <!-- Product Services -->


### PR DESCRIPTION
### Summary

ports https://github.com/quarkus-qe/quarkus-test-suite/pull/1855

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Port
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)