### PR TITLE
Set podman disabled true by default

### DIFF
--- a/build/podman/pom.xml
+++ b/build/podman/pom.xml
@@ -12,6 +12,7 @@
     <name>Quarkus QE TS: Podman-build</name>
     <properties>
         <quarkus.container-image.build>true</quarkus.container-image.build>
+        <podman-disabled>true</podman-disabled>
         <quarkus.build.skip>${podman-disabled}</quarkus.build.skip>
     </properties>
     <dependencies>


### PR DESCRIPTION
### Summary

Still, it doesn't skip Podman by default, with this change we are skipping the Podman build.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)