### PR TITLE
[3.15] 3.15 Backport Enable kafka tests on aarch64 for test coverage issue #43319

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftAmqStreamsKafkaStreamIT.java
@@ -6,13 +6,11 @@ import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnAarch64Native;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @OpenShiftScenario
-@DisabledOnAarch64Native(reason = "https://issues.redhat.com/browse/QUARKUS-4321")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTest {
 

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftStrimziKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OpenShiftStrimziKafkaStreamIT.java
@@ -1,9 +1,7 @@
 package io.quarkus.ts.messaging.kafka.reactive.streams;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnAarch64Native;
 
 @OpenShiftScenario
-@DisabledOnAarch64Native(reason = "https://issues.redhat.com/browse/QUARKUS-4321")
 public class OpenShiftStrimziKafkaStreamIT extends StrimziKafkaStreamIT {
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
@@ -3,13 +3,11 @@ package io.quarkus.ts.messaging.kafka.reactive.streams;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnAarch64Native;
 import io.quarkus.test.services.Operator;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.operator.KafkaInstance;
 
 @OpenShiftScenario
-@DisabledOnAarch64Native(reason = "https://issues.redhat.com/browse/QUARKUS-4321")
 public class OperatorOpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTest {
 
     @Operator(name = "amq-streams", source = "redhat-operators")

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SaslSslAlertMonitorIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SaslSslAlertMonitorIT.java
@@ -4,7 +4,6 @@ import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnAarch64Native;
 import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndNative;
 import io.quarkus.test.scenarios.annotations.DisabledOnRHBQandWindows;
 import io.quarkus.test.services.KafkaContainer;
@@ -15,7 +14,6 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 @QuarkusScenario
 @DisabledOnFipsAndNative(reason = "QUARKUS-5233")
 @DisabledOnRHBQandWindows(reason = "QUARKUS-3434")
-@DisabledOnAarch64Native(reason = "QUARKUS-4321")
 public class SaslSslAlertMonitorIT extends BaseKafkaStreamTest {
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI, protocol = KafkaProtocol.SASL_SSL)

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SslAlertMonitorIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/SslAlertMonitorIT.java
@@ -4,7 +4,6 @@ import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnAarch64Native;
 import io.quarkus.test.scenarios.annotations.DisabledOnRHBQandWindows;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
@@ -13,7 +12,6 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @QuarkusScenario
 @DisabledOnRHBQandWindows(reason = "QUARKUS-3434")
-@DisabledOnAarch64Native(reason = "QUARKUS-4321")
 public class SslAlertMonitorIT extends BaseKafkaStreamTest {
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI, protocol = KafkaProtocol.SSL)

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/StrimziKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/StrimziKafkaStreamIT.java
@@ -4,7 +4,6 @@ import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnAarch64Native;
 import io.quarkus.test.scenarios.annotations.DisabledOnRHBQandWindows;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
@@ -12,7 +11,6 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @QuarkusScenario
 @DisabledOnRHBQandWindows(reason = "QUARKUS-3434")
-@DisabledOnAarch64Native(reason = "QUARKUS-4321")
 public class StrimziKafkaStreamIT extends BaseKafkaStreamTest {
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI)


### PR DESCRIPTION
### Summary

Remove the  @DisabledOnAarch64Native annotations on kafka tests addressing https://github.com/quarkusio/quarkus/pull/43985/commits/cff4148abcd42f3bf5fc34c49cb77d582887b02c that fix https://github.com/quarkusio/quarkus/issues/43319
I created a specific aarch64 Jenkins node to verify and execute these tests.


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)