### PR TITLE
Allow wait container to run on different architectures

### DIFF
--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/init/OpenShiftDefaultInitContainerIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/init/OpenShiftDefaultInitContainerIT.java
@@ -11,7 +11,6 @@ import java.nio.file.Paths;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.yaml.snakeyaml.Yaml;
 
 import io.quarkus.test.bootstrap.MySqlService;
@@ -22,13 +21,11 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2071")
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "Same reason as aarch64 https://github.com/quarkus-qe/quarkus-test-suite/issues/2071")
 public class OpenShiftDefaultInitContainerIT {
 
     private final Path openShiftYaml = Paths.get("target/", this.getClass().getSimpleName(),
             "app/target/kubernetes/openshift.yml");
-    private static final String CUSTOM_IMAGE = "quay.io/quarkusqeteam/wait:0.0.2";
+    private static final String CUSTOM_IMAGE = "quay.io/quarkusqeteam/wait:0.0.4";
 
     @Container(image = "${mysql.80.image}", port = 3306, expectedLog = "Only MySQL server logs after this point")
     static MySqlService database = new MySqlService();

--- a/sql-db/panache-flyway/src/test/resources/build.sh
+++ b/sql-db/panache-flyway/src/test/resources/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# based on these guides: https://blog.while-true-do.io/podman-multi-arch-images/ and https://community.ibm.com/community/user/powerdeveloper/blogs/mayur-waghmode/2022/09/19/building-multi-arch-container-images-with-github-a
+
+set -euxo pipefail
+
+version=${1}
+if [ -z "$version" ]; then
+        echo "Provide version for https://quay.io/repository/quarkusqeteam/wait container!"
+        exit 1
+fi
+TAG="quay.io/quarkusqeteam/wait:$version"
+podman manifest create $TAG
+podman build . --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x --manifest $TAG  --file Dockerfile
+podman manifest push $TAG


### PR DESCRIPTION
### Summary

- Add a script to generate an image for x86, ARM, IBM P and IBM Z
- Enable back the tests on the new architectures

Fixes https://github.com/quarkus-qe/quarkus-test-suite/issues/2071

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)