### PR TITLE
Disable tests missing aarch64 test services

### DIFF
--- a/logging/thirdparty/src/test/java/io/quarkus/ts/logging/jboss/SyslogIT.java
+++ b/logging/thirdparty/src/test/java/io/quarkus/ts/logging/jboss/SyslogIT.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.logging.jboss;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -9,6 +10,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2024")
 public class SyslogIT {
 
     /*

--- a/spring/spring-cloud-config/src/test/java/io/quarkus/ts/spring/cloud/config/SpringCloudConfigIT.java
+++ b/spring/spring-cloud-config/src/test/java/io/quarkus/ts/spring/cloud/config/SpringCloudConfigIT.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.is;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -14,6 +15,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2025")
 public class SpringCloudConfigIT {
 
     @Container(image = "${spring.cloud.server.image}", port = 8888, expectedLog = "Started ConfigServer")


### PR DESCRIPTION
### Summary

* Disabling syslog tests on aarch64 as the currently used container is
  not multiarch.
* Disabling Spring Cloud Server tests on aarch64 as there's no aarch64
  based container we can use as test service.

Related issues:
* https://github.com/quarkus-qe/quarkus-test-suite/issues/2024
* https://github.com/quarkus-qe/quarkus-test-suite/issues/2025

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)