### PR TITLE
Add test to verify missing servlet-class in web.xml doesn't cause build failure with Undertow

### DIFF
--- a/http/servlet-undertow/src/test/java/io/quarkus/ts/http/undertow/UndertowMissingServletClassIT.java
+++ b/http/servlet-undertow/src/test/java/io/quarkus/ts/http/undertow/UndertowMissingServletClassIT.java
@@ -1,0 +1,50 @@
+package io.quarkus.ts.http.undertow;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.bootstrap.Service;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class UndertowMissingServletClassIT {
+    @QuarkusApplication(builder = WithMissingServlet.class)
+    static RestService app = new RestService()
+            .setAutoStart(false);
+
+    @Tag("https://github.com/quarkusio/quarkus/issues/44063")
+    @Test
+    void verifyUndertowIgnoreServletClassMissing() {
+        assertDoesNotThrow(() -> app.start(),
+                "The app should start without any issue");
+        app.logs().assertDoesNotContain("Local name must not be null");
+    }
+
+    public static void replaceForInvalidXML(Service service) {
+        if (service instanceof RestService) {
+            RestService restService = (RestService) service;
+            Path invalidWebXml = Path.of("src/test/resources/META-INF/invalid-web.xml");
+
+            Path targetWebXml = restService.getServiceFolder().resolve("META-INF/web.xml");
+            try {
+                Files.createDirectories(targetWebXml.getParent());
+                Files.copy(invalidWebXml, targetWebXml, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to replace web.xml with invalid version", e);
+            }
+        } else {
+            throw new IllegalArgumentException("Service is not an instance of RestService");
+        }
+
+    }
+
+}

--- a/http/servlet-undertow/src/test/java/io/quarkus/ts/http/undertow/WithMissingServlet.java
+++ b/http/servlet-undertow/src/test/java/io/quarkus/ts/http/undertow/WithMissingServlet.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.http.undertow;
+
+import static io.quarkus.ts.http.undertow.UndertowMissingServletClassIT.replaceForInvalidXML;
+
+import io.quarkus.test.services.quarkus.ProdQuarkusApplicationManagedResourceBuilder;
+
+public class WithMissingServlet extends ProdQuarkusApplicationManagedResourceBuilder {
+
+    @Override
+    protected void copyResourcesToAppFolder() {
+        super.copyResourcesToAppFolder();
+        replaceForInvalidXML(getContext().getOwner());
+    }
+}

--- a/http/servlet-undertow/src/test/resources/META-INF/invalid-web.xml
+++ b/http/servlet-undertow/src/test/resources/META-INF/invalid-web.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app>
+    <servlet>
+        <servlet-name>InvalidServlet</servlet-name>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>InvalidServlet</servlet-name>
+        <url-pattern>/invalid</url-pattern>
+    </servlet-mapping>
+</web-app>


### PR DESCRIPTION
### Summary

This PR introduces a test to verify that the absence of a <servlet-class> tag in web.xml does not cause a build failure when using Undertow. It adds coverage for the fix implemented https://github.com/quarkusio/quarkus/pull/44063 for the original issue: https://github.com/quarkusio/quarkus/issues/43825


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)