### PR TITLE
Revert "[3.8] Do not expect index page in DEV mode on Windows"

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -79,13 +79,7 @@ public class QuarkusCliCreateJvmApplicationIT {
 
         // Start using DEV mode
         app.start();
-        if (OS.WINDOWS.isCurrentOs()) {
-            // there is empty page on Windows as we don't use registry prepared by prod team
-            // related to https://github.com/quarkusio/quarkus/issues/39909
-            app.given().get("/hello").then().statusCode(HttpStatus.SC_OK);
-        } else {
-            app.given().get().then().statusCode(HttpStatus.SC_OK);
-        }
+        app.given().get().then().statusCode(HttpStatus.SC_OK);
     }
 
     @Tag("QUARKUS-1472")


### PR DESCRIPTION
Reverts quarkus-qe/quarkus-test-suite#1759

As landing page on windows is fixed in RHBQ 3.8.5, it is no longer necessary to have this exception in 3.8 branch.