### PR TITLE
[3.2] Backport 8/10/2024

### DIFF
--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AbstractAnalyticsIT.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AbstractAnalyticsIT.java
@@ -142,12 +142,17 @@ public abstract class AbstractAnalyticsIT {
                 .map(payloadExtension -> mapToGA(payloadExtension.getGroupId(), payloadExtension.getArtifactId()))
                 .collect(Collectors.toList());
         assertEquals(pomDependencyGAs, payloadExtensionGAs);
-        List<PayloadExtension> extensionsWithMismatchedVersion = payloadExtensions.stream()
-                .filter(extension -> !QUARKUS_EXTENSION_VERSION_PATTERN.matcher(extension.getVersion()).matches())
-                .collect(Collectors.toList());
-        assertEquals(0, extensionsWithMismatchedVersion.size(),
-                String.format("All extensions versions must match pattern: '%s'. Offending extensions: %s",
-                        QUARKUS_EXTENSION_VERSION_PATTERN.pattern(), extensionsWithMismatchedVersion));
+
+        // RHBQ doesn't guarantee the same version of the platform and core extensions
+        boolean isRHBQ = QuarkusProperties.getVersion().contains("redhat");
+        if (!isRHBQ) {
+            List<PayloadExtension> extensionsWithMismatchedVersion = payloadExtensions.stream()
+                    .filter(extension -> !QUARKUS_EXTENSION_VERSION_PATTERN.matcher(extension.getVersion()).matches())
+                    .collect(Collectors.toList());
+            assertEquals(0, extensionsWithMismatchedVersion.size(),
+                    String.format("All extensions versions must match pattern: '%s'. Offending extensions: %s",
+                            QUARKUS_EXTENSION_VERSION_PATTERN.pattern(), extensionsWithMismatchedVersion));
+        }
     }
 
     private List<Dependency> getPomDependencies(QuarkusCliRestService app) {

--- a/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/BlockingProducerIT.java
+++ b/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/BlockingProducerIT.java
@@ -25,7 +25,7 @@ public class BlockingProducerIT {
     static final long NETWORK_DELAY_MS = 300;
     static final long KAFKA_MAX_BLOCK_TIME_MS = KAFKA_MAX_BLOCK_MS + NETWORK_DELAY_MS;
 
-    @KafkaContainer(vendor = KafkaVendor.STRIMZI, version = "0.24.0-kafka-2.7.0")
+    @KafkaContainer(vendor = KafkaVendor.STRIMZI)
     static final KafkaService kafka = new KafkaService().withProperty("auto.create.topics.enable", "false");
 
     @QuarkusApplication

--- a/messaging/kafka-streams-reactive-messaging/src/main/java/io/quarkus/ts/messaging/kafka/reactive/streams/shutdown/SlowTopicResource.java
+++ b/messaging/kafka-streams-reactive-messaging/src/main/java/io/quarkus/ts/messaging/kafka/reactive/streams/shutdown/SlowTopicResource.java
@@ -8,6 +8,8 @@ import jakarta.ws.rs.PathParam;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 
+import io.smallrye.mutiny.Uni;
+
 @Path("/slow-topic")
 public class SlowTopicResource {
 
@@ -22,4 +24,11 @@ public class SlowTopicResource {
             emitter.send("Message " + index);
         }
     }
+
+    @POST
+    @Path("/sendMessage/{content}")
+    public Uni<Void> sendMessage(@PathParam("content") String message) {
+        return Uni.createFrom().completionStage(emitter.send(message));
+    }
+
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/KafkaGratefulShutdownIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/KafkaGratefulShutdownIT.java
@@ -5,11 +5,18 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.logging.log4j.util.Strings;
 import org.jboss.logmanager.Level;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.DisabledIf;
 
 import io.quarkus.test.bootstrap.KafkaService;
@@ -22,6 +29,7 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 import io.quarkus.ts.messaging.kafka.reactive.streams.shutdown.SlowTopicConsumer;
 import io.quarkus.ts.messaging.kafka.reactive.streams.shutdown.SlowTopicResource;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DisabledIf(value = DISABLED_IF_RHBQ_ON_WINDOWS, disabledReason = "QUARKUS-3434")
 @QuarkusScenario
 @DisabledOnNative(reason = "Due to high native build execution time")
@@ -36,6 +44,19 @@ public class KafkaGratefulShutdownIT {
     @KafkaContainer(vendor = KafkaVendor.STRIMZI)
     static KafkaService kafka = new KafkaService();
 
+    /**
+     * If topic is not created before the test, messages inside it will not be processed.
+     * for details and todo see https://github.com/quarkusio/quarkus/issues/41441
+     */
+    private void createTopic(KafkaService service) throws InterruptedException {
+        Properties properties = new Properties();
+        properties.put("bootstrap.servers", service.getBootstrapUrl());
+        try (AdminClient client = AdminClient.create(properties)) {
+            client.createTopics(List.of(new NewTopic("slow", 1, (short) 1)));
+        }
+        Thread.sleep(1000);
+    }
+
     @QuarkusApplication(classes = { SlowTopicConsumer.class,
             SlowTopicResource.class }, properties = "kafka.grateful.shutdown.application.properties")
     static RestService app = new RestService()
@@ -43,14 +64,23 @@ public class KafkaGratefulShutdownIT {
             .withProperty("quarkus.kafka-streams.bootstrap-servers", kafka::getBootstrapUrl)
             .withProperty(KAFKA_LOG_PROPERTY, Level.DEBUG.getName());
 
+    @Order(1)
     @Test
-    public void shouldWaitForMessagesWhenGratefulShutdownIsEnabled() {
-        givenApplicationWithGratefulShutdownEnabled();
+    public void testConnection() throws InterruptedException {
+        createTopic(kafka);
+        app.given().post("/slow-topic/sendMessage/ave").then().statusCode(200);
+        app.logs().assertContains("ave");
+    }
+
+    @Order(2)
+    @Test
+    public void shouldWaitForMessagesWhenGratefulShutdownIsEnabled() throws InterruptedException {
         givenMessagesInTopic();
         whenStopApplication();
         thenAllMessagesAreProcessedOrKafkaIsShutdown();
     }
 
+    @Order(3)
     @Test
     public void shouldNotWaitForMessagesWhenGratefulShutdownIsDisabled() {
         givenApplicationWithGratefulShutdownDisabled();
@@ -97,7 +127,7 @@ public class KafkaGratefulShutdownIT {
         await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
             List<String> elements = app.getLogs();
 
-            assertTrue(elements.stream().anyMatch(assertion), message + ":" + elements);
+            assertTrue(elements.stream().anyMatch(assertion), message + ":" + Strings.join(elements, '\n'));
         });
     }
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
@@ -13,6 +13,7 @@ import io.quarkus.test.services.operator.KafkaInstance;
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1147")
 @DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "debezium/zookeeper container not available on s390x & ppc64le.")
 public class OperatorOpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTest {
+
     @Operator(name = "amq-streams", source = "redhat-operators")
     static KafkaInstance kafka = new KafkaInstance();
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <!-- Docker images used by both surefire and failsafe plugin -->
         <postgresql.latest.image>docker.io/library/postgres:15</postgresql.latest.image>
         <build-reporter-maven-extension.version>3.2.0</build-reporter-maven-extension.version>
+        <strimzi.testcontainers.version>0.107.0</strimzi.testcontainers.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -161,6 +162,22 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- Quarkus BOM brings older version of this dependency, so we need to override it manually -->
+            <groupId>io.strimzi</groupId>
+            <artifactId>strimzi-test-container</artifactId>
+            <version>${strimzi.testcontainers.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.2.12.Final</quarkus.platform.version>
         <quarkus.ide.version>3.2.12.Final</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.3.1.Final</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.3.2.Final</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.4.0</quarkus-qpid-jms.version>
         <apache-httpclient-fluent.version>4.5.14</apache-httpclient-fluent.version>
         <confluent.kafka-avro-serializer.version>7.3.1</confluent.kafka-avro-serializer.version>

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MssqlTransactionGeneralUsageIT.java
@@ -26,8 +26,8 @@ public class MssqlTransactionGeneralUsageIT extends TransactionCommons {
             self
                     .<GenericContainer<?>> getPropertyFromContext(DOCKER_INNER_CONTAINER)
                     .execInContainer(
-                            "/opt/mssql-tools/bin/sqlcmd", "-S", "localhost", "-U", self.getUser(), "-P", self.getPassword(),
-                            "-Q", "EXEC sp_sqljdbc_xa_install");
+                            "/opt/mssql-tools18/bin/sqlcmd", "-C", "-S", "localhost", "-U", self.getUser(),
+                            "-P", self.getPassword(), "-Q", "EXEC sp_sqljdbc_xa_install");
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
### Summary

Bump of framework.

Backporting features which causing testing of RHBQ failing. Testing it with latest RHBQ will leave comment when it's done.

Backport of:
- https://github.com/quarkus-qe/quarkus-test-suite/pull/1854
  - Removed snappy as 3.2 was never tested with it
  - Added `strimzi-test-container` artifact as 3.2 branch seems to have old version and for kraft we need new
- https://github.com/quarkus-qe/quarkus-test-suite/pull/1899
- https://github.com/quarkus-qe/quarkus-test-suite/pull/1905

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)