### PR TITLE
Change syslog image

### DIFF
--- a/logging/thirdparty/pom.xml
+++ b/logging/thirdparty/pom.xml
@@ -7,7 +7,7 @@
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
-    <artifactId>logging-thridparty</artifactId>
+    <artifactId>logging-thirdparty</artifactId>
     <packaging>jar</packaging>
     <name>Quarkus QE TS: Logging: Third party</name>
     <dependencies>

--- a/logging/thirdparty/src/main/java/io/quarkus/ts/logging/jboss/LogResource.java
+++ b/logging/thirdparty/src/main/java/io/quarkus/ts/logging/jboss/LogResource.java
@@ -44,13 +44,14 @@ public class LogResource {
     }
 
     @GET
-    public void logExample() {
+    public String logExample() {
         LOG.fatal("Fatal log example");
         LOG.error("Error log example");
         LOG.warn("Warn log example");
         LOG.info("Info log example");
         LOG.debug("Debug log example");
         LOG.trace("Trace log example");
+        return "Logs sent!";
     }
 
     private void addLogMessage(Logger logger, String level, String message) {

--- a/logging/thirdparty/src/main/resources/application.properties
+++ b/logging/thirdparty/src/main/resources/application.properties
@@ -15,4 +15,4 @@ quarkus.log.level=INFO
 %syslog.quarkus.log.syslog.syslog-type=rfc3164
 %syslog.quarkus.log.syslog.protocol=tcp
 # the option below is overriden in @QuarkusScenario tests
-%syslog.quarkus.log.syslog.endpoint=localhost:1514
+%syslog.quarkus.log.syslog.endpoint=localhost:8514

--- a/logging/thirdparty/src/test/resources/syslog-ng.conf
+++ b/logging/thirdparty/src/test/resources/syslog-ng.conf
@@ -4,8 +4,8 @@
 log {
 	source {
 		#network();
-		tcp(ip(0.0.0.0) port(514));
+		tcp(ip(0.0.0.0) port(8514));
 	};
-	#destination { file("/var/log/syslog"); };
+	destination { file("/tmp/mylog"); };
 	destination {stdout();};
 };


### PR DESCRIPTION
### Summary

1. Use new syslog image (fixes https://github.com/quarkus-qe/quarkus-test-suite/issues/2024)
2. Refactor the test, since Quarkus changed the minimal limit to 128

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)