### PR TITLE
Refactor the spring serialization test disabled by quarkus#41292

### DIFF
--- a/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/primitivetypes/BookStore.java
+++ b/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/primitivetypes/BookStore.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.spring.data.primitivetypes;
 
+import java.util.List;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.springframework.data.domain.Page;
@@ -12,6 +14,7 @@ import io.quarkus.ts.spring.data.primitivetypes.model.Book;
 @ApplicationScoped
 public class BookStore implements PanacheRepository<Book> {
     public Page<Book> findPaged(Pageable pageable) {
-        return new PageImpl<>(this.findAll().page(pageable.getPageNumber(), pageable.getPageSize()).list());
+        List<Book> list = this.findAll().list();
+        return new PageImpl<>(list, pageable, list.size());
     }
 }

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/SpringDataCompositeEntityIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/SpringDataCompositeEntityIT.java
@@ -9,12 +9,11 @@ import static org.jboss.resteasy.spi.HttpResponseCodes.SC_OK;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -98,18 +97,21 @@ public class SpringDataCompositeEntityIT extends AbstractDbIT {
     }
 
     @Test
-    @Tag("QUARKUS-1521")
-    @Disabled("https://github.com/quarkusio/quarkus/issues/41292")
-    void ensureFieldPageableIsSerialized() {
+    void ensureFieldPageableContainsInfoAboutPage() {
+        int size = 2;
+        int page = 1;
         Response response = app.given()
                 .accept("application/json")
-                .queryParam("size", "2")
-                .queryParam("page", "1")
+                .queryParam("size", size)
+                .queryParam("page", page)
                 .when().get("/book/paged");
         Assertions.assertEquals(200, response.statusCode());
-        String pageable = response.body().jsonPath().get("pageable");
-        Assertions.assertNotNull(pageable,
-                "Field 'pageable' of org.springframework.data.domain.PageImpl was not serialized");
+        LinkedHashMap<String, Object> pageable = response.body().jsonPath().get("pageable");
+        Assertions.assertNotNull(pageable, "Field 'pageable' should not be null");
+        Assertions.assertEquals(true, pageable.get("paged"),
+                "The part of pageable response should contain paged equals to true");
+        Assertions.assertEquals(size, pageable.get("pageSize"), "Element pageSize should be " + size);
+        Assertions.assertEquals(page, pageable.get("pageNumber"), "Element pageNumber should be " + page);
     }
 
     private Book updateBook(Book book) {


### PR DESCRIPTION
### Summary

The original test was based on serialization, which is no longer possible out of bot. In quarkusio/quarkus#41292 was suggested use this modification to make the original code work. Now we checking if retunred json, pageable item contains specific values.

For more info see https://github.com/quarkusio/quarkus/issues/41292#issuecomment-2371862795

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)