### PR TITLE
Fix gRPC DEV UI tests on Windows as Vaadin grid is formed differently and we cannot see shadow DOM content

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeGrpcIntegrationReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeGrpcIntegrationReactiveIT.java
@@ -3,6 +3,7 @@ package io.quarkus.ts.http.advanced.reactive;
 import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.ExecutionException;
@@ -34,12 +35,17 @@ public class DevModeGrpcIntegrationReactiveIT {
 
     /**
      * Expect streaming service and hello service definition from 'helloworld.proto'
-     * as well as full generated service names and communication method type (UNARY, CLIENT_STREAMING, ...).
+     * and communication method type (UNARY, CLIENT_STREAMING, ...).
      */
     private static final String[] GRPC_SERVICE_VIEW_EXPECTED_CONTENT = {
-            "UNARY", "helloworld.Greeter", "io.quarkus.ts.http.advanced.reactive.GrpcService", "SayHello", "SERVER_STREAMING",
-            "io.quarkus.ts.http.advanced.reactive.GrpcStreamingService", "BIDI_STREAMING", "CLIENT_STREAMING", "ServerStream",
+            "UNARY", "helloworld.Greeter", "SayHello", "SERVER_STREAMING",
+            "BIDI_STREAMING", "CLIENT_STREAMING", "ServerStream",
             "BidirectionalStream", "ClientStream"
+    };
+
+    private static final String[] GRPC_SERVICE_IMPLEMENTATION_CLASSES = {
+            "io.quarkus.ts.http.advanced.reactive.GrpcService",
+            "io.quarkus.ts.http.advanced.reactive.GrpcStreamingService"
     };
 
     @DevModeQuarkusApplication(grpc = true)
@@ -78,6 +84,15 @@ public class DevModeGrpcIntegrationReactiveIT {
             var grpcSvcView = page.waitForSelector("#page > qwc-grpc-services > vaadin-grid").innerText();
             for (String text : GRPC_SERVICE_VIEW_EXPECTED_CONTENT) {
                 assertTrue(grpcSvcView.contains(text), "DevUI gRPC services view is incomplete: " + grpcSvcView);
+            }
+            // search for gRPC service implementation classes differently as they are in a shadow root and sometimes
+            // (like on Windows) they cannot be accessed
+            for (String implClass : GRPC_SERVICE_IMPLEMENTATION_CLASSES) {
+                var locator = page.getByText(implClass);
+                assertNotNull(locator, "DevUI gRPC services view is missing implementation class:" + implClass);
+                assertNotNull(locator.textContent(), "DevUI gRPC services view is missing implementation class:" + implClass);
+                assertTrue(locator.textContent().contains(implClass),
+                        "DevUI gRPC services view is missing implementation class:" + implClass);
             }
         });
     }


### PR DESCRIPTION
### Summary

These tests were long disabled, I enabled and refactored them lately https://github.com/quarkus-qe/quarkus-test-suite/pull/1833 but it turns out that Playwright doesn't return same content of shadow DOMs. I think gRPC service implementations needs to be accessed directly as they are in visible DOM.

For context, the check I am changing here wasn't part of original test development, I included it as it seems right that implementation class signatures should be displayed.

Tested this PR both on Windows and Linux and works. Original failures can only be reproduced on Windows runners with Docker as we don't run DEV mode tests on GitHub runners. Reason for this is that we cannot detect automatically if Dev Service requiring Linux containers is started.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)