### PR TITLE
Test OpenTelemetry integration with TLS registry and exporting traces using secured channel

### DIFF
--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryManagementIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryManagementIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.opentelemetry;
 
+import static io.quarkus.test.services.containers.JaegerGenericDockerContainerManagedResource.CERTIFICATE_CONTEXT_KEY;
+import static io.quarkus.test.services.containers.JaegerGenericDockerContainerManagedResource.JAEGER_CLIENT_CERT_CN;
 import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsString;
@@ -10,23 +12,32 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.JaegerService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.security.certificate.Certificate;
+import io.quarkus.test.security.certificate.PemClientCertificate;
 import io.quarkus.test.services.JaegerContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
+@Tag("QUARKUS-4592")
 @QuarkusScenario
 public class OpenTelemetryManagementIT {
-    @JaegerContainer
+    @JaegerContainer(tls = true)
     static final JaegerService jaeger = new JaegerService();
 
     @QuarkusApplication
     static RestService pong = new RestService()
             .withProperty("quarkus.application.name", "pong")
             .withProperty("quarkus.management.enabled", "true")
-            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", () -> jaeger.getCollectorUrl(Protocol.HTTPS))
+            .withProperty("quarkus.otel.exporter.otlp.traces.tls-configuration-name", "jaeger")
+            .withProperty("quarkus.tls.jaeger.key-store.pem.0.cert", OpenTelemetryManagementIT::getTlsCertPath)
+            .withProperty("quarkus.tls.jaeger.key-store.pem.0.key", OpenTelemetryManagementIT::getTlsKeyPath)
+            .withProperty("quarkus.tls.jaeger.trust-store.pem.certs", OpenTelemetryManagementIT::getTlsCaCertPath);
 
     private static final String PONG_ENDPOINT = "/hello";
     private static final String MANAGEMENT_ENDPOINT = "/q/health/ready";
@@ -65,5 +76,31 @@ public class OpenTelemetryManagementIT {
         // check that management endpoint is not present in traces, while correct trace is there
         Assertions.assertTrue(traces.contains(PONG_ENDPOINT), "Pong endpoint should be logged in traces");
         Assertions.assertFalse(traces.contains(MANAGEMENT_ENDPOINT), "Management endpoint should not be logged in traces");
+    }
+
+    private static String getTlsKeyPath() {
+        return addEscapes(getClientCertificate().keyPath());
+    }
+
+    private static String getTlsCertPath() {
+        return addEscapes(getClientCertificate().certPath());
+    }
+
+    private static String getTlsCaCertPath() {
+        return addEscapes(getClientCertificate().truststorePath());
+    }
+
+    private static PemClientCertificate getClientCertificate() {
+        return (PemClientCertificate) jaeger.<Certificate> getPropertyFromContext(CERTIFICATE_CONTEXT_KEY)
+                .getClientCertificateByCn(JAEGER_CLIENT_CERT_CN);
+    }
+
+    static String addEscapes(String path) {
+        if (OS.WINDOWS.isCurrentOs()) {
+            // TODO: move this to the FW
+            // back-slashes have special meaning in Cygwin etc.
+            return path.replace("\\", "\\\\");
+        }
+        return path;
     }
 }


### PR DESCRIPTION
### Summary

We have 15 tests with Jaeger container, so I have decided to enable TLS in one of them and include test coverage for TLS registry integration with OpenTelemetry there.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)