### PR TITLE
Update mongodb image for IBM Z/ P openshift in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -852,7 +852,7 @@
                                         <mariadb.105.image>registry.redhat.io/rhel8/mariadb-105</mariadb.105.image>
                                         <amq-streams.image>registry.redhat.io/amq-streams/kafka-35-rhel8</amq-streams.image>
                                         <amq-streams.version>2.6.0</amq-streams.version>
-                                        <mongodb.image>docker.io/library/mongo:7.0</mongodb.image>
+                                        <mongodb.image>docker.io/library/mongo:4.4.6</mongodb.image>
                                     </systemPropertyVariables>
                                     <rerunFailingTestsCount>${oc.reruns}</rerunFailingTestsCount>
                                 </configuration>


### PR DESCRIPTION
### Summary

Updated mongodb image for IBM Z/ P openshift in pom.xml because mongodb 4.4.6 is the supported image for IBM Z/P, noticed while testing RHBQ 3.15.1 version.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)