### PR TITLE
Don't use Maven cache option in Flaky workflow Java setup

### DIFF
--- a/.github/workflows/add-flaky-test-label.yml
+++ b/.github/workflows/add-flaky-test-label.yml
@@ -36,7 +36,6 @@ jobs:
           distribution: 'temurin'
           java-version: 21
           check-latest: true
-          cache: 'maven'
       - name: 'Comment on PR about flaky tests'
         if: ${{ hashFiles('**/pr-number') != '' }}
         run: |


### PR DESCRIPTION
### Summary

Tried it here https://github.com/quarkus-qe/quarkus-test-suite/pull/2050 and got https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/11049285587/job/30694514227. `Error: No file in /home/runner/work/quarkus-test-suite/quarkus-test-suite matched to [**/pom.xml], make sure you have checked out the target repository`

I made mistake. I read https://github.com/actions/setup-java?tab=readme-ov-file#caching-packages-dependencies. What I need is POM.xml if I want to cache it's dependencies, but there is no pom and JBang deps are not supported.


Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)