### PR TITLE
Raise Many extensions module native image `Xmx` to avoid out of memory build failures and decrease Xmx used by GH actions to 4g from 5g

### DIFF
--- a/.github/quarkus-ecosystem-test
+++ b/.github/quarkus-ecosystem-test
@@ -5,4 +5,4 @@ set -e
 mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P $MAVEN_PROFILES -Dts.quarkus.cli.cmd="${HOME}/.jbang/bin/quarkus"
 
 # run the tests on Native
-mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P $MAVEN_PROFILES -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=5g -Dts.quarkus.cli.cmd="${HOME}/.jbang/bin/quarkus"
+mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -P $MAVEN_PROFILES -Dnative -Dquarkus.native.container-build=true -Dts.quarkus.cli.cmd="${HOME}/.jbang/bin/quarkus"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,6 @@ jobs:
       - name: Build with Maven
         run: |
             mvn -fae -V -B --no-transfer-progress -fae \
-                        -Dquarkus.native.native-image-xmx=5g \
                         -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" \
                         ${{ matrix.module-mvn-args }} clean verify -Dnative -am -DexcludedGroups=long-running
       - name: Detect flaky tests

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -129,7 +129,6 @@ jobs:
         run: |
           mvn -fae -V -B --no-transfer-progress -s .github/mvn-settings.xml -P ${{ matrix.profiles }} -fae clean verify -Dnative \
             -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }} \
-            -Dquarkus.native.native-image-xmx=5g \
             -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - name: Zip Artifacts
         if: failure()

--- a/super-size/many-extensions/pom.xml
+++ b/super-size/many-extensions/pom.xml
@@ -10,7 +10,8 @@
     <artifactId>many-extensions</artifactId>
     <name>Quarkus QE TS: Many extensions</name>
     <properties>
-        <quarkus.native.native-image-xmx>5g</quarkus.native.native-image-xmx>
+        <!-- set to 7g after we experienced https://github.com/quarkusio/quarkus/issues/44216 -->
+        <quarkus.native.native-image-xmx>7g</quarkus.native.native-image-xmx>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
### Summary

Daily build is failing in native mode due raised build-time RSS usage https://github.com/quarkusio/quarkus/issues/44216. It was suggested that we should raise Xmx https://github.com/quarkusio/quarkus/issues/44216#issuecomment-2449753077. Increasing Xmx by 2 g works around the issue.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)