### PR TITLE
Temporarily disable Java EE health check tests until NPE is fixed or upstream issue clarified

### DIFF
--- a/javaee-like-getting-started/src/test/java/io/quarkus/ts/javaee/gettingstarted/JavaEELikeHealthCheckIT.java
+++ b/javaee-like-getting-started/src/test/java/io/quarkus/ts/javaee/gettingstarted/JavaEELikeHealthCheckIT.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -15,6 +16,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 @QuarkusScenario
 public class JavaEELikeHealthCheckIT {
 
+    @Disabled("https://github.com/quarkusio/quarkus/issues/43990")
     @Test
     public void testHealthEndpoint() {
         given()
@@ -42,6 +44,7 @@ public class JavaEELikeHealthCheckIT {
                         "checks.status", hasItem("UP"));
     }
 
+    @Disabled("https://github.com/quarkusio/quarkus/issues/43990")
     @Test
     public void testReadinessEndpoint() {
         given()


### PR DESCRIPTION
### Summary

Disabling failing tests until https://github.com/quarkusio/quarkus/issues/43990 is fixed because we need daily build and CI green so that other problems are caught. If it gets fixed soon, we simply enable it (CI doesn't run long).

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)