### PR TITLE
Disable SSL requirement for keycloak realms

### DIFF
--- a/security/keycloak-oidc-client-extended/src/test/resources/kc-logout-realm.json
+++ b/security/keycloak-oidc-client-extended/src/test/resources/kc-logout-realm.json
@@ -26,7 +26,7 @@
   "oauth2DeviceCodeLifespan" : 600,
   "oauth2DevicePollingInterval" : 5,
   "enabled" : true,
-  "sslRequired" : "external",
+  "sslRequired" : "none",
   "registrationAllowed" : false,
   "registrationEmailAsUsername" : false,
   "rememberMe" : false,

--- a/security/keycloak-oidc-client-reactive-extended/src/test/resources/kc-logout-realm.json
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/resources/kc-logout-realm.json
@@ -26,7 +26,7 @@
   "oauth2DeviceCodeLifespan" : 600,
   "oauth2DevicePollingInterval" : 5,
   "enabled" : true,
-  "sslRequired" : "external",
+  "sslRequired" : "none",
   "registrationAllowed" : false,
   "registrationEmailAsUsername" : false,
   "rememberMe" : false,


### PR DESCRIPTION
### Summary

Tests for aarch64 are failing, because keycloak requires secure context for cookies, unless configured otherwise. (Which AFAIK means, it should require either TLS connection or running on localhost). This causes tests to fail during keycloak login. This PR changes keycloak to not require TLS.

What I found about this, it should be expected behavior for keycloak v24+.
https://github.com/keycloak/keycloak/issues/24821
https://github.com/keycloak/keycloak/issues/30977

Honestly I have no idea why is this not failing in other test suites.


Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)