### PR TITLE
Use RH postgres image and fix prepare statements usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <exclude.quarkus.cli.tests>**/QuarkusCli*IT.java</exclude.quarkus.cli.tests>
         <exclude.quarkus.devmode.tests>no</exclude.quarkus.devmode.tests>
         <!-- Docker images used by both surefire and failsafe plugin -->
-        <postgresql.latest.image>docker.io/library/postgres:16</postgresql.latest.image>
+        <postgresql.latest.image>registry.access.redhat.com/rhel9/postgresql-16</postgresql.latest.image>
         <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7:latest</mysql.80.image>
         <rhbk.image>registry.redhat.io/rhbk/keycloak-rhel9:24</rhbk.image>
         <wiremock-jre8.version>2.35.2</wiremock-jre8.version>

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlTransactionGeneralUsageIT.java
@@ -8,11 +8,9 @@ import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
 public class PostgresqlTransactionGeneralUsageIT extends AbstractPostgresqlTransactionGeneralUsageIT {
-
-    private static final String ENABLE_PREPARED_TRANSACTIONS = "--max_prepared_transactions=100";
-
-    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address", command = ENABLE_PREPARED_TRANSACTIONS)
-    static final PostgresqlService database = new PostgresqlService().withProperty("PGDATA", "/tmp/psql");
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    static final PostgresqlService database = new PostgresqlService().withProperty("PGDATA", "/tmp/psql")
+            .withProperty("POSTGRESQL_MAX_PREPARED_TRANSACTIONS", "100");
 
     @QuarkusApplication
     public static final RestService app = createQuarkusApp(database);


### PR DESCRIPTION
### Summary

Postgres image from docker.io has completely different startup mechanism than RH images. On RH images using `--max_prepared_transactions=100` causes it to crash.

I'm changing the default docker image to be the RH one, and changing the prepared transaction enablement to RH-image-supported approach.

Is there a reason to use docker.io image anyway? RH image for postgres is publicly available. 

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)