### PR TITLE
[3.2] Update framework to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.2.12.Final</quarkus.platform.version>
         <quarkus.ide.version>3.2.12.Final</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.3.0.Beta32</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.3.1.Final</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.4.0</quarkus-qpid-jms.version>
         <apache-httpclient-fluent.version>4.5.14</apache-httpclient-fluent.version>
         <confluent.kafka-avro-serializer.version>7.3.1</confluent.kafka-avro-serializer.version>

--- a/websockets/quarkus-websockets/pom.xml
+++ b/websockets/quarkus-websockets/pom.xml
@@ -14,5 +14,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-websockets</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-routes</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
### Summary
Update framework to the 1.3.1 and fix weird compilation failure in websockets, where java was not able to find io.quarkus.vertx.web.RouteFilter

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)