### PR TITLE
Excluding DB2 tests from aarch64 profile

### DIFF
--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/DB2DatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/DB2DatabaseIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.sqldb.compatibility;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.Db2Service;
 import io.quarkus.test.bootstrap.RestService;
@@ -13,6 +14,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @DisabledOnNative(reason = "Compatibility mode check in JVM mode is enough for this DB")
 @Tag("fips-incompatible") // Reported in https://github.com/IBM/Db2/issues/43
 @Tag("podman-incompatible") //TODO https://github.com/containers/podman/issues/16432
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2020")
 public class DB2DatabaseIT extends AbstractSqlDatabaseIT {
 
     @Container(image = "${db2.image}", port = 50000, expectedLog = "Setup has completed")

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DB2DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DB2DatabaseIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.Db2Service;
 import io.quarkus.test.bootstrap.RestService;
@@ -11,6 +12,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 @Tag("fips-incompatible") // Reported in https://github.com/IBM/Db2/issues/43
 @Tag("podman-incompatible") //TODO: https://github.com/containers/podman/issues/16432
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2020")
 public class DB2DatabaseIT extends AbstractSqlDatabaseIT {
 
     @Container(image = "${db2.image}", port = 50000, expectedLog = "Setup has completed")


### PR DESCRIPTION
### Summary

* Disabling DB2 tests on aarch64 profile as DB2 is not supported on aarch64 architecture, so our test service will not work.

Related issue:
* https://github.com/quarkus-qe/quarkus-test-suite/issues/2020

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)