### PR TITLE
[3.8] Turn openshift-arm profile into general aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ By default, all your tests are running on bare metal (JVM / Dev mode), but you c
 * Redhat-registry: use Redhat docker registry with official supported images instead of community images
 * Serverless: enable Knative or serverless scenarios
 * Operator-scenarios: enable operator scenarios, where the ecosystem of your test is going to be deployed by k8s/OCP operators
+* `aarch64`: profile using versions of containers for test services that work on aarch64
 
 All of these profiles are not mutual exclusive, indeed we encourage you to combine these profiles in order to run complex scenarios.
 
@@ -107,6 +108,16 @@ mvn clean verify -Dall-modules -Dopenshift -pl http/http-minimum
 ```
 
 **NOTE:** here we are combining two profiles, profile `openshift` in order to trigger OpenShift execution mode and property `all-modules` to enable `http-modules` profile, where `http/http-minimum` is located.
+
+#### OpenShift & Aarch64
+
+To run test services on OpenShift clusters installed on aarch64, make sure you enable aarch64 profile:
+
+```shell
+mvn clean verify -Dall-modules -Dopenshift -Daarch64 -pl http/http-minimum
+```
+
+**NOTE:** You can comine this with native profile also.
 
 ### OpenShift & Native
 
@@ -168,6 +179,15 @@ User: `Run http-minimum module.`
 
 ```shell
 mvn clean verify -Dall-modules -pl http/http-minimum
+```
+
+#### Bare metal & Aarch64
+
+To run tests on bare metal aarch64, make sure you enable aarch64 profile so that tests are able to launch test service 
+containers:
+
+```shell
+mvn clean verify -Dall-modules -Daarch64 -pl http/http-minimum
 ```
 
 #### Bare metal & Native

--- a/pom.xml
+++ b/pom.xml
@@ -808,24 +808,10 @@
             </build>
         </profile>
         <profile>
-            <!-- You need to be connected to an OpenShift instance to activate this
-                profile! -->
-            <id>openshift-arm</id>
+            <id>aarch64</id>
             <activation>
                 <property>
-                    <name>openshift-arm</name>
-                </property>
-            </activation>
-            <properties>
-                <include.tests>**/*OpenShift*IT.java</include.tests>
-                <exclude.openshift.tests>no</exclude.openshift.tests>
-            </properties>
-        </profile>
-        <profile>
-            <id>openshift-arm-containers</id>
-            <activation>
-                <property>
-                    <name>openshift-arm</name>
+                    <name>aarch64</name>
                 </property>
             </activation>
             <build>
@@ -842,7 +828,6 @@
                                 <configuration>
                                     <systemPropertyVariables>
                                         <!-- always set 'OpenShift' property as that's how detect OpenShift tests inside FW -->
-                                        <openshift>true</openshift>
                                         <ts.arm.missing.services.excludes>true</ts.arm.missing.services.excludes>
                                         <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                         <!-- Product Services -->


### PR DESCRIPTION
### Summary

* To avoid needing to define the same multiarch container versions for bare metal and OpenShift use cases, this commit turns openshift-arm into general aarch64 profile.
* Updating the readme file with examples on how to run this profile with both OpenShift and bare metal uses.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)