### PR TITLE
Ensure abstract jakarta.ws.rs.core.Application is ignored

### DIFF
--- a/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/AbstractApplication.java
+++ b/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/AbstractApplication.java
@@ -1,0 +1,9 @@
+package io.quarkus.ts.http.minimum.reactive;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/rest")
+public abstract class AbstractApplication extends Application {
+    // Abstract jakarta.ws.rs.core.Application classes should be ignored
+}

--- a/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/AbstractApplication.java
+++ b/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/AbstractApplication.java
@@ -1,0 +1,10 @@
+package io.quarkus.ts.http.minimum;
+
+//import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+// TODO uncomment when https://github.com/quarkusio/quarkus/issues/42963 is fixed
+//@ApplicationPath("/rest")
+public abstract class AbstractApplication extends Application {
+    // Abstract jakarta.ws.rs.core.Application classes should be ignored
+}


### PR DESCRIPTION
Ensure abstract jakarta.ws.rs.core.Application is ignored

Trigger: https://github.com/quarkusio/quarkus/pull/41465

Identified issue: https://github.com/quarkusio/quarkus/issues/42963

PASS:  `mvn clean verify -f http/http-minimum -Dreruns=0 -Dquarkus.platform.version=3.12.1`
FAIL: `mvn clean verify -f http/http-minimum -Dreruns=0 -Dquarkus.platform.version=3.12.0`
Reactive - `mvn clean verify -f http/http-minimum-reactive -Dreruns=0 -Dquarkus.platform.version=3.12.0`

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)