### PR TITLE
Fix secretFormat on QuarkusCliConfigEncryptIT for Windows job

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigEncryptIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigEncryptIT.java
@@ -41,6 +41,7 @@ public class QuarkusCliConfigEncryptIT {
 
     private static QuarkusEncryptConfigCommandBuilder encryptBuilder = null;
     private static String encryptionKey = null;
+    private static final String secretFormat = OS.WINDOWS.isCurrentOs() ? "\"%s\"" : "%s";
 
     @Inject
     static QuarkusConfigCommand configCommand;
@@ -63,9 +64,8 @@ public class QuarkusCliConfigEncryptIT {
                 .secretConsumer(Assertions::assertNotNull)
                 .storeSecretAsSecretExpression(SECRET_1.propertyName)
                 .generatedKeyConsumer(encKey -> encryptionKey = encKey)
-                .assertCommandOutputContains("""
-                        The secret %s was encrypted to
-                        """.formatted(SECRET_1.secret))
+                .assertCommandOutputContains(String.format("The secret " + secretFormat
+                        + " was encrypted to", SECRET_1.secret))
                 .assertCommandOutputContains("""
                         with the generated encryption key (base64):
                         """);
@@ -84,9 +84,8 @@ public class QuarkusCliConfigEncryptIT {
                 .executeCommand()
                 .secretConsumer(Assertions::assertNotNull)
                 .storeSecretAsSecretExpression(SECRET_2.propertyName)
-                .assertCommandOutputContains("""
-                        The secret %s was encrypted to
-                        """.formatted(SECRET_2.secret))
+                .assertCommandOutputContains(String.format("The secret " + secretFormat
+                        + " was encrypted to", SECRET_2.secret))
                 .assertCommandOutputNotContains("with the generated encryption key");
     }
 
@@ -109,9 +108,8 @@ public class QuarkusCliConfigEncryptIT {
                 .secretConsumer(Assertions::assertNotNull)
                 .storeSecretAsSecretExpression(SECRET_3.propertyName)
                 .storeSecretAsRawValue(ENCRYPTED_SECRET_3_PROPERTY)
-                .assertCommandOutputContains("""
-                        The secret %s was encrypted to
-                        """.formatted(SECRET_3.secret))
+                .assertCommandOutputContains(String.format("The secret " + secretFormat
+                        + " was encrypted to", SECRET_3.secret))
                 .assertCommandOutputNotContains("with the generated encryption key");
     }
 
@@ -152,9 +150,8 @@ public class QuarkusCliConfigEncryptIT {
                 .assertApplicationPropertiesDoesNotContain(SECRET_4.secret)
                 .assertApplicationPropertiesDoesNotContain(SECRET_4.propertyName)
                 .assertApplicationPropertiesDoesNotContain(encKeyBase64Encoded)
-                .assertCommandOutputContains("""
-                        The secret %s was encrypted to
-                        """.formatted(SECRET_4.secret));
+                .assertCommandOutputContains(String.format("The secret " + secretFormat
+                        + " was encrypted to", SECRET_4.secret));
     }
 
     @Order(5)


### PR DESCRIPTION
### Summary

Related to this test framewor changes-->  https://github.com/quarkus-qe/quarkus-test-framework/pull/1238 
There are some failures in our win jenkins jobs related to QuarkusCliConfigEncryptIT because special characters and bold formatted Strings that affect the test execution on Windows OS.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)