### PR TITLE
Add git rebase to PR CI and fix not running full CI when pom.xml is changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
 
           for module in $MODULES
           do
+            # Check if files contains main pom.xml as we want to run all modules here.
+            if [[ $CHANGED_FILE =~ [^\/]pom\.xml|^pom\.xml ]]; then
+                CHANGED=""
+                break
+            fi
             if [[ $CHANGED_FILE =~ ("$module") ]] ; then
                 CHANGED=$(echo $CHANGED" "$module)
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - id: fetch-latest-target-branch-commits # makes sure that latest target branch HEAD commit is available locally
-        # fetching the latest 2 commits, one should be enough but 2 could avoid race (diff between GH PR event base sha and actual remote base sha)
+        # fetching the latest 15 commits as we want to rebase the PR to target branch to ensure just changed file are parsed.
+        # If someone have outdated branch (16+ commits) the job fail
         name: 'Fetch the latest 2 target (base) branch commits'
         run: |
           git remote add quarkus_qe_target_repo https://github.com/quarkus-qe/quarkus-test-suite.git
-          git fetch quarkus_qe_target_repo ${GITHUB_BASE_REF} --depth=2
+          git fetch quarkus_qe_target_repo ${GITHUB_BASE_REF} --depth=15
+          git config user.email "qe@quarkus"
+          git config user.name "Quarkus QE"
+          git rebase quarkus_qe_target_repo/${GITHUB_BASE_REF}
       - id: files
         uses: tj-actions/changed-files@v45
         continue-on-error: true


### PR DESCRIPTION
### Summary

This adding the rebase for us to test on latest version of branch, it help only detect the changed file in the PR. Also the rebase fail if the contributor have outdated branch in this case 16 or more commits (in my POV it should be enough)

To test the rebase I used the f66d24d805480689a62b4f863bb3c64ca23ae3e8 commit as base for this branch


This PR also fix the problem when main `pom.xml` was updated but the PR also contains other changes (updating tests etc.) so only selected modules were run. Wth this fix all the modules will be executed.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)