### PR TITLE
Ensure Kafka version is visible in metrics, especially in native mode

### DIFF
--- a/monitoring/micrometer-prometheus-kafka-reactive/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/KafkaAndMetricsIT.java
+++ b/monitoring/micrometer-prometheus-kafka-reactive/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/KafkaAndMetricsIT.java
@@ -1,0 +1,40 @@
+package io.quarkus.ts.micrometer.prometheus.kafka.reactive;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.KafkaService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KafkaContainer;
+import io.quarkus.test.services.QuarkusApplication;
+
+/**
+ * Tests for Kafka and Metrics scenarios
+ */
+@QuarkusScenario
+public class KafkaAndMetricsIT {
+    @KafkaContainer
+    static final KafkaService kafka = new KafkaService();
+
+    @QuarkusApplication
+    static RestService app = new RestService().withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl);
+
+    /**
+     * Test to ensure Kafka version is visible in metrics, especially in native mode
+     * Issues: https://github.com/quarkusio/quarkus/pull/41278 and https://github.com/quarkusio/quarkus/issues/42865
+     */
+    @Test
+    public void testKafkaVersionInMetrics() {
+        String metrics = app.given().when().get("/q/metrics").then().statusCode(200).extract().asString();
+
+        boolean isKafkaVersionPresent = metrics.contains("kafka_version");
+        boolean isKafkaVersionUnknown = metrics.contains("kafka_version=\"unknown\"");
+
+        assertTrue(isKafkaVersionPresent, "'kafka_version' string is  not present in the metrics response");
+        assertFalse(isKafkaVersionUnknown, "'kafka_version' is 'unknown' in the metrics response");
+    }
+}


### PR DESCRIPTION
Ensure Kafka version is visible in metrics, especially in native mode

Triggers: https://github.com/quarkusio/quarkus/pull/41278 and https://github.com/quarkusio/quarkus/issues/42865

Backport is blocked until fix for https://github.com/quarkusio/quarkus/issues/42865 gets into Quarkus 3.8 and 3.15

FAIL: `mvn clean verify -f monitoring/micrometer-prometheus-kafka-reactive -Dit.test=KafkaAndMetricsIT -Dnative -Dquarkus.platform.version=3.14.1 -Dquarkus.native.container-build=false -Dreruns=0`
PASS: `mvn clean verify -f monitoring/micrometer-prometheus-kafka-reactive -Dit.test=KafkaAndMetricsIT -Dnative -Dquarkus.platform.version=999-SNAPSHOT -Dquarkus.native.container-build=false`

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)