### PR TITLE
Increase the await time and add quarkus.otel.bsp.schedule.delay property in ProdAmqpReactiveIT on messaging-amqp-reactive module  to avoid intermitent error in CI 

### DIFF
--- a/messaging/amqp-reactive/src/test/java/io/quarkus/ts/messaging/amqpreactive/ProdAmqpReactiveIT.java
+++ b/messaging/amqp-reactive/src/test/java/io/quarkus/ts/messaging/amqpreactive/ProdAmqpReactiveIT.java
@@ -32,7 +32,8 @@ public class ProdAmqpReactiveIT extends BaseAmqpReactiveIT {
     static RestService app = new RestService()
             .withProperty("amqp-host", amq::getAmqpHost)
             .withProperty("amqp-port", () -> "" + amq.getPort())
-            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
+            .withProperty("quarkus.otel.bsp.schedule.delay", "700ms");
 
     private Response resp;
 


### PR DESCRIPTION
### Summary

There are some daily builds failed in native mode on  messaging-amqp-reactive module :

https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/9801813961/job/27065934362 

https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/9815533151/job/27105022373

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 22.14 s <<< FAILURE! -- in io.quarkus.ts.messaging.amqpreactive.ProdAmqpReactiveIT
2024-07-11T02:05:07.0393352Z [ERROR] io.quarkus.ts.messaging.amqpreactive.ProdAmqpReactiveIT.testContextPropagation -- Time elapsed: 5.096 s <<< ERROR!
2024-07-11T02:05:07.0394844Z org.awaitility.core.ConditionTimeoutException: 
2024-07-11T02:05:07.0396314Z Assertion condition defined as a Lambda expression in io.quarkus.ts.messaging.amqpreactive.ProdAmqpReactiveIT 1 expectation failed.
2024-07-11T02:05:07.0397826Z JSON path data[0].spans.size() doesn't match.
2024-07-11T02:05:07.0398823Z Expected: is <1>
2024-07-11T02:05:07.0399278Z   Actual: null
2024-07-11T02:05:07.0399775Z  within 5 seconds.
2024-07-11T02:05:07.0400586Z 	at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:167)
2024-07-11T02:05:07.0401927Z 	at org.awaitility.core.AssertionCondition.await(AssertionCondition.java:119)
2024-07-11T02:05:07.0402845Z 	at org.awaitility.core.AssertionCondition.await(AssertionCondition.java:31)
2024-07-11T02:05:07.0403641Z 	at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:1006)
2024-07-11T02:05:07.0404525Z 	at org.awaitility.core.ConditionFactory.untilAsserted(ConditionFactory.java:790)
2024-07-11T02:05:07.0406224Z 	at io.quarkus.ts.messaging.amqpreactive.ProdAmqpReactiveIT.testContextPropagation(ProdAmqpReactiveIT.java:45)
2024-07-11T02:05:07.0407787Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
2024-07-11T02:05:07.0408862Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
2024-07-11T02:05:07.0410181Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
2024-07-11T02:05:07.0411213Z Caused by: java.lang.AssertionError: 1 expectation failed.
2024-07-11T02:05:07.0412303Z JSON path data[0].spans.size() doesn't match.
2024-07-11T02:05:07.0413229Z Expected: is <1>
2024-07-11T02:05:07.0413712Z   Actual: null
2024-07-11T02:05:07.0414042Z 
2024-07-11T02:05:07.0414770Z 	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
2024-07-11T02:05:07.0417186Z 	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
2024-07-11T02:05:07.0419418Z 	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
2024-07-11T02:05:07.0421423Z 	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
2024-07-11T02:05:07.0423361Z 	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
2024-07-11T02:05:07.0424883Z 	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:73)
2024-07-11T02:05:07.0426907Z 	at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrapNoCoerce.callConstructor(ConstructorSite.java:108)
2024-07-11T02:05:07.0429275Z 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:277)
2024-07-11T02:05:07.0431374Z 	at io.restassured.internal.ResponseSpecificationImpl$HamcrestAssertionClosure.validate(ResponseSpecificationImpl.groovy:512)
2024-07-11T02:05:07.0433666Z 	at io.restassured.internal.ResponseSpecificationImpl$HamcrestAssertionClosure$validate$1.call(Unknown Source)
2024-07-11T02:05:07.0435765Z 	at io.restassured.internal.ResponseSpecificationImpl.validateResponseIfRequired(ResponseSpecificationImpl.groovy:696)
2024-07-11T02:05:07.0438416Z 	at io.restassured.internal.ResponseSpecificationImpl.this$2$validateResponseIfRequired(ResponseSpecificationImpl.groovy)
2024-07-11T02:05:07.0440484Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2024-07-11T02:05:07.0442097Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
2024-07-11T02:05:07.0444025Z 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2024-07-11T02:05:07.0445713Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
2024-07-11T02:05:07.0447295Z 	at org.codehaus.groovy.runtime.callsite.PlainObjectMetaMethodSite.doInvoke(PlainObjectMetaMethodSite.java:43)
2024-07-11T02:05:07.0449578Z 	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:198)
2024-07-11T02:05:07.0451837Z 	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:62)
2024-07-11T02:05:07.0453773Z 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:185)
2024-07-11T02:05:07.0455817Z 	at io.restassured.internal.ResponseSpecificationImpl.body(ResponseSpecificationImpl.groovy:270)
2024-07-11T02:05:07.0457597Z 	at io.restassured.specification.ResponseSpecification$body$1.callCurrent(Unknown Source)
2024-07-11T02:05:07.0459296Z 	at io.restassured.internal.ResponseSpecificationImpl.body(ResponseSpecificationImpl.groovy:117)
2024-07-11T02:05:07.0461139Z 	at io.restassured.internal.ValidatableResponseOptionsImpl.body(ValidatableResponseOptionsImpl.java:244)
2024-07-11T02:05:07.0463438Z 	at io.quarkus.ts.messaging.amqpreactive.ProdAmqpReactiveIT.thenTraceSpanSizeMustBe(ProdAmqpReactiveIT.java:64)
2024-07-11T02:05:07.0465594Z 	at io.quarkus.ts.messaging.amqpreactive.ProdAmqpReactiveIT.lambda$testContextPropagation$1(ProdAmqpReactiveIT.java:47)
2024-07-11T02:05:07.0467375Z 	at org.awaitility.core.AssertionCondition.lambda$new$0(AssertionCondition.java:53)
2024-07-11T02:05:07.0468948Z 	at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:248)
2024-07-11T02:05:07.0470445Z 	at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:235)
2024-07-11T02:05:07.0471771Z 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
2024-07-11T02:05:07.0473360Z 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
2024-07-11T02:05:07.0475029Z 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
2024-07-11T02:05:07.0476602Z 	at java.base/java.lang.Thread.run(Thread.java:840) 
```

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)