### PR TITLE
Add quarkus-cli tag to update test and check RH version only on RHBQ

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/AbstractQuarkusCliUpdateIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/AbstractQuarkusCliUpdateIT.java
@@ -13,6 +13,7 @@ import jakarta.inject.Inject;
 import org.apache.http.HttpStatus;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient;
@@ -27,6 +28,7 @@ import io.quarkus.test.utils.AwaitilityUtils;
 
 @QuarkusScenario
 @DisabledOnNative // Only for JVM verification
+@Tag("quarkus-cli")
 public abstract class AbstractQuarkusCliUpdateIT {
     @Inject
     static QuarkusCliClient cliClient;
@@ -68,9 +70,11 @@ public abstract class AbstractQuarkusCliUpdateIT {
                 "Major version for app updated to " + newVersionStream + "should be " + newVersionStream.getMajorVersion());
         assertEquals(newVersionStream.getMinorVersion(), updatedVersion.getMinorVersion(),
                 "Minor version for app updated to " + newVersionStream + " should be " + newVersionStream.getMinorVersion());
-        // check that updated app is using RHBQ
-        assertTrue(updatedVersion.toString().contains("redhat"),
-                "Updated app is not using \"redhat\" version. Found version: " + updatedVersion);
+        // check that updated app is using RHBQ, if we're testing with RHBQ
+        if (QuarkusProperties.getVersion().contains("redhat")) {
+            assertTrue(updatedVersion.toString().contains("redhat"),
+                    "Updated app is not using \"redhat\" version. Found version: " + updatedVersion);
+        }
 
         Log.info("Starting updated app");
         // start the updated app and verify that basic /hello endpoint works


### PR DESCRIPTION
### Summary

Similar to https://github.com/quarkus-qe/quarkus-test-suite/pull/1967. add quarkus-cli tag. Check RHBQ version in updated app only if we actually work RHBQ.

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [X] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)