### PR TITLE
Fix QuarksCliTlsCommandIT when executed on Windows as backslashes disappears which leads to illegal config property value

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliTlsCommandIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliTlsCommandIT.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.logging.Log;
 import io.quarkus.test.bootstrap.QuarkusCliCommandResult;
@@ -134,7 +135,16 @@ public class QuarkusCliTlsCommandIT {
             // add generated env vars also to application properties under test profile
             // so that we can also use them in TlsCommandTest
             var propertyValue = cmd.getPropertyValueFromEnvFile("%dev." + propertyKey);
-            return "%test." + propertyKey + "=" + propertyValue;
+            return "%test." + propertyKey + "=" + addEscapes(propertyValue);
         };
+    }
+
+    private static String addEscapes(String propertyValue) {
+        if (OS.WINDOWS.isCurrentOs()) {
+            // we need to quote back slashes passed as command lines in Windows as they have special meaning
+            // TODO: move this to the QE Test Framework as this is repeated a lot
+            return propertyValue.replace("\\", "\\\\");
+        }
+        return propertyValue;
     }
 }


### PR DESCRIPTION
### Summary

Backslashes has a special meaning, so escaping them to keep certification path in config property correct.

```
Caused by: io.smallrye.config.ConfigValidationException: Configuration validation failed:
 java.lang.IllegalArgumentException: SRCFG00039: The config property %test.quarkus.tls.key-store.p12.path with the config value "C:UsershushAppDataLocalTempquarkus-tls-command-tests1580066748273078464 ls-command-testquarkus-qe-cert-keystore.p12" threw an Exception whilst being converted Illegal char < > at index 73: C:UsershudsonAppDataLocalTempquarkus-tls-command-tests1580066748273078464 ls-command-testquarkus-qe-cert-keystore.p12
 at io.smallrye.config.SmallRyeConfig.buildMappings(SmallRyeConfig.java:139)
 at io.smallrye.config.SmallRyeConfig.<init>(SmallRyeConfig.java:93)
 at io.smallrye.config.SmallRyeConfigBuilder.build(SmallRyeConfigBuilder.java:736)
 at io.quarkus.runtime.generated.Config.readConfig(Unknown Source)
 at io.quarkus.runtime.generated.Config.createRunTimeConfig(Unknown Source)
 at io.quarkus.deployment.steps.RuntimeConfigSetup.deploy(Unknown Source)
 ... 8 more
```

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)