### PR TITLE
Drop @IfBuildProfile from injection points in VertX SQL module as it has no function at all

### DIFF
--- a/sql-db/vertx-sql/src/main/java/io/quarkus/ts/vertx/sql/Application.java
+++ b/sql-db/vertx-sql/src/main/java/io/quarkus/ts/vertx/sql/Application.java
@@ -13,7 +13,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.quarkus.arc.profile.IfBuildProfile;
 import io.quarkus.runtime.StartupEvent;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.ts.vertx.sql.services.DbPoolService;
@@ -47,17 +46,14 @@ public class Application {
 
     @Inject
     @Named("mysql")
-    @IfBuildProfile("mysql")
     MySQLPool mysql;
 
     @Inject
     @Named("mssql")
-    @IfBuildProfile("mssql")
     MSSQLPool mssql;
 
     @Inject
     @Named("oracle")
-    @IfBuildProfile("oracle")
     OraclePool oracle;
 
     void onStart(@Observes StartupEvent ev) {


### PR DESCRIPTION
### Summary

The `@IfBuildProfile` is for bean classes and method and field bean producers, not for injection points. It has no function as far as I could tell. I search Quarkus code base and reference and cannot find a single mention this should work for injection points. I think it is only confusing us when we leave it there.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)