### PR TITLE
Fix flaky KafkaGratefulShutdownIT by waiting until messaging channels are ready

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/main/java/io/quarkus/ts/messaging/kafka/reactive/streams/shutdown/ReadinessObserver.java
+++ b/messaging/kafka-streams-reactive-messaging/src/main/java/io/quarkus/ts/messaging/kafka/reactive/streams/shutdown/ReadinessObserver.java
@@ -1,0 +1,51 @@
+package io.quarkus.ts.messaging.kafka.reactive.streams.shutdown;
+
+import jakarta.enterprise.event.Observes;
+
+import io.quarkus.logging.Log;
+import io.quarkus.runtime.StartupEvent;
+import io.smallrye.reactive.messaging.health.HealthReport;
+import io.smallrye.reactive.messaging.providers.extension.HealthCenter;
+
+public class ReadinessObserver {
+
+    private static final int SLEEP_PERIOD = 250;
+
+    /**
+     * Quarkus starts before channels are ready, but our tests publish messages that need to be delivered.
+     * Please find more information in the <a href="https://github.com/quarkusio/quarkus/issues/41441">issue #41441</a>.
+     *
+     * @param ignored startup event
+     * @param healthCenter bean with health reports produced by the Quarkus Messaging
+     * @throws InterruptedException if a sleep operation on a local thread fails
+     */
+    void observe(@Observes StartupEvent ignored, HealthCenter healthCenter) throws InterruptedException {
+        Log.info("Delaying application startup until incoming channel 'slow' and outgoing channel 'slow-topic' are ready");
+        while (true) {
+            final HealthReport healthReport = healthCenter.getReadiness();
+            if (areChannelsReady(healthReport)) {
+                Log.info("Channels 'slow' and 'slow-topic' are ready, proceeding with application startup");
+                return;
+            }
+            Log.infof("Channel 'slow-topic' or 'slow' is not ready. Going to sleep for %d milliseconds", SLEEP_PERIOD);
+            Thread.sleep(SLEEP_PERIOD);
+        }
+    }
+
+    private static boolean areChannelsReady(HealthReport healthReport) {
+        boolean channelSlowReady = false;
+        boolean channelSlowTopicReady = false;
+        for (HealthReport.ChannelInfo channel : healthReport.getChannels()) {
+            String channelName = channel.getChannel();
+            if ("slow".equalsIgnoreCase(channelName) && channel.isOk()) {
+                channelSlowReady = true;
+            } else if ("slow-topic".equalsIgnoreCase(channelName) && channel.isOk()) {
+                channelSlowTopicReady = true;
+            }
+            if (channelSlowReady && channelSlowTopicReady) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/messaging/kafka-streams-reactive-messaging/src/test/resources/kafka.grateful.shutdown.application.properties
+++ b/messaging/kafka-streams-reactive-messaging/src/test/resources/kafka.grateful.shutdown.application.properties
@@ -2,9 +2,13 @@
 # Don't add serializers / deserializer to these properties
 
 # Kafka shutdown config
+mp.messaging.outgoing.slow-topic.health-enabled=true
+mp.messaging.outgoing.slow-topic.health-topic-verification-enabled=true
 mp.messaging.outgoing.slow-topic.connector=smallrye-kafka
 mp.messaging.outgoing.slow-topic.topic=slow
 
+mp.messaging.incoming.slow.health-enabled=true
+mp.messaging.incoming.slow.health-topic-verification-enabled=true
 mp.messaging.incoming.slow.connector=smallrye-kafka
 
 quarkus.kafka-streams.application-id=slow-topic-app


### PR DESCRIPTION
### Summary

- closes https://github.com/quarkus-qe/quarkus-test-suite/issues/2016

I analyzed our flaky tests and `io.quarkus.ts.messaging.kafka.reactive.streams.KafkaGratefulShutdownIT.testConnection` probably fails most often (I didn't count it, maybe AgroalPoolTest that I have also fixed failed as often). When we started to use Kafka Kraft mode https://github.com/quarkus-qe/quarkus-test-suite/pull/1854 we were affected by the fact that Quarkus application is ready even though Kafka channels are not. According to the https://github.com/quarkusio/quarkus/issues/41441 this is expected (ha ha). Suggested solution was to add either custom check or rebalancer https://github.com/quarkusio/quarkus/issues/41441#issuecomment-2203068816. Custom check is unnecessary because SR Messaging can already test whether channel is ready or not https://smallrye.io/smallrye-reactive-messaging/4.25.0/kafka/health/#metrics-based-strategy. So I used the existing health report. I prefer this instead of writing rebalancer because it's complex as ... (at least from me POV). There are other ways to do it, but it would require busy waiting on the test side instead of Quarkus application side, not sure that is better. In production, you would just expose readiness probe, but this is a baremetal test.

This PR also removes `testConnection` because that was only added as a workaround for channels not being ready. Now we know they are ready.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)