### PR TITLE
Increase the default memory limit for native-image to 5g

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -702,7 +702,7 @@
                 <profile.id>native</profile.id>
                 <quarkus.native.enabled>true</quarkus.native.enabled>
                 <quarkus.native.container-build>true</quarkus.native.container-build>
-                <quarkus.native.native-image-xmx>4g</quarkus.native.native-image-xmx>
+                <quarkus.native.native-image-xmx>5g</quarkus.native.native-image-xmx>
                 <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21</quarkus.native.builder-image>
                 <exclude.quarkus.devmode.tests>**/*DevMode*IT.java</exclude.quarkus.devmode.tests>
             </properties>

--- a/sql-db/sql-app-compatibility/pom.xml
+++ b/sql-db/sql-app-compatibility/pom.xml
@@ -10,9 +10,6 @@
     <artifactId>sqldb-sqlapp-compatibility</artifactId>
     <packaging>jar</packaging>
     <name>Quarkus QE TS: SQL Database: Application Compatibility</name>
-    <properties>
-        <quarkus.native.native-image-xmx>5g</quarkus.native.native-image-xmx>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/sql-db/sql-app/pom.xml
+++ b/sql-db/sql-app/pom.xml
@@ -10,9 +10,6 @@
     <artifactId>sqldb-sqlapp</artifactId>
     <packaging>jar</packaging>
     <name>Quarkus QE TS: SQL Database: Application</name>
-    <properties>
-        <quarkus.native.native-image-xmx>5g</quarkus.native.native-image-xmx>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Increase the default memory limit for native-image to 5g

GitHib Actions runners have more memory now, Jenkins runners are usualy having 16GB
More memory should mean slightly faster native image build and less GC activity

This should also help with daily CI failure in `funqy-knative-events` module probably caused by https://github.com/quarkusio/quarkus/issues/44216

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)