### PR TITLE
Rename some deprecated `quarkus.health` properties to `quarkus.smallrye-health`

### DIFF
--- a/http/http-advanced-reactive/src/main/resources/application.properties
+++ b/http/http-advanced-reactive/src/main/resources/application.properties
@@ -4,7 +4,7 @@ quarkus.http.non-application-root-path=/q
 #quarkus.smallrye-metrics.path=/metricas
 # enable swagger-ui on prod mode in order to test swagger-ui endpoint redirection to /q/swagger-ui
 quarkus.swagger-ui.always-include=true
-quarkus.health.openapi.included=true
+quarkus.smallrye-health.openapi.included=true
 quarkus.http.http2=true
 # HttpClient config
 io.quarkus.ts.http.advanced.reactive.HealthClientService/mp-rest/url=http://localhost:${quarkus.http.port}

--- a/http/http-advanced/src/main/resources/application.properties
+++ b/http/http-advanced/src/main/resources/application.properties
@@ -4,7 +4,7 @@ quarkus.http.non-application-root-path=/q
 #quarkus.smallrye-metrics.path=/metricas
 # enable swagger-ui on prod mode in order to test swagger-ui endpoint redirection to /q/swagger-ui
 quarkus.swagger-ui.always-include=true
-quarkus.health.openapi.included=true
+quarkus.smallrye-health.openapi.included=true
 quarkus.http.http2=true
 # HttpClient config
 io.quarkus.ts.http.advanced.HealthClientService/mp-rest/url=http://localhost:${quarkus.http.port}

--- a/super-size/many-extensions/src/main/resources/application.properties
+++ b/super-size/many-extensions/src/main/resources/application.properties
@@ -9,4 +9,4 @@ quarkus.oidc.auth-server-url=https://localhost:8180/auth/realms/quarkus
 quarkus.oidc.client-id=quarkus-app
 
 # Disable health as OpenShift needs the Health to be UP, but we're not deploying the components like database and Artemis
-quarkus.health.extensions.enabled=false
+quarkus.smallrye-health.extensions.enabled=false


### PR DESCRIPTION
### Summary

Renaming 
- `quarkus.health.extensions.enabled` → `quarkus.smallrye-health.extensions.enabled`
- `quarkus.health.openapi.included` → `quarkus.smallrye-health.openapi.included`

For more info see https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.14#smallrye-health

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)