### PR TITLE
Disable kafka snappy tests on aarch64 native

### DIFF
--- a/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/OpenShiftKafkaSnappyIT.java
+++ b/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/OpenShiftKafkaSnappyIT.java
@@ -12,6 +12,7 @@ import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnAarch64Native;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
@@ -20,6 +21,7 @@ import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.vertx.mutiny.core.buffer.Buffer;
 
 @OpenShiftScenario
+@DisabledOnAarch64Native(reason = "https://github.com/quarkusio/quarkus/issues/43801")
 public class OpenShiftKafkaSnappyIT {
 
     private static final int TIMEOUT_SEC = 5;

--- a/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/SnappyCompressionIT.java
+++ b/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/SnappyCompressionIT.java
@@ -23,6 +23,7 @@ import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnAarch64Native;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.DockerContainerManagedResource;
@@ -32,6 +33,7 @@ import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.vertx.mutiny.core.buffer.Buffer;
 
 @QuarkusScenario
+@DisabledOnAarch64Native(reason = "https://github.com/quarkusio/quarkus/issues/43801")
 public class SnappyCompressionIT {
 
     private static final int TIMEOUT_SEC = 5;


### PR DESCRIPTION
### Summary

Disabling kafka-snappy tests on aarch64 native because of https://github.com/quarkusio/quarkus/issues/43801.

Disabling annotation is added in https://github.com/quarkus-qe/quarkus-test-framework/pull/1365, so don't merge before it is added.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [X] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)