### PR TITLE
Add plugins snapshots repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           check-latest: true
       - name: Build with Maven
         run: |
-          mvn -V -B --no-transfer-progress -s .github/quarkus-snapshots-mvn-settings.xml verify -Dall-modules -Dvalidate-format -DskipTests -DskipITs -Dquarkus.container-image.build=false -Dquarkus.container-image.push=false
+          mvn -V -B --no-transfer-progress -s .github/mvn-settings.xml verify -Dall-modules -Dvalidate-format -DskipTests -DskipITs -Dquarkus.container-image.build=false -Dquarkus.container-image.push=false
   linux-build-jvm-latest:
     name: PR - Linux - JVM build - Latest Version
     runs-on: ubuntu-latest
@@ -250,7 +250,7 @@ jobs:
       - name: Build in JVM mode
         shell: bash
         run: |
-          mvn -B --no-transfer-progress -fae -s .github/quarkus-snapshots-mvn-settings.xml clean verify ${{ matrix.module-mvn-args }} -am
+          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean verify ${{ matrix.module-mvn-args }} -am
       - name: Detect flaky tests
         id: flaky-test-detector
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Build in JVM mode
         shell: bash
         run: |
-          mvn -B --no-transfer-progress -fae -s .github/quarkus-snapshots-mvn-settings.xml clean verify
+          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean verify
       - name: Zip Artifacts
         shell: bash
         if: failure()
@@ -140,7 +140,7 @@ jobs:
         shell: bash
         run: |
           # Running only http/http-minimum as after some time, it gives disk full in Windows when running on Native.
-          mvn -B --no-transfer-progress -fae -s .github/quarkus-snapshots-mvn-settings.xml clean verify -Dall-modules -Dnative -Dquarkus.native.container-build=false -pl http/http-minimum
+          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean verify -Dall-modules -Dnative -Dquarkus.native.container-build=false -pl http/http-minimum
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,18 @@
             </releases>
         </repository>
     </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>quarkus-snapshots-plugin-repository</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
     <build>
         <extensions>
             <!-- Build Reporter collects and generates build reports analyzed by Jenkins jobs using AWS EC2 Windows-->


### PR DESCRIPTION
### Summary

When someone does `mvn clean verify` and doesn't have Quarkus QE Test Framework built locally already, compilation fails over missing artifacts (unless you have your settings configured for the snapshots). We already have the snapshots repository added here https://github.com/quarkus-qe/quarkus-test-suite/pull/2224/files so there is no point of not doing same for plugins (because the test preparer is a plugin).

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)