### PR TITLE
Improve GitHub PR comments on flaky tests

### DIFF
--- a/.github/workflows/add-flaky-test-label.yml
+++ b/.github/workflows/add-flaky-test-label.yml
@@ -19,6 +19,12 @@ jobs:
       - name: 'Get PR number'
         if: ${{ hashFiles('**/jobs-with-flaky-tests') != '' }}
         run: gh run download $WORKFLOW_ID -n pr-number || true
+      - name: 'Download Flaky Run Reports'
+        if: ${{ hashFiles('**/pr-number') != '' }}
+        run: |
+          gh run download $WORKFLOW_ID -n flaky-run-report-linux-jvm-latest || true
+          gh run download $WORKFLOW_ID -n flaky-run-report-linux-native-latest || true
+          gh run download $WORKFLOW_ID -n flaky-run-report-windows-jvm-latest || true
       - name: 'Add "triage/flaky-test" label'
         if: ${{ hashFiles('**/pr-number') != '' }}
         run: |
@@ -26,4 +32,6 @@ jobs:
       - name: 'Comment on PR about flaky tests'
         if: ${{ hashFiles('**/pr-number') != '' }}
         run: |
-          gh pr comment "$(cat pr-number)" --body "Following jobs contain at least one flaky test: $(cat jobs-with-flaky-tests)"
+          curl -Ls https://sh.jbang.dev | bash -s - app setup
+          ~/.jbang/bin/jbang trust add https://raw.githubusercontent.com/quarkus-qe/flaky-run-reporter/main/jbang-scripts/
+          gh pr comment "$(cat pr-number)" --body "$(~/.jbang/bin/jbang https://raw.githubusercontent.com/quarkus-qe/flaky-run-reporter/main/jbang-scripts/GitHubPrCommentator.java overview-file=jobs-with-flaky-tests flaky-reports-file-prefix=flaky-run-report)"


### PR DESCRIPTION
### Summary

This workflow needs to be in the main repo to test it (so this CI doesn't test this PR). What changes do is basically to download (optionally) flaky test reports (if present). And then use JBang script to create comment. I am using JBang script because parsing of the report is non-trivial. Any future improvements can be driven from the Flaky Run Reporter for both TS and FW.

I have tried it locally and I also wrote automated tests for that JBang script, but I cannot guarantee this will work OOTB.

One thing I am not sure about is uniqueness of the artifact names in case there is matrix within same job with multiple flakes. It's not exactly easy to figure from GH docs so far, so I say we shall see.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)