### PR TITLE
[3.8] [QUARKUS-4184] Re-enable CLI Gradle test

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -118,7 +118,6 @@ public class QuarkusCliCreateJvmApplicationIT {
 
     @Tag("QUARKUS-1071")
     @Test
-    @DisabledOnQuarkusVersion(version = "3.8.*redhat.*", reason = "https://issues.redhat.com/browse/QUARKUS-4184")
     public void shouldCreateApplicationWithGradleOnJvm() {
 
         // Create application


### PR DESCRIPTION
### Summary

* Re-enabling test that's fixed in Quarkus 3.8.5.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)