### PR TITLE
Configure postgres transaction separately for images

### DIFF
--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/annotations/EnabledIfPostgresImageCommunity.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/annotations/EnabledIfPostgresImageCommunity.java
@@ -1,0 +1,15 @@
+package io.quarkus.ts.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(EnabledIfPostgresImageCommunityCondition.class)
+public @interface EnabledIfPostgresImageCommunity {
+
+}

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/annotations/EnabledIfPostgresImageCommunityCondition.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/annotations/EnabledIfPostgresImageCommunityCondition.java
@@ -1,0 +1,19 @@
+package io.quarkus.ts.annotations;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.quarkus.test.scenarios.annotations.CheckIfSystemPropertyCondition;
+
+public class EnabledIfPostgresImageCommunityCondition extends CheckIfSystemPropertyCondition {
+
+    @Override
+    protected String getSystemPropertyName(ExtensionContext context) {
+        return "postgresql.latest.image";
+    }
+
+    @Override
+    protected boolean checkEnableCondition(ExtensionContext context, String actual) {
+        return actual != null && actual.contains("docker.io");
+
+    }
+}

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/annotations/EnabledIfPostgresImageProduct.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/annotations/EnabledIfPostgresImageProduct.java
@@ -1,0 +1,15 @@
+package io.quarkus.ts.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(EnabledIfPostgresImageProductCondition.class)
+public @interface EnabledIfPostgresImageProduct {
+
+}

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/annotations/EnabledIfPostgresImageProductCondition.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/annotations/EnabledIfPostgresImageProductCondition.java
@@ -1,0 +1,18 @@
+package io.quarkus.ts.annotations;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.quarkus.test.scenarios.annotations.CheckIfSystemPropertyCondition;
+
+public class EnabledIfPostgresImageProductCondition extends CheckIfSystemPropertyCondition {
+
+    @Override
+    protected String getSystemPropertyName(ExtensionContext context) {
+        return "postgresql.latest.image";
+    }
+
+    @Override
+    protected boolean checkEnableCondition(ExtensionContext context, String actual) {
+        return actual != null && actual.contains("registry.redhat.io");
+    }
+}

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlCommunityTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlCommunityTransactionGeneralUsageIT.java
@@ -5,12 +5,17 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.annotations.EnabledIfPostgresImageCommunity;
 
 @QuarkusScenario
-public class PostgresqlTransactionGeneralUsageIT extends AbstractPostgresqlTransactionGeneralUsageIT {
+@EnabledIfPostgresImageCommunity
+public class PostgresqlCommunityTransactionGeneralUsageIT extends AbstractPostgresqlTransactionGeneralUsageIT {
 
     private static final String ENABLE_PREPARED_TRANSACTIONS = "--max_prepared_transactions=100";
 
+    /**
+     * Product and community postgresql image has different setup system, so we need to instantiate it differently.
+     */
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address", command = ENABLE_PREPARED_TRANSACTIONS)
     static final PostgresqlService database = new PostgresqlService().withProperty("PGDATA", "/tmp/psql");
 

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlProductTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/PostgresqlProductTransactionGeneralUsageIT.java
@@ -1,0 +1,29 @@
+package io.quarkus.ts.transactions;
+
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.annotations.EnabledIfPostgresImageProduct;
+
+@QuarkusScenario
+@EnabledIfPostgresImageProduct
+public class PostgresqlProductTransactionGeneralUsageIT extends AbstractPostgresqlTransactionGeneralUsageIT {
+
+    /**
+     * Product and community postgresql image has different setup system, so we need to instantiate it differently
+     */
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    static final PostgresqlService database = new PostgresqlService().withProperty("PGDATA", "/tmp/psql")
+            .withProperty("POSTGRESQL_MAX_PREPARED_TRANSACTIONS", "100");
+
+    @QuarkusApplication
+    public static final RestService app = createQuarkusApp(database);
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+
+}


### PR DESCRIPTION
### Summary

Since #2129 is not going to fly, we need another way how to use both community and product psotgres image with prepared transaction. Configuring two versions for this.

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [X] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)