### PR TITLE
Fix MySQL container host used in AgroalPoolTest as Windows tests are using remote Docker client

### DIFF
--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/MySqlDatabaseTestResource.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/MySqlDatabaseTestResource.java
@@ -45,7 +45,7 @@ public class MySqlDatabaseTestResource implements QuarkusTestResourceLifecycleMa
         container.withEnv(DATABASE_PROPERTY, DEFAULT_SCHEMA);
         container.start();
 
-        var jdbcUrl = "jdbc:mysql://localhost:%d/%s".formatted(container.getMappedPort(3306), DEFAULT_SCHEMA);
+        var jdbcUrl = "jdbc:mysql://%s:%d/%s".formatted(container.getHost(), container.getMappedPort(3306), DEFAULT_SCHEMA);
         Map<String, String> config = new HashMap<>();
         config.put(defaultDataSource(QUARKUS_DB_JDBC_URL), jdbcUrl);
         config.put(defaultDataSource(QUARKUS_DB_USER), USER);


### PR DESCRIPTION
### Summary

We cannot rely on `localhost`. This is consequence of my PR https://github.com/quarkus-qe/quarkus-test-suite/pull/1782 but it only demonstrates when run on our Windows runners that rely on Minikube.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)