### PR TITLE
Add test  for @RestForm Map<String, String> handling in REST Client

### DIFF
--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/BookClient.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/BookClient.java
@@ -2,9 +2,11 @@ package io.quarkus.ts.http.restclient.reactive;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
@@ -13,6 +15,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.RestQuery;
 
 import io.quarkus.ts.http.restclient.reactive.json.Book;
@@ -110,4 +113,10 @@ public interface BookClient {
     @Path("/suffix_priority")
     @Produces("application/text+json")
     Uni<String> getPriorities(@QueryParam("content") String text);
+
+    @POST
+    @Path("/search")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.APPLICATION_JSON)
+    Set<Book> postFilter(@RestForm Map<String, String> filter);
 }

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/PlainBookResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/PlainBookResource.java
@@ -9,9 +9,12 @@ import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
@@ -161,6 +164,14 @@ public class PlainBookResource {
                 .build(BookClient.class)
                 .getBook("The Hobbit: An Unexpected Journey", "J. R. R. Tolkien")
                 .map(Book::getTitle);
+    }
+
+    @POST
+    @Path("/search")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Set<Book> searchBooks(@FormParam("author") String author) {
+        return Set.of(new Book("The Wind-Up Bird Chronicle", author));
     }
 
     private KeyStore trustStore() throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/ReactiveClientBookResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/ReactiveClientBookResource.java
@@ -2,9 +2,11 @@ package io.quarkus.ts.http.restclient.reactive.resources;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -115,5 +117,11 @@ public class ReactiveClientBookResource {
             default:
                 throw new IllegalStateException("Unexpected value: " + type);
         }
+    }
+
+    @POST
+    @Path("/search")
+    public Set<Book> postFilter() {
+        return bookInterface.postFilter(Map.of("author", "Haruki Murakami"));
     }
 }

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
@@ -7,7 +7,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
 import java.util.UUID;
+
+import jakarta.ws.rs.core.MediaType;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
@@ -58,6 +61,23 @@ public class ReactiveRestClientIT {
                 .get("/client/book/{id}/json");
         assertEquals(HttpStatus.SC_OK, response.statusCode());
         assertEquals("Title in Json: 123", response.jsonPath().getString("title"));
+    }
+
+    @Tag("https://github.com/quarkusio/quarkus/issues/43784")
+    @Test
+    public void shouldPostBook() {
+        Response response = app.given()
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .when()
+                .post("/client/book/search");
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+        List<Book> books = response.jsonPath().getList(".", Book.class);
+        assertEquals(1, books.size());
+
+        Book book = books.iterator().next();
+
+        assertEquals("The Wind-Up Bird Chronicle", book.getTitle());
+        assertEquals("Haruki Murakami", book.getAuthor());
     }
 
     @Tag("QUARKUS-1568")


### PR DESCRIPTION
### Summary
This PR form part of the _[3.15] 3.15.2 backports 1_ (https://github.com/quarkusio/quarkus/pull/43985)  and adds test coverage to ensure that` @RestForm Map<String, String>` is properly handled in REST client requests, covering the fix for Quarkus issue [#43784](https://github.com/quarkusio/quarkus/issues/43784). 


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)