### PR TITLE
Excluding Oracle tests from aarch64 profile

### DIFF
--- a/security/jpa/src/test/java/io/quarkus/ts/security/jpa/OraclePlaintextExternalRolesJpaIT.java
+++ b/security/jpa/src/test/java/io/quarkus/ts/security/jpa/OraclePlaintextExternalRolesJpaIT.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.security.jpa;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.OracleService;
 import io.quarkus.test.bootstrap.RestService;
@@ -11,6 +12,7 @@ import io.quarkus.test.services.QuarkusApplication;
 
 @Tag("QUARKUS-3866")
 @QuarkusScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2022")
 public class OraclePlaintextExternalRolesJpaIT extends BaseJpaSecurityRealmIT {
 
     static final int ORACLE_PORT = 1521;

--- a/security/jpa/src/test/java/io/quarkus/ts/security/jpa/OracleSha512JpaIT.java
+++ b/security/jpa/src/test/java/io/quarkus/ts/security/jpa/OracleSha512JpaIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.security.jpa;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.OracleService;
 import io.quarkus.test.bootstrap.RestService;
@@ -10,6 +11,7 @@ import io.quarkus.test.services.QuarkusApplication;
 
 @Tag("QUARKUS-3866")
 @QuarkusScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2022")
 public class OracleSha512JpaIT extends BaseJpaSecurityRealmIT {
 
     static final int ORACLE_PORT = 1521;

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/OracleDatabaseIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/OracleDatabaseIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.hibernate.reactive;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.OracleService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -7,6 +9,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2022")
 public class OracleDatabaseIT extends AbstractDatabaseHibernateReactiveIT {
 
     private static final String ORACLE_USER = "quarkus_test";

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OracleTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OracleTransactionGeneralUsageIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.transactions;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.OracleService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -8,6 +10,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 
 @QuarkusScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2022")
 public class OracleTransactionGeneralUsageIT extends TransactionCommons {
 
     static final int ORACLE_PORT = 1521;

--- a/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/OraclePanacheResourceIT.java
+++ b/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/OraclePanacheResourceIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.reactive.rest.data.panache;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.OracleService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -7,6 +9,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2022")
 public class OraclePanacheResourceIT extends AbstractPanacheResourceIT {
 
     static final int ORACLE_PORT = 1521;

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/OracleDatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/OracleDatabaseIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.sqldb.compatibility;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.OracleService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -9,6 +11,7 @@ import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
 @DisabledOnNative(reason = "Compatibility mode check in JVM mode is enough for this DB")
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2022")
 public class OracleDatabaseIT extends AbstractSqlDatabaseIT {
 
     static final int ORACLE_PORT = 1521;

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeOracleDevServiceUserExperienceIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeOracleDevServiceUserExperienceIT.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import com.github.dockerjava.api.model.Image;
 
@@ -18,6 +19,7 @@ import io.quarkus.test.utils.SocketUtils;
 
 @QuarkusScenario
 @Tag("podman-incompatible") //TODO: https://github.com/quarkusio/quarkus/issues/38003
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkusio/quarkus/issues/43375")
 public class DevModeOracleDevServiceUserExperienceIT {
 
     private static final String ORACLE_NAME = getImageName("oracle.image");

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeOracleIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeOracleIT.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.sqldb.sqlapp;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -9,6 +10,7 @@ import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @QuarkusScenario
 @Tag("podman-incompatible") //TODO: https://github.com/quarkusio/quarkus/issues/38003
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkusio/quarkus/issues/43375")
 public class DevModeOracleIT extends AbstractSqlDatabaseIT {
 
     @DevModeQuarkusApplication

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OracleDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OracleDatabaseIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.OracleService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -7,6 +9,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2022")
 public class OracleDatabaseIT extends AbstractSqlDatabaseIT {
 
     static final int ORACLE_PORT = 1521;

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/OracleHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/OracleHandlerIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.vertx.sql.handlers;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.OracleService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -7,6 +9,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2022")
 public class OracleHandlerIT extends CommonTestCases {
     private static final int ORACLE_PORT = 1521;
     private static final String DATABASE = "amadeus";


### PR DESCRIPTION
### Summary

* Disabling Oracle tests on aarch64 profile as there's no Oracle container available for aarch64 architecture, so our test service will not work.

Related issues:
* https://github.com/quarkusio/quarkus/issues/43375
* https://github.com/quarkus-qe/quarkus-test-suite/issues/2022

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)