### PR TITLE
Add test coverage to verify correct application order of update receipes duiring Quarkus update

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli35to315UpdateIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli35to315UpdateIT.java
@@ -1,0 +1,58 @@
+package io.quarkus.ts.quarkus.cli.update;
+
+import static io.quarkus.test.util.QuarkusCLIUtils.getDependencies;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.model.Dependency;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.QuarkusCliRestService;
+
+public class QuarkusCli35to315UpdateIT extends AbstractQuarkusCliUpdateIT {
+    private static final DefaultArtifactVersion oldVersion = new DefaultArtifactVersion("3.5");
+    private static final DefaultArtifactVersion newVersion = new DefaultArtifactVersion("3.15");
+
+    public QuarkusCli35to315UpdateIT() {
+        super(oldVersion, newVersion);
+    }
+
+    /**
+     * Test that updating from Quarkus 3.5 to 3.15 correctly transforms
+     * the 'quarkus-rest-client-reactive-jackson' extension to 'quarkus-rest-client-jackson',
+     * and does not incorrectly transform it to 'quarkus-resteasy-client-jackson'.
+     * This test addresses a specific issue where the update recipes could apply in the wrong order,
+     * causing incorrect dependency transformations. More info here:https://github.com/quarkusio/quarkus/issues/44183
+     *
+     */
+    @Tag("https://github.com/quarkusio/quarkus/issues/44183")
+    @Test
+    public void testCorrectRecipesOrder() throws XmlPullParserException, IOException {
+
+        QuarkusCliRestService app = quarkusCLIAppManager
+                .createApplicationWithExtensions("quarkus-rest-client-reactive-jackson");
+
+        quarkusCLIAppManager.updateApp(app);
+        List<Dependency> dependencies = getDependencies(app);
+        assertTrue(
+                dependencies.stream().anyMatch(dependency -> dependency.getArtifactId().equals("quarkus-rest-client-jackson")),
+                "'quarkus-rest-client-jackson' should be present after the update.");
+
+        assertFalse(
+                dependencies.stream()
+                        .anyMatch(dependency -> dependency.getArtifactId().equals("quarkus-rest-client-reactive-jackson")),
+                "'quarkus-rest-client-reactive-jackson' should not be present after the update.");
+
+        assertFalse(
+                dependencies.stream()
+                        .anyMatch(dependency -> dependency.getArtifactId().equals("quarkus-resteasy-client-jackson")),
+                "'quarkus-resteasy-client-jackson' should not be present after the update.");
+    }
+
+}


### PR DESCRIPTION
### Summary

Add test coverage for coverage for [44183](https://github.com/quarkusio/quarkus/issues/44183)
This PR adds a test to verify that when updating a Quarkus application from version 3.5 to 3.15, the `quarkus-rest-client-reactive-jackson` extension is correctly transformed to `quarkus-rest-client-jackson`, and not incorrectly transformed to `quarkus-resteasy-client-jackson`.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)