### PR TITLE
[3.8] Disable MysqlDatabaseIT and DevModeMultipleReactiveSqlClientsIT in FIPS-enabled environment

### DIFF
--- a/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeMultipleReactiveSqlClientsIT.java
+++ b/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeMultipleReactiveSqlClientsIT.java
@@ -20,6 +20,7 @@ import io.quarkus.ts.reactive.db.clients.model.NoteBook;
 import io.quarkus.ts.reactive.db.clients.model.SoftCoverBook;
 import io.vertx.core.json.JsonObject;
 
+@Tag("fips-incompatible") // TODO: enable when https://github.com/quarkusio/quarkus/issues/40526 gets fixed
 @Tag("QUARKUS-1080")
 @Tag("QUARKUS-1408")
 @QuarkusScenario

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MySqlDatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MySqlDatabaseIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.sqldb.compatibility;
 
+import org.junit.jupiter.api.Tag;
+
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -7,6 +9,7 @@ import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
+@Tag("fips-incompatible") // disabled as only works in 3.9+
 @QuarkusScenario
 @DisabledOnNative(reason = "Compatibility mode check in JVM mode is enough for this DB")
 public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MySqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MySqlDatabaseIT.java
@@ -1,11 +1,14 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
+import org.junit.jupiter.api.Tag;
+
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
+@Tag("fips-incompatible") // disabled as only works in 3.9+
 @QuarkusScenario
 public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {
 


### PR DESCRIPTION
### Summary

- backports https://github.com/quarkus-qe/quarkus-test-suite/pull/1867
- MySqlDatabaseIT is disabled in FIPS-enabled environment as it only works in 3.9+

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)