### PR TITLE
[3.8] Disable OpenShiftTodoDemoIT in IBM PE/Z Maven profile as webbundler does not have supported for s390x & ppc64le. 

### DIFF
--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftTodoDemoIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftTodoDemoIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.external.applications;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.PostgresqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -8,6 +10,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
 @DisabledOnNative(reason = "Native + s2i not supported")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "webbundler does not have supported for s390x & ppc64le.")
 @OpenShiftScenario
 public class OpenShiftTodoDemoIT extends AbstractTodoDemoIT {
 


### PR DESCRIPTION


### Summary

webbundler does not have supported for s390x & ppc64le. OpenShiftTodoDemoIT for p/z
Please select the relevant options.


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)