### PR TITLE
Disable TodoDemoIT on windows

### DIFF
--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/TodoDemoIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/TodoDemoIT.java
@@ -4,6 +4,8 @@ import static org.hamcrest.Matchers.is;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.PostgresqlService;
 import io.quarkus.test.bootstrap.RestService;
@@ -14,6 +16,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 import io.restassured.http.ContentType;
 
 @DisabledOnNative(reason = "This scenario is using uber-jar, so it's incompatible with Native")
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Tested app fails to build into uber-jar on windows. See https://github.com/quarkusio/todo-demo-app/issues/36")
 @QuarkusScenario
 public class TodoDemoIT {
     private static final String TODO_REPO = "https://github.com/quarkusio/todo-demo-app.git";


### PR DESCRIPTION
### Summary

TodoDemoIT is failing on windows with issue https://github.com/quarkusio/todo-demo-app/issues/36, where is fails to build into uber-jar with quarkus since 3.16.1. This problem is not caused by our TS, it also happens with plain TodoDemoApp.

I tried to package some other apps from quickstart the same way, and encountered no problems. I don't know what is the root source of this problem, but the TodoDemoApp is using quarkus 3.11.0 by default and seems to not be updated much since.

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)