### PR TITLE
[3.8] Bump Quarkus version to 3.8.6 and enable sendMaximumAllowedPayload test in native

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         java: [ 17 ]
-        cli: [ 3.8.5 ]
+        cli: [ 3.8.6 ]
         module-mvn-args: ${{ fromJSON(needs.prepare-jvm-latest-modules-mvn-param.outputs.MODULES_MAVEN_PARAM) }}
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
@@ -124,7 +124,7 @@ jobs:
     strategy:
       matrix:
         java: [ 17 ]
-        cli: [ 3.8.5 ]
+        cli: [ 3.8.6 ]
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
     steps:

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/GzipMaxInputIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/GzipMaxInputIT.java
@@ -8,12 +8,10 @@ import java.util.zip.GZIPOutputStream;
 
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.response.Response;
 
@@ -59,8 +57,6 @@ public class GzipMaxInputIT {
                 "The response should be 200 OK because sending just 512 bytes");
     }
 
-    @DisabledOnNative
-    @Tag("Issue in native mode--> https://issues.redhat.com/browse/QUARKUS-4570")
     @Test
     void sendMaximumAllowedPayload() throws IOException {
         byte[] compressedData = generateCompressedData(LIMIT_PAYLOAD);

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
         <failsafe-plugin.version>3.2.5</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.8.5</quarkus.platform.version>
-        <quarkus.ide.version>3.8.5</quarkus.ide.version>
+        <quarkus.platform.version>3.8.6</quarkus.platform.version>
+        <quarkus.ide.version>3.8.6</quarkus.ide.version>
         <quarkus.qe.framework.version>1.4.9</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.5.0</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>


### PR DESCRIPTION
### Summary

- Bumps Quarkus version to 3.8.6
- Enable gzip `sendMaximumAllowedPayload` test in native mode as issue was fixed and backported to 3.8 (3.8.6)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)