### PR TITLE
[3.15] Archive flaky run reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,13 @@ jobs:
         id: flaky-test-detector
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
         run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
+      - name: Archive flaky run report
+        id: archive-flaky-run-report
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaky-run-report-linux-jvm-latest
+          path: target/flaky-run-report.json
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -218,6 +225,13 @@ jobs:
         id: flaky-test-detector
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
         run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
+      - name: Archive flaky run report
+        id: archive-flaky-run-report
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaky-run-report-linux-native-latest
+          path: target/flaky-run-report.json
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -270,6 +284,13 @@ jobs:
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
         shell: bash
         run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
+      - name: Archive flaky run report
+        id: archive-flaky-run-report
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaky-run-report-windows-jvm-latest
+          path: target/flaky-run-report.json
       - name: Zip Artifacts
         shell: bash
         if: failure()


### PR DESCRIPTION
### Summary

Same as here https://github.com/quarkus-qe/quarkus-test-suite/pull/2045. I am creating dedicated commit because release workflows are not identical between main and the 3.15 branch. I believe changes on the main https://github.com/quarkus-qe/quarkus-test-suite/pull/2047 will also report 3.15 if this gets in and the 3.15 branch is going to be around for a while.

For example, here I saw flakes report comment: https://github.com/quarkus-qe/quarkus-test-suite/pull/2046

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)