### PR TITLE
Disable kafka streams test also on quarkus main aarch native

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DisabledOnAarch64Native.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DisabledOnAarch64Native.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Inherited
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(DisabledOnRHBQAarch64NativeConditions.class)
-public @interface DisabledOnRHBQAarch64Native {
+@ExtendWith(DisabledOnAarch64NativeConditions.class)
+public @interface DisabledOnAarch64Native {
 
     /**
      * Why is the annotated test class or test method disabled.

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DisabledOnAarch64NativeConditions.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DisabledOnAarch64NativeConditions.java
@@ -6,17 +6,16 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
-public class DisabledOnRHBQAarch64NativeConditions implements ExecutionCondition {
+public class DisabledOnAarch64NativeConditions implements ExecutionCondition {
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
-        boolean isRHBQ = QuarkusProperties.isRHBQ();
         boolean isNative = QuarkusProperties.isNativeEnabled();
         boolean isAarch64 = "true".equals(System.getProperty("ts.arm.missing.services.excludes"));
-        if (isRHBQ && isAarch64 && isNative) {
-            return ConditionEvaluationResult.disabled("It is RHBQ running on aarch64 in native mode.");
+        if (isAarch64 && isNative) {
+            return ConditionEvaluationResult.disabled("It is running on aarch64 in native mode.");
         } else {
-            return ConditionEvaluationResult.enabled("It is not RHBQ running on aarch64 in native mode.");
+            return ConditionEvaluationResult.enabled("It is not running on aarch64 in native mode.");
         }
     }
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftAmqStreamsKafkaStreamIT.java
@@ -11,6 +11,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @OpenShiftScenario
+@DisabledOnAarch64Native(reason = "https://issues.redhat.com/browse/QUARKUS-4321")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTest {
 

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftStrimziKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftStrimziKafkaStreamIT.java
@@ -3,6 +3,6 @@ package io.quarkus.ts.messaging.kafka.reactive.streams;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@DisabledOnRHBQAarch64Native(reason = "https://issues.redhat.com/browse/QUARKUS-4321")
+@DisabledOnAarch64Native(reason = "https://issues.redhat.com/browse/QUARKUS-4321")
 public class OpenShiftStrimziKafkaStreamIT extends StrimziKafkaStreamIT {
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
@@ -8,6 +8,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.operator.KafkaInstance;
 
 @OpenShiftScenario
+@DisabledOnAarch64Native(reason = "https://issues.redhat.com/browse/QUARKUS-4321")
 public class OperatorOpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTest {
 
     @Operator(name = "amq-streams", source = "redhat-operators")


### PR DESCRIPTION
### Summary

Generalizing the DisabledOnAarch annotation, since the same failure (https://issues.redhat.com/browse/QUARKUS-4321) also affect quarkus main. It is also reported upstream for some time - https://github.com/quarkusio/quarkus/issues/30545


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [X] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)