### PR TITLE
Disable DevModeMultipleReactiveSqlClientsIT on FIPS-enabled env

### DIFF
--- a/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeMultipleReactiveSqlClientsIT.java
+++ b/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeMultipleReactiveSqlClientsIT.java
@@ -20,6 +20,7 @@ import io.quarkus.ts.reactive.db.clients.model.NoteBook;
 import io.quarkus.ts.reactive.db.clients.model.SoftCoverBook;
 import io.vertx.core.json.JsonObject;
 
+@Tag("fips-incompatible") // TODO: enable when https://github.com/quarkusio/quarkus/issues/40526 gets fixed
 @Tag("QUARKUS-1080")
 @Tag("QUARKUS-1408")
 @QuarkusScenario


### PR DESCRIPTION
### Summary

Disabling as it's failing during 3.8.5 processing in FIPS-enabled environment.
Failures are due to known issue https://github.com/quarkusio/quarkus/issues/40526.
Test plan for FIPS expects this test to be disabled https://github.com/quarkus-qe/quarkus-test-plans/blob/d1a665ed050a3cbbc02ab7996ea494a0eec442b6/QUARKUS-3225.md?plain=1#L48.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)