### PR TITLE
Make nginx proxy resolver configurable

### DIFF
--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientProxyIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientProxyIT.java
@@ -19,7 +19,9 @@ public class ReactiveRestClientProxyIT {
 
     @Container(image = "${nginx.image}", port = 8090, expectedLog = "Configuration complete; ready for start up")
     static RestService proxy = new RestService()
-            .withProperty("_whatever", "resource_with_destination::/etc/nginx/|nginx.conf");
+            .withProperty("FORWARD_PROXY_RESOLVER", System.getProperty("forward-proxy-resolver"))
+            .withProperty("NGINX_ENVSUBST_OUTPUT_DIR", "/etc/nginx")
+            .withProperty("_whatever", "resource_with_destination::/etc/nginx/templates/|nginx.conf.template");
 
     @QuarkusApplication
     static RestService proxyApp = new RestService()

--- a/http/rest-client-reactive/src/test/resources/nginx.conf.template
+++ b/http/rest-client-reactive/src/test/resources/nginx.conf.template
@@ -7,7 +7,7 @@ events {}
 http {
 	server {
 		listen 8090;
-			resolver 8.8.8.8;
+		resolver ${FORWARD_PROXY_RESOLVER};
 		location / {
 			proxy_pass http://$host;
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <reruns>2</reruns>
         <oc.reruns>1</oc.reruns>
         <flaky-run-reporter.version>0.1.4</flaky-run-reporter.version>
+        <forward-proxy-resolver>8.8.8.8</forward-proxy-resolver>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -266,6 +267,7 @@
                                 <keycloak.image>quay.io/keycloak/keycloak:25.0</keycloak.image>
                                 <bouncycastle.bctls-fips.version>1.0.12.2</bouncycastle.bctls-fips.version>
                                 <rhbk.image>${rhbk.image}</rhbk.image>
+                                <forward-proxy-resolver>${forward-proxy-resolver}</forward-proxy-resolver>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>


### PR DESCRIPTION
### Summary

* Since in some environments we are not allowed to use external DNS, this commit allows to configure resolver to be used by nginx. Default will still be 8.8.8.8.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)