### PR TITLE
Fix platform and core version assumption for buildtimeanalytics tests

### DIFF
--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AbstractAnalyticsIT.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AbstractAnalyticsIT.java
@@ -141,12 +141,17 @@ public abstract class AbstractAnalyticsIT {
                 .map(payloadExtension -> mapToGA(payloadExtension.getGroupId(), payloadExtension.getArtifactId()))
                 .collect(Collectors.toList());
         assertEquals(pomDependencyGAs, payloadExtensionGAs);
-        List<PayloadExtension> extensionsWithMismatchedVersion = payloadExtensions.stream()
-                .filter(extension -> !QUARKUS_EXTENSION_VERSION_PATTERN.matcher(extension.getVersion()).matches())
-                .collect(Collectors.toList());
-        assertEquals(0, extensionsWithMismatchedVersion.size(),
-                String.format("All extensions versions must match pattern: '%s'. Offending extensions: %s",
-                        QUARKUS_EXTENSION_VERSION_PATTERN.pattern(), extensionsWithMismatchedVersion));
+
+        // RHBQ doesn't guarantee the same version of the platform and core extensions
+        boolean isRHBQ = QuarkusProperties.getVersion().contains("redhat");
+        if (!isRHBQ) {
+            List<PayloadExtension> extensionsWithMismatchedVersion = payloadExtensions.stream()
+                    .filter(extension -> !QUARKUS_EXTENSION_VERSION_PATTERN.matcher(extension.getVersion()).matches())
+                    .collect(Collectors.toList());
+            assertEquals(0, extensionsWithMismatchedVersion.size(),
+                    String.format("All extensions versions must match pattern: '%s'. Offending extensions: %s",
+                            QUARKUS_EXTENSION_VERSION_PATTERN.pattern(), extensionsWithMismatchedVersion));
+        }
     }
 
     private List<Dependency> getPomDependencies(QuarkusCliRestService app) {


### PR DESCRIPTION
Fix platform and core version assumption for buildtimeanalytics tests

An example of problematic failure from RHBQ run
```
All extensions versions must match pattern: '3.8.5.SP1-redhat-00001'. Offending extensions: 
  [io.quarkus:quarkus-arc:3.8.5.redhat-00004] ==> expected: <0> but was: <1>
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)