### PR TITLE
Use periodic Quarkus snapshot build in PR workflows

### DIFF
--- a/.github/quarkus-snapshots-mvn-settings.xml
+++ b/.github/quarkus-snapshots-mvn-settings.xml
@@ -1,0 +1,67 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+    </servers>
+    <profiles>
+        <profile>
+            <id>google-mirror</id>
+            <repositories>
+                <repository>
+                    <id>google-maven-central</id>
+                    <name>GCS Maven Central mirror EU</name>
+                    <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>google-maven-central</id>
+                    <name>GCS Maven Central mirror EU</name>
+                    <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+        <profile>
+            <id>quarkus-snapshots</id>
+            <repositories>
+                <repository>
+                    <id>quarkus-snapshots-repository</id>
+                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>quarkus-snapshots-plugin-repository</id>
+                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>google-mirror</activeProfile>
+        <activeProfile>quarkus-snapshots</activeProfile>
+    </activeProfiles>
+</settings>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
     outputs:
       JVM_MODULES_MAVEN_PARAM: ${{ steps.prepare-modules-mvn-param.outputs.JVM_MODULES_MAVEN_PARAM }}
       NATIVE_MODULES_MAVEN_PARAM: ${{ steps.prepare-modules-mvn-param.outputs.NATIVE_MODULES_MAVEN_PARAM }}
-  build-dependencies:
-    name: Build Dependencies
+  linux-validate-format:
+    name: Linux - Validate format
     runs-on: ubuntu-latest
     needs: prepare-jvm-native-latest-modules-mvn-param
     strategy:
@@ -73,54 +73,15 @@ jobs:
         java: [ 17 ]
     steps:
       - uses: actions/checkout@v4
-      - name: Reclaim Disk Space
-        run: .github/ci-prerequisites.sh
-      - name: Install required tools
-        run: sudo apt update && sudo apt install pigz
       - name: Install JDK {{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           check-latest: true
-      - name: Build Quarkus main
-        run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
-      - name: Tar Maven Repo
-        shell: bash
-        run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
-      - name: Persist Maven Repo
-        uses: actions/upload-artifact@v4
-        with:
-          name: maven-repo
-          path: maven-repo.tgz
-          retention-days: 1
-  linux-validate-format:
-    name: Linux - Validate format
-    runs-on: ubuntu-latest
-    needs: build-dependencies
-    strategy:
-      matrix:
-        java: [ 17 ]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install JDK {{ matrix.java }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java }}
-          check-latest: true
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Build with Maven
         run: |
-          mvn -V -B --no-transfer-progress -s .github/mvn-settings.xml verify -Dall-modules -Dvalidate-format -DskipTests -DskipITs -Dquarkus.container-image.build=false -Dquarkus.container-image.push=false
+          mvn -V -B --no-transfer-progress -s .github/quarkus-snapshots-mvn-settings.xml verify -Dall-modules -Dvalidate-format -DskipTests -DskipITs -Dquarkus.container-image.build=false -Dquarkus.container-image.push=false
   linux-build-jvm-latest:
     name: PR - Linux - JVM build - Latest Version
     runs-on: ubuntu-latest
@@ -144,14 +105,10 @@ jobs:
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: 'maven'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
+      - name: Set up Maven settings.xml # we need to do this because of CLI and external app tests does not propagate '-s' option
+        run: cp .github/quarkus-snapshots-mvn-settings.xml ~/.m2/settings.xml
+      - name: Download Quarkus CLI
+        run: mvn org.apache.maven.plugins:maven-dependency-plugin:get -Dartifact=io.quarkus:quarkus-cli:999-SNAPSHOT:jar:runner
       - name: Install Quarkus CLI
         run: |
           cat <<EOF > ./quarkus-dev-cli
@@ -162,7 +119,7 @@ jobs:
           ./quarkus-dev-cli version
       - name: Build with Maven
         run: |
-          mvn -fae -V -B --no-transfer-progress -s .github/mvn-settings.xml clean verify -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"${{ matrix.module-mvn-args }} -am -DexcludedGroups=long-running
+          mvn -fae -V -B --no-transfer-progress clean verify -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"${{ matrix.module-mvn-args }} -am -DexcludedGroups=long-running
       - name: Detect flaky tests
         id: flaky-test-detector
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
@@ -210,14 +167,10 @@ jobs:
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: 'maven'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
+      - name: Set up Maven settings.xml # we need to do this because of CLI and external app tests does not propagate '-s' option
+        run: cp .github/quarkus-snapshots-mvn-settings.xml ~/.m2/settings.xml
+      - name: Download Quarkus CLI
+        run: mvn org.apache.maven.plugins:maven-dependency-plugin:get -Dartifact=io.quarkus:quarkus-cli:999-SNAPSHOT:jar:runner
       - name: Install Quarkus CLI
         run: |
           cat <<EOF > ./quarkus-dev-cli
@@ -228,7 +181,7 @@ jobs:
           ./quarkus-dev-cli version
       - name: Build with Maven
         run: |
-            mvn -fae -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae \
+            mvn -fae -V -B --no-transfer-progress -fae \
                         -Dquarkus.native.native-image-xmx=5g \
                         -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" \
                         ${{ matrix.module-mvn-args }} clean verify -Dnative -am -DexcludedGroups=long-running
@@ -277,14 +230,6 @@ jobs:
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: 'maven'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Build in JVM mode
         shell: bash
         run: |
@@ -294,7 +239,7 @@ jobs:
             MODULES_MAVEN_PARAM="-pl ${MODULES_ARG}"
           fi
 
-          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean verify -Dall-modules $MODULES_MAVEN_PARAM -am -DexcludedGroups=long-running
+          mvn -B --no-transfer-progress -fae -s .github/quarkus-snapshots-mvn-settings.xml clean verify -Dall-modules $MODULES_MAVEN_PARAM -am -DexcludedGroups=long-running
       - name: Detect flaky tests
         id: flaky-test-detector
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}


### PR DESCRIPTION
### Summary

Spare cca 20 minuts in every PR. Not making change in the daily build as there no one is waiting and it might be smart to have independent build checked from time to time (in case upstream does something wrong?).

Big disadvantage is that if we want to enable some test after PR fix or if our CI is affected by something fixed in the main, we need to the next periodic build (every 24 hours) for the fix. We could have both (new approach and old workflow that builds Quarkus main) but it would add complexity.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)