### PR TITLE
Properly disable the build of podman on openshift

### DIFF
--- a/build/podman/pom.xml
+++ b/build/podman/pom.xml
@@ -57,9 +57,11 @@
         </profile>
         <profile>
             <id>openshift</id>
-            <properties>
-                <quarkus.container-image.build>false</quarkus.container-image.build>
-            </properties>
+            <activation>
+                <property>
+                    <name>openshift</name>
+                </property>
+            </activation>
             <build>
                 <plugins>
                     <plugin>
@@ -70,6 +72,14 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>${quarkus.platform.group-id}</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${quarkus.platform.version}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>


### PR DESCRIPTION
### Summary

Follow-up to https://github.com/quarkus-qe/quarkus-test-suite/pull/1981 which id double verified on our Jenkins

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)