### PR TITLE
Disable external application on Aarch OCP

### DIFF
--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/DisabledOnAarch64Snapshot.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/DisabledOnAarch64Snapshot.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.external.applications;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Inherited
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledOnAarch64SnapshotConditions.class)
+public @interface DisabledOnAarch64Snapshot {
+
+    /**
+     * Why is the annotated test class or test method disabled.
+     */
+    String reason();
+}

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/DisabledOnAarch64SnapshotConditions.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/DisabledOnAarch64SnapshotConditions.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.external.applications;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+
+public class DisabledOnAarch64SnapshotConditions implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        boolean isAarch64 = "true".equals(System.getProperty("ts.arm.missing.services.excludes"));
+        boolean isSnapshot = QuarkusProperties.getVersion().contains("SNAPSHOT");
+        if (isAarch64 && isSnapshot) {
+            return ConditionEvaluationResult.disabled("It is snapshot running on aarch64.");
+        } else {
+            return ConditionEvaluationResult.enabled("It is not snapshot running on aarch64.");
+        }
+    }
+}

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftQuickstartIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftQuickstartIT.java
@@ -5,5 +5,6 @@ import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 
 @DisabledOnNative(reason = "Native + s2i not supported")
 @OpenShiftScenario
+@DisabledOnAarch64Snapshot(reason = "S2I external repo not supported on aarch OCP yet")
 public class OpenShiftQuickstartIT extends QuickstartIT {
 }

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftTodoDemoIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftTodoDemoIT.java
@@ -5,5 +5,6 @@ import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 
 @DisabledOnNative(reason = "Native + s2i not supported")
 @OpenShiftScenario
+@DisabledOnAarch64Snapshot(reason = "S2I external repo not supported on aarch OCP yet")
 public class OpenShiftTodoDemoIT extends TodoDemoIT {
 }

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
@@ -22,6 +22,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 import io.restassured.http.ContentType;
 
 @DisabledOnNative(reason = "Native + s2i not supported")
+@DisabledOnAarch64Snapshot(reason = "S2I external repo not supported on aarch OCP yet")
 @OpenShiftScenario
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")


### PR DESCRIPTION
### Summary

Tests for external applications requires a s2i.maven.remote.repository property to be defined, if running against snapshot builds. Lacking this in aarch jobs caused several failures in its tests.
Since we cannot use external S2I repo in aarch cluster RN, disabling these tests.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)