### PR TITLE
Fix PostgresqlResource which failing to start when using RH postgres image

### DIFF
--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/dbpool/PostgresqlResource.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/dbpool/PostgresqlResource.java
@@ -17,9 +17,13 @@ public class PostgresqlResource implements QuarkusTestResourceLifecycleManager {
     @Override
     public Map<String, String> start() {
         postgresContainer = new GenericContainer<>(DockerImageName.parse(POSTGRESQL_IMAGE_NAME))
+                // Need to set POSTGRES and POSTGRESQL for usage with Docker hub and RH images
                 .withEnv("POSTGRES_USER", "test")
                 .withEnv("POSTGRES_PASSWORD", "test")
                 .withEnv("POSTGRES_DB", "amadeus")
+                .withEnv("POSTGRESQL_USER", "test")
+                .withEnv("POSTGRESQL_PASSWORD", "test")
+                .withEnv("POSTGRESQL_DATABASE", "amadeus")
                 .withExposedPorts(5432);
 
         postgresContainer.waitingFor(new HostPortWaitStrategy()).start();


### PR DESCRIPTION
### Summary

Porting this fix from 3.8 as it will need to be in 3.15 and future releases as well not to break IBM testing.

Fix PR https://github.com/quarkus-qe/quarkus-test-suite/pull/2004

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)