### PR TITLE
Rename Flaky Run reports to avoid conflicts when multiple flakes happen in different runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,13 +167,18 @@ jobs:
         id: flaky-test-detector
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
         run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
+      - name: Rename flaky test run report to avoid file name conflicts
+        id: rename-flaky-test-run-report
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        shell: bash
+        run: mv target/flaky-run-report.json target/flaky-run-report-linux-jvm-latest.json
       - name: Archive flaky run report
         id: archive-flaky-run-report
-        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        if: ${{ hashFiles('**/flaky-run-report-linux-jvm-latest.json') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: flaky-run-report-linux-jvm-latest
-          path: target/flaky-run-report.json
+          path: target/flaky-run-report-linux-jvm-latest.json
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -231,13 +236,18 @@ jobs:
         id: flaky-test-detector
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
         run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
+      - name: Rename flaky test run report to avoid file name conflicts
+        id: rename-flaky-test-run-report
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        shell: bash
+        run: mv target/flaky-run-report.json target/flaky-run-report-linux-native-latest.json
       - name: Archive flaky run report
         id: archive-flaky-run-report
-        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        if: ${{ hashFiles('**/flaky-run-report-linux-native-latest.json') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: flaky-run-report-linux-native-latest
-          path: target/flaky-run-report.json
+          path: target/flaky-run-report-linux-native-latest.json
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -290,13 +300,18 @@ jobs:
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
         shell: bash
         run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
+      - name: Rename flaky test run report to avoid file name conflicts
+        id: rename-flaky-test-run-report
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        shell: bash
+        run: mv target/flaky-run-report.json target/flaky-run-report-windows-jvm-latest.json
       - name: Archive flaky run report
         id: archive-flaky-run-report
-        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        if: ${{ hashFiles('**/flaky-run-report-windows-jvm-latest.json') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: flaky-run-report-windows-jvm-latest
-          path: target/flaky-run-report.json
+          path: target/flaky-run-report-windows-jvm-latest.json
       - name: Zip Artifacts
         shell: bash
         if: failure()


### PR DESCRIPTION
### Summary

Here https://github.com/quarkus-qe/quarkus-test-suite/pull/2050#issuecomment-2376688319 I have got comment that was extracted from flaky run report. However there wasn't all the information I wanted show as in the action https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/11051367395/job/30701097990 that parses these information following thing happened:

```
Run gh run download $WORKFLOW_ID -n flaky-run-report-linux-jvm-latest || true
error downloading flaky-run-report-linux-native-latest: error extracting zip archive: error extracting "flaky-run-report.json": open flaky-run-report.json: file exists
error downloading flaky-run-report-windows-jvm-latest: error extracting zip archive: error extracting "flaky-run-report.json": open flaky-run-report.json: file exists
```

So my thinking is that files in the artifacts must be uniquely named, which will help with the PR comment where it is is: `Artifact flaky-run-report.json contains following failures:` so I think it saying artifact `flaky-run-report-linux-jvm-latest.json` would be much better. (maybe there should be _artifact file_ but that's for flaky run reporter not this project).

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)