### PR TITLE
Optimize GzipMaxInputIT in order to reduce the JVM memory consumption

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/GzipMaxInputIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/GzipMaxInputIT.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.http.advanced;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.zip.GZIPOutputStream;
@@ -20,11 +21,12 @@ import io.restassured.response.Response;
 @QuarkusScenario
 public class GzipMaxInputIT {
 
-    final byte[] zero_bytes = new byte[0];
-    final String invalid_value = "";
-    final byte[] SMALL_PAYLOAD = new byte[512];
-    final byte[] LIMIT_PAYLOAD = new byte[100 * 1024 * 1024];
-    final byte[] OVER_LIMIT_PAYLOAD = new byte[200 * 1024 * 1024];
+    final static String INVALID_VALUE = "";
+    final static long SMALL_PAYLOAD = 512;
+    final static long LIMIT_PAYLOAD = 100 * 1024 * 1024;
+    final static long OVER_LIMIT_PAYLOAD = 200 * 1024 * 1024;
+
+    private final byte[] buffer = new byte[4096];
 
     /**
      *
@@ -37,16 +39,43 @@ public class GzipMaxInputIT {
     @QuarkusApplication(classes = { GzipResource.class }, properties = "gzip.properties")
     static RestService app = new RestService();
 
+    private ByteArrayInputStream generateCompressedDataStream(long sizeInBytes) {
+        try {
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream)) {
+                long bytesRemaining = sizeInBytes;
+
+                while (bytesRemaining > 0) {
+                    int bytesToWrite;
+
+                    if (bytesRemaining >= buffer.length) {
+                        bytesToWrite = buffer.length;
+                    } else {
+                        bytesToWrite = (int) bytesRemaining;
+                    }
+
+                    gzipOutputStream.write(buffer, 0, bytesToWrite);
+                    bytesRemaining = bytesRemaining - bytesToWrite;
+                }
+            }
+
+            return new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
+
+        } catch (IOException e) {
+            throw new RuntimeException("Error generating compressed data stream", e);
+        }
+    }
+
     @Test
     void sendInvalidContent() {
-        Response response = sendStringDataToGzipEndpoint(invalid_value);
+        Response response = sendStringDataToGzipEndpoint(INVALID_VALUE);
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.statusCode(),
                 "Invalid data as this void string should result in 400 BAD_REQUEST response");
     }
 
     @Test
     void sendZeroBytesPayload() throws IOException {
-        byte[] compressedData = generateCompressedData(zero_bytes);
+        ByteArrayInputStream compressedData = generateCompressedDataStream(0);
         Response response = sendDataToGzipEndpoint(compressedData);
         assertEquals(HttpStatus.SC_OK, response.statusCode(),
                 "The response should be 200 OK because the compression returns 2 bytes");
@@ -54,7 +83,7 @@ public class GzipMaxInputIT {
 
     @Test
     void sendPayloadBelowMaxInputLimit() throws IOException {
-        byte[] compressedData = generateCompressedData(SMALL_PAYLOAD);
+        ByteArrayInputStream compressedData = generateCompressedDataStream(SMALL_PAYLOAD);
         Response response = sendDataToGzipEndpoint(compressedData);
         assertEquals(HttpStatus.SC_OK, response.statusCode(),
                 "The response should be 200 OK because sending just 512 bytes");
@@ -63,7 +92,7 @@ public class GzipMaxInputIT {
     @Tag("https://github.com/quarkusio/quarkus/issues/39636")
     @Test
     void sendMaximumAllowedPayload() throws IOException {
-        byte[] compressedData = generateCompressedData(LIMIT_PAYLOAD);
+        ByteArrayInputStream compressedData = generateCompressedDataStream(LIMIT_PAYLOAD);
         Response response = sendDataToGzipEndpoint(compressedData);
         assertEquals(HttpStatus.SC_OK, response.statusCode(),
                 "The response should be 200 OK because sending just the limit payload configured using " +
@@ -73,13 +102,13 @@ public class GzipMaxInputIT {
 
     @Test
     void sendMoreThanMaximumAllowedPayload() throws IOException {
-        byte[] compressedData = generateCompressedData(OVER_LIMIT_PAYLOAD);
+        ByteArrayInputStream compressedData = generateCompressedDataStream(OVER_LIMIT_PAYLOAD);
         Response response = sendDataToGzipEndpoint(compressedData);
         assertEquals(HttpStatus.SC_REQUEST_TOO_LONG, response.statusCode(),
                 "The response should be 413 REQUEST_TOO_LONG when sending larger payload than the limit");
     }
 
-    private Response sendDataToGzipEndpoint(byte[] data) {
+    private Response sendDataToGzipEndpoint(ByteArrayInputStream data) {
         return app.given()
                 .header(HttpHeaders.CONTENT_ENCODING, "gzip")
                 .body(data)
@@ -97,17 +126,6 @@ public class GzipMaxInputIT {
                 .post("/gzip")
                 .then()
                 .extract().response();
-    }
-
-    public byte[] generateCompressedData(byte[] data) throws IOException {
-        byte[] result;
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                GZIPOutputStream gzipOut = new GZIPOutputStream(baos)) {
-            gzipOut.write(data);
-            gzipOut.close();
-            result = baos.toByteArray();
-        }
-        return result;
     }
 
 }


### PR DESCRIPTION
### Summary

Refactors `GzipMaxInputIT` to reduce memory usage, avoiding spikes in memory consumption.

I compared prints on our Jenkins jobs in the previous one GzipMaxInputIT and observed a rapid spike in memory consumption, but currently, these changes are almost negligible.

This approach addresses the memory issues observed in Podman Jenkins jobs related to Keycloak container failures.


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)