### PR TITLE
Remove property JAVA_OPT_KC_HEAP

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
@@ -15,9 +15,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class HttpAdvancedIT extends BaseHttpAdvancedIT {
 
     @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
-    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
-            // TODO remove this propery when this issue will be resolved: https://github.com/quarkus-qe/quarkus-test-suite/issues/2106
-            .withProperty("JAVA_OPTS_KC_HEAP", "-Xms512m -Xmx1g");
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureHttpServer = true, useTlsRegistry = false))
     static RestService app = new RestService().withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);


### PR DESCRIPTION
### Summary

As we discussed in this fix: https://github.com/quarkus-qe/quarkus-test-framework/pull/1389
It is not already necessary to have this property `JAVA_OPT_KC_HEAP` for KeycloakService

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)