### PR TITLE
Raise the buffer for max file size to fix run on jenkins

### DIFF
--- a/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/AccessLoggingIT.java
+++ b/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/AccessLoggingIT.java
@@ -77,10 +77,11 @@ public class AccessLoggingIT {
         assertEquals(3, logFileNames.size(), "There should be 3 log file - one active and two backups");
 
         // check main log file size, we have max 5KB configured
-        // adding extra 420 because the max file is not actual maximum of the file size :-)
+        // adding extra 520 because the max file is not actual maximum of the file size :-)
         // it is just a limit after which Quarkus rotates (when logging finishes)
         // see https://github.com/quarkusio/quarkus/issues/44346
-        assertTrue(Files.size(accessLogPath()) <= 5420, "Main log size should be max 5KB");
+        assertTrue(Files.size(accessLogPath()) <= 5520,
+                "Main log size should be max 5KB + 520B buffer, but was " + Files.size(accessLogPath()));
 
         // check that archive logs are valid zip files
         for (String filename : logFileNames) {


### PR DESCRIPTION
### Summary

This fixes problem when running native on jenkins, This is affected by long path what our jenkins runners using. The actual size from my testing is around `5449`.

I also try to move it to more nested directory named `test` and the actual size were `5499`.

From this testing I thing the raise the buffer by `100` should be enough.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)