### PR TITLE
Fix not enough space error for keycloak container image quay.io/keycloak/keycloak:25.0

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
@@ -15,7 +15,9 @@ import io.quarkus.test.services.QuarkusApplication;
 public class HttpAdvancedIT extends BaseHttpAdvancedIT {
 
     @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
-    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
+            // TODO remove this propery when this issue will be resolved: https://github.com/quarkus-qe/quarkus-test-suite/issues/2106
+            .withProperty("JAVA_OPTS", "-Xms512m -Xmx1g");
 
     @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureHttpServer = true, useTlsRegistry = false))
     static RestService app = new RestService().withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);


### PR DESCRIPTION
### Summary

In our daily jobs, we experienced `OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00000006af400000, 4034920448, 0) failed; error=' Not enough space' (errno=12)#`.

It was some improvements with https://github.com/quarkus-qe/quarkus-test-framework/pull/1351 
Apart from that, the' HttpAdvancedIT' test also needs to be updated, and I did with this PR. 
I've tested in our Jenkins-job and the test PASSED.


Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)