### PR TITLE
Use Red Hat PostgreSQL image in OpenShift and fix OpenShiftPostgresqlTransactionGeneralUsageIT when its run with PostgreSQL image from Red Hat registry

### DIFF
--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/AbstractTodoDemoIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/AbstractTodoDemoIT.java
@@ -1,0 +1,42 @@
+package io.quarkus.ts.external.applications;
+
+import static org.hamcrest.Matchers.is;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.restassured.http.ContentType;
+
+@DisabledOnNative(reason = "This scenario is using uber-jar, so it's incompatible with Native")
+public abstract class AbstractTodoDemoIT {
+    protected static final String TODO_REPO = "https://github.com/quarkusio/todo-demo-app.git";
+    protected static final String VERSIONS = "-Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} ";
+    protected static final String DEFAULT_OPTIONS = " -DskipTests=true " + VERSIONS;
+
+    protected abstract RestService getApp();
+
+    protected abstract RestService getReplaced();
+
+    @Test
+    public void startsSuccessfully() {
+        getApp().given()
+                .contentType(ContentType.JSON)
+                .body("{\"title\": \"Use Quarkus\", \"order\": 1, \"url\": \"https://quarkus.io\"}")
+                .post("/api")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED);
+    }
+
+    @Test
+    public void replacedStartsSuccessfully() {
+        getReplaced().given()
+                .accept(ContentType.JSON)
+                .get("/api")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("$.size()", is(1))
+                .body("title[0]", is("Use Quarkus"));
+    }
+}

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftTodoDemoIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftTodoDemoIT.java
@@ -1,9 +1,42 @@
 package io.quarkus.ts.external.applications;
 
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
 @DisabledOnNative(reason = "Native + s2i not supported")
 @OpenShiftScenario
-public class OpenShiftTodoDemoIT extends TodoDemoIT {
+public class OpenShiftTodoDemoIT extends AbstractTodoDemoIT {
+
+    // FIXME: change expected log when https://github.com/quarkus-qe/quarkus-test-framework/issues/1183 is fixed
+    @Container(image = "${postgresql.latest.image}", port = 5432, expectedLog = "Future log output will appear in directory")
+    static PostgresqlService database = new PostgresqlService()
+            // store data in /tmp/psql as in OpenShift we don't have permissions to /var/lib/postgresql/data
+            .withProperty("PGDATA", "/tmp/psql");
+
+    @GitRepositoryQuarkusApplication(repo = TODO_REPO, mavenArgs = "-Dquarkus.package.jar.type=uber-jar" + DEFAULT_OPTIONS)
+    static final RestService app = new RestService()
+            .withProperty("quarkus.datasource.username", database.getUser())
+            .withProperty("quarkus.datasource.password", database.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+
+    @GitRepositoryQuarkusApplication(repo = TODO_REPO, artifact = "todo-backend-1.0-SNAPSHOT.jar", mavenArgs = "-Dquarkus.package.jar.type=uber-jar -Dquarkus.package.add-runner-suffix=false"
+            + DEFAULT_OPTIONS)
+    static final RestService replaced = new RestService()
+            .withProperty("quarkus.datasource.username", database.getUser())
+            .withProperty("quarkus.datasource.password", database.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+
+    @Override
+    protected RestService getReplaced() {
+        return replaced;
+    }
 }

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
@@ -41,7 +41,8 @@ public class OpenShiftWorkshopHeroesIT {
 
     private static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    // FIXME: change expected log when https://github.com/quarkus-qe/quarkus-test-framework/issues/1183 is fixed
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "Future log output will appear in directory")
     static PostgresqlService database = new PostgresqlService()
             .withProperty("PGDATA", "/tmp/psql");
 

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopVillainsIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopVillainsIT.java
@@ -44,7 +44,8 @@ public class OpenShiftWorkshopVillainsIT {
 
     private static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    // FIXME: change expected log when https://github.com/quarkus-qe/quarkus-test-framework/issues/1183 is fixed
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "Future log output will appear in directory")
     static PostgresqlService database = new PostgresqlService()
             .withProperty("PGDATA", "/tmp/psql");
 

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/TodoDemoIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/TodoDemoIT.java
@@ -1,24 +1,13 @@
 package io.quarkus.ts.external.applications;
 
-import static org.hamcrest.Matchers.is;
-
-import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Test;
-
 import io.quarkus.test.bootstrap.PostgresqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
-import io.restassured.http.ContentType;
 
-@DisabledOnNative(reason = "This scenario is using uber-jar, so it's incompatible with Native")
 @QuarkusScenario
-public class TodoDemoIT {
-    private static final String TODO_REPO = "https://github.com/quarkusio/todo-demo-app.git";
-    private static final String VERSIONS = "-Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} ";
-    private static final String DEFAULT_OPTIONS = " -DskipTests=true " + VERSIONS;
+public class TodoDemoIT extends AbstractTodoDemoIT {
 
     @Container(image = "${postgresql.latest.image}", port = 5432, expectedLog = "listening on IPv4 address")
     static PostgresqlService database = new PostgresqlService()
@@ -38,24 +27,13 @@ public class TodoDemoIT {
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
 
-    @Test
-    public void startsSuccessfully() {
-        app.given()
-                .contentType(ContentType.JSON)
-                .body("{\"title\": \"Use Quarkus\", \"order\": 1, \"url\": \"https://quarkus.io\"}")
-                .post("/api")
-                .then()
-                .statusCode(HttpStatus.SC_CREATED);
+    @Override
+    protected RestService getApp() {
+        return app;
     }
 
-    @Test
-    public void replacedStartsSuccessfully() {
-        replaced.given()
-                .accept(ContentType.JSON)
-                .get("/api")
-                .then()
-                .statusCode(HttpStatus.SC_OK)
-                .body("$.size()", is(1))
-                .body("title[0]", is("Use Quarkus"));
+    @Override
+    protected RestService getReplaced() {
+        return replaced;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -804,6 +804,7 @@
                                         <!-- Product Services -->
                                         <rhbk.image>${rhbk.image}</rhbk.image>
                                         <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10</postgresql.10.image>
+                                        <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-15</postgresql.latest.image>
                                         <mysql.80.image>registry.redhat.io/rhel8/mysql-80</mysql.80.image>
                                         <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103</mariadb.103.image>
                                         <mariadb.105.image>registry.redhat.io/rhel8/mariadb-105</mariadb.105.image>
@@ -860,6 +861,7 @@
                                         <amqbroker.image>registry.redhat.io/amq7/amq-broker-rhel8:7.11</amqbroker.image>
                                         <rhbk.image>${rhbk.image}</rhbk.image>
                                         <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10</postgresql.10.image>
+                                        <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-15</postgresql.latest.image>
                                         <mysql.80.image>registry.redhat.io/rhel8/mysql-80</mysql.80.image>
                                         <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103</mariadb.103.image>
                                         <mariadb.105.image>registry.redhat.io/rhel8/mariadb-105</mariadb.105.image>

--- a/pom.xml
+++ b/pom.xml
@@ -745,20 +745,28 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
-                                <!-- Product Services -->
-                                <rhbk.image>${rhbk.image}</rhbk.image>
-                                <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10</postgresql.10.image>
-                                <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-15</postgresql.latest.image>
-                                <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103</mariadb.103.image>
-                                <mariadb.105.image>registry.redhat.io/rhel9/mariadb-105</mariadb.105.image>
-                                <amq-streams.image>registry.redhat.io/amq-streams/kafka-35-rhel8</amq-streams.image>
-                                <amq-streams.version>2.6.0</amq-streams.version>
-                            </systemPropertyVariables>
-                            <rerunFailingTestsCount>${oc.reruns}</rerunFailingTestsCount>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
+                                        <!-- Product Services -->
+                                        <rhbk.image>${rhbk.image}</rhbk.image>
+                                        <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10</postgresql.10.image>
+                                        <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-15</postgresql.latest.image>
+                                        <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103</mariadb.103.image>
+                                        <mariadb.105.image>registry.redhat.io/rhel9/mariadb-105</mariadb.105.image>
+                                        <amq-streams.image>registry.redhat.io/amq-streams/kafka-35-rhel8</amq-streams.image>
+                                        <amq-streams.version>2.6.0</amq-streams.version>
+                                    </systemPropertyVariables>
+                                    <rerunFailingTestsCount>${oc.reruns}</rerunFailingTestsCount>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/AbstractDbIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/AbstractDbIT.java
@@ -8,7 +8,10 @@ import io.quarkus.test.services.QuarkusApplication;
 public class AbstractDbIT {
     static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    // FIXME: here PG image must not be hardcoded, we need to use ${postgresql.latest.image} system property;
+    //   however using Red Hat image here would require a lot of refactoring
+    //   we need to address https://github.com/quarkus-qe/quarkus-test-framework/issues/1183 first
+    @Container(image = "docker.io/postgres:16.1", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static final PostgresqlService database = new PostgresqlService()
             .withProperty("PGDATA", "/tmp/psql");
 

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftPostgresqlHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftPostgresqlHibernateReactiveIT.java
@@ -1,8 +1,37 @@
 package io.quarkus.ts.hibernate.reactive.openshift;
 
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.ts.hibernate.reactive.PostgresqlDatabaseHibernateReactiveIT;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.hibernate.reactive.AbstractDatabaseHibernateReactiveIT;
 
 @OpenShiftScenario
-public class OpenShiftPostgresqlHibernateReactiveIT extends PostgresqlDatabaseHibernateReactiveIT {
+public class OpenShiftPostgresqlHibernateReactiveIT extends AbstractDatabaseHibernateReactiveIT {
+
+    private static final String POSTGRES_USER = "quarkus_test";
+    private static final String POSTGRES_PASSWORD = "quarkus_test";
+    private static final String POSTGRES_DATABASE = "quarkus_test";
+    private static final int POSTGRES_PORT = 5432;
+
+    // FIXME: change expected log when https://github.com/quarkus-qe/quarkus-test-framework/issues/1183 is fixed
+    @Container(image = "${postgresql.latest.image}", port = POSTGRES_PORT, expectedLog = "Future log output will appear in directory")
+    static PostgresqlService database = new PostgresqlService()
+            .withUser(POSTGRES_USER)
+            .withPassword(POSTGRES_PASSWORD)
+            .withDatabase(POSTGRES_DATABASE)
+            .withProperty("PGDATA", "/tmp/psql");
+
+    @QuarkusApplication
+    static RestService app = new RestService().withProperties("postgresql.properties")
+            .withProperty("quarkus.datasource.username", POSTGRES_USER)
+            .withProperty("quarkus.datasource.password", POSTGRES_PASSWORD)
+            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl);
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+
 }

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
@@ -20,7 +20,8 @@ public class OpenShiftMultiplePersistenceIT extends AbstractMultiplePersistenceI
     @Container(image = "${mariadb.103.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
     static MariaDbService mariadb = new MariaDbService();
 
-    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    // FIXME: change expected log when https://github.com/quarkus-qe/quarkus-test-framework/issues/1183 is fixed
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "Future log output will appear in directory")
     static PostgresqlService postgresql = new PostgresqlService()
             .withProperty("PGDATA", "/tmp/psql");
 

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/AbstractPostgresqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/AbstractPostgresqlTransactionGeneralUsageIT.java
@@ -1,0 +1,24 @@
+package io.quarkus.ts.transactions;
+
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.ts.transactions.recovery.TransactionExecutor;
+
+public abstract class AbstractPostgresqlTransactionGeneralUsageIT extends TransactionCommons {
+
+    static final int POSTGRESQL_PORT = 5432;
+
+    @Override
+    protected TransactionExecutor getTransactionExecutorUsedForRecovery() {
+        return TransactionExecutor.TRANSACTIONAL_ANNOTATION;
+    }
+
+    protected static RestService createQuarkusApp(PostgresqlService database) {
+        return new RestService().withProperties("postgresql.properties")
+                .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
+                .withProperty("quarkus.datasource.jdbc.telemetry", "true")
+                .withProperty("quarkus.datasource.username", database.getUser())
+                .withProperty("quarkus.datasource.password", database.getPassword())
+                .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+    }
+}

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftPostgresqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftPostgresqlTransactionGeneralUsageIT.java
@@ -1,8 +1,26 @@
 package io.quarkus.ts.transactions;
 
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-public class OpenShiftPostgresqlTransactionGeneralUsageIT extends PostgresqlTransactionGeneralUsageIT {
+public class OpenShiftPostgresqlTransactionGeneralUsageIT extends AbstractPostgresqlTransactionGeneralUsageIT {
+
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    static final PostgresqlService database = new PostgresqlService()
+            // following env variable is accepted by PG images from Red Hat registry
+            .withProperty("POSTGRESQL_MAX_PREPARED_TRANSACTIONS", "100")
+            .withProperty("PGDATA", "/tmp/psql");
+
+    @QuarkusApplication
+    public static final RestService app = createQuarkusApp(database);
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
 
 }

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftPostgresqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftPostgresqlTransactionGeneralUsageIT.java
@@ -9,7 +9,8 @@ import io.quarkus.test.services.QuarkusApplication;
 @OpenShiftScenario
 public class OpenShiftPostgresqlTransactionGeneralUsageIT extends AbstractPostgresqlTransactionGeneralUsageIT {
 
-    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    // FIXME: change expected log when https://github.com/quarkus-qe/quarkus-test-framework/issues/1183 is fixed
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "Future log output will appear in directory")
     static final PostgresqlService database = new PostgresqlService()
             // following env variable is accepted by PG images from Red Hat registry
             .withProperty("POSTGRESQL_MAX_PREPARED_TRANSACTIONS", "100")

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlTransactionGeneralUsageIT.java
@@ -5,32 +5,21 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 
 @QuarkusScenario
-public class PostgresqlTransactionGeneralUsageIT extends TransactionCommons {
+public class PostgresqlTransactionGeneralUsageIT extends AbstractPostgresqlTransactionGeneralUsageIT {
 
     private static final String ENABLE_PREPARED_TRANSACTIONS = "--max_prepared_transactions=100";
-    static final int POSTGRESQL_PORT = 5432;
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address", command = ENABLE_PREPARED_TRANSACTIONS)
     static final PostgresqlService database = new PostgresqlService().withProperty("PGDATA", "/tmp/psql");
 
     @QuarkusApplication
-    public static final RestService app = new RestService().withProperties("postgresql.properties")
-            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
-            .withProperty("quarkus.datasource.jdbc.telemetry", "true")
-            .withProperty("quarkus.datasource.username", database.getUser())
-            .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+    public static final RestService app = createQuarkusApp(database);
 
     @Override
     protected RestService getApp() {
         return app;
     }
 
-    @Override
-    protected TransactionExecutor getTransactionExecutorUsedForRecovery() {
-        return TransactionExecutor.TRANSACTIONAL_ANNOTATION;
-    }
 }

--- a/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/OpenShiftPostgresqlPanacheResourceIT.java
+++ b/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/OpenShiftPostgresqlPanacheResourceIT.java
@@ -1,7 +1,26 @@
 package io.quarkus.ts.reactive.rest.data.panache;
 
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-public class OpenShiftPostgresqlPanacheResourceIT extends PostgresqlPanacheResourceIT {
+public class OpenShiftPostgresqlPanacheResourceIT extends AbstractPanacheResourceIT {
+
+    private static final int POSTGRESQL_PORT = 5432;
+
+    // FIXME: change expected log when https://github.com/quarkus-qe/quarkus-test-framework/issues/1183 is fixed
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "Future log output will appear in directory")
+    public static final PostgresqlService database = new PostgresqlService()
+            .withProperty("POSTGRES_DB", "mydb")
+            .withProperty("PGDATA", "/tmp/psql");
+
+    @QuarkusApplication
+    public static final RestService app = new RestService().withProperties("postgresql.properties")
+            .withProperty("quarkus.datasource.username", database.getUser())
+            .withProperty("quarkus.datasource.password", database.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+
 }

--- a/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/PostgresqlPanacheResourceIT.java
+++ b/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/PostgresqlPanacheResourceIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class PostgresqlPanacheResourceIT extends AbstractPanacheResourceIT {
 
-    static final int POSTGRESQL_PORT = 5432;
+    private static final int POSTGRESQL_PORT = 5432;
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     public static final PostgresqlService database = new PostgresqlService()
@@ -21,4 +21,5 @@ public class PostgresqlPanacheResourceIT extends AbstractPanacheResourceIT {
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresqlDatabaseIT.java
@@ -14,7 +14,8 @@ public class OpenShiftPostgresqlDatabaseIT extends AbstractSqlDatabaseIT {
 
     static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    // FIXME: change expected log when https://github.com/quarkus-qe/quarkus-test-framework/issues/1183 is fixed
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "Future log output will appear in directory")
     static PostgresqlService database = new PostgresqlService()
             .withProperty("PGDATA", "/tmp/psql");
 


### PR DESCRIPTION
### Summary

Ports https://github.com/quarkus-qe/quarkus-test-suite/pull/1861. My plan is to have this as a workaround and we should address this in FW as part of TS refinement ticket I have in a backlog.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Port
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)