### PR TITLE
Test to verify that failed unis are not cached

### DIFF
--- a/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/ReactiveWithCacheResource.java
+++ b/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/ReactiveWithCacheResource.java
@@ -4,6 +4,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
 
 import io.quarkus.cache.CacheInvalidate;
 import io.quarkus.cache.CacheInvalidateAll;
@@ -53,4 +54,16 @@ public class ReactiveWithCacheResource {
     public Uni<Void> invalidateAll() {
         return Uni.createFrom().nullItem();
     }
+
+    @GET
+    @Path("/failing-value")
+    @CacheResult(cacheName = CACHE_NAME)
+    public Uni<String> getFailingValue(@QueryParam("fail") boolean fail) {
+        if (fail) {
+            return Uni.createFrom().failure(new RuntimeException("Simulated error for cache"));
+        } else {
+            return Uni.createFrom().item("Value " + counter++);
+        }
+    }
+
 }


### PR DESCRIPTION
### Summary

Add test  to verify that failed unis are not cached according this fix:

https://github.com/quarkusio/quarkus/pull/39762 

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)