### PR TITLE
Fix GitHub changed-files issue occurring when fork branch is not rebased on the PR target branch resulting in inability to detect changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,72 @@ name: "Pull Request CI"
 on:
   - pull_request
 jobs:
+  detect-test-suite-modules:
+    name: Detect Modules in PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - id: fetch-latest-target-branch-commits # makes sure that latest target branch HEAD commit is available locally
+        # fetching the latest 2 commits, one should be enough but 2 could avoid race (diff between GH PR event base sha and actual remote base sha)
+        name: 'Fetch the latest 2 target (base) branch commits'
+        run: |
+          git remote add quarkus_qe_target_repo https://github.com/quarkus-qe/quarkus-test-suite.git
+          git fetch quarkus_qe_target_repo ${GITHUB_BASE_REF} --depth=2
+      - id: files
+        uses: tj-actions/changed-files@v45
+        continue-on-error: true
+      - id: detect-changes
+        run: |
+          MODULES=$(find -name pom.xml | sed -e 's|pom.xml| |' | sed -e 's|./| |' | grep -v " quarkus/" | grep -v resources)
+          CHANGED=""
+          MODULES_ARG=""
+
+          # If changed file have some special character, its path is surrounded with quotes which causing the if statement fail
+          CHANGED_FILE=$(echo ${{ steps.files.outputs.all_changed_and_modified_files }} | sed 's/\"/\\"/')
+
+          for module in $MODULES
+          do
+            if [[ $CHANGED_FILE =~ ("$module") ]] ; then
+                CHANGED=$(echo $CHANGED" "$module)
+            fi
+          done
+
+          # trim leading spaces so that module args don't start with comma
+          CHANGED="$(echo $CHANGED | xargs)"
+
+          MODULES_ARG="${CHANGED// /,}"
+          echo "MODULES_ARG=$MODULES_ARG" >> $GITHUB_OUTPUT
+    outputs:
+      MODULES_ARG: ${{ steps.detect-changes.outputs.MODULES_ARG }}
+  prepare-jvm-native-latest-modules-mvn-param:
+    name: Prepare Maven Params For Linux JVM and native Build
+    runs-on: ubuntu-latest
+    needs: detect-test-suite-modules
+    env:
+      MODULES_ARG: ${{ needs.detect-test-suite-modules.outputs.MODULES_ARG }}
+    steps:
+      - id: prepare-modules-mvn-param
+        run: |
+          if [[ -n ${MODULES_ARG} ]]; then
+            echo "Running modules: ${MODULES_ARG}"
+            echo "JVM_MODULES_MAVEN_PARAM=[\" -pl ${MODULES_ARG} -Dall-modules\"]" >> $GITHUB_OUTPUT
+            echo "NATIVE_MODULES_MAVEN_PARAM=[\" -pl ${MODULES_ARG} -Dall-modules\"]" >> $GITHUB_OUTPUT
+          else
+            echo "JVM_MODULES_MAVEN_PARAM=[' -P root-modules,cache-modules,spring-modules,http-modules,test-tooling-modules,messaging-modules,monitoring-modules', ' -P security-modules,sql-db-modules,websockets-modules,nosql-db-modules']" >> $GITHUB_OUTPUT
+            echo "NATIVE_MODULES_MAVEN_PARAM=[' -P root-modules,websockets-modules,test-tooling-modules,nosql-db-modules', ' -P http-modules,cache-modules', ' -P security-modules,spring-modules',
+              ' -P sql-db-modules -pl env-info,sql-db/hibernate,sql-db/sql-app,sql-db/sql-app-compatibility,sql-db/multiple-pus,sql-db/panache-flyway,sql-db/hibernate-reactive',
+              ' -P sql-db-modules -pl env-info,sql-db/reactive-rest-data-panache,sql-db/vertx-sql,sql-db/reactive-vanilla,sql-db/hibernate-fulltext-search,sql-db/narayana-transactions',
+              ' -P messaging-modules,monitoring-modules']" | tr -d -s '\n' ' ' >> $GITHUB_OUTPUT
+          fi
+    outputs:
+      JVM_MODULES_MAVEN_PARAM: ${{ steps.prepare-modules-mvn-param.outputs.JVM_MODULES_MAVEN_PARAM }}
+      NATIVE_MODULES_MAVEN_PARAM: ${{ steps.prepare-modules-mvn-param.outputs.NATIVE_MODULES_MAVEN_PARAM }}
   build-dependencies:
     name: Build Dependencies
     runs-on: ubuntu-latest
+    needs: prepare-jvm-native-latest-modules-mvn-param
     strategy:
       matrix:
         java: [ 17 ]
@@ -58,68 +121,11 @@ jobs:
       - name: Build with Maven
         run: |
           mvn -V -B --no-transfer-progress -s .github/mvn-settings.xml verify -Dall-modules -Dvalidate-format -DskipTests -DskipITs -Dquarkus.container-image.build=false -Dquarkus.container-image.push=false
-  detect-test-suite-modules:
-    name: Detect Modules in PR
-    runs-on: ubuntu-latest
-    needs: [ build-dependencies, linux-validate-format ]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - id: files
-        uses: tj-actions/changed-files@v45
-        continue-on-error: true
-      - id: detect-changes
-        run: |
-          MODULES=$(find -name pom.xml | sed -e 's|pom.xml| |' | sed -e 's|./| |' | grep -v " quarkus/" | grep -v resources)
-          CHANGED=""
-          MODULES_ARG=""
-
-          # If changed file have some special character, its path is surrounded with quotes which causing the if statement fail
-          CHANGED_FILE=$(echo ${{ steps.files.outputs.all_changed_and_modified_files }} | sed 's/\"/\\"/')
-
-          for module in $MODULES
-          do
-            if [[ $CHANGED_FILE =~ ("$module") ]] ; then
-                CHANGED=$(echo $CHANGED" "$module)
-            fi
-          done
-
-          # trim leading spaces so that module args don't start with comma
-          CHANGED="$(echo $CHANGED | xargs)"
-
-          MODULES_ARG="${CHANGED// /,}"
-          echo "MODULES_ARG=$MODULES_ARG" >> $GITHUB_OUTPUT
-    outputs:
-      MODULES_ARG: ${{ steps.detect-changes.outputs.MODULES_ARG }}
-  prepare-jvm-native-latest-modules-mvn-param:
-    name: Prepare Maven Params For Linux JVM and native Build
-    runs-on: ubuntu-latest
-    needs: [ detect-test-suite-modules ]
-    env:
-      MODULES_ARG: ${{ needs.detect-test-suite-modules.outputs.MODULES_ARG }}
-    steps:
-      - id: prepare-modules-mvn-param
-        run: |
-          if [[ -n ${MODULES_ARG} ]]; then
-            echo "Running modules: ${MODULES_ARG}"
-            echo "JVM_MODULES_MAVEN_PARAM=[\" -pl ${MODULES_ARG} -Dall-modules\"]" >> $GITHUB_OUTPUT
-            echo "NATIVE_MODULES_MAVEN_PARAM=[\" -pl ${MODULES_ARG} -Dall-modules\"]" >> $GITHUB_OUTPUT
-          else
-            echo "JVM_MODULES_MAVEN_PARAM=[' -P root-modules,cache-modules,spring-modules,http-modules,test-tooling-modules,messaging-modules,monitoring-modules', ' -P security-modules,sql-db-modules,websockets-modules,nosql-db-modules']" >> $GITHUB_OUTPUT
-            echo "NATIVE_MODULES_MAVEN_PARAM=[' -P root-modules,websockets-modules,test-tooling-modules,nosql-db-modules', ' -P http-modules,cache-modules', ' -P security-modules,spring-modules',
-              ' -P sql-db-modules -pl env-info,sql-db/hibernate,sql-db/sql-app,sql-db/sql-app-compatibility,sql-db/multiple-pus,sql-db/panache-flyway,sql-db/hibernate-reactive',
-              ' -P sql-db-modules -pl env-info,sql-db/reactive-rest-data-panache,sql-db/vertx-sql,sql-db/reactive-vanilla,sql-db/hibernate-fulltext-search,sql-db/narayana-transactions',
-              ' -P messaging-modules,monitoring-modules']" | tr -d -s '\n' ' ' >> $GITHUB_OUTPUT
-          fi
-    outputs:
-      JVM_MODULES_MAVEN_PARAM: ${{ steps.prepare-modules-mvn-param.outputs.JVM_MODULES_MAVEN_PARAM }}
-      NATIVE_MODULES_MAVEN_PARAM: ${{ steps.prepare-modules-mvn-param.outputs.NATIVE_MODULES_MAVEN_PARAM }}
   linux-build-jvm-latest:
     name: PR - Linux - JVM build - Latest Version
     runs-on: ubuntu-latest
     timeout-minutes: 240
-    needs: prepare-jvm-native-latest-modules-mvn-param
+    needs: [linux-validate-format, prepare-jvm-native-latest-modules-mvn-param]
     strategy:
       matrix:
         java: [ 17 ]
@@ -173,7 +179,7 @@ jobs:
   linux-build-native-latest:
     name: PR - Linux - Native build - Latest Version
     runs-on: ubuntu-latest
-    needs: prepare-jvm-native-latest-modules-mvn-param
+    needs: [linux-validate-format, prepare-jvm-native-latest-modules-mvn-param]
     strategy:
       matrix:
         java: [ 17 ]
@@ -230,7 +236,7 @@ jobs:
   windows-build-jvm-latest:
     name: PR - Windows - JVM build - Latest Version
     runs-on: windows-latest
-    needs: detect-test-suite-modules
+    needs: [detect-test-suite-modules, linux-validate-format]
     env:
       MODULES_ARG: ${{ needs.detect-test-suite-modules.outputs.MODULES_ARG }}
     strategy:


### PR DESCRIPTION
### Summary

Sometimes we see that GitHub action `tj-actions/changed-files` fails with `Merge base is not in the local history, fetching remote target branch again..` and `Unable to find merge base between ...` etc.

We have seen this message (it is present twice in that script, but we hit the one I am pointing to): https://github.com/tj-actions/changed-files/blob/1d9fdda44c9da3604e9be858b3edb3e0501302af/src/commitSha.ts#L598

My thinking is that we compare it with base branch HEAD SHA from GH PR event. However:

- between PR event and time when `changed-files` action and `checkout` are run, there is some time so there can be changes on the target branch, therefore ideally we want to have event base HEAD SHA to be matching to the actual base HEAD sha that is fetched; action taken
  - moving checkout and change file detection to be the first thing that is done
  - refactoring - moving `Prepare Maven Params For Linux JVM and native Build` to the second place as they are alike
- I am making sure that base HEAD SHA is always present myself, using `git` instead of raising `changed-files` `depth`. This way, we know that when changed-files look for the base HEAD SHA locally, it will always be present.

There is one, hmm, discrepancy. Based on documentation here https://github.com/tj-actions/changed-files/blob/1d9fdda44c9da3604e9be858b3edb3e0501302af/README.md?plain=1#L654 I would say we should use `with: since_last_remote_commit: true`. However, the way I read their script, it doesn't work as it is described. We want to have diff between target branch HEAD SHA and fork branch HEAD SHA, however with that option it would result in `target = current` https://github.com/tj-actions/changed-files/blob/1d9fdda44c9da3604e9be858b3edb3e0501302af/src/commitSha.ts#L347. So I'd way say we don't want that option.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)