### PR TITLE
Disabling Kafka Streams tests due to QUARKUS-4321

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SaslSslAlertMonitorIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SaslSslAlertMonitorIT.java
@@ -4,6 +4,7 @@ import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnAarch64Native;
 import io.quarkus.test.scenarios.annotations.DisabledOnRHBQandWindows;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
@@ -12,6 +13,7 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @QuarkusScenario
 @DisabledOnRHBQandWindows(reason = "QUARKUS-3434")
+@DisabledOnAarch64Native(reason = "QUARKUS-4321")
 public class SaslSslAlertMonitorIT extends BaseKafkaStreamTest {
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI, protocol = KafkaProtocol.SASL_SSL)

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SslAlertMonitorIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SslAlertMonitorIT.java
@@ -4,6 +4,7 @@ import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnAarch64Native;
 import io.quarkus.test.scenarios.annotations.DisabledOnRHBQandWindows;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
@@ -12,6 +13,7 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @QuarkusScenario
 @DisabledOnRHBQandWindows(reason = "QUARKUS-3434")
+@DisabledOnAarch64Native(reason = "QUARKUS-4321")
 public class SslAlertMonitorIT extends BaseKafkaStreamTest {
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI, protocol = KafkaProtocol.SSL)

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/StrimziKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/StrimziKafkaStreamIT.java
@@ -4,6 +4,7 @@ import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnAarch64Native;
 import io.quarkus.test.scenarios.annotations.DisabledOnRHBQandWindows;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
@@ -11,6 +12,7 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @QuarkusScenario
 @DisabledOnRHBQandWindows(reason = "QUARKUS-3434")
+@DisabledOnAarch64Native(reason = "QUARKUS-4321")
 public class StrimziKafkaStreamIT extends BaseKafkaStreamTest {
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI)


### PR DESCRIPTION
### Summary

* See https://issues.redhat.com/browse/QUARKUS-4321.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)