### PR TITLE
Add QUARKUS-4612 workaround to nosql/infinispan

### DIFF
--- a/nosql-db/infinispan/src/main/resources/application.properties
+++ b/nosql-db/infinispan/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 quarkus.infinispan-client.cache."cache".configuration-uri=cache-configuration.xml
+
+# todo workaround for https://issues.redhat.com/browse/QUARKUS-4612
+quarkus.native.auto-service-loader-registration=true

--- a/nosql-db/infinispan/src/test/resources/infinispan-it.properties
+++ b/nosql-db/infinispan/src/test/resources/infinispan-it.properties
@@ -1,3 +1,6 @@
 quarkus.infinispan-client.username=admin
 quarkus.infinispan-client.password=password
 quarkus.infinispan-client.client-intelligence=BASIC
+
+# todo workaround for https://issues.redhat.com/browse/QUARKUS-4612
+quarkus.infinispan-client.sasl-mechanism=DIGEST-SHA-512


### PR DESCRIPTION
### Summary

https://issues.redhat.com/browse/QUARKUS-4612 causes nosql/infinispan module to fail on FIPS and mandrel. Add workaround for that

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)