### PR TITLE
Increase memory limit for many-extensions test

### DIFF
--- a/super-size/many-extensions/pom.xml
+++ b/super-size/many-extensions/pom.xml
@@ -11,7 +11,7 @@
     <name>Quarkus QE TS: Many extensions</name>
     <properties>
         <!-- set to 7g after we experienced https://github.com/quarkusio/quarkus/issues/44216 -->
-        <quarkus.native.native-image-xmx>7g</quarkus.native.native-image-xmx>
+        <quarkus.native.native-image-xmx>10g</quarkus.native.native-image-xmx>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
### Summary

Increase memory limit for super-size/many-extensions test. Migration to `@ConfigMapping` makes the native compilation require a lot more memory - see https://github.com/quarkusio/quarkus/issues/44216

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)