### PR TITLE
Disable Openshift tests that have no IBM ppc64le or s390x supporting …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -875,6 +875,8 @@
                                         <amq-streams.image>registry.redhat.io/amq-streams/kafka-35-rhel8</amq-streams.image>
                                         <amq-streams.version>2.6.0</amq-streams.version>
                                         <mongodb.image>docker.io/library/mongo:7.0</mongodb.image>
+                                        <infinispan.image>registry.redhat.io/datagrid/datagrid-8-rhel9:1.5-8.5.0.GA</infinispan.image>
+                                        <infinispan.expected-log>Red Hat Data Grid.*started in</infinispan.expected-log>
                                     </systemPropertyVariables>
                                     <rerunFailingTestsCount>${oc.reruns}</rerunFailingTestsCount>
                                 </configuration>

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftHibernateReactiveMsSQLIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftHibernateReactiveMsSQLIT.java
@@ -8,6 +8,7 @@ import io.quarkus.ts.hibernate.reactive.MsSQLDatabaseHibernateReactiveIT;
 
 @OpenShiftScenario
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2017")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "MSSQL image is not available for IBM s390x and ppc64le")
 @Disabled("https://github.com/microsoft/mssql-docker/issues/769")
 public class OpenShiftHibernateReactiveMsSQLIT extends MsSQLDatabaseHibernateReactiveIT {
 }

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMssqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMssqlTransactionGeneralUsageIT.java
@@ -7,6 +7,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2017")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "MSSQL image is not available for IBM s390x and ppc64le")
 @Disabled("https://github.com/microsoft/mssql-docker/issues/769")
 public class OpenShiftMssqlTransactionGeneralUsageIT extends MssqlTransactionGeneralUsageIT {
 }

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/init/OpenShiftDefaultInitContainerIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/init/OpenShiftDefaultInitContainerIT.java
@@ -23,6 +23,7 @@ import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2071")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "Same reason as aarch64 https://github.com/quarkus-qe/quarkus-test-suite/issues/2071")
 public class OpenShiftDefaultInitContainerIT {
 
     private final Path openShiftYaml = Paths.get("target/", this.getClass().getSimpleName(),

--- a/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/OpenShiftMssqlPanacheResourceIT.java
+++ b/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/OpenShiftMssqlPanacheResourceIT.java
@@ -7,6 +7,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2017")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "MSSQL image is not available for IBM s390x and ppc64le")
 @Disabled("https://github.com/microsoft/mssql-docker/issues/769")
 public class OpenShiftMssqlPanacheResourceIT extends MssqlPanacheResourceIT {
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMssqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMssqlDatabaseIT.java
@@ -7,6 +7,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2017")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "MSSQL image is not available for IBM s390x and ppc64le")
 @Disabled("https://github.com/microsoft/mssql-docker/issues/769")
 public class OpenShiftMssqlDatabaseIT extends MssqlDatabaseIT {
 


### PR DESCRIPTION
### Summary

Disable Openshift tests that have no IBM ppc64le or s390x supporting images. Also, reference images, in the POM file, that do support ppc64le or s390x.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)