### PR TITLE
Disable Quarkus CLI config tests on Quarkus version older than 3.13 due to breaking changes between 3.13 and 3.12

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigEncryptIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigEncryptIT.java
@@ -28,8 +28,10 @@ import io.quarkus.test.bootstrap.config.QuarkusEncryptConfigCommandBuilder.Encry
 import io.quarkus.test.bootstrap.config.QuarkusEncryptConfigCommandBuilder.EncryptionKeyOpt;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.ts.quarkus.cli.config.surefire.EncryptPropertyTest;
 
+@DisabledOnQuarkusVersion(version = "3\\.(9|10|11|12)\\..*", reason = "https://github.com/quarkusio/quarkus/pull/41203 merged in 3.13")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class) // remember, this is stateful test as well as stateful cmd builder
 @Tag("QUARKUS-3456")
 @Tag("quarkus-cli")

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigRemoveIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigRemoveIT.java
@@ -13,8 +13,10 @@ import org.junit.jupiter.api.TestMethodOrder;
 import io.quarkus.test.bootstrap.config.QuarkusConfigCommand;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.ts.quarkus.cli.config.surefire.RemovePropertyTest;
 
+@DisabledOnQuarkusVersion(version = "3\\.(9|10|11|12)\\..*", reason = "https://github.com/quarkusio/quarkus/pull/41203 merged in 3.13")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class) // remember, this is stateful test as well as stateful cmd builder
 @Tag("QUARKUS-3456")
 @Tag("quarkus-cli")

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigSetIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigSetIT.java
@@ -20,8 +20,10 @@ import io.quarkus.test.bootstrap.config.QuarkusConfigCommand;
 import io.quarkus.test.bootstrap.config.QuarkusSetConfigCommandBuilder.EncryptOption;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.ts.quarkus.cli.config.surefire.SetPropertyTest;
 
+@DisabledOnQuarkusVersion(version = "3\\.(9|10|11|12)\\..*", reason = "https://github.com/quarkusio/quarkus/pull/41203 merged in 3.13")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class) // remember, this is stateful test as well as stateful cmd builder
 @Tag("QUARKUS-3456")
 @Tag("quarkus-cli")


### PR DESCRIPTION
### Summary

Disabling tests introduced in https://github.com/quarkus-qe/quarkus-test-suite/pull/1902 to fix Windows failures and make it possible to run Quarkus CLI module with older versions.

- https://github.com/quarkusio/quarkus/pull/41203 introduced breaking changes that I didn't mention
- ATM our Windows runners use the latest released Quarkus 3.12
- if anyone want to run Quarkus CLI module with older version to debug older versions, the test would fail

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)