### PR TITLE
Replace deprecated API in HTTP modules

### DIFF
--- a/http/jakarta-rest-reactive/src/main/java/io/quarkus/ts/http/jakartarest/reactive/client/MultipartService.java
+++ b/http/jakarta-rest-reactive/src/main/java/io/quarkus/ts/http/jakartarest/reactive/client/MultipartService.java
@@ -7,7 +7,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import org.jboss.resteasy.reactive.MultipartForm;
 
 @Path("/multipart/echo")
 @RegisterRestClient
@@ -16,5 +15,5 @@ public interface MultipartService {
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.TEXT_PLAIN)
-    String sendMultipartData(@MultipartForm ClientMultipartBody data);
+    String sendMultipartData(ClientMultipartBody data);
 }

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/files/FileResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/files/FileResource.java
@@ -16,7 +16,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.resteasy.reactive.MultipartForm;
 import org.jboss.resteasy.reactive.RestResponse;
 
 import io.quarkus.logging.Log;
@@ -61,7 +60,7 @@ public class FileResource {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/upload-multipart")
     @Blocking
-    public String uploadMultipart(@MultipartForm FileWrapper body) {
+    public String uploadMultipart(FileWrapper body) {
         deathRow.add(body.file);
         return utils.getSum(body.file.getAbsoluteFile().toPath());
     }

--- a/http/vertx-web-client/src/main/java/io/quarkus/ts/http/vertx/webclient/handler/ChuckNorrisResource.java
+++ b/http/vertx-web-client/src/main/java/io/quarkus/ts/http/vertx/webclient/handler/ChuckNorrisResource.java
@@ -71,7 +71,7 @@ public class ChuckNorrisResource {
         return Uni.combine()
                 .all()
                 .unis(jokeOne, jokeTwo)
-                .combinedWith((BiFunction<Joke, Joke, List<Joke>>) Arrays::asList);
+                .with((BiFunction<Joke, Joke, List<Joke>>) Arrays::asList);
     }
 
     @Route(methods = HttpMethod.GET, path = "/pong", produces = "application/json", order = 3)


### PR DESCRIPTION
### Summary

Replace deprecated APIs in HTTP modules. 

- `@MultipartForm` Can be removed without replacement in certain conditions (that we meet).

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [X] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)