### PR TITLE
Dereference schema to workaround Strimzi/Apicurio failures

### DIFF
--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/main/resources/application.properties
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/main/resources/application.properties
@@ -22,3 +22,6 @@ mp.messaging.incoming.channel-stock-price-batch.value.deserializer=io.apicurio.r
 mp.messaging.incoming.channel-stock-price-batch.apicurio.registry.avro-datum-provider=io.apicurio.registry.serde.avro.ReflectAvroDatumProvider
 mp.messaging.incoming.channel-stock-price-batch.auto.offset.reset=earliest
 mp.messaging.incoming.channel-stock-price-batch.enable.auto.commit=true
+
+# TODO https://github.com/quarkusio/quarkus/issues/42504#issuecomment-2286638391
+mp.messaging.connector.smallrye-kafka.apicurio.registry.dereference-schema=true


### PR DESCRIPTION
### Summary

Daily build fails over https://github.com/quarkusio/quarkus/issues/42504. I copied this workaround from https://github.com/quarkus-qe/beefy-scenarios/pull/498 so that we run other tests as well (now they are cancelled) and detect problems early.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)