### PR TITLE
Test Kafka TLS registry support and manual reloading of TLS registry configuration

### DIFF
--- a/messaging/infinispan-grpc-kafka/src/main/java/io/quarkus/ts/messaging/infinispan/grpc/kafka/providers/SaslSslKafkaProvider.java
+++ b/messaging/infinispan-grpc-kafka/src/main/java/io/quarkus/ts/messaging/infinispan/grpc/kafka/providers/SaslSslKafkaProvider.java
@@ -1,47 +1,39 @@
 package io.quarkus.ts.messaging.infinispan.grpc.kafka.providers;
 
-import java.io.File;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
-import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import io.smallrye.common.annotation.Identifier;
+
 public class SaslSslKafkaProvider extends KafkaProviders {
-
-    private final static String SASL_USERNAME_VALUE = "client";
-    private final static String SASL_PASSWORD_VALUE = "client-secret12345678912345678912";
-
-    @ConfigProperty(name = "kafka.ssl.truststore.location")
-    Optional<String> trustStoreFile;
-
-    @ConfigProperty(name = "kafka.ssl.truststore.password")
-    Optional<String> trustStorePassword;
-
-    @ConfigProperty(name = "kafka.ssl.truststore.type")
-    Optional<String> trustStoreType;
 
     @ConfigProperty(name = "kafka-client-sasl-ssl.bootstrap.servers")
     Optional<String> saslSslKafkaBootStrap;
+
+    @Inject
+    @Identifier("default-kafka-broker")
+    Map<String, Object> defaultKafkaBrokerConfig;
 
     @ApplicationScoped
     @Produces
     @Named("kafka-consumer-sasl-ssl")
     KafkaConsumer<String, String> getSaslSslConsumer() {
         Properties props = setupConsumerProperties(saslSslKafkaBootStrap.get());
-        saslSetup(props);
-        sslSetup(props);
+        saslSslSetup(props);
         KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props);
         consumer.subscribe(Collections.singletonList("test-ssl-consumer"));
         return consumer;
@@ -52,8 +44,7 @@ public class SaslSslKafkaProvider extends KafkaProviders {
     @Named("kafka-producer-sasl-ssl")
     KafkaProducer<String, String> getSaslSslProducer() {
         Properties props = setupProducerProperties(saslSslKafkaBootStrap.get());
-        saslSetup(props);
-        sslSetup(props);
+        saslSslSetup(props);
         return new KafkaProducer<>(props);
     }
 
@@ -62,24 +53,12 @@ public class SaslSslKafkaProvider extends KafkaProviders {
     @Named("kafka-admin-sasl-ssl")
     AdminClient getSaslSslAdmin() {
         Properties props = setupConsumerProperties(saslSslKafkaBootStrap.get());
-        saslSetup(props);
-        sslSetup(props);
+        saslSslSetup(props);
         return KafkaAdminClient.create(props);
     }
 
-    private static void saslSetup(Properties props) {
-        props.setProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        props.setProperty(SaslConfigs.SASL_MECHANISM, "SCRAM-SHA-512");
-        props.setProperty(SaslConfigs.SASL_JAAS_CONFIG,
-                "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"%s\" password=\"%s\";"
-                        .formatted(SASL_USERNAME_VALUE, SASL_PASSWORD_VALUE));
-    }
-
-    protected void sslSetup(Properties props) {
-        File tsFile = new File(trustStoreFile.get());
-        props.setProperty(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, tsFile.getPath());
-        props.setProperty(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, trustStorePassword.get());
-        props.setProperty(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, trustStoreType.get());
+    protected void saslSslSetup(Properties props) {
+        defaultKafkaBrokerConfig.forEach(props::putIfAbsent);
         props.setProperty(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
     }
 }

--- a/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/ts/messaging/infinispan/grpc/kafka/InfinispanKafkaSaslSslIT.java
+++ b/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/ts/messaging/infinispan/grpc/kafka/InfinispanKafkaSaslSslIT.java
@@ -19,6 +19,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaProtocol;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
+@Tag("QUARKUS-4592")
 @Tag("QUARKUS-2036")
 @QuarkusScenario
 public class InfinispanKafkaSaslSslIT {
@@ -29,7 +30,7 @@ public class InfinispanKafkaSaslSslIT {
             .withSecretFiles(CertUtils.KEYSTORE)
             .onPreStart((action) -> CertUtils.prepareCerts());
 
-    @KafkaContainer(vendor = KafkaVendor.STRIMZI, protocol = KafkaProtocol.SASL_SSL)
+    @KafkaContainer(vendor = KafkaVendor.STRIMZI, protocol = KafkaProtocol.SASL_SSL, tlsRegistryEnabled = true, tlsConfigName = "kafka-sasl-ssl")
     static final KafkaService kafkaSaslSsl = new KafkaService();
 
     @QuarkusApplication

--- a/messaging/kafkaSSL/src/main/java/io/quarkus/qe/messaging/ssl/providers/SaslSslKafkaProvider.java
+++ b/messaging/kafkaSSL/src/main/java/io/quarkus/qe/messaging/ssl/providers/SaslSslKafkaProvider.java
@@ -1,84 +1,63 @@
 package io.quarkus.qe.messaging.ssl.providers;
 
-import java.io.File;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
 import jakarta.inject.Named;
-import jakarta.inject.Singleton;
 
-import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-public class SaslSslKafkaProvider extends KafkaProviders {
+import io.smallrye.common.annotation.Identifier;
 
-    private final static String SASL_USERNAME_VALUE = "client";
-    private final static String SASL_PASSWORD_VALUE = "client-secret12345678912345678912";
+public class SaslSslKafkaProvider extends KafkaProviders {
 
     @ConfigProperty(name = "kafka-client-sasl-ssl.bootstrap.servers", defaultValue = "localhost:9092")
     String saslSslKafkaBootStrap;
 
-    @ConfigProperty(name = "kafka.ssl.truststore.location", defaultValue = "server.jks")
-    String trustStoreFile;
+    @Inject
+    @Identifier("default-kafka-broker")
+    Map<String, Object> defaultKafkaBrokerConfig;
 
-    @ConfigProperty(name = "kafka.ssl.truststore.password", defaultValue = "top-secret")
-    String trustStorePassword;
-
-    @ConfigProperty(name = "kafka.ssl.truststore.type", defaultValue = "PKCS12")
-    String trustStoreType;
-
-    @Singleton
+    @ApplicationScoped // don't create bean when testing Kafka SSL
     @Produces
     @Named("kafka-consumer-sasl-ssl")
     KafkaConsumer<String, String> getSaslSslConsumer() {
         Properties props = setupConsumerProperties(saslSslKafkaBootStrap);
-        saslSetup(props);
-        sslSetup(props);
+        saslSslSetup(props);
         KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props);
         consumer.subscribe(Collections.singletonList("test-sasl-ssl-consumer"));
         return consumer;
     }
 
-    @Singleton
+    @ApplicationScoped // don't create bean when testing Kafka SSL
     @Produces
     @Named("kafka-producer-sasl-ssl")
     KafkaProducer<String, String> getSaslSslProducer() {
         Properties props = setupProducerProperties(saslSslKafkaBootStrap);
-        saslSetup(props);
-        sslSetup(props);
+        saslSslSetup(props);
         return new KafkaProducer<>(props);
     }
 
-    @Singleton
+    @ApplicationScoped // don't create bean when testing Kafka SSL
     @Produces
     @Named("kafka-admin-sasl-ssl")
     AdminClient getSaslSslAdmin() {
         Properties props = setupConsumerProperties(saslSslKafkaBootStrap);
-        saslSetup(props);
-        sslSetup(props);
+        saslSslSetup(props);
         return KafkaAdminClient.create(props);
     }
 
-    private static void saslSetup(Properties props) {
-        props.setProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        props.setProperty(SaslConfigs.SASL_MECHANISM, "SCRAM-SHA-512");
-        props.setProperty(SaslConfigs.SASL_JAAS_CONFIG,
-                "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"%s\" password=\"%s\";"
-                        .formatted(SASL_USERNAME_VALUE, SASL_PASSWORD_VALUE));
-    }
-
-    protected void sslSetup(Properties props) {
-        File tsFile = new File(trustStoreFile);
-        props.setProperty(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, tsFile.getPath());
-        props.setProperty(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, trustStorePassword);
-        props.setProperty(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, trustStoreType);
+    protected void saslSslSetup(Properties props) {
+        props.putAll(defaultKafkaBrokerConfig);
         props.setProperty(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
     }
 }

--- a/messaging/kafkaSSL/src/main/java/io/quarkus/qe/messaging/ssl/quickstart/SaslSslKafkaEndpoint.java
+++ b/messaging/kafkaSSL/src/main/java/io/quarkus/qe/messaging/ssl/quickstart/SaslSslKafkaEndpoint.java
@@ -40,8 +40,8 @@ public class SaslSslKafkaEndpoint extends KafkaEndpoint {
     AdminClient saslSslAdmin;
 
     public void initialize(@Observes StartupEvent ev,
-            @ConfigProperty(name = "kafka.ssl.enable", defaultValue = "false") Boolean sslEnabled) {
-        if (sslEnabled) {
+            @ConfigProperty(name = "kafka.security.protocol", defaultValue = "") String kafkaSecurityProtocol) {
+        if ("SASL_SSL".equals(kafkaSecurityProtocol)) {
             super.initialize(saslSslConsumer);
         }
     }

--- a/messaging/kafkaSSL/src/main/java/io/quarkus/qe/messaging/ssl/quickstart/SslKafkaEndpoint.java
+++ b/messaging/kafkaSSL/src/main/java/io/quarkus/qe/messaging/ssl/quickstart/SslKafkaEndpoint.java
@@ -41,8 +41,8 @@ public class SslKafkaEndpoint extends KafkaEndpoint {
     Provider<AdminClient> sslAdmin;
 
     public void initialize(@Observes StartupEvent ev,
-            @ConfigProperty(name = "kafka.ssl.enable", defaultValue = "false") Boolean sslEnabled) {
-        if (sslEnabled) {
+            @ConfigProperty(name = "kafka.security.protocol", defaultValue = "") String kafkaSecurityProtocol) {
+        if ("SSL".equals(kafkaSecurityProtocol)) {
             super.initialize(sslConsumer.get());
         }
     }

--- a/messaging/kafkaSSL/src/test/java/io/quarkus/qe/messaging/ssl/KafkaSaslSslTlsRegistryIT.java
+++ b/messaging/kafkaSSL/src/test/java/io/quarkus/qe/messaging/ssl/KafkaSaslSslTlsRegistryIT.java
@@ -1,0 +1,61 @@
+package io.quarkus.qe.messaging.ssl;
+
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+
+import org.hamcrest.core.StringContains;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.KafkaService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KafkaContainer;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.containers.model.KafkaProtocol;
+import io.quarkus.test.services.containers.model.KafkaVendor;
+
+@QuarkusScenario
+public class KafkaSaslSslTlsRegistryIT {
+
+    @KafkaContainer(vendor = KafkaVendor.STRIMZI, protocol = KafkaProtocol.SASL_SSL, tlsRegistryEnabled = true, tlsConfigName = "kafka-sasl-ssl-config")
+    static final KafkaService kafka = new KafkaService();
+
+    @QuarkusApplication
+    static final RestService app = new RestService()
+            .withProperties(kafka::getSslProperties)
+            .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
+            .withProperty("kafka-client-sasl-ssl.bootstrap.servers", kafka::getBootstrapUrl);
+
+    @Test
+    void testKafkaClientSaslSsl() {
+        await().untilAsserted(() -> {
+            pushEvent("my-key", "my-value");
+            verifyEventWasProcessed("my-key-my-value");
+            pushEvent("my-key", "my-value-two");
+            verifyEventWasProcessed("my-key-my-value-two");
+        });
+
+        get("/kafka/sasl/ssl/topics")
+                .then()
+                .statusCode(200)
+                .body(StringContains.containsString("hello"));
+    }
+
+    private void pushEvent(String key, String value) {
+        given()
+                .queryParam("key", key)
+                .queryParam("value", value)
+                .when()
+                .post("/kafka/sasl/ssl")
+                .then()
+                .statusCode(200);
+    }
+
+    private void verifyEventWasProcessed(String expectedEvent) {
+        get("/kafka/sasl/ssl")
+                .then()
+                .statusCode(200)
+                .body(StringContains.containsString(expectedEvent));
+    }
+}

--- a/messaging/kafkaSSL/src/test/java/io/quarkus/qe/messaging/ssl/KafkaSaslSslTlsRegistryIT.java
+++ b/messaging/kafkaSSL/src/test/java/io/quarkus/qe/messaging/ssl/KafkaSaslSslTlsRegistryIT.java
@@ -5,6 +5,7 @@ import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 
 import org.hamcrest.core.StringContains;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KafkaService;
@@ -15,6 +16,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaProtocol;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
+@Tag("QUARKUS-4592")
 @QuarkusScenario
 public class KafkaSaslSslTlsRegistryIT {
 

--- a/messaging/kafkaSSL/src/test/java/io/quarkus/qe/messaging/ssl/KafkaSslTlsRegistryIT.java
+++ b/messaging/kafkaSSL/src/test/java/io/quarkus/qe/messaging/ssl/KafkaSslTlsRegistryIT.java
@@ -1,0 +1,62 @@
+package io.quarkus.qe.messaging.ssl;
+
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+
+import org.hamcrest.core.StringContains;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.KafkaService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KafkaContainer;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.containers.model.KafkaProtocol;
+import io.quarkus.test.services.containers.model.KafkaVendor;
+
+@QuarkusScenario
+public class KafkaSslTlsRegistryIT {
+
+    @KafkaContainer(vendor = KafkaVendor.STRIMZI, protocol = KafkaProtocol.SSL, tlsRegistryEnabled = true, tlsConfigName = "kafka-ssl-config")
+    static final KafkaService kafkassl = new KafkaService();
+
+    @QuarkusApplication
+    static final RestService app = new RestService()
+            .withProperty("kafka.bootstrap.servers", kafkassl::getBootstrapUrl)
+            .withProperties(kafkassl::getSslProperties)
+            .withProperty("kafka-streams.state.dir", "target")
+            .withProperty("kafka-client-ssl.bootstrap.servers", kafkassl::getBootstrapUrl);
+
+    @Test
+    public void testKafkaClientSSL() {
+        await().untilAsserted(() -> {
+            pushEvent("my-key", "my-value");
+            verifyEventWasProcessed("my-key-my-value");
+            pushEvent("my-key", "my-value-two");
+            verifyEventWasProcessed("my-key-my-value-two");
+        });
+
+        get("/kafka/ssl/topics")
+                .then()
+                .statusCode(200)
+                .body(StringContains.containsString("hello"));
+    }
+
+    private void pushEvent(String key, String value) {
+        given()
+                .queryParam("key", key)
+                .queryParam("value", value)
+                .when()
+                .post("/kafka/ssl")
+                .then()
+                .statusCode(200);
+    }
+
+    private void verifyEventWasProcessed(String expectedEvent) {
+        get("/kafka/ssl")
+                .then()
+                .statusCode(200)
+                .body(StringContains.containsString(expectedEvent));
+    }
+}

--- a/messaging/kafkaSSL/src/test/java/io/quarkus/qe/messaging/ssl/KafkaSslTlsRegistryIT.java
+++ b/messaging/kafkaSSL/src/test/java/io/quarkus/qe/messaging/ssl/KafkaSslTlsRegistryIT.java
@@ -5,6 +5,7 @@ import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 
 import org.hamcrest.core.StringContains;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KafkaService;
@@ -15,6 +16,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaProtocol;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
+@Tag("QUARKUS-4592")
 @QuarkusScenario
 public class KafkaSslTlsRegistryIT {
 

--- a/security/https/src/main/java/io/quarkus/ts/security/https/CertificateReloader.java
+++ b/security/https/src/main/java/io/quarkus/ts/security/https/CertificateReloader.java
@@ -1,0 +1,39 @@
+package io.quarkus.ts.security.https;
+
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.event.Observes;
+
+import io.quarkus.tls.CertificateUpdatedEvent;
+import io.quarkus.tls.TlsConfiguration;
+import io.quarkus.tls.TlsConfigurationRegistry;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.Router;
+
+public class CertificateReloader {
+
+    private static final String MTLS_CONFIG_NAME = "mtls-http";
+
+    void setupCertificateReloadingTriggerRoute(@Observes Router router, Event<CertificateUpdatedEvent> certUpdatedEvent,
+            TlsConfigurationRegistry registry, Vertx vertx) {
+        router.route("/reload-mtls-certificates").handler(ctx -> {
+            TlsConfiguration config = registry.get(MTLS_CONFIG_NAME).orElseThrow();
+            vertx
+                    .executeBlocking(() -> {
+                        boolean reloaded = config.reload();
+                        if (reloaded) {
+                            certUpdatedEvent.fire(new CertificateUpdatedEvent(MTLS_CONFIG_NAME, config));
+                        }
+                        return reloaded;
+                    })
+                    .onSuccess(reloaded -> {
+                        if (reloaded) {
+                            ctx.response().end("Certificates reloaded.");
+                        } else {
+                            ctx.fail(500, new RuntimeException("Could not reload mTLS certificates."));
+                        }
+                    })
+                    .onFailure(ctx::fail);
+        });
+    }
+
+}

--- a/security/https/src/main/java/io/quarkus/ts/security/https/SecuredResource.java
+++ b/security/https/src/main/java/io/quarkus/ts/security/https/SecuredResource.java
@@ -16,9 +16,20 @@ public class SecuredResource {
     @Inject
     SecurityIdentity identity;
 
+    @GET // requires 'user' role
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getHttps() {
+        return getResponse();
+    }
+
+    @Path("mtls") // requires authentication
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    public String get() {
+    public String getMtls() {
+        return getResponse();
+    }
+
+    private String getResponse() {
         X509Certificate certificate = identity.getCredential(CertificateCredential.class).getCertificate();
         return "Client certificate: " + certificate.getSubjectX500Principal().getName();
     }

--- a/security/https/src/main/resources/application.properties
+++ b/security/https/src/main/resources/application.properties
@@ -4,5 +4,8 @@ quarkus.http.auth.policy.users-only.roles-allowed=user
 quarkus.http.auth.permission.secured-urls.paths=/secured/*
 quarkus.http.auth.permission.secured-urls.policy=users-only
 
+quarkus.http.auth.permission.mtls.paths=/secured/mtls
+quarkus.http.auth.permission.mtls.policy=authenticated
+
 quarkus.http.auth.certificate-role-properties=role-mappings.txt
 quarkus.native.additional-build-args=-H:IncludeResources=.*\\.txt

--- a/security/https/src/test/java/io/quarkus/ts/security/https/secured/MutualTlsSecurityIT.java
+++ b/security/https/src/test/java/io/quarkus/ts/security/https/secured/MutualTlsSecurityIT.java
@@ -1,0 +1,97 @@
+package io.quarkus.ts.security.https.secured;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.security.certificate.CertificateBuilder;
+import io.quarkus.test.security.certificate.ClientCertificateRequest;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.Certificate.ClientCertificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.utils.AwaitilityUtils;
+
+@Tag("QUARKUS-4592")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@QuarkusScenario
+public class MutualTlsSecurityIT {
+
+    private static final String MTLS_PATH = "/secured/mtls";
+    private static final String CERT_PREFIX = "qe-test";
+    private static final String CLIENT = "client";
+    private static final String GUEST_CLIENT = "guest-client";
+
+    @QuarkusApplication(ssl = true, certificates = @Certificate(prefix = CERT_PREFIX, clientCertificates = {
+            @ClientCertificate(cnAttribute = CLIENT),
+            @ClientCertificate(cnAttribute = GUEST_CLIENT, unknownToServer = true)
+    }, configureKeystore = true, configureTruststore = true, tlsConfigName = "mtls-http", configureHttpServer = true))
+    static final RestService app = new RestService()
+            .withProperty("quarkus.http.auth.proactive", "false")
+            .withProperty("quarkus.http.ssl.client-auth", "required")
+            .withProperty("quarkus.http.insecure-requests", "disabled");
+
+    @Order(1)
+    @Test
+    public void testMutualTlsForHttpServer() {
+        var client1 = app.mutinyHttps(CLIENT);
+        var httpResponse = client1.get(MTLS_PATH).sendAndAwait();
+        assertEquals(HttpStatus.SC_OK, httpResponse.statusCode());
+        assertEquals("Client certificate: CN=" + CLIENT, httpResponse.bodyAsString());
+
+        callSecuredEndpointAndExpectFailure(GUEST_CLIENT);
+    }
+
+    @Order(2)
+    @Test
+    public void testCertificateReloading() {
+        // important to load before certificates are reloaded because otherwise
+        // we would have new invalid certificate on test side and expected different certs on the server side
+        var clientBeforeReload = app.mutinyHttps(CLIENT);
+
+        app
+                .<CertificateBuilder> getPropertyFromContext(CertificateBuilder.INSTANCE_KEY)
+                .regenerateCertificate(CERT_PREFIX, certRequest -> {
+                    // regenerate client certificates
+                    // make the first client invalid
+                    var clientOneCert = new ClientCertificateRequest(CLIENT, true);
+                    // make the second client valid
+                    var clientTwoCert = new ClientCertificateRequest(GUEST_CLIENT, false);
+                    certRequest.withClientRequests(clientOneCert, clientTwoCert);
+                });
+
+        var response = clientBeforeReload.get("/reload-mtls-certificates").sendAndAwait();
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+        assertEquals("Certificates reloaded.", response.bodyAsString());
+
+        // now we expect opposite from what we tested in step one: client 1 must fail and client 2 must succeed
+        AwaitilityUtils.untilAsserted(() -> {
+            var httpResponse = app.mutinyHttps(GUEST_CLIENT).get(MTLS_PATH).sendAndAwait();
+            assertEquals(HttpStatus.SC_OK, httpResponse.statusCode());
+            assertEquals("Client certificate: CN=" + GUEST_CLIENT, httpResponse.bodyAsString());
+
+            callSecuredEndpointAndExpectFailure(CLIENT);
+        });
+    }
+
+    private static void callSecuredEndpointAndExpectFailure(String clientCn) {
+        // this client certs are not in the server truststore, therefore they cannot be trusted
+        try {
+            app.mutinyHttps(clientCn).get(MTLS_PATH).sendAndAwait();
+            // this must never happen, basically as SSL handshake must throw exception
+            Assertions.fail("SSL handshake didn't fail even though certificate host is unknown");
+        } catch (Exception e) {
+            // failure is expected
+            assertTrue(e.getMessage().contains("Received fatal alert: bad_certificate"),
+                    "Expected failure over bad certificate, but got: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
### Summary

- adds Kafka TLS registry test coverage as https://github.com/quarkusio/quarkus/issues/43107 is fixed now; changes:
  - SASL_SSL client and producer were created and initialized (tried to consume topic) when only SSL was tested and vice versa, so I made sure we don't initialize it when we don't test it (as it would fail for TLS registry [missing named config])
  - newly we are taking SSL/SASL_SSL config from default broker as documented here https://quarkus.io/guides/kafka#kafka-bare-clients because it already contains what we set plus for TLS config scenario it also contains what Quarkus Kafka extension set (`ssl.engine.factory.class=io.quarkus.kafka.client.tls.QuarkusKafkaSslEngineFactory` among other non-TLS props) which is required otherwise SSL context is not created from the TLS registry config
  - I didn't cover message channel specific config like `mp.messaging.incoming.your-channel.tls-configuration-name=your-tls-config` I think it's tested upstream reasonably and don't want to add more tests
- adds test coverage for manual reloading of TLS registry config https://quarkus.io/guides/tls-registry-reference#reloading-certificates because I realized during TLS config reference review I missed that; we already have test coverage for periodic reloading of certs https://github.com/quarkus-qe/quarkus-test-suite/pull/1986

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)