### PR TITLE
Add version suffix to docker images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <exclude.quarkus.devmode.tests>no</exclude.quarkus.devmode.tests>
         <!-- Docker images used by both surefire and failsafe plugin -->
         <postgresql.latest.image>docker.io/library/postgres:16</postgresql.latest.image>
-        <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7</mysql.80.image>
+        <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7:latest</mysql.80.image>
         <rhbk.image>registry.redhat.io/rhbk/keycloak-rhel9:24</rhbk.image>
         <wiremock-jre8.version>2.35.2</wiremock-jre8.version>
         <build-reporter-maven-extension.version>3.9.5</build-reporter-maven-extension.version>
@@ -749,10 +749,11 @@
                                         <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                         <!-- Product Services -->
                                         <rhbk.image>${rhbk.image}</rhbk.image>
-                                        <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10</postgresql.10.image>
-                                        <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16</postgresql.latest.image>
-                                        <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103</mariadb.103.image>
-                                        <mariadb.105.image>registry.redhat.io/rhel9/mariadb-105</mariadb.105.image>
+                                        <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10:latest</postgresql.10.image>
+                                        <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16:latest</postgresql.latest.image>
+                                        <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103:latest</mariadb.103.image>
+                                        <mariadb.105.image>registry.redhat.io/rhel9/mariadb-105:latest</mariadb.105.image>
+                                        <!-- Kafka  (amq-streams) requires separate properties for image and version -->
                                         <amq-streams.image>registry.redhat.io/amq-streams/kafka-35-rhel8</amq-streams.image>
                                         <amq-streams.version>2.6.0</amq-streams.version>
                                     </systemPropertyVariables>
@@ -789,12 +790,13 @@
                                         <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                         <!-- Product Services -->
                                         <rhbk.image>${rhbk.image}</rhbk.image>
-                                        <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10</postgresql.10.image>
-                                        <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16</postgresql.latest.image>
-                                        <mysql.80.image>registry.redhat.io/rhel8/mysql-80</mysql.80.image>
-                                        <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103</mariadb.103.image>
-                                        <mariadb.105.image>registry.redhat.io/rhel8/mariadb-105</mariadb.105.image>
+                                        <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10:latest</postgresql.10.image>
+                                        <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16:latest</postgresql.latest.image>
+                                        <mysql.80.image>registry.redhat.io/rhel8/mysql-80:latest</mysql.80.image>
+                                        <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103:latest</mariadb.103.image>
+                                        <mariadb.105.image>registry.redhat.io/rhel8/mariadb-105:latest</mariadb.105.image>
                                         <amqbroker.image>registry.redhat.io/amq7/amq-broker-rhel8:7.12</amqbroker.image>
+                                        <!-- Kafka  (amq-streams) requires separate properties for image and version -->
                                         <amq-streams.image>registry.redhat.io/amq-streams/kafka-35-rhel8</amq-streams.image>
                                         <amq-streams.version>2.6.0</amq-streams.version>
                                     </systemPropertyVariables>
@@ -845,11 +847,12 @@
                                         <!-- Product Services -->
                                         <amqbroker.image>registry.redhat.io/amq7/amq-broker-rhel8:7.12</amqbroker.image>
                                         <rhbk.image>${rhbk.image}</rhbk.image>
-                                        <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10</postgresql.10.image>
-                                        <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16</postgresql.latest.image>
-                                        <mysql.80.image>registry.redhat.io/rhel8/mysql-80</mysql.80.image>
-                                        <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103</mariadb.103.image>
-                                        <mariadb.105.image>registry.redhat.io/rhel8/mariadb-105</mariadb.105.image>
+                                        <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10:latest</postgresql.10.image>
+                                        <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16:latest</postgresql.latest.image>
+                                        <mysql.80.image>registry.redhat.io/rhel8/mysql-80:latest</mysql.80.image>
+                                        <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103:latest</mariadb.103.image>
+                                        <mariadb.105.image>registry.redhat.io/rhel8/mariadb-105:latest</mariadb.105.image>
+                                        <!-- Kafka  (amq-streams) requires separate properties for image and version -->
                                         <amq-streams.image>registry.redhat.io/amq-streams/kafka-35-rhel8</amq-streams.image>
                                         <amq-streams.version>2.6.0</amq-streams.version>
                                         <mongodb.image>docker.io/library/mongo:7.0</mongodb.image>


### PR DESCRIPTION
### Summary

Adding ":latest" suffix to all docker images, that didn't have version. 

Our test framework [expects the images to have version](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/quarkus-test-images/src/main/java/io/quarkus/test/utils/ImageUtil.java#L29). Otherwise it will fail.

On some places, tests are also working with image version so it makes sense to have them.

This is also causing failures in aarch64 tests.

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)