### PR TITLE
Fix using of inactive datasource in Reactive Vanilla module

### DIFF
--- a/sql-db/reactive-vanilla/src/main/java/io/quarkus/ts/reactive/db/clients/NoteBookResource.java
+++ b/sql-db/reactive-vanilla/src/main/java/io/quarkus/ts/reactive/db/clients/NoteBookResource.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.reactive.db.clients;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.GET;
@@ -22,12 +23,12 @@ public class NoteBookResource extends CommonResource {
 
     @Inject
     @Named("mysql")
-    MySQLPool mysql;
+    Instance<MySQLPool> mysql;
 
     @GET
     @Produces(APPLICATION_JSON)
     public Uni<Response> getAll() {
-        return NoteBook.findAll(mysql)
+        return NoteBook.findAll(mysql.get())
                 .onItem().transform(books -> Response.ok(Book.toJsonStringify(books)).build());
     }
 
@@ -35,12 +36,13 @@ public class NoteBookResource extends CommonResource {
     @Path("/{id}")
     @Produces(APPLICATION_JSON)
     public Uni<Response> findById(@PathParam("id") Long id) {
-        return NoteBook.findById(mysql, id).onItem().transform(noteBook -> Response.ok(noteBook.toJsonStringify()).build());
+        return NoteBook.findById(mysql.get(), id).onItem()
+                .transform(noteBook -> Response.ok(noteBook.toJsonStringify()).build());
     }
 
     @POST
     public Uni<Response> create(NoteBook noteBook, UriInfo uriInfo) {
-        return noteBook.save(mysql)
+        return noteBook.save(mysql.get())
                 .onItem().transform(id -> fromId(id, uriInfo))
                 .onItem().transform(uri -> Response.created(uri).build());
     }

--- a/sql-db/reactive-vanilla/src/main/java/io/quarkus/ts/reactive/db/clients/ReactiveClientConverter.java
+++ b/sql-db/reactive-vanilla/src/main/java/io/quarkus/ts/reactive/db/clients/ReactiveClientConverter.java
@@ -3,6 +3,7 @@ package io.quarkus.ts.reactive.db.clients;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.ext.ParamConverter;
@@ -18,11 +19,11 @@ public class ReactiveClientConverter implements ParamConverterProvider, ParamCon
 
     @Inject
     @Named("mssql")
-    MSSQLPool mssql;
+    Instance<MSSQLPool> mssql;
 
     @Inject
     @ReactiveDataSource("mariadb")
-    Pool mariadb;
+    Instance<Pool> mariadb;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -36,8 +37,8 @@ public class ReactiveClientConverter implements ParamConverterProvider, ParamCon
     @Override
     public Pool fromString(String reactiveClient) {
         return switch (reactiveClient) {
-            case "mariadb" -> mariadb;
-            case "mssql" -> mssql;
+            case "mariadb" -> mariadb.get();
+            case "mssql" -> mssql.get();
             default -> throw new IllegalStateException("Unexpected reactive client: " + reactiveClient);
         };
     }

--- a/sql-db/reactive-vanilla/src/main/java/io/quarkus/ts/reactive/db/clients/SoftCoverBookResource.java
+++ b/sql-db/reactive-vanilla/src/main/java/io/quarkus/ts/reactive/db/clients/SoftCoverBookResource.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.reactive.db.clients;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -20,12 +21,12 @@ import io.vertx.mutiny.pgclient.PgPool;
 public class SoftCoverBookResource extends CommonResource {
 
     @Inject
-    PgPool postgresql;
+    Instance<PgPool> postgresql;
 
     @GET
     @Produces(APPLICATION_JSON)
     public Uni<Response> getAll() {
-        return SoftCoverBook.findAll(postgresql)
+        return SoftCoverBook.findAll(postgresql.get())
                 .onItem().transform(books -> Response.ok(Book.toJsonStringify(books)).build());
     }
 
@@ -33,13 +34,13 @@ public class SoftCoverBookResource extends CommonResource {
     @Path("/{id}")
     @Produces(APPLICATION_JSON)
     public Uni<Response> findById(@PathParam("id") Long id) {
-        return SoftCoverBook.findById(postgresql, id).onItem().transform(
+        return SoftCoverBook.findById(postgresql.get(), id).onItem().transform(
                 softCoverBook -> Response.ok(softCoverBook.toJsonStringify()).build());
     }
 
     @POST
     public Uni<Response> create(SoftCoverBook softCoverBook, UriInfo uriInfo) {
-        return softCoverBook.save(postgresql)
+        return softCoverBook.save(postgresql.get())
                 .onItem().transform(id -> fromId(id, uriInfo))
                 .onItem().transform(uri -> Response.created(uri).build());
     }


### PR DESCRIPTION
### Summary

Now that datasources can be deactivated, see  https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.17, our DEV mode tests in the Reactive Vanilla module are failing because they don't have set URL (which is a good thing, we don't test them so don't start database). I followed migration guide and choose to use `Instance` for pool injection points that may or may not be active.

This is one of the failures of our GH CI daily build.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)