### PR TITLE
Disable ReactiveRestClientProxyIT on aarch64

### DIFF
--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/DisabledOnAarch64.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/DisabledOnAarch64.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.http.restclient.reactive;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Inherited
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledOnAarch64Conditions.class)
+public @interface DisabledOnAarch64 {
+
+    /**
+     * Why is the annotated test class or test method disabled.
+     */
+    String reason();
+}

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/DisabledOnAarch64Conditions.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/DisabledOnAarch64Conditions.java
@@ -1,0 +1,18 @@
+package io.quarkus.ts.http.restclient.reactive;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class DisabledOnAarch64Conditions implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        boolean isAarch64 = "true".equals(System.getProperty("ts.arm.missing.services.excludes"));
+        if (isAarch64) {
+            return ConditionEvaluationResult.disabled("It is running on aarch64");
+        } else {
+            return ConditionEvaluationResult.enabled("It is not running on aarch64");
+        }
+    }
+}

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientProxyIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientProxyIT.java
@@ -13,6 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.response.Response;
 
 @QuarkusScenario
+@DisabledOnAarch64(reason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2111")
 public class ReactiveRestClientProxyIT {
     private static final String USER = "proxyuser";
     private static final String PASSWORD = "proxypassword";


### PR DESCRIPTION
### Summary

Disable ReactiveRestClientProxyIT on aarch. The test tries to connect to domain `example.com` and this domain return 499 (token required) on arch. We are probably hitting some threshold. 

It is IMHO generally bad idea to use domain we don't own/control in our TS. But it is going OK for other nodes, AFAIK fails only on aarch so disabling it only on it.

Filed an issue for this - https://github.com/quarkus-qe/quarkus-test-suite/issues/2111

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [X] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)