### PR TITLE
Let created extension to use insecure repositories

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
@@ -24,7 +24,7 @@ public class QuarkusCliCreateExtensionIT {
         QuarkusCliDefaultService app = cliClient.createExtension("extension-abc");
 
         // Should build on Jvm
-        QuarkusCliClient.Result result = app.buildOnJvm();
+        QuarkusCliClient.Result result = app.buildOnJvm("-Dinsecure.repositories=WARN");
         assertTrue(result.isSuccessful(), "The extension build failed. Output: " + result.getOutput());
     }
 }


### PR DESCRIPTION
### Summary

Generated extensions use maven-enforcer-plugin, which,among other things, enforces https for repositories and mirrors.  This patch disables this behavior.

Potential permanent solution: https://issues.redhat.com/browse/QQE-907

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)