### PR TITLE
Added isRHBQ method to check if the version contains string redhat

### DIFF
--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AbstractAnalyticsIT.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AbstractAnalyticsIT.java
@@ -143,8 +143,7 @@ public abstract class AbstractAnalyticsIT {
         assertEquals(pomDependencyGAs, payloadExtensionGAs);
 
         // RHBQ doesn't guarantee the same version of the platform and core extensions
-        boolean isRHBQ = QuarkusProperties.getVersion().contains("redhat");
-        if (!isRHBQ) {
+        if (!QuarkusProperties.isRHBQ()) {
             List<PayloadExtension> extensionsWithMismatchedVersion = payloadExtensions.stream()
                     .filter(extension -> !QUARKUS_EXTENSION_VERSION_PATTERN.matcher(extension.getVersion()).matches())
                     .collect(Collectors.toList());

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DisabledOnRHBQAarch64NativeConditions.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DisabledOnRHBQAarch64NativeConditions.java
@@ -10,7 +10,7 @@ public class DisabledOnRHBQAarch64NativeConditions implements ExecutionCondition
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
-        boolean isRHBQ = QuarkusProperties.getVersion().contains("redhat");
+        boolean isRHBQ = QuarkusProperties.isRHBQ();
         boolean isNative = QuarkusProperties.isNativeEnabled();
         boolean isAarch64 = "true".equals(System.getProperty("ts.arm.missing.services.excludes"));
         if (isRHBQ && isAarch64 && isNative) {

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DisabledOnRHBQWindowsConditions.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DisabledOnRHBQWindowsConditions.java
@@ -11,7 +11,7 @@ public class DisabledOnRHBQWindowsConditions implements ExecutionCondition {
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
-        boolean isRHBQ = QuarkusProperties.getVersion().contains("redhat");
+        boolean isRHBQ = QuarkusProperties.isRHBQ();
         boolean isWindows = OS.current().equals(OS.WINDOWS);
         if (isRHBQ && isWindows) {
             return ConditionEvaluationResult.disabled("It is RHBQ on Windows");

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -88,7 +88,7 @@ public class QuarkusCliExtensionsIT {
     public void shouldListExtensionsUsingStream() {
         var req = ListExtensionRequest.withSetStream();
         result = cliClient.listExtensions(req, "--origins");
-        if (QuarkusProperties.getVersion().contains("redhat")) {
+        if (QuarkusProperties.isRHBQ()) {
             assertTrue(result.getOutput().contains("com.redhat.quarkus.platform:quarkus-bom:" + req.stream()));
         } else {
             assertTrue(result.getOutput().contains("io.quarkus.platform:quarkus-bom:" + req.stream()));

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/AbstractQuarkusCliUpdateIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/AbstractQuarkusCliUpdateIT.java
@@ -49,7 +49,7 @@ public abstract class AbstractQuarkusCliUpdateIT {
     }
 
     protected IQuarkusCLIAppManager createAppManager() {
-        if (this.newVersionFromProperties != null && this.newVersionFromProperties.contains("redhat")) {
+        if (this.newVersionFromProperties != null && QuarkusProperties.isRHBQ()) {
             return new RHBQPlatformAppManager(cliClient, oldVersionStream, newVersionStream,
                     new DefaultArtifactVersion(newVersionFromProperties));
         }
@@ -71,7 +71,7 @@ public abstract class AbstractQuarkusCliUpdateIT {
         assertEquals(newVersionStream.getMinorVersion(), updatedVersion.getMinorVersion(),
                 "Minor version for app updated to " + newVersionStream + " should be " + newVersionStream.getMinorVersion());
         // check that updated app is using RHBQ, if we're testing with RHBQ
-        if (QuarkusProperties.getVersion().contains("redhat")) {
+        if (QuarkusProperties.isRHBQ()) {
             assertTrue(updatedVersion.toString().contains("redhat"),
                     "Updated app is not using \"redhat\" version. Found version: " + updatedVersion);
         }


### PR DESCRIPTION
### Summary

Replaced `QuarkusProperties.getVersion().contains("redhat")` usage with `QuarkusProperties.isRHBQ()`

https://github.com/quarkus-qe/quarkus-test-framework/pull/1294
Waiting for merge

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)