### PR TITLE
Improve flakiness reporting by storing flaky run report with failed test name and failure message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,13 @@ jobs:
         id: flaky-test-detector
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
         run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
+      - name: Archive flaky run report
+        id: archive-flaky-run-report
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaky-run-report-linux-jvm-latest
+          path: target/flaky-run-report.json
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -224,6 +231,13 @@ jobs:
         id: flaky-test-detector
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
         run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
+      - name: Archive flaky run report
+        id: archive-flaky-run-report
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaky-run-report-linux-native-latest
+          path: target/flaky-run-report.json
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -276,6 +290,13 @@ jobs:
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
         shell: bash
         run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
+      - name: Archive flaky run report
+        id: archive-flaky-run-report
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaky-run-report-windows-jvm-latest
+          path: target/flaky-run-report.json
       - name: Zip Artifacts
         shell: bash
         if: failure()


### PR DESCRIPTION
### Summary

This is the first step to improve flakiness reporting. I need to have the file that we can inspect. Later I can experiment on commenting etc..

Tested: https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/11019026504?pr=2045

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)