### PR TITLE
Use Docker PostgreSQL image from Docker.io and not from Red Hat registry in Dev Service tests on Aarch64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -802,6 +802,7 @@
                                         <!-- Product Services -->
                                         <rhbk.image>${rhbk.image}</rhbk.image>
                                         <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10:latest</postgresql.10.image>
+                                        <postgresql.dev.svc.latest.image>${postgresql.latest.image}</postgresql.dev.svc.latest.image>
                                         <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16:latest</postgresql.latest.image>
                                         <mysql.80.image>registry.redhat.io/rhel8/mysql-80:latest</mysql.80.image>
                                         <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103:latest</mariadb.103.image>

--- a/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeReactivePostgresqlDevServiceUserExperienceIT.java
+++ b/sql-db/reactive-vanilla/src/test/java/io/quarkus/ts/reactive/db/clients/DevModeReactivePostgresqlDevServiceUserExperienceIT.java
@@ -21,12 +21,25 @@ public class DevModeReactivePostgresqlDevServiceUserExperienceIT {
     // we use '-bullseye' version as no other test is using it, which mitigates the fact that sometimes
     // io.quarkus.test.utils.DockerUtils.removeImage doesn't work as expected
     // TODO: drop suffix when https://github.com/quarkus-qe/quarkus-test-suite/issues/1227 is fixed
-    private static final String POSTGRESQL_VERSION = getImageVersion("postgresql.latest.image") + "-bullseye";
-    private static final String POSTGRES_NAME = getImageName("postgresql.latest.image");
+    private static final String POSTGRESQL_VERSION;
+    private static final String POSTGRES_NAME;
+    private static final String POSTGRESQL_IMAGE_NAME;
+
+    static {
+        // TODO: simplify when https://github.com/quarkus-qe/quarkus-test-suite/pull/2147 is fixed
+        boolean useDevSvcSpecificImg = System.getProperty("postgresql.dev.svc.latest.image") != null;
+        if (useDevSvcSpecificImg) {
+            POSTGRESQL_IMAGE_NAME = "postgresql.dev.svc.latest.image";
+        } else {
+            POSTGRESQL_IMAGE_NAME = "postgresql.latest.image";
+        }
+        POSTGRESQL_VERSION = getImageVersion(POSTGRESQL_IMAGE_NAME) + "-bullseye";
+        POSTGRES_NAME = getImageName(POSTGRESQL_IMAGE_NAME);
+    }
 
     @DevModeQuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.datasource.devservices.image-name", "${postgresql.latest.image}-bullseye")
+            .withProperty("quarkus.datasource.devservices.image-name", "${" + POSTGRESQL_IMAGE_NAME + "}-bullseye")
             .withProperty("quarkus.datasource.mysql.devservices.enabled", "false")
             .withProperty("quarkus.datasource.mariadb.devservices.enabled", "false")
             .withProperty("quarkus.datasource.mssql.devservices.enabled", "false")

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlDevServiceUserExperienceIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlDevServiceUserExperienceIT.java
@@ -23,14 +23,27 @@ public class DevModePostgresqlDevServiceUserExperienceIT {
     // we use '-alpine' version as no other test is using it, which mitigates the fact that sometimes
     // io.quarkus.test.utils.DockerUtils.removeImage doesn't work as expected
     // TODO: drop suffix when https://github.com/quarkus-qe/quarkus-test-suite/issues/1227 is fixed
-    private static final String POSTGRESQL_VERSION = getImageVersion("postgresql.latest.image") + "-alpine";
-    private static final String POSTGRES_NAME = getImageName("postgresql.latest.image");
+    private static final String POSTGRESQL_VERSION;
+    private static final String POSTGRES_NAME;
+    private static final String POSTGRESQL_IMAGE_NAME;
+
+    static {
+        // TODO: simplify when https://github.com/quarkus-qe/quarkus-test-suite/pull/2147 is fixed
+        boolean useDevSvcSpecificImg = System.getProperty("postgresql.dev.svc.latest.image") != null;
+        if (useDevSvcSpecificImg) {
+            POSTGRESQL_IMAGE_NAME = "postgresql.dev.svc.latest.image";
+        } else {
+            POSTGRESQL_IMAGE_NAME = "postgresql.latest.image";
+        }
+        POSTGRESQL_VERSION = getImageVersion(POSTGRESQL_IMAGE_NAME) + "-alpine";
+        POSTGRES_NAME = getImageName(POSTGRESQL_IMAGE_NAME);
+    }
 
     @DevModeQuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.datasource.db-kind", "postgresql")
             .withProperty("quarkus.datasource.devservices.port", Integer.toString(SocketUtils.findAvailablePort()))
-            .withProperty("quarkus.datasource.devservices.image-name", "${postgresql.latest.image}-alpine")
+            .withProperty("quarkus.datasource.devservices.image-name", "${" + POSTGRESQL_IMAGE_NAME + "}-alpine")
             .withProperty("quarkus.hibernate-orm.database.generation", "none")
             .onPreStart(s -> DockerUtils.removeImage(POSTGRES_NAME, POSTGRESQL_VERSION));
 


### PR DESCRIPTION
### Summary

Image from Red Hat registry currently doesn't work in Dev Services for PostgreSQL: https://github.com/quarkusio/quarkus/issues/44196. So using Docker.io one.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)