### PR TITLE
Remane vectorized/redpanda to redpandadata/redpanda as the name was realocated

### DIFF
--- a/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/DevModeKafkaSnappyIT.java
+++ b/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/DevModeKafkaSnappyIT.java
@@ -17,7 +17,7 @@ public class DevModeKafkaSnappyIT extends SnappyCompressionIT {
 
     @Test
     public void kafkaContainerShouldBeStarted() {
-        app.logs().assertContains("Creating container for image: docker.io/vectorized/redpanda");
+        app.logs().assertContains("Creating container for image: docker.io/redpandadata/redpanda");
     }
 
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeKafkaStreamIT.java
@@ -28,6 +28,6 @@ public class DevModeKafkaStreamIT extends BaseKafkaStreamTest {
 
     @Test
     public void kafkaContainerShouldBeStarted() {
-        app.logs().assertContains("Creating container for image: docker.io/vectorized/redpanda");
+        app.logs().assertContains("Creating container for image: docker.io/redpandadata/redpanda");
     }
 }


### PR DESCRIPTION
### Summary

Renaming the veztorized to redpandadata in tests. For more info see https://github.com/quarkusio/quarkus/pull/45028

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)