### PR TITLE
Fix possible CI (detect modules) failure because of the special characters in filename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,13 @@ jobs:
           CHANGED=""
           MODULES_ARG=""
 
+          # If changed file have some special character, its path is surrounded with quotes which causing the if statement fail
+          CHANGED_FILE=$(echo ${{ steps.files.outputs.all_changed_and_modified_files }} | sed 's/\"/\\"/')
+
           for module in $MODULES
           do
-            if [[ "${{ steps.files.outputs.all_changed_and_modified_files }}" =~ ("$module") ]] ; then
-              CHANGED=$(echo $CHANGED" "$module)
+            if [[ $CHANGED_FILE =~ ("$module") ]] ; then
+                CHANGED=$(echo $CHANGED" "$module)
             fi
           done
 


### PR DESCRIPTION
### Summary

This is port from https://github.com/quarkus-qe/quarkus-test-suite/pull/1866 because the name of [file](https://github.com/quarkus-qe/quarkus-test-suite/pull/1866/files#diff-4b63f5a6e9db4df956e6009a8113f592e5b43ffe603949d060255ad90bcb216e) contains special character. This wasn't caught on main because of some wierd bug with CI where it sometimes don't detecting files.

Don't expect this happend much often but it's better to have it in main also

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)