### PR TITLE
Test enable win CLI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,10 +247,27 @@ jobs:
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: 'maven'
+      - name: Set up Maven settings.xml
+        run: Copy-Item -Path ".github/quarkus-snapshots-mvn-settings.xml" -Destination "$env:USERPROFILE/.m2/settings.xml"
+      - name: Download Quarkus CLI
+        shell: bash
+        run: mvn -B --no-transfer-progress org.apache.maven.plugins:maven-dependency-plugin:get -Dartifact=io.quarkus:quarkus-cli:999-SNAPSHOT:jar:runner
+      - name: Install Quarkus CLI
+        run: |
+          $quarkusCliFileContent = @"
+          @ECHO OFF
+          java -jar %HOMEDRIVE%%HOMEPATH%\.m2\repository\io\quarkus\quarkus-cli\999-SNAPSHOT\quarkus-cli-999-SNAPSHOT-runner.jar %*
+          "@
+          New-Item -Path "$(pwd)\quarkus-dev-cli.bat" -ItemType File
+          Set-Content -Path "$(pwd)\quarkus-dev-cli.bat" -Value $quarkusCliFileContent
+          ./quarkus-dev-cli.bat version
       - name: Build in JVM mode
         shell: bash
         run: |
-          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean verify ${{ matrix.module-mvn-args }} -am
+          # Need to set UTF-8 as otherwise the cp1252 is used on GH windows runner
+          # TODO revisit this with Windows 2025 when available or when we move testing to JDK 21+ only
+          export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+          mvn -B --no-transfer-progress -fae clean verify ${{ matrix.module-mvn-args }} -am -D"include.quarkus-cli-tests" -D"ts.quarkus.cli.cmd=$(pwd)\quarkus-dev-cli.bat" -D"gh-action-disable-on-win"
       - name: Detect flaky tests
         id: flaky-test-detector
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -92,10 +92,27 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           check-latest: true
+      - name: Set up Maven settings.xml
+        run: Copy-Item -Path ".github/quarkus-snapshots-mvn-settings.xml" -Destination "$env:USERPROFILE/.m2/settings.xml"
+      - name: Download Quarkus CLI
+        shell: bash
+        run: mvn -B --no-transfer-progress org.apache.maven.plugins:maven-dependency-plugin:get -Dartifact=io.quarkus:quarkus-cli:999-SNAPSHOT:jar:runner
+      - name: Install Quarkus CLI
+        run: |
+          $quarkusCliFileContent = @"
+          @ECHO OFF
+          java -jar %HOMEDRIVE%%HOMEPATH%\.m2\repository\io\quarkus\quarkus-cli\999-SNAPSHOT\quarkus-cli-999-SNAPSHOT-runner.jar %*
+          "@
+          New-Item -Path "$(pwd)\quarkus-dev-cli.bat" -ItemType File
+          Set-Content -Path "$(pwd)\quarkus-dev-cli.bat" -Value $quarkusCliFileContent
+          ./quarkus-dev-cli.bat version
       - name: Build in JVM mode
         shell: bash
         run: |
-          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean verify
+          # Need to set UTF-8 as otherwise the cp1252 is used on GH windows runner
+          # TODO revisit this with Windows 2025 when available or when we move testing to JDK 21+ only
+          export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+          mvn -B --no-transfer-progress -fae clean verify -D"include.quarkus-cli-tests" -D"ts.quarkus.cli.cmd=$(pwd)\quarkus-dev-cli.bat" -D"gh-action-disable-on-win"
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigSetIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigSetIT.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.config.QuarkusConfigCommand;
 import io.quarkus.test.bootstrap.config.QuarkusSetConfigCommandBuilder.EncryptOption;
@@ -84,6 +85,7 @@ public class QuarkusCliConfigSetIT {
 
     @Order(3)
     @Test
+    @DisabledIfSystemProperty(named = "gh-action-disable-on-win", matches = "true", disabledReason = "Some windows don't have all language pack/locales so it causing it fail")
     public void createPropertyCommand_EncryptValue_UseExistingEncryptionKey() {
         // configured props tested by SetPropertyTest#createPropertyCommand_EncryptValue_UseExistingEncryptionKey
         // use existing secret
@@ -178,6 +180,7 @@ public class QuarkusCliConfigSetIT {
 
     @Order(8)
     @Test
+    @DisabledIfSystemProperty(named = "gh-action-disable-on-win", matches = "true", disabledReason = "Some windows don't have all language pack/locales so it causing it fail")
     public void testQuarkusApplicationWithModifiedApplicationProperties() {
         configCommand.buildAppAndExpectSuccess(SetPropertyTest.class);
     }

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
@@ -6,6 +6,7 @@ import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.condition.OS;
@@ -46,16 +47,19 @@ public class QuarkusCliSpecialCharsIT {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "gh-action-disable-on-win", matches = "true", disabledReason = "Some windows don't have all language pack/locales so it causing it fail")
     public void shouldCreateApplicationOnJvmWithDiacritics() {
         assertCreateJavaApplicationAtFolder(FOLDER_WITH_DIACRITICS);
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "gh-action-disable-on-win", matches = "true", disabledReason = "Some windows don't have all language pack/locales so it causing it fail")
     public void shouldCreateApplicationOnJvmWithJapanese() {
         assertCreateJavaApplicationAtFolder(FOLDER_WITH_JAPANESE);
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "gh-action-disable-on-win", matches = "true", disabledReason = "Some windows don't have all language pack/locales so it causing it fail")
     public void shouldCreateApplicationOnJvmWithInternationalization() {
         assertCreateJavaApplicationAtFolder(FOLDER_WITH_INTERNATIONALIZATION);
     }

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliVersionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliVersionIT.java
@@ -1,14 +1,12 @@
 package io.quarkus.ts.quarkus.cli;
 
-import static io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshotCondition.isQuarkusSnapshotVersion;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
-import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.builder.Version;
 import io.quarkus.test.bootstrap.QuarkusCliClient;
@@ -16,12 +14,12 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 
-@DisabledIf(value = "isQuarkusSnapshotRunOnWindows", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1464")
 @Tag("QUARKUS-960")
 @Tag("quarkus-cli")
 @QuarkusScenario
 @DisabledOnQuarkusVersion(version = ".*redhat.*", reason = "Do not run CLI version check on productized bits")
 @DisabledOnNative // Only for JVM verification
+@DisabledIfSystemProperty(named = "gh-action-disable-on-win", matches = "true", disabledReason = "We setting `-Dfile.encoding=UTF8` on GH windows action. This causing the output the `picked up java_tool_options` which is not expected in this test.") // TODO remove when We test with JDK 21+
 public class QuarkusCliVersionIT {
 
     @Inject
@@ -34,9 +32,5 @@ public class QuarkusCliVersionIT {
 
         // Using shortcut
         assertEquals(Version.getVersion(), cliClient.run("-v").getOutput());
-    }
-
-    static boolean isQuarkusSnapshotRunOnWindows() {
-        return isQuarkusSnapshotVersion() && OS.current() == OS.WINDOWS;
     }
 }

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/config/surefire/SetPropertyTest.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/config/surefire/SetPropertyTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.config.SmallRyeConfig;
@@ -34,6 +35,7 @@ public class SetPropertyTest {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "gh-action-disable-on-win", matches = "true", disabledReason = "Some windows don't have all language pack/locales so it causing it fail")
     void createPropertyCommand_EncryptValue_UseExistingEncryptionKey() {
         assertEquals(CREATE_3.propertyValue, config.getRawValue(CREATE_3.propertyName));
     }


### PR DESCRIPTION
### Summary

This PR enable the testing Quarkus CLI in 999-SNAPSHOT version on windows machine. Fixes #1464

On GH action the windows runners are missing some language packs so they are not able to represent all chars (not happening at our AWS images). As this is a reason we need to disable some test which using these "unknow" characters.

I add the `gh-action-disable-on-win` as we only want them disable here on GH windows

The `QuarkusCliVersionIT` can be enable as we move to JDK 21 as lowest testing java and `Dfile.encoding=UTF8` can be removed as since JDK 18 the UFT-8 is default encoding.


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)