### PR TITLE
Run SpringCloudConfigIT on Aarch64

### DIFF
--- a/spring/spring-cloud-config/src/test/java/io/quarkus/ts/spring/cloud/config/SpringCloudConfigIT.java
+++ b/spring/spring-cloud-config/src/test/java/io/quarkus/ts/spring/cloud/config/SpringCloudConfigIT.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.is;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -15,7 +14,6 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2025")
 public class SpringCloudConfigIT {
 
     @Container(image = "${spring.cloud.server.image}", port = 8888, expectedLog = "Started ConfigServer")


### PR DESCRIPTION
### Summary

- closes https://github.com/quarkus-qe/quarkus-test-suite/issues/2025

I have rebuild Quarkus QE image and created manifest for both Aarch64 and AMD64. I also updated instructions how to do it here https://quay.io/repository/quarkusqeteam/spring-cloud-config-server?tab=info. Then I tested this new image in beaker executor and the test is now passing on Aarch64.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)