### PR TITLE
[3.15] Disable Keycloak in devmode

### DIFF
--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/DevModeKeycloakDevServiceUserExperienceIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/DevModeKeycloakDevServiceUserExperienceIT.java
@@ -11,11 +11,13 @@ import com.github.dockerjava.api.model.Image;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.DockerUtils;
 
 @Tag("QUARKUS-959")
 @QuarkusScenario
+@DisabledOnQuarkusVersion(version = "3\\.15\\.1\\..*", reason = "https://issues.redhat.com/browse/QUARKUS-5054")
 public class DevModeKeycloakDevServiceUserExperienceIT {
 
     private static final String KEYCLOAK_VERSION = getImageVersion("keycloak.image");

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/DevModeOidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/DevModeOidcSecurityIT.java
@@ -8,11 +8,13 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @Tag("QUARKUS-959")
 @Tag("QUARKUS-1026")
 @QuarkusScenario
+@DisabledOnQuarkusVersion(version = "3\\.15\\.1\\..*", reason = "https://issues.redhat.com/browse/QUARKUS-5054")
 public class DevModeOidcSecurityIT {
 
     @DevModeQuarkusApplication


### PR DESCRIPTION
### Summary

See https://issues.redhat.com/browse/QUARKUS-5054 for details

This is already fixed in upstream and should be backported to 3.15.2, so this pr goes directly to 3.15 and not in main

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)