### PR TITLE
Document why we use GenericContainer in PostgresqlResource

### DIFF
--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/dbpool/PostgresqlResource.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/dbpool/PostgresqlResource.java
@@ -16,6 +16,9 @@ public class PostgresqlResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
+        // on Aarch64 we use PostgreSQL from Red Hat container registry
+        // this image is difficult to run with `org.testcontainers.containers.PostgreSQLContainer`
+        // see comments in the https://github.com/quarkusio/quarkus/issues/44196 for more info
         postgresContainer = new GenericContainer<>(DockerImageName.parse(POSTGRESQL_IMAGE_NAME))
                 // Need to set POSTGRES and POSTGRESQL for usage with Docker hub and RH images
                 .withEnv("POSTGRES_USER", "test")


### PR DESCRIPTION
### Summary

- closes https://github.com/quarkus-qe/quarkus-test-suite/issues/2076

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)