### PR TITLE
[3.8] [QUARKUS-4541] Fix test to verify that failed unis are not cached

### DIFF
--- a/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/ReactiveWithCacheResource.java
+++ b/cache/caffeine/src/main/java/io/quarkus/ts/cache/caffeine/ReactiveWithCacheResource.java
@@ -1,10 +1,12 @@
 package io.quarkus.ts.cache.caffeine;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
 
 import io.quarkus.cache.CacheInvalidate;
 import io.quarkus.cache.CacheInvalidateAll;
@@ -20,6 +22,7 @@ public class ReactiveWithCacheResource {
     private static final String CACHE_NAME = "api-reactive-cache";
 
     private static int counter = 0;
+    private AtomicInteger atomicCounter = new AtomicInteger(0);
 
     @GET
     @CacheResult(cacheName = CACHE_NAME)
@@ -56,14 +59,22 @@ public class ReactiveWithCacheResource {
     }
 
     @GET
-    @Path("/failing-value")
+    @Path("/failure/{key}")
     @CacheResult(cacheName = CACHE_NAME)
-    public Uni<String> getFailingValue(@QueryParam("fail") boolean fail) {
-        if (fail) {
-            return Uni.createFrom().failure(new RuntimeException("Simulated error for cache"));
+    public Uni<Response> getValueWithFailure(@PathParam("key") @CacheKey String key) {
+
+        int currentCounter = incrementCounter();
+
+        // Simulate a failure based on the key
+        if (currentCounter == 0) {
+            return Uni.createFrom().failure(new RuntimeException("Simulated failure for key: " + key));
         } else {
-            return Uni.createFrom().item("Value " + counter++);
+            return Uni.createFrom().item(Response.ok("Success for key: " + key).build());
         }
+    }
+
+    private int incrementCounter() {
+        return atomicCounter.getAndIncrement();
     }
 
 }

--- a/cache/caffeine/src/test/java/io/quarkus/ts/cache/caffeine/cache/caffeine/CaffeineCacheIT.java
+++ b/cache/caffeine/src/test/java/io/quarkus/ts/cache/caffeine/cache/caffeine/CaffeineCacheIT.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.restassured.response.Response;
 
 @QuarkusScenario
 public class CaffeineCacheIT {
@@ -79,24 +80,24 @@ public class CaffeineCacheIT {
      */
     @Tag("QUARKUS-4541")
     @Test
-    public void shouldNotbeTheFailureCached() {
-        String path = RESOURCE_REACTIVE_API_PATH + "/failing-value";
+    public void shouldNotCacheFailures() {
+        String path = RESOURCE_REACTIVE_API_PATH + "/failure/key-failure";
+
         // First call to register the failure
         given()
-                .queryParam("fail", true)
                 .when().get(path)
                 .then()
                 .statusCode(500);
 
-        // second call to be success
-        String value = given()
-                .queryParam("fail", false)
+        // second call should be success
+        Response response = given()
                 .when().get(path)
                 .then()
-                .statusCode(200)
-                .extract().asString();
+                .extract()
+                .response();
 
-        assertEquals("Value 0", value, "Value should be 'Value 0' if not the failures is being cached");
+        assertNotEquals(500, response.statusCode(), "The failure has been cached and should not be");
+        assertEquals("Success for key: key-failure", response.asString());
 
     }
 


### PR DESCRIPTION
### Summary

Fix logic test to verify that failed unis are not cached according this fix:

https://github.com/quarkusio/quarkus/pull/39762
It's backport of https://github.com/quarkus-qe/quarkus-test-suite/pull/1873#pullrequestreview-2165906696

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)