### PR TITLE
Fix QuarkusCli35to315UpdateIT to proper handling RHBQ versions

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/AbstractQuarkusCliUpdateIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/AbstractQuarkusCliUpdateIT.java
@@ -41,7 +41,11 @@ public abstract class AbstractQuarkusCliUpdateIT {
         this.oldVersionStream = oldVersionStream;
         this.newVersionStream = newVersionStream;
 
-        this.quarkusCLIAppManager = QuarkusCLIUtils.createAppManager(cliClient, oldVersionStream, newVersionStream);
+        this.quarkusCLIAppManager = createQuarkusCLIAppManager();
+    }
+
+    protected IQuarkusCLIAppManager createQuarkusCLIAppManager() {
+        return QuarkusCLIUtils.createAppManager(cliClient, oldVersionStream, newVersionStream);
     }
 
     /**

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli35to315UpdateIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli35to315UpdateIT.java
@@ -14,13 +14,21 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.util.DefaultQuarkusCLIAppManager;
+import io.quarkus.test.util.IQuarkusCLIAppManager;
 
+@Tag("quarkus-cli")
 public class QuarkusCli35to315UpdateIT extends AbstractQuarkusCliUpdateIT {
     private static final DefaultArtifactVersion oldVersion = new DefaultArtifactVersion("3.5");
     private static final DefaultArtifactVersion newVersion = new DefaultArtifactVersion("3.15");
 
     public QuarkusCli35to315UpdateIT() {
         super(oldVersion, newVersion);
+    }
+
+    @Override
+    protected IQuarkusCLIAppManager createQuarkusCLIAppManager() {
+        return new DefaultQuarkusCLIAppManager(cliClient, oldVersionStream, newVersionStream);
     }
 
     /**


### PR DESCRIPTION
### Summary

This PR addresses the issue encountered in the QuarkusCli35to315UpdateIT test suite when verifying RHBQ-specific version.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)