### PR TITLE
Rename package names in redis cache module

### DIFF
--- a/cache/redis/src/main/java/io/quarkus/ts/cache/redis/ApplicationScopeService.java
+++ b/cache/redis/src/main/java/io/quarkus/ts/cache/redis/ApplicationScopeService.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.cache.caffeine;
+package io.quarkus.ts.cache.redis;
 
 import jakarta.enterprise.context.ApplicationScoped;
 

--- a/cache/redis/src/main/java/io/quarkus/ts/cache/redis/BaseServiceWithCache.java
+++ b/cache/redis/src/main/java/io/quarkus/ts/cache/redis/BaseServiceWithCache.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.cache.caffeine;
+package io.quarkus.ts.cache.redis;
 
 import io.quarkus.cache.CacheInvalidate;
 import io.quarkus.cache.CacheInvalidateAll;

--- a/cache/redis/src/main/java/io/quarkus/ts/cache/redis/RequestScopeService.java
+++ b/cache/redis/src/main/java/io/quarkus/ts/cache/redis/RequestScopeService.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.cache.caffeine;
+package io.quarkus.ts.cache.redis;
 
 import jakarta.enterprise.context.RequestScoped;
 

--- a/cache/redis/src/main/java/io/quarkus/ts/cache/redis/ServiceWithCacheResource.java
+++ b/cache/redis/src/main/java/io/quarkus/ts/cache/redis/ServiceWithCacheResource.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.cache.caffeine;
+package io.quarkus.ts.cache.redis;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;

--- a/cache/redis/src/main/java/io/quarkus/ts/cache/redis/TemplateCacheResource.java
+++ b/cache/redis/src/main/java/io/quarkus/ts/cache/redis/TemplateCacheResource.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.cache.caffeine;
+package io.quarkus.ts.cache.redis;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;

--- a/cache/redis/src/test/java/io/quarkus/ts/cache/redis/RedisCacheIT.java
+++ b/cache/redis/src/test/java/io/quarkus/ts/cache/redis/RedisCacheIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.ts.cache.redis;
 
-import static io.quarkus.ts.cache.caffeine.ServiceWithCacheResource.APPLICATION_SCOPE_SERVICE_PATH;
-import static io.quarkus.ts.cache.caffeine.ServiceWithCacheResource.REQUEST_SCOPE_SERVICE_PATH;
+import static io.quarkus.ts.cache.redis.ServiceWithCacheResource.APPLICATION_SCOPE_SERVICE_PATH;
+import static io.quarkus.ts.cache.redis.ServiceWithCacheResource.REQUEST_SCOPE_SERVICE_PATH;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
### Summary

Fix package names inside `cache/redis` module. I think, them were copied from `cache/caffeine` without change.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)