### PR TITLE
Stop using simple class name in MP Rest client configuration property keys as upstream removed support lately

### DIFF
--- a/http/http-advanced-reactive/src/main/resources/application.properties
+++ b/http/http-advanced-reactive/src/main/resources/application.properties
@@ -7,8 +7,8 @@ quarkus.swagger-ui.always-include=true
 quarkus.health.openapi.included=true
 quarkus.http.http2=true
 # HttpClient config
-HealthClientService/mp-rest/url=http://localhost:${quarkus.http.port}
-HealthClientService/mp-rest/scope=jakarta.inject.Singleton
+io.quarkus.ts.http.advanced.reactive.HealthClientService/mp-rest/url=http://localhost:${quarkus.http.port}
+io.quarkus.ts.http.advanced.reactive.HealthClientService/mp-rest/scope=jakarta.inject.Singleton
 # FollowRedirect not supported QUARKUS-781
 # HealthClientService/mp-rest/followRedirects=true
 # gRPC

--- a/http/http-advanced/src/main/resources/application.properties
+++ b/http/http-advanced/src/main/resources/application.properties
@@ -7,8 +7,8 @@ quarkus.swagger-ui.always-include=true
 quarkus.health.openapi.included=true
 quarkus.http.http2=true
 # HttpClient config
-HealthClientService/mp-rest/url=http://localhost:${quarkus.http.port}
-HealthClientService/mp-rest/scope=jakarta.inject.Singleton
+io.quarkus.ts.http.advanced.HealthClientService/mp-rest/url=http://localhost:${quarkus.http.port}
+io.quarkus.ts.http.advanced.HealthClientService/mp-rest/scope=jakarta.inject.Singleton
 # FollowRedirect not supported QUARKUS-781
 # HealthClientService/mp-rest/followRedirects=true
 # gRPC


### PR DESCRIPTION
### Summary

Here https://github.com/quarkusio/quarkus/pull/43345 behavior for MP Rest client configuration changed. Reasons are explained in here https://github.com/quarkusio/quarkus/issues/44067#issuecomment-2434913091. This behavior was never documented and now it is removed. Migration guide mentions this change https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.17#rest-client. I plan to use config key when https://github.com/quarkusio/quarkus/pull/44073 is merged and 999-SNAPSHOT artifacts are deployed to Sonatype.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)