### PR TITLE
Increase expected maximum file size of rotated access log as file rotation limit is not hard

### DIFF
--- a/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/AccessLoggingIT.java
+++ b/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/AccessLoggingIT.java
@@ -77,7 +77,10 @@ public class AccessLoggingIT {
         assertEquals(3, logFileNames.size(), "There should be 3 log file - one active and two backups");
 
         // check main log file size, we have max 5KB configured
-        assertTrue(Files.size(accessLogPath()) <= 5120, "Main log size should be max 5KB");
+        // adding extra 420 because the max file is not actual maximum of the file size :-)
+        // it is just a limit after which Quarkus rotates (when logging finishes)
+        // see https://github.com/quarkusio/quarkus/issues/44346
+        assertTrue(Files.size(accessLogPath()) <= 5420, "Main log size should be max 5KB");
 
         // check that archive logs are valid zip files
         for (String filename : logFileNames) {


### PR DESCRIPTION
### Summary

All is explained in https://github.com/quarkusio/quarkus/issues/44346 comments. Max file size is not actual file size maximum.

Supersedes: https://github.com/quarkus-qe/quarkus-test-suite/pull/2167

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)