### PR TITLE
Add coverage for @CacheResult with resteasy client to cover QUARKUS-5068

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,6 +1139,12 @@ It covers different usages:
 3. from a blocking endpoint
 4. from a reactive endpoint
 
+### `cache/caffeine-resteasy`
+
+Verifies the `quarkus-cache` extension with RESTEasy.
+It covers different usages:
+1. `@CacheResult`, `@CacheInvalidate` and `@CacheInvalidateAll` set in RESTEasy client
+
 ### `cache/infinispan`
 Verifies the `quarkus-infinispan-cache` extension using `@CacheResult`, `@CacheInvalidate`, `@CacheInvalidateAll` and `@CacheKey`.
 It covers different usages:

--- a/cache/caffeine-resteasy/pom.xml
+++ b/cache/caffeine-resteasy/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>cache-caffeine-resteasy</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: Cache: Caffeine Resteasy</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-client-jaxb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-cache</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/cache/caffeine-resteasy/src/main/java/io/quarkus/ts/cache/caffeine/restclient/ClientBookResource.java
+++ b/cache/caffeine-resteasy/src/main/java/io/quarkus/ts/cache/caffeine/restclient/ClientBookResource.java
@@ -1,0 +1,45 @@
+package io.quarkus.ts.cache.caffeine.restclient;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.quarkus.ts.cache.caffeine.restclient.types.Book;
+
+@Path("/client/book")
+public class ClientBookResource {
+
+    @Inject
+    @RestClient
+    RestInterface restInterface;
+
+    @GET
+    @Path("/xml-cache")
+    @Produces(MediaType.APPLICATION_XML)
+    public Book getAsXmlWithCache() {
+        return restInterface.getAsXmlWithCache();
+    }
+
+    @GET
+    @Path("/json-cache")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Book getAsJsonWithCache() {
+        return restInterface.getAsJsonWithCache();
+    }
+
+    @GET
+    @Path("/invalidate-xml")
+    public String invalidateXml() {
+        return restInterface.invalidateXml();
+    }
+
+    @GET
+    @Path("/invalidate-json")
+    public String invalidateJson() {
+        return restInterface.invalidateJson();
+    }
+}

--- a/cache/caffeine-resteasy/src/main/java/io/quarkus/ts/cache/caffeine/restclient/RestInterface.java
+++ b/cache/caffeine-resteasy/src/main/java/io/quarkus/ts/cache/caffeine/restclient/RestInterface.java
@@ -1,0 +1,43 @@
+package io.quarkus.ts.cache.caffeine.restclient;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.ts.cache.caffeine.restclient.types.Book;
+
+@RegisterRestClient
+@Path("/book")
+@RegisterClientHeaders
+public interface RestInterface {
+
+    @GET
+    @Path("/xml-cache")
+    @CacheResult(cacheName = "xml")
+    @Produces(MediaType.APPLICATION_XML)
+    Book getAsXmlWithCache();
+
+    @GET
+    @Path("/json-cache")
+    @CacheResult(cacheName = "json")
+    @Produces(MediaType.APPLICATION_JSON)
+    Book getAsJsonWithCache();
+
+    @GET
+    @Path("/xml-cache-invalidate")
+    @Produces(MediaType.TEXT_PLAIN)
+    @CacheInvalidateAll(cacheName = "xml")
+    String invalidateXml();
+
+    @GET
+    @Path("/json-cache-invalidate")
+    @CacheInvalidate(cacheName = "json")
+    String invalidateJson();
+}

--- a/cache/caffeine-resteasy/src/main/java/io/quarkus/ts/cache/caffeine/restclient/types/Book.java
+++ b/cache/caffeine-resteasy/src/main/java/io/quarkus/ts/cache/caffeine/restclient/types/Book.java
@@ -1,0 +1,24 @@
+package io.quarkus.ts.cache.caffeine.restclient.types;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class Book {
+
+    private String title;
+
+    public Book() {
+    }
+
+    public Book(String title) {
+        this.title = title;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+}

--- a/cache/caffeine-resteasy/src/main/java/io/quarkus/ts/cache/caffeine/restclient/types/BookAsJsonResource.java
+++ b/cache/caffeine-resteasy/src/main/java/io/quarkus/ts/cache/caffeine/restclient/types/BookAsJsonResource.java
@@ -1,0 +1,33 @@
+package io.quarkus.ts.cache.caffeine.restclient.types;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/book")
+public class BookAsJsonResource {
+
+    public static int counter = 0;
+
+    @GET
+    @Path("/json-cache")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String getCache() throws InterruptedException {
+        counter++;
+        return "{\"title\":\"Title in Json with counter equal to " + counter + "\"}";
+    }
+
+    @GET
+    @Path("/json-cache-invalidate")
+    public String invalidateCache() {
+        return "json cache was invalidated";
+    }
+
+    @GET
+    @Path("/reset-counter-json")
+    public String resetCounter() {
+        counter = 0;
+        return "Counter reset";
+    }
+}

--- a/cache/caffeine-resteasy/src/main/java/io/quarkus/ts/cache/caffeine/restclient/types/BookAsXmlResource.java
+++ b/cache/caffeine-resteasy/src/main/java/io/quarkus/ts/cache/caffeine/restclient/types/BookAsXmlResource.java
@@ -1,0 +1,34 @@
+package io.quarkus.ts.cache.caffeine.restclient.types;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/book")
+public class BookAsXmlResource {
+
+    private static int counter = 0;
+
+    @GET
+    @Path("/xml-cache")
+    @Produces(MediaType.APPLICATION_XML)
+    public String helloCache() throws InterruptedException {
+        counter++;
+        return "<book><title>Title in Xml with counter equal to " + counter + "</title></book>";
+    }
+
+    @GET
+    @Path("/xml-cache-invalidate")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String invalidateCache() {
+        return "xml cache was invalidated";
+    }
+
+    @GET
+    @Path("/reset-counter-xml")
+    public String resetCounter() {
+        counter = 0;
+        return "Counter reset";
+    }
+}

--- a/cache/caffeine-resteasy/src/main/resources/application.properties
+++ b/cache/caffeine-resteasy/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+io.quarkus.ts.cache.caffeine.restclient.RestInterface/mp-rest/url=http://localhost:${quarkus.http.port}
+cache.expire.time=4000
+cache.expire.json.time=2000
+quarkus.cache.caffeine.expire-after-write=${cache.expire.time}ms
+quarkus.cache.caffeine."json".expire-after-write=${cache.expire.json.time}ms

--- a/cache/caffeine-resteasy/src/test/java/io/quarkus/ts/cache/caffeine/restclient/OpenShiftRestClientWithCacheIT.java
+++ b/cache/caffeine-resteasy/src/test/java/io/quarkus/ts/cache/caffeine/restclient/OpenShiftRestClientWithCacheIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.cache.caffeine.restclient;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftRestClientWithCacheIT extends RestClientWithCacheIT {
+}

--- a/cache/caffeine-resteasy/src/test/java/io/quarkus/ts/cache/caffeine/restclient/RestClientWithCacheIT.java
+++ b/cache/caffeine-resteasy/src/test/java/io/quarkus/ts/cache/caffeine/restclient/RestClientWithCacheIT.java
@@ -1,0 +1,115 @@
+package io.quarkus.ts.cache.caffeine.restclient;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import org.apache.http.HttpStatus;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class RestClientWithCacheIT {
+
+    @QuarkusApplication
+    static RestService app = new RestService();
+
+    @BeforeEach
+    public void resetCounterAndInvalidateCache() {
+        invalidateCache("xml");
+        invalidateCache("json");
+        resetCounter("xml");
+        resetCounter("json");
+    }
+
+    @Test
+    @Tag("QUARKUS-5068")
+    public void shouldGetBookFromRestClientXmlWithCache() {
+        // Check if request is cached
+        sendRequestAndReturnResponseTime("/client/book/xml-cache",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><book><title>Title in Xml with counter equal to 1</title></book>");
+        sendRequestAndReturnResponseTime("/client/book/xml-cache",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><book><title>Title in Xml with counter equal to 1</title></book>");
+
+        // Invalidate cache
+        invalidateCache("xml");
+
+        // The request shouldn't be cached and counter should be different then previous requests
+        sendRequestAndReturnResponseTime("/client/book/xml-cache",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><book><title>Title in Xml with counter equal to 2</title></book>");
+    }
+
+    @Test
+    @Tag("QUARKUS-5068")
+    public void shouldGetBookFromRestClientJsonWithCache() {
+        sendRequestAndReturnResponseTime("/client/book/json-cache",
+                "{\"title\":\"Title in Json with counter equal to 1\"}");
+        sendRequestAndReturnResponseTime("/client/book/json-cache",
+                "{\"title\":\"Title in Json with counter equal to 1\"}");
+
+        // Invalidate cache
+        invalidateCache("json");
+
+        // The request shouldn't be cached and counter should be different then previous requests
+        sendRequestAndReturnResponseTime("/client/book/json-cache",
+                "{\"title\":\"Title in Json with counter equal to 2\"}");
+    }
+
+    @Test
+    public void testExpireAfterWritePropertyWithSpecificName() throws InterruptedException {
+        sendRequestAndReturnResponseTime("/client/book/json-cache",
+                "{\"title\":\"Title in Json with counter equal to 1\"}");
+        sendRequestAndReturnResponseTime("/client/book/json-cache",
+                "{\"title\":\"Title in Json with counter equal to 1\"}");
+
+        // Sleep same time as the cache expiration time + adding 100ms as safe buffer
+        Thread.sleep(ConfigProvider.getConfig().getValue("cache.expire.json.time", Integer.class) + 100);
+
+        // The request shouldn't be cached and counter should be different then previous requests
+        sendRequestAndReturnResponseTime("/client/book/json-cache",
+                "{\"title\":\"Title in Json with counter equal to 2\"}");
+    }
+
+    @Test
+    public void testExpireAfterWritePropertyWith() throws InterruptedException {
+        sendRequestAndReturnResponseTime("/client/book/xml-cache",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><book><title>Title in Xml with counter equal to 1</title></book>");
+        sendRequestAndReturnResponseTime("/client/book/xml-cache",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><book><title>Title in Xml with counter equal to 1</title></book>");
+
+        // Sleep same time as the cache expiration time + adding 100ms as safe buffer
+        Thread.sleep(ConfigProvider.getConfig().getValue("cache.expire.time", Integer.class) + 100);
+
+        // The request shouldn't be cached and counter should be different then previous requests
+        sendRequestAndReturnResponseTime("/client/book/xml-cache",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><book><title>Title in Xml with counter equal to 2</title></book>");
+    }
+
+    public void sendRequestAndReturnResponseTime(String path, String expectedBody) {
+        app.given()
+                .get(path)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is(expectedBody));
+    }
+
+    public void invalidateCache(String cacheName) {
+        app.given()
+                .get("/client/book/invalidate-" + cacheName)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is(cacheName + " cache was invalidated"));
+    }
+
+    public void resetCounter(String fileType) {
+        app.given()
+                .get("/book/reset-counter-" + fileType)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is("Counter reset"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -459,6 +459,7 @@
             <modules>
                 <module>env-info</module>
                 <module>cache/caffeine</module>
+                <module>cache/caffeine-resteasy</module>
                 <module>cache/redis</module>
                 <module>cache/infinispan</module>
                 <module>infinispan-client</module>


### PR DESCRIPTION
### Summary

Adding coverage for [QUARKUS-5068](https://issues.redhat.com/browse/QUARKUS-5068).

Adding it to new module as this mainly check cache with reasteasy client. Atm we don't have any cache module where we using `resteasy-client` or `resteasy` extension. If you want I can add it to resteasy client test module but personally thing it should be more in cache modules.

**Note for 3.8 backport** it should be [QUARKUS-5293](https://issues.redhat.com/browse/QUARKUS-5293)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)