### PR TITLE
Fix QuarkusCliTlsCommandIT truststore config property value on Windows

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliTlsCommandIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliTlsCommandIT.java
@@ -79,7 +79,7 @@ public class QuarkusCliTlsCommandIT {
                 .assertFileExistsStr(cmd -> cmd.getOutputLineRemainder("Key Store File:"))
                 .assertFileExistsStr(cmd -> cmd.getOutputLineRemainder("Trust Store File:"))
                 // save truststore path in application properties so that we can use it in TlsCommandTest
-                .addToAppProps(cmd -> TRUST_STORE_PATH + "=" + cmd.getOutputLineRemainder("Trust Store File:"))
+                .addToAppProps(cmd -> TRUST_STORE_PATH + "=" + addEscapes(cmd.getOutputLineRemainder("Trust Store File:")))
                 .assertCommandOutputContains(
                         "Signed Certificate generated successfully and exported into `%s-keystore.p12`".formatted(CERT_NAME))
                 // following properties are set by this tls command, and we want to use them TlsCommandTest as well


### PR DESCRIPTION
### Summary

Here https://github.com/quarkus-qe/quarkus-test-suite/pull/2036 I fixed the issue for a keystore and didn't realize there is another issue with a truststore. I apologize for doing it on parts, but honestly, spawning Windows machine and setting up environment (or adjusting job) is way more time consuming then just fixing it here. Hope it's alright. Fixes:

```
[ERROR] io.quarkus.ts.quarkus.cli.tls.surefire.TlsCommandTest.testCommunicationUsingGeneratedCerts -- Time elapsed: 1.479 s <<< ERROR!
java.io.FileNotFoundException: C:UsersnameAppDataLocalTempquarkus-tls-command-tests17294939791165376470 ls-command-testquarkus-qe-cert-truststore.p12 (The filename, directory name, or volume label syntax is incorrect)
```

If there will be yet another issue after this one, I'll setup an instance.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)