### PR TITLE
Re-enable tests on IBM platforms due to removal of zookeeper

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftAmqStreamsKafkaStreamIT.java
@@ -1,6 +1,5 @@
 package io.quarkus.ts.messaging.kafka.reactive.streams;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KafkaService;
@@ -12,7 +11,6 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTest {
 

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftStrimziKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftStrimziKafkaStreamIT.java
@@ -1,11 +1,8 @@
 package io.quarkus.ts.messaging.kafka.reactive.streams;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 @DisabledOnRHBQAarch64Native(reason = "https://issues.redhat.com/browse/QUARKUS-4321")
 public class OpenShiftStrimziKafkaStreamIT extends StrimziKafkaStreamIT {
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.messaging.kafka.reactive.streams;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -10,7 +8,6 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.operator.KafkaInstance;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 public class OperatorOpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTest {
 
     @Operator(name = "amq-streams", source = "redhat-operators")

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/OpenShiftAmqStreamsKafkaAvroIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/OpenShiftAmqStreamsKafkaAvroIT.java
@@ -1,6 +1,5 @@
 package io.quarkus.ts.messaging.strimzi.kafka.reactive;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KafkaService;
@@ -11,7 +10,6 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsKafkaAvroIT extends BaseKafkaAvroIT {
 

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/OpenShiftStrimziKafkaAvroIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/OpenShiftStrimziKafkaAvroIT.java
@@ -1,10 +1,7 @@
 package io.quarkus.ts.messaging.strimzi.kafka.reactive;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 public class OpenShiftStrimziKafkaAvroIT extends StrimziKafkaAvroIT {
 }

--- a/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/StrimziKafkaAvroIT.java
+++ b/messaging/kafka-strimzi-avro-reactive-messaging/src/test/java/io/quarkus/ts/messaging/strimzi/kafka/reactive/StrimziKafkaAvroIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.messaging.strimzi.kafka.reactive;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -10,7 +8,6 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @QuarkusScenario
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 public class StrimziKafkaAvroIT extends BaseKafkaAvroIT {
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI, withRegistry = true, registryPath = "/apis/registry/v2")

--- a/monitoring/micrometer-prometheus-kafka-reactive/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/OpenShiftAmqStreamsAlertEventsReactiveIT.java
+++ b/monitoring/micrometer-prometheus-kafka-reactive/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/OpenShiftAmqStreamsAlertEventsReactiveIT.java
@@ -1,6 +1,5 @@
 package io.quarkus.ts.micrometer.prometheus.kafka.reactive;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KafkaService;
@@ -10,7 +9,6 @@ import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsAlertEventsReactiveIT extends BaseOpenShiftAlertEventsReactiveIT {
 

--- a/monitoring/micrometer-prometheus-kafka-reactive/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/OpenShiftKafkaAlertEventsReactiveIT.java
+++ b/monitoring/micrometer-prometheus-kafka-reactive/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/reactive/OpenShiftKafkaAlertEventsReactiveIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.micrometer.prometheus.kafka.reactive;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -9,7 +7,6 @@ import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 public class OpenShiftKafkaAlertEventsReactiveIT extends BaseOpenShiftAlertEventsReactiveIT {
 
     @KafkaContainer

--- a/monitoring/micrometer-prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftAmqStreamsAlertEventsIT.java
+++ b/monitoring/micrometer-prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftAmqStreamsAlertEventsIT.java
@@ -1,6 +1,5 @@
 package io.quarkus.ts.micrometer.prometheus.kafka;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KafkaService;
@@ -10,7 +9,6 @@ import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsAlertEventsIT extends BaseOpenShiftAlertEventsIT {
 

--- a/monitoring/micrometer-prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftKafkaAlertEventsIT.java
+++ b/monitoring/micrometer-prometheus-kafka/src/test/java/io/quarkus/ts/micrometer/prometheus/kafka/OpenShiftKafkaAlertEventsIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.micrometer.prometheus.kafka;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -9,7 +7,6 @@ import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 public class OpenShiftKafkaAlertEventsIT extends BaseOpenShiftAlertEventsIT {
 
     @KafkaContainer


### PR DESCRIPTION
### Summary

Same as https://github.com/quarkus-qe/quarkus-test-suite/pull/2030, cherry-picking commit from previous PR.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)