### PR TITLE
Disable MariaDB XA transaction recovery test in OpenShift

### DIFF
--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMariaDbTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMariaDbTransactionGeneralUsageIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.transactions;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.MariaDbService;
@@ -37,4 +38,9 @@ public class OpenShiftMariaDbTransactionGeneralUsageIT extends TransactionCommon
         return TransactionExecutor.STATIC_TRANSACTION_MANAGER;
     }
 
+    @Disabled("https://github.com/quarkusio/quarkus/issues/44160")
+    @Override
+    public void testTransactionRecovery() {
+        // TODO: drop this method when https://github.com/quarkusio/quarkus/issues/44160 is fixed
+    }
 }


### PR DESCRIPTION
### Summary

https://github.com/quarkus-qe/quarkus-test-suite/pull/2143 follow-up

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)