### PR TITLE
Bump Quarkus QE framework to 1.6.0.Beta15 and adapt TS to the framework changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <quarkus.ide.version>3.16.3</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.6.0.Beta14</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.6.0.Beta15</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.7.1</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.24.1</formatter-maven-plugin.version>
@@ -186,6 +186,18 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>io.quarkus.qe</groupId>
+                <artifactId>quarkus-test-preparer</artifactId>
+                <version>${quarkus.qe.framework.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-pom-mojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>

--- a/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PongReplicaResource.java
+++ b/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PongReplicaResource.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.stork;
 
-import static io.quarkus.ts.stork.PongResource.PONG_SERVICE_NAME;
-
 import jakarta.enterprise.event.Observes;
 import jakarta.ws.rs.core.MediaType;
 
@@ -19,6 +17,7 @@ import io.vertx.mutiny.ext.consul.ConsulClient;
 @RouteBase(path = "/pong", produces = MediaType.TEXT_PLAIN)
 public class PongReplicaResource {
 
+    private static final String PONG_SERVICE_NAME = "pong";
     private static final String DEFAULT_PONG_REPLICA_RESPONSE = "pongReplica";
 
     @ConfigProperty(name = "quarkus.stork.pong-replica.service-discovery.consul-host", defaultValue = "localhost")

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/DB2DatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/DB2DatabaseIT.java
@@ -20,8 +20,8 @@ public class DB2DatabaseIT extends AbstractSqlDatabaseIT {
     @Container(image = "${db2.image}", port = 50000, expectedLog = "Setup has completed")
     static Db2Service db2 = new Db2Service();
 
-    @QuarkusApplication
-    static RestService app = new RestService().withProperties("db2_app.properties")
+    @QuarkusApplication(properties = "db2_app.properties")
+    static RestService app = new RestService()
             .withProperty("quarkus.datasource.username", db2.getUser())
             .withProperty("quarkus.datasource.password", db2.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", db2::getJdbcUrl);

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MariaDBDatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MariaDBDatabaseIT.java
@@ -15,8 +15,8 @@ public class MariaDBDatabaseIT extends AbstractSqlDatabaseIT {
             + MARIADB_PORT)
     static MariaDbService database = new MariaDbService();
 
-    @QuarkusApplication
-    static RestService app = new RestService().withProperties("mariadb_app.properties")
+    @QuarkusApplication(properties = "mariadb_app.properties")
+    static RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MssqlDatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MssqlDatabaseIT.java
@@ -17,9 +17,8 @@ public class MssqlDatabaseIT extends AbstractSqlDatabaseIT {
     @SqlServerContainer
     static SqlServerService database = new SqlServerService();
 
-    @QuarkusApplication
+    @QuarkusApplication(properties = "mssql.properties")
     static final RestService app = new RestService()
-            .withProperties("mssql.properties")
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MySqlDatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MySqlDatabaseIT.java
@@ -16,8 +16,8 @@ public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {
     @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService();
 
-    @QuarkusApplication
-    static RestService app = new RestService().withProperties("mysql.properties")
+    @QuarkusApplication(properties = "mysql.properties")
+    static RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/OracleDatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/OracleDatabaseIT.java
@@ -19,8 +19,8 @@ public class OracleDatabaseIT extends AbstractSqlDatabaseIT {
     @Container(image = "${oracle.image}", port = ORACLE_PORT, expectedLog = "DATABASE IS READY TO USE!")
     static OracleService database = new OracleService();
 
-    @QuarkusApplication
-    static RestService app = new RestService().withProperties("oracle.properties")
+    @QuarkusApplication(properties = "oracle.properties")
+    static RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/PostgresqlDatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/PostgresqlDatabaseIT.java
@@ -14,8 +14,8 @@ public class PostgresqlDatabaseIT extends AbstractSqlDatabaseIT {
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static PostgresqlService database = new PostgresqlService();
 
-    @QuarkusApplication
-    static RestService app = new RestService().withProperties("postgresql.properties")
+    @QuarkusApplication(properties = "postgresql.properties")
+    static RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);


### PR DESCRIPTION
### Summary

Bumps Quarkus QE Framework to https://github.com/quarkus-qe/quarkus-test-framework/releases/tag/1.6.0.Beta15.

**Update:** 
- SQL Compatibility changes: I'll investigate why are changes in the SQL Compatiblity module required separately (let's not wait for this and proceed with this PR). I think there must be a flaw in build-time properties detection when `withProperties` is used, but in general, I think changes in SQL Compatibility module are more frequent way to import property files.
- Stork module changes on the other hand shows great improvement of this bump - it shows that tested app is now truly isolated from the rest. Previously static import `import static io.quarkus.ts.stork.PongResource.PONG_SERVICE_NAME;` should had failed for the `pongReplicaService` app build if the `PongResource` wasn't present. But in past it didn't fail, now it fails. That is a good thing.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)