### PR TITLE
Switch to supported service type

### DIFF
--- a/infinispan-client/src/test/resources/infinispan_cluster_config.yaml
+++ b/infinispan-client/src/test/resources/infinispan_cluster_config.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   replicas: 1
   service:
-    type: Cache
+    type: DataGrid
   container:
     extraJvmOpts: "-XX:NativeMemoryTracking=summary"
     cpu: "2000m"


### PR DESCRIPTION
### Summary

"Cache" service is deprecated and removed from the newest versions of Inifinspan[1][2] and it already became a problem for IBM folks[3]

[1] https://access.redhat.com/solutions/7010384
[2] https://access.redhat.com/solutions/6972352
[3] https://issues.redhat.com/browse/QQE-961


Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)