### PR TITLE
Move brotli4j into test sources and disable it on aarch64

### DIFF
--- a/http/http-advanced-reactive/pom.xml
+++ b/http/http-advanced-reactive/pom.xml
@@ -95,10 +95,6 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.aayushatharva.brotli4j</groupId>
-            <artifactId>brotli4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.microsoft.playwright</groupId>
             <artifactId>playwright</artifactId>
             <scope>test</scope>

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/Brotli4JHttpIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/Brotli4JHttpIT.java
@@ -20,15 +20,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Dependency;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.utils.FileUtils;
+import io.quarkus.ts.http.advanced.reactive.brotli4j.Brotli4JHttpServerConfig;
+import io.quarkus.ts.http.advanced.reactive.brotli4j.Brotli4JResource;
+import io.quarkus.ts.http.advanced.reactive.brotli4j.Brotli4JRestMock;
 import io.restassured.response.Response;
 
 @Tag("QQE-378")
 @QuarkusScenario
 public class Brotli4JHttpIT {
     @QuarkusApplication(classes = { Brotli4JHttpServerConfig.class, Brotli4JResource.class,
-            Brotli4JRestMock.class }, properties = "compression.properties")
+            Brotli4JRestMock.class }, dependencies = @Dependency(groupId = "com.aayushatharva.brotli4j", artifactId = "brotli4j"), properties = "compression.properties")
     static RestService app = new RestService();
 
     private final static String DEFAULT_TEXT_PLAIN = Brotli4JResource.DEFAULT_TEXT_PLAIN;

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeBrotli4JHttpIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeBrotli4JHttpIT.java
@@ -1,5 +1,17 @@
 package io.quarkus.ts.http.advanced.reactive;
 
+import static io.quarkus.ts.http.advanced.reactive.Brotli4JHttpIT.CONTENT_LENGTH_DEFAULT_TEXT_PLAIN;
+import static io.quarkus.ts.http.advanced.reactive.brotli4j.Brotli4JResource.DEFAULT_TEXT_PLAIN;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+
+import org.junit.jupiter.api.Test;
+
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
@@ -7,16 +19,6 @@ import io.quarkus.ts.http.advanced.reactive.brotli4j.Brotli4JHttpServerConfig;
 import io.quarkus.ts.http.advanced.reactive.brotli4j.Brotli4JResource;
 import io.quarkus.ts.http.advanced.reactive.brotli4j.Brotli4JRestMock;
 import io.restassured.response.Response;
-import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.MediaType;
-import org.junit.jupiter.api.Test;
-
-import static io.quarkus.ts.http.advanced.reactive.Brotli4JHttpIT.CONTENT_LENGTH_DEFAULT_TEXT_PLAIN;
-import static io.quarkus.ts.http.advanced.reactive.brotli4j.Brotli4JResource.DEFAULT_TEXT_PLAIN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 
 @QuarkusScenario
 public class DevModeBrotli4JHttpIT {

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeBrotli4JHttpIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeBrotli4JHttpIT.java
@@ -1,21 +1,22 @@
 package io.quarkus.ts.http.advanced.reactive;
 
+import io.quarkus.test.bootstrap.DevModeQuarkusService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.ts.http.advanced.reactive.brotli4j.Brotli4JHttpServerConfig;
+import io.quarkus.ts.http.advanced.reactive.brotli4j.Brotli4JResource;
+import io.quarkus.ts.http.advanced.reactive.brotli4j.Brotli4JRestMock;
+import io.restassured.response.Response;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.Test;
+
 import static io.quarkus.ts.http.advanced.reactive.Brotli4JHttpIT.CONTENT_LENGTH_DEFAULT_TEXT_PLAIN;
-import static io.quarkus.ts.http.advanced.reactive.Brotli4JResource.DEFAULT_TEXT_PLAIN;
+import static io.quarkus.ts.http.advanced.reactive.brotli4j.Brotli4JResource.DEFAULT_TEXT_PLAIN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-
-import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.MediaType;
-
-import org.junit.jupiter.api.Test;
-
-import io.quarkus.test.bootstrap.DevModeQuarkusService;
-import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.DevModeQuarkusApplication;
-import io.restassured.response.Response;
 
 @QuarkusScenario
 public class DevModeBrotli4JHttpIT {

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftBrotli4JIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftBrotli4JIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.ts.http.advanced.reactive;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkusio/quarkus/issues/43770")
 public class OpenShiftBrotli4JIT extends Brotli4JHttpIT {
 }

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/brotli4j/Brotli4JHttpServerConfig.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/brotli4j/Brotli4JHttpServerConfig.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.http.advanced.reactive;
+package io.quarkus.ts.http.advanced.reactive.brotli4j;
 
 import jakarta.enterprise.context.ApplicationScoped;
 

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/brotli4j/Brotli4JResource.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/brotli4j/Brotli4JResource.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.http.advanced.reactive;
+package io.quarkus.ts.http.advanced.reactive.brotli4j;
 
 import java.util.HashMap;
 

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/brotli4j/Brotli4JRestMock.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/brotli4j/Brotli4JRestMock.java
@@ -1,4 +1,4 @@
-package io.quarkus.ts.http.advanced.reactive;
+package io.quarkus.ts.http.advanced.reactive.brotli4j;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
### Summary

Move brotli4j sources to test/src, because it breakes other tests on OCP on aarch.

Also disable this test on aarch64, where it is failing because of https://github.com/quarkusio/quarkus/issues/43770

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [X] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)