### PR TITLE
Fix DevModeInfinispanIT on Aarch64 platform as only image from Red Hat registry is supported for this platform

### DIFF
--- a/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/DevModeInfinispanIT.java
+++ b/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/DevModeInfinispanIT.java
@@ -2,18 +2,44 @@ package io.quarkus.ts.infinispan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Map;
+
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.test.utils.FileUtils;
 
 @QuarkusScenario
 public class DevModeInfinispanIT {
 
+    // TODO: drop this Aarch64 workaround when https://issues.redhat.com/browse/QUARKUS-5242 is fixed
+    private static final boolean IS_AARCH64_PLATFORM = Boolean.getBoolean("ts.arm.missing.services.excludes");
+
     @DevModeQuarkusApplication()
-    static RestService service = new RestService();
+    static RestService service = new RestService()
+            .withProperties(() -> {
+                if (IS_AARCH64_PLATFORM) {
+                    return Map.of("quarkus.infinispan-client.devservices.image-name", "${datagrid.image}");
+                }
+                return Map.of();
+            })
+            .onPreStart(service -> {
+                if (IS_AARCH64_PLATFORM) {
+                    // override default Ryuk used by Infinispan as it doesn't work on Aarch64
+                    RestService restService = (RestService) service;
+                    var testContainersPropsPath = restService
+                            .getServiceFolder()
+                            .resolve("src")
+                            .resolve("main")
+                            .resolve("resources")
+                            .resolve("testcontainers.properties");
+                    FileUtils.copyContentTo("ryuk.container.image=testcontainers/ryuk:0.3.3" + System.lineSeparator(),
+                            testContainersPropsPath);
+                }
+            });
 
     @Test
     void smoke() {

--- a/pom.xml
+++ b/pom.xml
@@ -810,6 +810,7 @@
                                         <!-- Kafka  (amq-streams) requires separate properties for image and version -->
                                         <amq-streams.image>registry.redhat.io/amq-streams/kafka-35-rhel8</amq-streams.image>
                                         <amq-streams.version>2.6.0</amq-streams.version>
+                                        <datagrid.image>registry.redhat.io/datagrid/datagrid-8-rhel9:latest</datagrid.image>
                                     </systemPropertyVariables>
                                     <rerunFailingTestsCount>${oc.reruns}</rerunFailingTestsCount>
                                 </configuration>


### PR DESCRIPTION
### Summary

This works around https://issues.redhat.com/browse/QUARKUS-5242 by using Datagrid image and disabling Ryuk for one test only.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)