### PR TITLE
Disable MariaDB transaction recovery test as it doesn't work with `mariadb-java-client` 3.5.0 bumped upstream

### DIFF
--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.transactions;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -31,5 +33,11 @@ public class MariaDbTransactionGeneralUsageIT extends TransactionCommons {
     @Override
     protected TransactionExecutor getTransactionExecutorUsedForRecovery() {
         return TransactionExecutor.QUARKUS_TRANSACTION;
+    }
+
+    @Disabled("https://github.com/quarkusio/quarkus/issues/44160")
+    @Override
+    public void testTransactionRecovery() {
+        // TODO: drop this method when https://github.com/quarkusio/quarkus/issues/44160 is fixed
     }
 }


### PR DESCRIPTION
### Summary

Daily build is failing, I reported this bug here https://github.com/quarkusio/quarkus/issues/44160 (see for details), no response so far, let's disable it.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)