### PR TITLE
Test OpenShift serving certificates and TLS registry with REST client

### DIFF
--- a/http/rest-client-reactive/src/test/java/hero/Hero.java
+++ b/http/rest-client-reactive/src/test/java/hero/Hero.java
@@ -1,0 +1,4 @@
+package hero;
+
+public record Hero(Long id, String name, String otherName, int level, String picture, String powers) {
+}

--- a/http/rest-client-reactive/src/test/java/hero/HeroClient.java
+++ b/http/rest-client-reactive/src/test/java/hero/HeroClient.java
@@ -1,0 +1,15 @@
+package hero;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey = "hero")
+public interface HeroClient {
+
+    @GET
+    @Path("/api/heroes/random")
+    Hero getRandomHero();
+
+}

--- a/http/rest-client-reactive/src/test/java/hero/HeroClientResource.java
+++ b/http/rest-client-reactive/src/test/java/hero/HeroClientResource.java
@@ -1,0 +1,19 @@
+package hero;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@Path("hero-client-resource")
+public class HeroClientResource {
+
+    @RestClient
+    HeroClient heroClient;
+
+    @GET
+    public Hero triggerClientToServerCommunication() {
+        return heroClient.getRandomHero();
+    }
+
+}

--- a/http/rest-client-reactive/src/test/java/hero/HeroResource.java
+++ b/http/rest-client-reactive/src/test/java/hero/HeroResource.java
@@ -1,0 +1,17 @@
+package hero;
+
+import java.util.random.RandomGenerator;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/api/heroes/random")
+public class HeroResource {
+
+    @GET
+    public Hero getRandomHero() {
+        long random = RandomGenerator.getDefault().nextLong();
+        return new Hero(random, "Name-" + random, "Other-" + random, 1, "placeholder", "root");
+    }
+
+}

--- a/http/rest-client-reactive/src/test/java/hero/Villain.java
+++ b/http/rest-client-reactive/src/test/java/hero/Villain.java
@@ -1,0 +1,4 @@
+package hero;
+
+public record Villain(Long id, String name, String otherName, int level, String picture, String powers) {
+}

--- a/http/rest-client-reactive/src/test/java/hero/VillainClient.java
+++ b/http/rest-client-reactive/src/test/java/hero/VillainClient.java
@@ -1,0 +1,15 @@
+package hero;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey = "villain")
+public interface VillainClient {
+
+    @GET
+    @Path("/api/villain/random")
+    Villain getRandomVillain();
+
+}

--- a/http/rest-client-reactive/src/test/java/hero/VillainClientResource.java
+++ b/http/rest-client-reactive/src/test/java/hero/VillainClientResource.java
@@ -1,0 +1,19 @@
+package hero;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@Path("villain-client-resource")
+public class VillainClientResource {
+
+    @RestClient
+    VillainClient villainClient;
+
+    @GET
+    public Villain triggerClientToServerCommunication() {
+        return villainClient.getRandomVillain();
+    }
+
+}

--- a/http/rest-client-reactive/src/test/java/hero/VillainResource.java
+++ b/http/rest-client-reactive/src/test/java/hero/VillainResource.java
@@ -1,0 +1,17 @@
+package hero;
+
+import java.util.random.RandomGenerator;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/api/villain/random")
+public class VillainResource {
+
+    @GET
+    public Villain getRandomVillain() {
+        long random = RandomGenerator.getDefault().nextLong();
+        return new Villain(random, "Name-" + random, "Other-" + random, 1, "placeholder", "root");
+    }
+
+}

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/OpenShiftServingCertificatesIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/OpenShiftServingCertificatesIT.java
@@ -1,0 +1,81 @@
+package io.quarkus.ts.http.restclient.reactive;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.Certificate.ServingCertificates;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.utils.AwaitilityUtils;
+
+import hero.Hero;
+import hero.HeroClient;
+import hero.HeroClientResource;
+import hero.HeroResource;
+import hero.Villain;
+import hero.VillainClient;
+import hero.VillainClientResource;
+import hero.VillainResource;
+
+/**
+ * Test OpenShift serving certificate support and Quarkus REST client.
+ */
+@Tag("QUARKUS-4592")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@OpenShiftScenario
+public class OpenShiftServingCertificatesIT {
+
+    private static final String HERO_CLIENT = "hero-client";
+    private static final String SERVER_TLS_CONFIG_NAME = "cert-serving-test-server";
+
+    @QuarkusApplication(ssl = true, certificates = @Certificate(tlsConfigName = SERVER_TLS_CONFIG_NAME, servingCertificates = {
+            @ServingCertificates(addServiceCertificate = true)
+    }), classes = { HeroResource.class, Hero.class, Villain.class,
+            VillainResource.class }, properties = "certificate-serving-server.properties")
+    static final RestService server = new RestService();
+
+    @QuarkusApplication(certificates = @Certificate(tlsConfigName = HERO_CLIENT, servingCertificates = @ServingCertificates(injectCABundle = true)), classes = {
+            HeroClient.class, Hero.class, HeroClientResource.class, Villain.class, VillainClient.class,
+            VillainClientResource.class }, properties = "certificate-serving-client.properties")
+    static final RestService client = new RestService()
+            .withProperty("quarkus.rest-client.hero.uri", () -> server.getURI(Protocol.HTTPS).getRestAssuredStyleUri());
+
+    @Order(1)
+    @Test
+    public void testSecuredCommunicationBetweenClientAndServer() {
+        // REST client use OpenShift internal CA
+        // server is configured with OpenShift serving certificates
+        // ad "untilAsserted": we experienced unknown SAN, so to avoid flakiness I am adding here retry:
+        AwaitilityUtils.untilAsserted(() -> {
+            var hero = client.given().get("hero-client-resource").then().statusCode(200).extract().as(Hero.class);
+            assertNotNull(hero);
+            assertNotNull(hero.name());
+            assertTrue(hero.name().startsWith("Name-"));
+            assertNotNull(hero.otherName());
+            assertTrue(hero.otherName().startsWith("Other-"));
+        }, AwaitilityUtils.AwaitilitySettings.usingTimeout(Duration.ofSeconds(50)));
+    }
+
+    @Order(2)
+    @Test
+    public void testConfiguredTlsProtocolEnforced() {
+        // verifies that protocol version set in TLS config is obliged by both HTTP server and client
+        // REST client requires TLSv1.2
+        // HTTP server requires TLSv1.3
+        client.logs().assertDoesNotContain("Received fatal alert: protocol_version");
+        client.given().get("villain-client-resource").then().statusCode(500);
+        client.logs().assertContains("Received fatal alert: protocol_version");
+    }
+
+}

--- a/http/rest-client-reactive/src/test/resources/certificate-serving-client.properties
+++ b/http/rest-client-reactive/src/test/resources/certificate-serving-client.properties
@@ -1,0 +1,6 @@
+quarkus.rest-client.hero.tls-configuration-name=hero-client
+quarkus.rest-client.villain.tls-configuration-name=villain-client
+quarkus.rest-client.villain.uri=${quarkus.rest-client.hero.uri}
+quarkus.tls.villain-client.trust-store.pem.certs=${quarkus.tls.hero-client.trust-store.pem.certs}
+quarkus.tls.hero-client.protocols=TLSv1.3
+quarkus.tls.villain-client.protocols=TLSv1.2

--- a/http/rest-client-reactive/src/test/resources/certificate-serving-server.properties
+++ b/http/rest-client-reactive/src/test/resources/certificate-serving-server.properties
@@ -1,0 +1,4 @@
+# the REST client use HTTPS but not mTLS
+quarkus.http.ssl.client-auth=request
+quarkus.http.insecure-requests=disabled
+quarkus.tls.cert-serving-test-server.protocols=TLSv1.3


### PR DESCRIPTION
### Summary

This is quite similar to what I have done in QE Test Framework https://github.com/quarkus-qe/quarkus-test-framework/pull/1270 because I think it tests all we need from TLS Registry integration with REST client and OpenShift certificate serving. Few differences:

- test native as well; what we want to test in native is:
  - certificates are picked up by Quarkus app in the native mode (that is TLS registry level, shared)
  - integration with OpenShift according to the TLS registry section https://quarkus.io/guides/tls-registry-reference#utilizing-openshift-serving-certificates (again, not relevant to specific client impl.)
- here it is tested that both HTTP server and REST client are configured with TLS version configured in TLS registry and they do require it

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)