### PR TITLE
Exclude apps in resources/* from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         continue-on-error: true
       - id: detect-changes
         run: |
-          MODULES=$(find -name pom.xml | sed -e 's|pom.xml| |' | sed -e 's|./| |' | grep -v " quarkus/")
+          MODULES=$(find -name pom.xml | sed -e 's|pom.xml| |' | sed -e 's|./| |' | grep -v " quarkus/" | grep -v resources)
           CHANGED=""
           MODULES_ARG=""
 


### PR DESCRIPTION
### Summary

CI is trying to build also apps that are stored in **/resouces/*. Run into this issue in https://github.com/quarkus-qe/quarkus-test-suite/pull/1927
These apps are not tests but are used in actual tests. We should not build them as a modules.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)