### PR TITLE
Disable OpenShiftDefaultInitContainerIT on aarch64

### DIFF
--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/init/OpenShiftDefaultInitContainerIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/init/OpenShiftDefaultInitContainerIT.java
@@ -11,6 +11,7 @@ import java.nio.file.Paths;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.yaml.snakeyaml.Yaml;
 
 import io.quarkus.test.bootstrap.MySqlService;
@@ -21,6 +22,7 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2071")
 public class OpenShiftDefaultInitContainerIT {
 
     private final Path openShiftYaml = Paths.get("target/", this.getClass().getSimpleName(),


### PR DESCRIPTION
### Summary

Disabling default init container on OCP and aarch64.

Related issue: https://github.com/quarkus-qe/quarkus-test-suite/issues/2071

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [X] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)