### PR TITLE
Updating PR CI to run full native if no changes in modules are detected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,8 @@ jobs:
           echo "MODULES_ARG=$MODULES_ARG" >> $GITHUB_OUTPUT
     outputs:
       MODULES_ARG: ${{ steps.detect-changes.outputs.MODULES_ARG }}
-  prepare-jvm-latest-modules-mvn-param:
-    name: Prepare Maven Params For Linux JVM Build
+  prepare-jvm-native-latest-modules-mvn-param:
+    name: Prepare Maven Params For Linux JVM and native Build
     runs-on: ubuntu-latest
     needs: [ detect-test-suite-modules ]
     env:
@@ -103,21 +103,27 @@ jobs:
         run: |
           if [[ -n ${MODULES_ARG} ]]; then
             echo "Running modules: ${MODULES_ARG}"
-            echo "MODULES_MAVEN_PARAM=[\" -pl ${MODULES_ARG} -Dall-modules\"]" >> $GITHUB_OUTPUT
+            echo "JVM_MODULES_MAVEN_PARAM=[\" -pl ${MODULES_ARG} -Dall-modules\"]" >> $GITHUB_OUTPUT
+            echo "NATIVE_MODULES_MAVEN_PARAM=[\" -pl ${MODULES_ARG} -Dall-modules\"]" >> $GITHUB_OUTPUT
           else
-            echo "MODULES_MAVEN_PARAM=[' -P root-modules,cache-modules,spring-modules,http-modules,test-tooling-modules,messaging-modules,monitoring-modules', ' -P security-modules,sql-db-modules,websockets-modules']" >> $GITHUB_OUTPUT
+            echo "JVM_MODULES_MAVEN_PARAM=[' -P root-modules,cache-modules,spring-modules,http-modules,test-tooling-modules,messaging-modules,monitoring-modules', ' -P security-modules,sql-db-modules,websockets-modules']" >> $GITHUB_OUTPUT
+            echo "NATIVE_MODULES_MAVEN_PARAM=[' -P root-modules,websockets-modules,test-tooling-modules,nosql-db-modules', ' -P http-modules,cache-modules', ' -P security-modules,spring-modules',
+              ' -P sql-db-modules -pl env-info,sql-db/hibernate,sql-db/sql-app,sql-db/sql-app-compatibility,sql-db/multiple-pus,sql-db/panache-flyway,sql-db/hibernate-reactive',
+              ' -P sql-db-modules -pl env-info,sql-db/reactive-rest-data-panache,sql-db/vertx-sql,sql-db/reactive-vanilla,sql-db/hibernate-fulltext-search,sql-db/narayana-transactions',
+              ' -P messaging-modules,monitoring-modules']" | tr -d -s '\n' ' ' >> $GITHUB_OUTPUT
           fi
     outputs:
-      MODULES_MAVEN_PARAM: ${{ steps.prepare-modules-mvn-param.outputs.MODULES_MAVEN_PARAM }}
+      JVM_MODULES_MAVEN_PARAM: ${{ steps.prepare-modules-mvn-param.outputs.JVM_MODULES_MAVEN_PARAM }}
+      NATIVE_MODULES_MAVEN_PARAM: ${{ steps.prepare-modules-mvn-param.outputs.NATIVE_MODULES_MAVEN_PARAM }}
   linux-build-jvm-latest:
     name: PR - Linux - JVM build - Latest Version
     runs-on: ubuntu-latest
     timeout-minutes: 240
-    needs: prepare-jvm-latest-modules-mvn-param
+    needs: prepare-jvm-native-latest-modules-mvn-param
     strategy:
       matrix:
         java: [ 17 ]
-        module-mvn-args: ${{ fromJSON(needs.prepare-jvm-latest-modules-mvn-param.outputs.MODULES_MAVEN_PARAM) }}
+        module-mvn-args: ${{ fromJSON(needs.prepare-jvm-native-latest-modules-mvn-param.outputs.JVM_MODULES_MAVEN_PARAM) }}
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
     steps:
@@ -167,12 +173,11 @@ jobs:
   linux-build-native-latest:
     name: PR - Linux - Native build - Latest Version
     runs-on: ubuntu-latest
-    needs: detect-test-suite-modules
-    env:
-      MODULES_ARG: ${{ needs.detect-test-suite-modules.outputs.MODULES_ARG }}
+    needs: prepare-jvm-native-latest-modules-mvn-param
     strategy:
       matrix:
         java: [ 17 ]
+        module-mvn-args: ${{ fromJSON(needs.prepare-jvm-native-latest-modules-mvn-param.outputs.NATIVE_MODULES_MAVEN_PARAM) }}
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
     steps:
@@ -205,13 +210,10 @@ jobs:
           ./quarkus-dev-cli version
       - name: Build with Maven
         run: |
-          if [[ -n ${MODULES_ARG} ]]; then
-            echo "Running modules: ${MODULES_ARG}"
-            mvn -fae -V -B -s .github/mvn-settings.xml -fae -Dall-modules \
+            mvn -fae -V -B -s .github/mvn-settings.xml -fae \
                         -Dquarkus.native.native-image-xmx=5g \
                         -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" \
-                        -pl $MODULES_ARG clean verify -Dnative -am
-          fi
+                        ${{ matrix.module-mvn-args }} clean verify -Dnative -am
       - name: Detect flaky tests
         id: flaky-test-detector
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -92,12 +92,12 @@ jobs:
       matrix:
         java: [ 17 ]
         image: [ "ubi-quarkus-graalvmce-builder-image:jdk-21", "ubi-quarkus-mandrel-builder-image:jdk-21" ]
-        profiles: [ "root-modules",
+        profiles: [ "root-modules,websockets-modules,test-tooling-modules,nosql-db-modules",
                    "http-modules,cache-modules",
                    "security-modules,spring-modules",
                     "sql-db-modules -pl env-info,sql-db/hibernate,sql-db/sql-app,sql-db/sql-app-compatibility,sql-db/multiple-pus,sql-db/panache-flyway,sql-db/hibernate-reactive",
                     "sql-db-modules -pl env-info,sql-db/reactive-rest-data-panache,sql-db/vertx-sql,sql-db/reactive-vanilla,sql-db/hibernate-fulltext-search,sql-db/narayana-transactions",
-                   "messaging-modules,websockets-modules,monitoring-modules,test-tooling-modules,nosql-db-modules"]
+                   "messaging-modules,monitoring-modules"]
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space


### PR DESCRIPTION
### Summary

Adding the logic to run the Linux native run if no modules are detected. This change not include windows as on PRs we don't even run native windows.

I decided make `NATIVE_MODULES_MAVEN_PARAM`  on multiple row as it's more readable. So I need to clean it with `tr -d -s '\n' ' '` for env variable to be one line string.

Also updating the modules load for native execution time be similar for all modules.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)