### PR TITLE
Add test to verify failed unis are not cached

### DIFF
--- a/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/ReactiveWithCacheResource.java
+++ b/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/ReactiveWithCacheResource.java
@@ -1,9 +1,12 @@
 package io.quarkus.ts.cache.caffeine;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Response;
 
 import io.quarkus.cache.CacheInvalidate;
 import io.quarkus.cache.CacheInvalidateAll;
@@ -19,6 +22,7 @@ public class ReactiveWithCacheResource {
     private static final String CACHE_NAME = "api-reactive-cache";
 
     private static int counter = 0;
+    private AtomicInteger atomicCounter = new AtomicInteger(0);
 
     @GET
     @CacheResult(cacheName = CACHE_NAME)
@@ -53,4 +57,23 @@ public class ReactiveWithCacheResource {
     public Uni<Void> invalidateAll() {
         return Uni.createFrom().nullItem();
     }
+
+    @GET
+    @Path("/failure/{key}")
+    @CacheResult(cacheName = CACHE_NAME)
+    public Uni<Response> getValueWithFailure(@PathParam("key") @CacheKey String key) {
+
+        int currentCounter = incrementCounter();
+        // Simulate a failure based on the key
+        if (currentCounter == 0) {
+            return Uni.createFrom().failure(new RuntimeException("Simulated failure for key: " + key));
+        } else {
+            return Uni.createFrom().item(Response.ok("Success for key: " + key).build());
+        }
+    }
+
+    private int incrementCounter() {
+        return atomicCounter.getAndIncrement();
+    }
+
 }


### PR DESCRIPTION
### Summary

Add test to verify that failed unis are not cached according the backport fix in 3.8.:

https://github.com/quarkusio/quarkus/pull/39762

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)