### PR TITLE
Disable PostgreSQL Dev Svc tests on Aarch64 platform as image for this OS is not available or not working with Dev Service

### DIFF
--- a/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeReactivePostgresqlDevServiceUserExperienceIT.java
+++ b/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeReactivePostgresqlDevServiceUserExperienceIT.java
@@ -6,6 +6,7 @@ import static io.quarkus.test.utils.ImageUtil.getImageVersion;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import com.github.dockerjava.api.model.Image;
 
@@ -14,6 +15,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.DockerUtils;
 
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkusio/quarkus/issues/44196")
 @Tag("QUARKUS-1080")
 @QuarkusScenario
 public class DevModeReactivePostgresqlDevServiceUserExperienceIT {

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlDevServiceUserExperienceIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlDevServiceUserExperienceIT.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import com.github.dockerjava.api.model.Image;
 
@@ -16,6 +17,7 @@ import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.DockerUtils;
 import io.quarkus.test.utils.SocketUtils;
 
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkusio/quarkus/issues/44196")
 @Tag("QUARKUS-959")
 @QuarkusScenario
 public class DevModePostgresqlDevServiceUserExperienceIT {


### PR DESCRIPTION
### Summary

Images in Docker.io doesn't work on Aarch64 platform and the image from Red Hat registry doesn't work with Dev Service, see https://github.com/quarkusio/quarkus/issues/44196.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)