### PR TITLE
Setup Java for JBang purposes in the Flaky test workflow

### DIFF
--- a/.github/workflows/add-flaky-test-label.yml
+++ b/.github/workflows/add-flaky-test-label.yml
@@ -29,6 +29,14 @@ jobs:
         if: ${{ hashFiles('**/pr-number') != '' }}
         run: |
           gh pr edit "$(cat pr-number)" --add-label 'triage/flaky-test'
+      - name: Install JDK 21 for JBang
+        uses: actions/setup-java@v4
+        if: ${{ hashFiles('**/pr-number') != '' }}
+        with:
+          distribution: 'temurin'
+          java-version: 21
+          check-latest: true
+          cache: 'maven'
       - name: 'Comment on PR about flaky tests'
         if: ${{ hashFiles('**/pr-number') != '' }}
         run: |


### PR DESCRIPTION
### Summary

I run test here https://github.com/quarkus-qe/quarkus-test-suite/pull/2050 and it seems that I need to setup Java for the JBang https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/11041992883/job/30673453268. I didn't experience this locally for obvious reasons.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)