### PR TITLE
Increase Native image Xmx used for `ServerlessExtensionOpenShiftFunqyKnEventsIT` in native mode

### DIFF
--- a/funqy/knative-events/pom.xml
+++ b/funqy/knative-events/pom.xml
@@ -10,6 +10,10 @@
     <artifactId>funqy-knative-events</artifactId>
     <packaging>jar</packaging>
     <name>Quarkus QE TS: Funqy - Knative Events</name>
+    <properties>
+        <!-- set to 7g after we experienced https://github.com/quarkusio/quarkus/issues/44216 in OpenShift -->
+        <quarkus.native.native-image-xmx>7g</quarkus.native.native-image-xmx>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
### Summary

follow-up for https://github.com/quarkus-qe/quarkus-test-suite/pull/2155 and https://github.com/quarkus-qe/quarkus-test-suite/pull/2153 as periodic OpenShift native build fails (also) over this.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)