### PR TITLE
Fix compression test failures as media types compressed by defaults has changed

### DIFF
--- a/http/jakarta-rest-reactive/src/main/java/io/quarkus/ts/http/jakartarest/reactive/CompressionResource.java
+++ b/http/jakarta-rest-reactive/src/main/java/io/quarkus/ts/http/jakartarest/reactive/CompressionResource.java
@@ -81,8 +81,16 @@ public class CompressionResource {
     @GET
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Path("/small/default_no_compression_json")
-    public Uni<String> defaultNoCompressionJson() {
+    @Path("/small/default_compression_json")
+    public Uni<String> defaultCompressionJson() {
+        return defaultSmallResponse();
+    }
+
+    @GET
+    @Consumes(MediaType.APPLICATION_XHTML_XML)
+    @Produces(MediaType.APPLICATION_XHTML_XML)
+    @Path("/small/default_compression_xhtml_xml")
+    public Uni<String> defaultCompressionXhtmlXml() {
         return defaultSmallResponse();
     }
 
@@ -103,8 +111,8 @@ public class CompressionResource {
     }
 
     @GET
-    @Consumes({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
-    @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
+    @Consumes({ MediaType.APPLICATION_XML, MediaType.TEXT_PLAIN })
+    @Produces({ MediaType.APPLICATION_XML, MediaType.TEXT_PLAIN })
     @Path("/small/mixing_types")
     public Uni<String> mixingContentTypes() {
         return defaultSmallResponse();

--- a/http/jakarta-rest-reactive/src/test/java/io/quarkus/ts/http/jakartarest/reactive/CompressionHandlerIT.java
+++ b/http/jakarta-rest-reactive/src/test/java/io/quarkus/ts/http/jakartarest/reactive/CompressionHandlerIT.java
@@ -29,12 +29,13 @@ public class CompressionHandlerIT {
             BASE_PATH + "/default_compression_text_plain", MediaType.TEXT_PLAIN,
             BASE_PATH + "/default_compression_text_html", MediaType.TEXT_HTML,
             BASE_PATH + "/default_compression_text_xml", MediaType.TEXT_XML,
+            BASE_PATH + "/default_compression_json", MediaType.APPLICATION_JSON,
+            BASE_PATH + "/default_compression_xhtml_xml", MediaType.APPLICATION_XHTML_XML,
             BASE_PATH + "/default_compression_text_css", "text/css",
             BASE_PATH + "/default_compression_text_js", "text/javascript",
             BASE_PATH + "/default_compression_app_js", "application/javascript");
 
     private static final Map<String, String> DEFAULT_SMALL_NO_GZIP_ENDPOINTS = Map.of(
-            BASE_PATH + "/default_no_compression_json", MediaType.APPLICATION_JSON,
             BASE_PATH + "/default_no_compression_xml", MediaType.APPLICATION_XML,
             BASE_PATH + "/default_no_compression_form_data", MediaType.MULTIPART_FORM_DATA);
 
@@ -64,7 +65,7 @@ public class CompressionHandlerIT {
 
     @Test
     public void mixingTypes() {
-        assertUnCompressed(BASE_PATH + "/mixing_types", MediaType.APPLICATION_JSON);
+        assertUnCompressed(BASE_PATH + "/mixing_types", MediaType.APPLICATION_XML);
         assertUnCompressed(BASE_PATH + "/mixing_types", MediaType.TEXT_PLAIN);
     }
 

--- a/http/reactive-routes/src/main/java/io/quarkus/ts/http/reactiveroutes/CompressionHandler.java
+++ b/http/reactive-routes/src/main/java/io/quarkus/ts/http/reactiveroutes/CompressionHandler.java
@@ -56,9 +56,15 @@ public class CompressionHandler {
         defaultSmallResponse(rc);
     }
 
-    @Route(path = "/default_no_compression_json", consumes = { MediaType.APPLICATION_JSON }, produces = {
+    @Route(path = "/default_compression_json", consumes = { MediaType.APPLICATION_JSON }, produces = {
             MediaType.APPLICATION_JSON })
-    public void defaultNoCompressionJson(RoutingContext rc) {
+    public void defaultCompressionJson(RoutingContext rc) {
+        defaultSmallResponse(rc);
+    }
+
+    @Route(path = "/default_compression_xhtml_xml", consumes = { MediaType.APPLICATION_XHTML_XML }, produces = {
+            MediaType.APPLICATION_XHTML_XML })
+    public void defaultCompressionXhtmlXml(RoutingContext rc) {
         defaultSmallResponse(rc);
     }
 
@@ -74,8 +80,8 @@ public class CompressionHandler {
         defaultSmallResponse(rc);
     }
 
-    @Route(path = "/mixing_types", consumes = { MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN }, produces = {
-            MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
+    @Route(path = "/mixing_types", consumes = { MediaType.APPLICATION_XML, MediaType.TEXT_PLAIN }, produces = {
+            MediaType.APPLICATION_XML, MediaType.TEXT_PLAIN })
     public void mixingContentTypes(RoutingContext rc) {
         defaultSmallResponse(rc);
     }

--- a/http/reactive-routes/src/test/java/io/quarkus/ts/http/reactiveroutes/CompressionHandlerIT.java
+++ b/http/reactive-routes/src/test/java/io/quarkus/ts/http/reactiveroutes/CompressionHandlerIT.java
@@ -37,12 +37,13 @@ public class CompressionHandlerIT {
             BASE_PATH + "/default_compression_text_plain", MediaType.TEXT_PLAIN,
             BASE_PATH + "/default_compression_text_html", MediaType.TEXT_HTML,
             BASE_PATH + "/default_compression_text_xml", MediaType.TEXT_XML,
+            BASE_PATH + "/default_compression_json", MediaType.APPLICATION_JSON,
+            BASE_PATH + "/default_compression_xhtml_xml", MediaType.APPLICATION_XHTML_XML,
             BASE_PATH + "/default_compression_text_css", "text/css",
             BASE_PATH + "/default_compression_text_js", "text/javascript",
             BASE_PATH + "/default_compression_app_js", "application/javascript");
 
     private static final Map<String, String> DEFAULT_SMALL_NO_GZIP_ENDPOINTS = Map.of(
-            BASE_PATH + "/default_no_compression_json", MediaType.APPLICATION_JSON,
             BASE_PATH + "/default_no_compression_xml", MediaType.APPLICATION_XML,
             BASE_PATH + "/default_no_compression_form_data", MediaType.MULTIPART_FORM_DATA);
 
@@ -77,7 +78,7 @@ public class CompressionHandlerIT {
 
     @Test
     public void mixingTypes() {
-        assertUnCompressed(BASE_PATH + "/mixing_types", MediaType.APPLICATION_JSON);
+        assertUnCompressed(BASE_PATH + "/mixing_types", MediaType.APPLICATION_XML);
         assertUnCompressed(BASE_PATH + "/mixing_types", MediaType.TEXT_PLAIN);
     }
 


### PR DESCRIPTION
### Summary

The `io.quarkus.ts.http.reactiveroutes.CompressionHandlerIT` and `io.quarkus.ts.http.jakartarest.reactive.CompressionHandlerIT` are failing because defaults has changed https://github.com/quarkusio/quarkus/pull/43497/files. Application/json and XHTML/XML are now compressed by default. This breaking changes is documented https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.16#http-compression.

This PR:

- moves APP/JSON from uncompressed by default to the types that are compressed by default
- adds new type that is compressed by default (XHTML/XML)
- keeps original behavior of test that verifies mixing of compressed and uncompressed types by default, the app/json is replaced by app/xml which is is uncompressed by default

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)