### PR TITLE
Quarkus CLI update test

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/AbstractQuarkusCliUpdateIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/AbstractQuarkusCliUpdateIT.java
@@ -1,0 +1,82 @@
+package io.quarkus.ts.quarkus.cli.update;
+
+import static io.quarkus.test.util.QuarkusCLIUtils.getQuarkusAppVersion;
+import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import jakarta.inject.Inject;
+
+import org.apache.http.HttpStatus;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.logging.Log;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+import io.quarkus.test.util.DefaultQuarkusCLIAppManager;
+import io.quarkus.test.util.IQuarkusCLIAppManager;
+import io.quarkus.test.utils.AwaitilityUtils;
+
+@QuarkusScenario
+@DisabledOnNative // Only for JVM verification
+public abstract class AbstractQuarkusCliUpdateIT {
+    @Inject
+    static QuarkusCliClient cliClient;
+
+    protected final DefaultArtifactVersion oldVersionStream;
+    protected final DefaultArtifactVersion newVersionStream;
+    protected final String newVersionFromProperties;
+    protected final IQuarkusCLIAppManager quarkusCLIAppManager;
+
+    public AbstractQuarkusCliUpdateIT(DefaultArtifactVersion oldVersionStream, DefaultArtifactVersion newVersionStream) {
+        this.oldVersionStream = oldVersionStream;
+        this.newVersionStream = newVersionStream;
+
+        // takes quarkus.platform.version from maven parameters. If present, it will update to this exact BOM version
+        // otherwise it will default to update to stream
+        this.newVersionFromProperties = QuarkusProperties.getVersion();
+        this.quarkusCLIAppManager = createAppManager();
+    }
+
+    protected IQuarkusCLIAppManager createAppManager() {
+        if (this.newVersionFromProperties != null && this.newVersionFromProperties.contains("redhat")) {
+            return new RHBQPlatformAppManager(cliClient, oldVersionStream, newVersionStream,
+                    new DefaultArtifactVersion(newVersionFromProperties));
+        }
+        return new DefaultQuarkusCLIAppManager(cliClient, oldVersionStream, newVersionStream);
+    }
+
+    /**
+     * Perform basic update to new stream and check version in pom.xml matches
+     */
+    @Test
+    public void versionUpdateTest() throws IOException, XmlPullParserException {
+        QuarkusCliRestService app = quarkusCLIAppManager.createApplication();
+
+        quarkusCLIAppManager.updateApp(app);
+
+        DefaultArtifactVersion updatedVersion = getQuarkusAppVersion(app);
+        assertEquals(newVersionStream.getMajorVersion(), updatedVersion.getMajorVersion(),
+                "Major version for app updated to " + newVersionStream + "should be " + newVersionStream.getMajorVersion());
+        assertEquals(newVersionStream.getMinorVersion(), updatedVersion.getMinorVersion(),
+                "Minor version for app updated to " + newVersionStream + " should be " + newVersionStream.getMinorVersion());
+        // check that updated app is using RHBQ
+        assertTrue(updatedVersion.toString().contains("redhat"),
+                "Updated app is not using \"redhat\" version. Found version: " + updatedVersion);
+
+        Log.info("Starting updated app");
+        // start the updated app and verify that basic /hello endpoint works
+        app.start();
+        untilAsserted(() -> app.given().get("/hello").then().statusCode(HttpStatus.SC_OK),
+                AwaitilityUtils.AwaitilitySettings.usingTimeout(Duration.ofSeconds(10))
+                        .timeoutMessage("Updated app failed to expose working /hello endpoint"));
+    }
+}

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/RHBQPlatformAppManager.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/RHBQPlatformAppManager.java
@@ -1,0 +1,30 @@
+package io.quarkus.ts.quarkus.cli.update;
+
+import static io.quarkus.test.bootstrap.QuarkusCliClient.UpdateApplicationRequest.defaultUpdate;
+
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.logging.Log;
+import io.quarkus.test.util.DefaultQuarkusCLIAppManager;
+
+/**
+ * AppManager designed to update app to specific quarkus-bom version, instead of to stream as DefaultQuarkusCLIAppManager
+ */
+public class RHBQPlatformAppManager extends DefaultQuarkusCLIAppManager {
+    protected final DefaultArtifactVersion newPlatformVersion;
+
+    public RHBQPlatformAppManager(QuarkusCliClient cliClient, DefaultArtifactVersion oldStreamVersion,
+            DefaultArtifactVersion newStreamVersion, DefaultArtifactVersion newPlatformVersion) {
+        super(cliClient, oldStreamVersion, newStreamVersion);
+        this.newPlatformVersion = newPlatformVersion;
+    }
+
+    @Override
+    public void updateApp(QuarkusCliRestService app) {
+        Log.info("Updating app to version: " + newPlatformVersion);
+        app.update(defaultUpdate()
+                .withPlatformVersion(newPlatformVersion.toString()));
+    }
+}


### PR DESCRIPTION
### Summary
This PR does not work, as it requires https://github.com/quarkus-qe/quarkus-test-framework/pull/1188 to be effective here.

This makes a proposal how Quarkus CLI test could look in the future. Idea is to create common tests and other support methods in parent class and making some kind of a "framework". For each new tested version we can add new class, which should be more or else simple.

Edit: This PR requires https://github.com/quarkus-qe/quarkus-test-framework/pull/1236 and other things in framework 1.5.0.Beta13. **So do not merge until this is released and updated in TS.** 

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [X] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)