### PR TITLE
Make control message smaller, so to not break ARM tests

### DIFF
--- a/logging/thirdparty/src/test/java/io/quarkus/ts/logging/jboss/SyslogIT.java
+++ b/logging/thirdparty/src/test/java/io/quarkus/ts/logging/jboss/SyslogIT.java
@@ -63,22 +63,19 @@ public class SyslogIT {
     @Test
     @Tag("https://issues.redhat.com/browse/QUARKUS-4531")
     public void filterBigMessage() {
-        String shorterMessage = "You won't believe it, but this message is exactly 64 chars long!";
-        String longerMessage = shorterMessage.repeat(2);
-        Assertions.assertEquals(64, shorterMessage.getBytes(StandardCharsets.UTF_8).length);
+        String longerMessage = "You won't believe it, but this message is exactly 64 chars long!".repeat(2);
+        String control = "control";
         Assertions.assertEquals(LENGTH_LIMIT, longerMessage.getBytes(StandardCharsets.UTF_8).length);
 
         // the order below is important. We must make sure, that the shorter message is sent after the longer
         app.given().when()
-                .post("/log/static/info?message={message}",
-                        longerMessage)
+                .post("/log/static/info?message={message}", longerMessage)
                 .then().statusCode(204);
         app.given().when()
-                .post("/log/static/info?message={message}",
-                        shorterMessage)
+                .post("/log/static/info?message={message}", control)
                 .then().statusCode(204);
 
-        syslog.logs().assertContains(shorterMessage);
+        syslog.logs().assertContains(control);
         syslog.getLogs()
                 .forEach(line -> {
                     Assertions.assertFalse(line.contains(longerMessage));


### PR DESCRIPTION
### Summary

While testing on ARM, our control message (64 symbols) is not shown in logs. I presume, that on ARM this message weight more, than 128 bytes; and so it is filtered by Quarkus. We should be careful around encodings and byte limits in the future.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)