### PR TITLE
[3.15] Backport for remove property JAVA_OPT_KC_HEAP

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
@@ -15,9 +15,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class HttpAdvancedIT extends BaseHttpAdvancedIT {
 
     @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
-    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH)
-            // TODO remove this propery when this issue will be resolved: https://github.com/quarkus-qe/quarkus-test-suite/issues/2106
-            .withProperty("JAVA_OPTS", "-Xms512m -Xmx1g");
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureHttpServer = true, useTlsRegistry = false))
     static RestService app = new RestService().withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.15.999-SNAPSHOT</quarkus.platform.version>
         <quarkus.ide.version>3.15.1</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.5.7</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.5.8</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.6.1</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.24.1</formatter-maven-plugin.version>


### PR DESCRIPTION
### Summary
It's a backport from https://github.com/quarkus-qe/quarkus-test-suite/pull/2154
It is not already necessary to have this property JAVA_OPT_KC_HEAP for KeycloakService

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)