### PR TITLE
Fix `AccessLoggingIT` when test is executed with long working directory path

### DIFF
--- a/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/AccessLoggingIT.java
+++ b/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/AccessLoggingIT.java
@@ -15,6 +15,7 @@ import java.util.zip.ZipFile;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -24,12 +25,27 @@ import io.quarkus.test.services.QuarkusApplication;
 @Tag("https://issues.redhat.com/browse/QUARKUS-4663")
 public class AccessLoggingIT {
     private static final String ACCESS_LOG_FILENAME = "appAccess.log";
-    private static final Path ACCESS_LOG_DIR = Path.of("target/AccessLoggingIT/app");
+    private static final Path ACCESS_LOG_DIR;
+
+    static {
+        // keeps access log directory path short due to https://github.com/quarkusio/quarkus/issues/44346
+        // if this ever starts to fail on Windows, we need to do something similar, but for now
+        // this issue is only reproducible in Jenkins when file job name is quite long (like when testing FIPS & native)
+        if (OS.WINDOWS.isCurrentOs()) {
+            ACCESS_LOG_DIR = Path.of("target").resolve("AccessLoggingIT").resolve("app");
+        } else {
+            try {
+                ACCESS_LOG_DIR = Files.createTempDirectory("AccessLoggingIT");
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to create temporary directory for access log", e);
+            }
+        }
+    }
 
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperties("accessLogging.properties")
-            .withProperty("quarkus.log.handler.file.access-log.path", ACCESS_LOG_FILENAME);
+            .withProperty("quarkus.log.handler.file.access-log.path", AccessLoggingIT::getAbsoluteLogPath);
 
     /**
      * We want each test to start with no log files from previous tests, so remove them;
@@ -147,8 +163,12 @@ public class AccessLoggingIT {
                 .toList();
     }
 
-    private Path accessLogPath() {
+    private static Path accessLogPath() {
         return ACCESS_LOG_DIR.resolve(ACCESS_LOG_FILENAME);
+    }
+
+    private static String getAbsoluteLogPath() {
+        return accessLogPath().toAbsolutePath().toString();
     }
 
     /**


### PR DESCRIPTION
### Summary

When `AccessLoggingIT` is executed in native mode in FIPS-enabled environment, working directory path in Jenkins can be long, which according to https://github.com/quarkusio/quarkus/issues/44346 means that maximum log file size can get bigger than required size. Therefore I am applying workaround - making sure that path to log directory is short.

This test was added recently https://github.com/quarkus-qe/quarkus-test-suite/pull/2119 and the TD was backported, therefore this fix needs to be backported to 3.15 as well.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)