### PR TITLE
Disable ConfigIT in native in FIPS-enabled environment due to Mandrel bug

### DIFF
--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/ConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/ConfigIT.java
@@ -16,6 +16,7 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.QuarkusApplication;
 
+@DisabledOnFipsAndNative(reason = "https://issues.redhat.com/browse/MANDREL-245")
 @QuarkusScenario
 public class ConfigIT {
 

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/DisabledOnFipsAndNative.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/DisabledOnFipsAndNative.java
@@ -1,0 +1,20 @@
+package io.quarkus.ts.configmap.api.server;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Inherited
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledOnFipsAndNativeCondition.class)
+public @interface DisabledOnFipsAndNative {
+    /**
+     * Why is the annotated test class or test method disabled.
+     */
+    String reason() default "";
+}

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/DisabledOnFipsAndNativeCondition.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/DisabledOnFipsAndNativeCondition.java
@@ -1,0 +1,29 @@
+package io.quarkus.ts.configmap.api.server;
+
+import static io.quarkus.test.services.quarkus.model.QuarkusProperties.isNativeEnabled;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class DisabledOnFipsAndNativeCondition implements ExecutionCondition {
+
+    /**
+     * We set environment variable "FIPS" to "fips" in our Jenkins jobs when FIPS are enabled.
+     */
+    private static final String FIPS_ENABLED = "fips";
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        if (isFipsEnabledEnvironment() && isNativeEnabled()) {
+            return ConditionEvaluationResult.disabled("The test is running in FIPS enabled environment in native mode");
+        }
+
+        return ConditionEvaluationResult.enabled("The test is not running in FIPS enabled environment in native mode");
+    }
+
+    private static boolean isFipsEnabledEnvironment() {
+        return FIPS_ENABLED.equalsIgnoreCase(System.getenv().get("FIPS"));
+    }
+
+}


### PR DESCRIPTION
### Summary

This test doesn't work in FIPS-enabled environment in native mode. I have talked to Severin and he wants to check if that is/is not Mandrel bug so I created https://issues.redhat.com/browse/MANDREL-245. Nothing that can be done on our side.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)