### PR TITLE
Overwrite images also in surefire plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -774,6 +774,15 @@
             <build>
                 <plugins>
                     <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16</postgresql.latest.image>
+                                <mysql.80.image>registry.redhat.io/rhel8/mysql-80</mysql.80.image>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <executions>
@@ -827,6 +836,15 @@
             </activation>
             <build>
                 <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16</postgresql.latest.image>
+                                <mysql.80.image>registry.redhat.io/rhel8/mysql-80</mysql.80.image>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>


### PR DESCRIPTION
### Summary

In aarch64 and openshift-ibm-z-p-containers profiles, we overwrite image for maven-failsafe plugin. But no images for surefire. Thus tests that are not IT will run with the default images and fail. (I found out about this with AgroalPoolTest on aarch64). This PR should fix that.

No sure what test ibm-z is running, if this is actually beneficial for it. But at least this shouldn't break it.


Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)