### PR TITLE
Fix OpenTelemetryManagementIT on Windows (when Linux containers are available) by porting remote Docker agent to localhost

### DIFF
--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/JaegerLocalhostDockerManagerResource.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/JaegerLocalhostDockerManagerResource.java
@@ -1,0 +1,20 @@
+package io.quarkus.ts.opentelemetry;
+
+import io.quarkus.test.bootstrap.LocalhostManagedResource;
+import io.quarkus.test.bootstrap.ManagedResource;
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.containers.JaegerContainerManagedResourceBuilder;
+
+/**
+ * This is analogy to {@link Container#portDockerHostToLocalhost()}.
+ * It is required because secured communication between Quarkus OpenTelemetry OTLP exporter
+ * and traces collector verifies host. But our Windows host runs 'remote' Docker agent.
+ * TODO: we should consider supporting 'portDockerHostToLocalhost' on the JaegerContainer annotation
+ */
+public class JaegerLocalhostDockerManagerResource extends JaegerContainerManagedResourceBuilder {
+    @Override
+    public ManagedResource build(ServiceContext context) {
+        return new LocalhostManagedResource(super.build(context));
+    }
+}

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryManagementIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryManagementIT.java
@@ -26,7 +26,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @Tag("QUARKUS-4592")
 @QuarkusScenario
 public class OpenTelemetryManagementIT {
-    @JaegerContainer(tls = true)
+    @JaegerContainer(tls = true, builder = JaegerLocalhostDockerManagerResource.class)
     static final JaegerService jaeger = new JaegerService();
 
     @QuarkusApplication


### PR DESCRIPTION
### Summary

Our AWS Windows runners use remote Docker agent and recently https://github.com/quarkus-qe/quarkus-test-suite/pull/1988 that forced host verification between Quarkus OpenTelemetry OTLP exporter and Jaeger traces collector. Hence test failed over:

```
15:48:19,981 INFO  [jaeger] {"level":"info","ts":1727106498.3438833,"caller":"grpc@v1.60.0/server.go:983","msg":"[core][Server #5] grpc: Server.Serve failed to create ServerTransport: connection error: desc = \"ServerHandshake(\\\"xx.xxx.xx.xx:51177\\\") failed: remote error: tls: unknown certificate\"","system":"grpc","grpc_log":true}
15:48:22,311 INFO  [pong] 15:48:18,305 Failed to export TraceRequestMarshalers. The request could not be executed. Full error message: Failed to create SSL connection
15:48:22,311 INFO  [pong] 15:48:18,305 Failed to export spans. Server responded with gRPC status code 2. Error message: Failed to export TraceRequestMarshalers. The request could not be executed. Full error message: Failed to create SSL connection
```

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)