### PR TITLE
Disable SSL and SASL_SSL Kafka and Infinispan tests in FIPS-enabled environment in native mode

### DIFF
--- a/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/ts/messaging/infinispan/grpc/kafka/InfinispanKafkaIT.java
+++ b/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/ts/messaging/infinispan/grpc/kafka/InfinispanKafkaIT.java
@@ -18,6 +18,7 @@ import io.quarkus.test.bootstrap.InfinispanService;
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndNative;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
@@ -25,6 +26,7 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 import io.quarkus.ts.messaging.infinispan.grpc.kafka.books.Book;
 import io.restassured.http.ContentType;
 
+@DisabledOnFipsAndNative(reason = "QUARKUS-5233")
 @Tag("QUARKUS-2036")
 @QuarkusScenario
 public class InfinispanKafkaIT {

--- a/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/ts/messaging/infinispan/grpc/kafka/InfinispanKafkaSaslSslIT.java
+++ b/messaging/infinispan-grpc-kafka/src/test/java/io/quarkus/ts/messaging/infinispan/grpc/kafka/InfinispanKafkaSaslSslIT.java
@@ -13,12 +13,14 @@ import io.quarkus.test.bootstrap.InfinispanService;
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndNative;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaProtocol;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
+@DisabledOnFipsAndNative(reason = "QUARKUS-5233")
 @Tag("QUARKUS-4592")
 @Tag("QUARKUS-2036")
 @QuarkusScenario

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SaslSslAlertMonitorIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SaslSslAlertMonitorIT.java
@@ -5,6 +5,7 @@ import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnAarch64Native;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndNative;
 import io.quarkus.test.scenarios.annotations.DisabledOnRHBQandWindows;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
@@ -12,6 +13,7 @@ import io.quarkus.test.services.containers.model.KafkaProtocol;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @QuarkusScenario
+@DisabledOnFipsAndNative(reason = "QUARKUS-5233")
 @DisabledOnRHBQandWindows(reason = "QUARKUS-3434")
 @DisabledOnAarch64Native(reason = "QUARKUS-4321")
 public class SaslSslAlertMonitorIT extends BaseKafkaStreamTest {

--- a/messaging/kafkaSSL/src/test/java/io/quarkus/qe/messaging/ssl/KafkaSaslSslIT.java
+++ b/messaging/kafkaSSL/src/test/java/io/quarkus/qe/messaging/ssl/KafkaSaslSslIT.java
@@ -10,11 +10,13 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndNative;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaProtocol;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
+@DisabledOnFipsAndNative(reason = "QUARKUS-5232")
 @QuarkusScenario
 public class KafkaSaslSslIT {
 

--- a/messaging/kafkaSSL/src/test/java/io/quarkus/qe/messaging/ssl/KafkaSaslSslTlsRegistryIT.java
+++ b/messaging/kafkaSSL/src/test/java/io/quarkus/qe/messaging/ssl/KafkaSaslSslTlsRegistryIT.java
@@ -11,11 +11,13 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndNative;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaProtocol;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
+@DisabledOnFipsAndNative(reason = "QUARKUS-5232")
 @Tag("QUARKUS-4592")
 @QuarkusScenario
 public class KafkaSaslSslTlsRegistryIT {


### PR DESCRIPTION
### Summary

Disables Infinispan and Kafka tests in native mode in FIPS-enabled environment due to reported known issue.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)