### PR TITLE
Update `root-modules-no-qute` profile modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -433,7 +433,8 @@
                 <module>env-info</module>
                 <module>config</module>
                 <module>properties</module>
-                <module>docker-build</module>
+                <module>build/docker</module>
+                <module>build/podman</module>
                 <module>javaee-like-getting-started</module>
                 <module>scaling</module>
                 <module>lifecycle-application</module>


### PR DESCRIPTION
### Summary

Updating the name of `build/docker` module for `root-modules-no-qute` profile. This should fix the problem with rebasing of dependabot.
Also adding `bulid/podman` to the profile.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)