### PR TITLE
Add test coverage for #43364 - InputStream when using multipart

### DIFF
--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MultipartResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/MultipartResource.java
@@ -2,8 +2,12 @@ package io.quarkus.ts.http.advanced.reactive;
 
 import static io.quarkus.ts.http.advanced.reactive.MultipartResource.MULTIPART_FORM_PATH;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
@@ -14,6 +18,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.server.multipart.MultipartFormDataInput;
 
 @Path(MULTIPART_FORM_PATH)
@@ -43,5 +48,44 @@ public class MultipartResource {
             LOGGER.warnf("Multipart Form Data does not contain value of form field '%s'.", TEXT);
         }
         return Response.status(Status.BAD_REQUEST).build();
+    }
+
+    @POST
+    @Path("/inputstream/without-media-type")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String handleInputStreamWithoutMediaType(
+            @RestForm("file") InputStream inputStream,
+            @RestForm("description") String description) {
+
+        String content;
+        try (InputStreamReader imputStreamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+                BufferedReader bufferedReader = new BufferedReader(imputStreamReader)) {
+            content = bufferedReader.lines().collect(Collectors.joining("\n"));
+        } catch (IOException e) {
+            LOGGER.error("Error reading the uploaded content", e);
+            return "Error processing the file.";
+        }
+
+        return "Received description: " + description + " with file content: " + content;
+    }
+
+    @POST
+    @Path("/inputstream/with-media-type")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String handleInputStreamWithMediaType(
+            @RestForm("file") InputStream inputStream,
+            @RestForm("description") String description) {
+
+        String content;
+        try (InputStreamReader imputStreamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+                BufferedReader bufferedReader = new BufferedReader(imputStreamReader)) {
+            content = bufferedReader.lines().collect(Collectors.joining("\n"));
+        } catch (IOException e) {
+            LOGGER.error("Error reading the uploaded content", e);
+            return "Error processing the uploaded content";
+        }
+        return "Received description: " + description + " with file content: " + content;
     }
 }

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/MultipartInputstreamIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/MultipartInputstreamIT.java
@@ -1,0 +1,60 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import static io.quarkus.ts.http.advanced.reactive.MultipartResource.MULTIPART_FORM_PATH;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.ws.rs.core.MediaType;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class MultipartInputstreamIT {
+
+    @QuarkusApplication(classes = { MultipartResource.class, MediaTypeResource.class, MediaTypeWrapper.class,
+            MultipartFormDataDTO.class }, properties = "oidcdisable.properties")
+    static RestService app = new RestService();
+
+    @Tag("https://github.com/quarkusio/quarkus/issues/43364")
+    @Test
+    public void testInputStreamWithoutMediaType() {
+        String testContent = "test content without media type";
+        InputStream fileStream = new ByteArrayInputStream(testContent.getBytes(StandardCharsets.UTF_8));
+        String description = "Test Description";
+
+        app.given()
+                .multiPart("file", "test.txt", fileStream)
+                .multiPart("description", description)
+                .when()
+                .post(MULTIPART_FORM_PATH + "/inputstream/without-media-type")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Received description: " + description + " with file content: " + testContent));
+    }
+
+    @Tag("https://github.com/quarkusio/quarkus/issues/43364")
+    @Test
+    public void testInputStreamWithMediaType() {
+        String testContent = "test content with media type";
+        InputStream fileStream = new ByteArrayInputStream(testContent.getBytes(StandardCharsets.UTF_8));
+        String description = "Test Description";
+
+        app.given()
+                .multiPart("file", "test.txt", fileStream, MediaType.TEXT_PLAIN)
+                .multiPart("description", description)
+                .when()
+                .post(MULTIPART_FORM_PATH + "/inputstream/with-media-type")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Received description: " + description + " with file content: " + testContent));
+    }
+
+}

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftMultipartInputstreamIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftMultipartInputstreamIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftMultipartInputstreamIT extends MultipartInputstreamIT {
+
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/FileUploadClient.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/FileUploadClient.java
@@ -1,0 +1,26 @@
+package io.quarkus.ts.http.restclient.reactive.multipart;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+public interface FileUploadClient {
+
+    @POST
+    @Path("/upload/without")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.TEXT_PLAIN)
+    String uploadFileWithoutMediaType(MultipartBodyWithoutMediaType data);
+
+    @POST
+    @Path("/upload/with")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.TEXT_PLAIN)
+    String uploadFileWithMediaType(MultipartBodyWithMediaType data);
+
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/MultipartBodyWithMediaType.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/MultipartBodyWithMediaType.java
@@ -1,0 +1,17 @@
+package io.quarkus.ts.http.restclient.reactive.multipart;
+
+import java.io.InputStream;
+
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+
+public class MultipartBodyWithMediaType {
+    @RestForm("file")
+    public InputStream file;
+
+    @RestForm("fileName")
+    @PartType(MediaType.TEXT_PLAIN)
+    public String fileName;
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/MultipartBodyWithoutMediaType.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/multipart/MultipartBodyWithoutMediaType.java
@@ -1,0 +1,13 @@
+package io.quarkus.ts.http.restclient.reactive.multipart;
+
+import java.io.InputStream;
+
+import org.jboss.resteasy.reactive.RestForm;
+
+public class MultipartBodyWithoutMediaType {
+    @RestForm("file")
+    public InputStream file;
+
+    @RestForm("fileName")
+    public String fileName;
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/FileUploadClientTestResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/FileUploadClientTestResource.java
@@ -1,0 +1,45 @@
+package io.quarkus.ts.http.restclient.reactive.resources;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.quarkus.ts.http.restclient.reactive.multipart.FileUploadClient;
+import io.quarkus.ts.http.restclient.reactive.multipart.MultipartBodyWithMediaType;
+import io.quarkus.ts.http.restclient.reactive.multipart.MultipartBodyWithoutMediaType;
+
+@Path("/client/upload")
+public class FileUploadClientTestResource {
+
+    @Inject
+    @RestClient
+    FileUploadClient fileUploadClient;
+
+    @GET
+    @Path("/without-media-type")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testUploadWithoutMediaType() {
+        MultipartBodyWithoutMediaType data = new MultipartBodyWithoutMediaType();
+        data.file = new ByteArrayInputStream("This is sample test content without media type".getBytes(StandardCharsets.UTF_8));
+        data.fileName = "fileTest.txt";
+        return fileUploadClient.uploadFileWithoutMediaType(data);
+    }
+
+    @GET
+    @Path("/with-media-type")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testUploadWithMediaType() {
+        MultipartBodyWithMediaType data = new MultipartBodyWithMediaType();
+        data.file = new ByteArrayInputStream("This is sample test content with media type".getBytes(StandardCharsets.UTF_8));
+        data.fileName = "fileTest.txt";
+
+        return fileUploadClient.uploadFileWithMediaType(data);
+    }
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/FileUploadResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/FileUploadResource.java
@@ -1,0 +1,56 @@
+package io.quarkus.ts.http.restclient.reactive.resources;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.ts.http.restclient.reactive.multipart.MultipartBodyWithMediaType;
+import io.quarkus.ts.http.restclient.reactive.multipart.MultipartBodyWithoutMediaType;
+
+@Path("/upload")
+public class FileUploadResource {
+
+    private static final Logger LOGGER = Logger.getLogger(FileUploadResource.class);
+
+    @POST
+    @Path("/without")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String uploadFileWithoutMediaType(MultipartBodyWithoutMediaType data) {
+        String content;
+        try (BufferedReader bufferedReader = new BufferedReader(
+                new InputStreamReader(data.file, StandardCharsets.UTF_8))) {
+            content = bufferedReader.lines().collect(Collectors.joining("\n"));
+        } catch (IOException e) {
+            LOGGER.error("Error reading data file without media type", e);
+            return "Error reading data file without media type " + e.getMessage();
+        }
+        return "File received: " + data.fileName + " content: " + content;
+    }
+
+    @POST
+    @Path("/with")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String uploadFileWithMediaType(MultipartBodyWithMediaType data) {
+        String content;
+        try (BufferedReader bufferedReader = new BufferedReader(
+                new InputStreamReader(data.file, StandardCharsets.UTF_8))) {
+            content = bufferedReader.lines().collect(Collectors.joining("\n"));
+        } catch (IOException e) {
+            LOGGER.error("Error reading data file with media type", e);
+            return "Error reading data file with media type " + e.getMessage();
+        }
+        return "File received: " + data.fileName + " content: " + content;
+    }
+}

--- a/http/rest-client-reactive/src/main/resources/modern.properties
+++ b/http/rest-client-reactive/src/main/resources/modern.properties
@@ -6,6 +6,7 @@ quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.BookClient.AuthorCli
 quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.ResourceAndSubResourcesClient".url=http://localhost:${quarkus.http.port}
 quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.MalformedClient".url=http://localhost:${quarkus.http.port}
 quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.failures.FailureClient".url=http://localhost:${quarkus.http.port}
+quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.multipart.FileUploadClient".url=http://localhost:${quarkus.http.port}
 
 quarkus.rest-client.logging.scope=request-response
 quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
@@ -314,6 +314,28 @@ public class ReactiveRestClientIT {
                 .body(containsString("visitor of this page"));
     }
 
+    @Test
+    @Tag("https://github.com/quarkusio/quarkus/issues/43364")
+    public void testUploadFileWithoutMediaType() {
+        app.given()
+                .get("/client/upload/without-media-type")
+                .then()
+                .statusCode(200)
+                .body(containsString("File received: fileTest.txt content: This is sample test content without media type"));
+
+    }
+
+    @Test
+    @Tag("https://github.com/quarkusio/quarkus/issues/43364")
+    public void testUploadFileWithMediaType() {
+        app.given()
+                .get("/client/upload/with-media-type")
+                .then()
+                .statusCode(200)
+                .body(containsString("File received: fileTest.txt content: This is sample test content with media type"));
+
+    }
+
     @AfterAll
     static void afterAll() {
         mockServer.stop();


### PR DESCRIPTION
### Summary

Add test coverage for the optional media type handling in InputStream multipart requests, testing Rest client-side and HTTP server-side handling. Addressing the issue https://github.com/quarkusio/quarkus/issues/43364 with the fix https://github.com/quarkusio/quarkus/pull/43985/commits/f6710518a8cc293664b888db7617047d30e2b5f8

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)