### PR TITLE
Fix QuarkusCli35to315UpdateIT

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/AbstractQuarkusCliUpdateIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/AbstractQuarkusCliUpdateIT.java
@@ -41,11 +41,7 @@ public abstract class AbstractQuarkusCliUpdateIT {
         this.oldVersionStream = oldVersionStream;
         this.newVersionStream = newVersionStream;
 
-        this.quarkusCLIAppManager = createQuarkusCLIAppManager();
-    }
-
-    protected IQuarkusCLIAppManager createQuarkusCLIAppManager() {
-        return QuarkusCLIUtils.createAppManager(cliClient, oldVersionStream, newVersionStream);
+        this.quarkusCLIAppManager = QuarkusCLIUtils.createAppManager(cliClient, oldVersionStream, newVersionStream);
     }
 
     /**

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli35to315UpdateIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli35to315UpdateIT.java
@@ -14,25 +14,18 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
-import io.quarkus.test.util.DefaultQuarkusCLIAppManager;
-import io.quarkus.test.util.IQuarkusCLIAppManager;
 
 @Tag("quarkus-cli")
 public class QuarkusCli35to315UpdateIT extends AbstractQuarkusCliUpdateIT {
-    private static final DefaultArtifactVersion oldVersion = new DefaultArtifactVersion("3.8");
+    private static final DefaultArtifactVersion oldVersion = new DefaultArtifactVersion("3.2");
     private static final DefaultArtifactVersion newVersion = new DefaultArtifactVersion("3.15");
 
     public QuarkusCli35to315UpdateIT() {
         super(oldVersion, newVersion);
     }
 
-    @Override
-    protected IQuarkusCLIAppManager createQuarkusCLIAppManager() {
-        return new DefaultQuarkusCLIAppManager(cliClient, oldVersionStream, newVersionStream);
-    }
-
     /**
-     * Test that updating from Quarkus 3.8 to 3.15 correctly transforms
+     * Test that updating from Quarkus 3.2 to 3.15 correctly transforms
      * the 'quarkus-rest-client-reactive-jackson' extension to 'quarkus-rest-client-jackson',
      * and does not incorrectly transform it to 'quarkus-resteasy-client-jackson'.
      * This test addresses a specific issue where the update recipes could apply in the wrong order,

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli35to315UpdateIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli35to315UpdateIT.java
@@ -19,7 +19,7 @@ import io.quarkus.test.util.IQuarkusCLIAppManager;
 
 @Tag("quarkus-cli")
 public class QuarkusCli35to315UpdateIT extends AbstractQuarkusCliUpdateIT {
-    private static final DefaultArtifactVersion oldVersion = new DefaultArtifactVersion("3.5");
+    private static final DefaultArtifactVersion oldVersion = new DefaultArtifactVersion("3.8");
     private static final DefaultArtifactVersion newVersion = new DefaultArtifactVersion("3.15");
 
     public QuarkusCli35to315UpdateIT() {
@@ -32,7 +32,7 @@ public class QuarkusCli35to315UpdateIT extends AbstractQuarkusCliUpdateIT {
     }
 
     /**
-     * Test that updating from Quarkus 3.5 to 3.15 correctly transforms
+     * Test that updating from Quarkus 3.8 to 3.15 correctly transforms
      * the 'quarkus-rest-client-reactive-jackson' extension to 'quarkus-rest-client-jackson',
      * and does not incorrectly transform it to 'quarkus-resteasy-client-jackson'.
      * This test addresses a specific issue where the update recipes could apply in the wrong order,


### PR DESCRIPTION
### Summary

 QuarkusCli35to315UpdateIT failed from 3.5 upstream to 3.15 RHBQ which is atm not supported, but with 3.8 as is LTS so it has RHBQ version then it works.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)