### PR TITLE
Change netty-native-epoll classifier to work on aarch

### DIFF
--- a/http/http-advanced/pom.xml
+++ b/http/http-advanced/pom.xml
@@ -10,6 +10,9 @@
     <artifactId>http-advanced</artifactId>
     <packaging>jar</packaging>
     <name>Quarkus QE TS: HTTP: advanced</name>
+    <properties>
+        <netty-transport-native-epoll.classifier>linux-x86_64</netty-transport-native-epoll.classifier>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -58,7 +61,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <classifier>linux-x86_64</classifier>
+            <classifier>${netty-transport-native-epoll.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -91,4 +94,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>aarch64</id>
+            <activation>
+                <property>
+                    <name>aarch64</name>
+                </property>
+            </activation>
+            <properties>
+                <netty-transport-native-epoll.classifier>linux-aarch_64</netty-transport-native-epoll.classifier>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
### Summary

We currently have a hardcoded classifier for linux_x86_64 which causes this module to fail on aarch. Change it to use aarch's version on aarch.

I'm not sold on putting the profile into module's pom, but this thing is related only to this module so I don't want to put it into parent pom.

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)