### PR TITLE
[3.8] Switch to supported service type

### DIFF
--- a/infinispan-client/src/test/resources/infinispan_cluster_config.yaml
+++ b/infinispan-client/src/test/resources/infinispan_cluster_config.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   replicas: 1
   service:
-    type: Cache
+    type: DataGrid
   container:
     extraJvmOpts: "-XX:NativeMemoryTracking=summary"
     cpu: "2000m"


### PR DESCRIPTION
### Summary
"Cache" service is deprecated and removed from the newest versions of Inifinspan[1][2] and it already became a problem for IBM testing folks[3]

[1] https://access.redhat.com/solutions/7010384
[2] https://access.redhat.com/solutions/6972352
[3] https://issues.redhat.com/browse/QQE-961

Backports https://github.com/quarkus-qe/quarkus-test-suite/pull/1994

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)