### PR TITLE
Fix flaky `OpentelemetryReactiveIT#testSecurityEvents` test

### DIFF
--- a/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpentelemetryReactiveIT.java
+++ b/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpentelemetryReactiveIT.java
@@ -79,8 +79,8 @@ public class OpentelemetryReactiveIT {
         int pageLimit = 10;
         String serviceName = "pingservice";
         String operationName = "GET /admin";
+        doSecurityEndpointRequest();
         await().atMost(30, TimeUnit.SECONDS).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
-            doSecurityEndpointRequest();
             thenRetrieveTraces(pageLimit, "1h", serviceName, operationName);
             assertSecurityEventsAndLogsPresent();
         });
@@ -143,7 +143,7 @@ public class OpentelemetryReactiveIT {
 
     private void assertSecurityEventsAndLogsPresent() {
         resp.then().body(
-                "data[0].spans.findAll { span -> span.operationName == 'GET /admin' }[0].logs.flatten().findAll { log -> log.fields.find { field -> field.key == 'event' && field.value == 'quarkus.security.authorization.success' } }",
+                "data.flatten().spans.flatten().findAll { span -> span.operationName == 'GET /admin' }.logs.flatten().findAll { log -> log.fields.find { field -> field.key == 'event' && field.value == 'quarkus.security.authorization.success' } }",
                 is(not(empty())));
     }
 


### PR DESCRIPTION
### Summary

The `OpentelemetryReactiveIT.testSecurityEvents` test is bit flaky:

- https://github.com/quarkus-qe/quarkus-test-suite/pull/2062#issuecomment-2392453159
- https://github.com/quarkus-qe/quarkus-test-suite/pull/2093#issuecomment-2416309511

I can't reproduce it, so this is very much a guessing game. Here are my findings:

- GPath always take `data[0]` and the first span matching `findAll { span -> span.operationName == 'GET /admin' }[0]`
- there are other spans matching this span GPath, looks like pre-flight request is unauthorized (which is correct), so it does not match `quarkus.security.authorization.success`
- if both spans are there in different order, the GPath will not match any result

Changes in this PR:

- don't care about span and log order
- stop polling admin endpoint as we only need one request and it's harder to get into 1 second interval for: endpoint request, traces request, response assertion

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)