### PR TITLE
Disable service binding tests as they often fail over inactive datasource

### DIFF
--- a/service-binding/postgresql-crunchy-classic/src/test/java/io/quarkus/ts/sb/postgresql/OpenShiftPostgreSqlSbIT.java
+++ b/service-binding/postgresql-crunchy-classic/src/test/java/io/quarkus/ts/sb/postgresql/OpenShiftPostgreSqlSbIT.java
@@ -11,6 +11,7 @@ import jakarta.inject.Inject;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -22,6 +23,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.utils.AwaitilityUtils;
 import io.quarkus.test.utils.Command;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/44297")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 @DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "Crunchy Postgres operator not available on s390x & ppc64le.")
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1755")

--- a/service-binding/postgresql-crunchy-reactive/src/test/java/io/quarkus/ts/sb/reactive/OpenShiftPostgreSqlReactiveSbIT.java
+++ b/service-binding/postgresql-crunchy-reactive/src/test/java/io/quarkus/ts/sb/reactive/OpenShiftPostgreSqlReactiveSbIT.java
@@ -12,6 +12,7 @@ import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -23,6 +24,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.utils.AwaitilityUtils;
 import io.quarkus.test.utils.Command;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/44297")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 @DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "Crunchy Postgres operator not available on s390x & ppc64le.")
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1755")


### PR DESCRIPTION
### Summary

See https://github.com/quarkusio/quarkus/issues/44297. I'll apply workarounds if we get them, but I'd like to get OpenShift tests green more.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)