### PR TITLE
[3.8] Bump Quarkus QE Test Framework to 1.4.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.8.6</quarkus.platform.version>
         <quarkus.ide.version>3.8.6</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.4.11</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.4.12</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.5.0</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>


### PR DESCRIPTION
### Summary

Bumps Quarkus QE Test Framework to 1.4.12.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)