### PR TITLE
[3.15] set JAVA_OPTS_KC_HEAP to avoid override all JVM opts in Keycloak cont…

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
@@ -17,7 +17,7 @@ public class HttpAdvancedIT extends BaseHttpAdvancedIT {
     @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
             // TODO remove this propery when this issue will be resolved: https://github.com/quarkus-qe/quarkus-test-suite/issues/2106
-            .withProperty("JAVA_OPTS", "-Xms512m -Xmx1g");
+            .withProperty("JAVA_OPTS_KC_HEAP", "-Xms512m -Xmx1g");
 
     @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureHttpServer = true, useTlsRegistry = false))
     static RestService app = new RestService().withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);


### PR DESCRIPTION
According this issue comment : https://github.com/quarkus-qe/quarkus-test-suite/issues/2106#issuecomment-2431786538
it's better set JAVA_OPTS_KC_HEAP in order to not override all JVM opts in Keycloak container

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)