### PR TITLE
Dont configure HTTPS in security Vert.X JWT tests

### DIFF
--- a/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/AbstractCommonIT.java
+++ b/security/vertx-jwt/src/test/java/io/quarkus/ts/security/vertx/AbstractCommonIT.java
@@ -43,8 +43,8 @@ public abstract class AbstractCommonIT {
     static DefaultService redis = new DefaultService().withProperty("ALLOW_EMPTY_PASSWORD", "YES");
 
     @QuarkusApplication(certificates = {
-            @Certificate(format = Certificate.Format.PEM, prefix = VALID_PEM_PREFIX, configureHttpServer = true, useTlsRegistry = false),
-            @Certificate(format = Certificate.Format.PEM, prefix = INVALID_PEM_PREFIX, configureHttpServer = true, useTlsRegistry = false),
+            @Certificate(format = Certificate.Format.PEM, prefix = VALID_PEM_PREFIX, useTlsRegistry = false, configureTruststore = true),
+            @Certificate(format = Certificate.Format.PEM, prefix = INVALID_PEM_PREFIX, useTlsRegistry = false, configureTruststore = true),
     })
     static RestService app = new RestService()
             .withProperty("quarkus.redis.hosts",


### PR DESCRIPTION
### Summary

Addresses correct point raised here https://github.com/quarkus-qe/quarkus-test-suite/pull/1973#discussion_r1743954822

Context: ATM we always set CA cert to truststore (which is correct place) even when `configureTruststore=false`. My logic was that you rarely need PEM key/cert without CA cert. But we need to tweak CertificateBuilder and correct Javadoc to explain why is CA cert set. Or agree to explicitly require `configureTruststore=true`.

Whatever we agree on, my thinking is that this option has no negative impact for this scenario while previous configures HTTPS.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)