### PR TITLE
Dissable the testHttp10WithoutHostHeader on openshift

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHeadersIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHeadersIT.java
@@ -1,7 +1,16 @@
 package io.quarkus.ts.http.advanced.reactive;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
 public class OpenShiftHeadersIT extends HeadersIT {
+
+    @Test
+    @Override
+    @Disabled("This test won't work on Openshift as the request expect valid `Host` header and this test check the http/1.0 without `Host` header")
+    public void testHttp10WithoutHostHeader() {
+    }
 }


### PR DESCRIPTION
### Summary

The test needs to be disabled on openshift as for comunication outside, the valid 'Host' header needs to be set. This not need to be set when the request and endpoint is running on same machine.

This is followup of https://github.com/quarkus-qe/quarkus-test-suite/pull/2215 where I miss that HeadersIt also run on openshift so I dind't check it.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)