### PR TITLE
Skip unit tests when IBM OpenShift Maven profile is active

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -828,6 +828,16 @@
                 <include.tests>**/*OpenShift*IT.java</include.tests>
                 <exclude.openshift.tests>no</exclude.openshift.tests>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>openshift-ibm-z-p-containers</id>
@@ -838,15 +848,6 @@
             </activation>
             <build>
                 <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16</postgresql.latest.image>
-                                <mysql.80.image>registry.redhat.io/rhel8/mysql-80</mysql.80.image>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>


### PR DESCRIPTION
### Summary

IBM only runs unit tests, they are hitting pull rate limit and investigating failures for no reason. This is outcome of https://github.com/quarkus-qe/quarkus-test-suite/pull/2123#issuecomment-2435035621.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)