### PR TITLE
Update OpenAPIIT to new schema in Spring data module after breaking upstream changes

### DIFF
--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/rest/additional/OpenAPIIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/rest/additional/OpenAPIIT.java
@@ -78,7 +78,7 @@ public class OpenAPIIT extends AbstractDbIT {
         assertEquals("#/components/schemas/Library", json.getString("library.$ref"));
 
         json.setRootPath("");
-        assertEquals("2022-03-10T12:15:50", json.getString("components.schemas.LocalDateTime.example"));
+        assertEquals("2022-03-10T12:15:50", json.getString("components.schemas.LocalDateTime.examples[0]"));
 
         assertEquals("http", json.getString("components.securitySchemes.SecurityScheme.type"));
         assertEquals("Authentication", json.getString("components.securitySchemes.SecurityScheme.description"));


### PR DESCRIPTION
### Summary

https://github.com/quarkusio/quarkus/pull/44055 updated OpenAPI to 4.0 and schema has changed, therefore our daily JVM build failed.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)