### PR TITLE
Fix MSSQL setup for narayana XA transactions

### DIFF
--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
@@ -26,8 +26,8 @@ public class MssqlTransactionGeneralUsageIT extends TransactionCommons {
             self
                     .<GenericContainer<?>> getPropertyFromContext(DOCKER_INNER_CONTAINER)
                     .execInContainer(
-                            "/opt/mssql-tools/bin/sqlcmd", "-S", "localhost", "-U", self.getUser(), "-P", self.getPassword(),
-                            "-Q", "EXEC sp_sqljdbc_xa_install");
+                            "/opt/mssql-tools18/bin/sqlcmd", "-C", "-S", "localhost", "-U", self.getUser(),
+                            "-P", self.getPassword(), "-Q", "EXEC sp_sqljdbc_xa_install");
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
### Summary

Adding `-C` argument to automaticaly trust server certificate (docs [here](https://learn.microsoft.com/en-us/sql/tools/sqlcmd/sqlcmd-utility?view=sql-server-ver16&tabs=go%2Clinux&pivots=cs1-bash#-c)). It seems that latest update change now need trusted certificate by default. 

Also for some unknow reason the `mssql-tools` dir change the name to `mssql-tools18`.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)