### PR TITLE
Run quarkus cli update only on RHBQ and with tag "quarkus-cli"

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/AbstractQuarkusCliUpdateIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/AbstractQuarkusCliUpdateIT.java
@@ -13,6 +13,7 @@ import jakarta.inject.Inject;
 import org.apache.http.HttpStatus;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient;
@@ -27,6 +28,7 @@ import io.quarkus.test.utils.AwaitilityUtils;
 
 @QuarkusScenario
 @DisabledOnNative // Only for JVM verification
+@Tag("quarkus-cli")
 public abstract class AbstractQuarkusCliUpdateIT {
     @Inject
     static QuarkusCliClient cliClient;

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/Quarkus213to38CliUpdateIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/Quarkus213to38CliUpdateIT.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 
 import org.apache.http.HttpStatus;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
@@ -14,7 +15,8 @@ import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.scenarios.annotations.EnabledOnQuarkusVersion;
 import io.quarkus.test.utils.AwaitilityUtils;
 
-@EnabledOnQuarkusVersion(version = "3.8.*", reason = "This class is testing only updates to 3.8.* versions")
+@Tag("quarkus-cli")
+@EnabledOnQuarkusVersion(version = "3.8.*redhat.*", reason = "This class is testing only updates to 3.8.* RHBQ versions")
 @DisabledOnQuarkusVersion(version = "3.8.[0-5].*", reason = "https://github.com/quarkusio/quarkus/issues/42567")
 public class Quarkus213to38CliUpdateIT extends AbstractQuarkusCliUpdateIT {
     private static final DefaultArtifactVersion oldVersion = new DefaultArtifactVersion("2.13");

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/Quarkus32to38CliUpdateIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/Quarkus32to38CliUpdateIT.java
@@ -26,6 +26,7 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
@@ -36,7 +37,8 @@ import io.quarkus.test.util.QuarkusCLIUtils;
 /**
  * Check updates from Quarkus 3.2 to 3.8
  */
-@EnabledOnQuarkusVersion(version = "3.8.*", reason = "This class is testing only updates to 3.8.* versions")
+@Tag("quarkus-cli")
+@EnabledOnQuarkusVersion(version = "3.8.*redhat.*", reason = "This class is testing only updates to 3.8.* RHBQ versions")
 @DisabledOnQuarkusVersion(version = "3.8.[0-5].*", reason = "https://github.com/quarkusio/quarkus/issues/42567")
 public class Quarkus32to38CliUpdateIT extends AbstractQuarkusCliUpdateIT {
     private static final DefaultArtifactVersion oldLtsStream = new DefaultArtifactVersion("3.2");


### PR DESCRIPTION
### Summary

Quarkus update test should only run if tested version is RHBQ (as we have test for RHBQ). Also adding tag "quarkus-cli" which was missing.

This should fix issues in GH CI, which was trying to run this on windows (missing quarkus-cli tag) and with upstream version. Which caused CI to fail (see fail in e.g. https://github.com/quarkus-qe/quarkus-test-suite/pull/1966)

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)