### PR TITLE
Fix webauthn failiures after changes on upstream

### DIFF
--- a/security/webauthn/src/main/java/io/quarkus/ts/security/webauthn/model/User.java
+++ b/security/webauthn/src/main/java/io/quarkus/ts/security/webauthn/model/User.java
@@ -13,12 +13,12 @@ import io.smallrye.mutiny.Uni;
 public class User extends PanacheEntity {
 
     @Column(unique = true)
-    public String userName;
+    public String username;
 
     @OneToOne(mappedBy = "user")
     public WebAuthnCredential webAuthnCredential;
 
-    public static Uni<User> findByUserName(String userName) {
-        return find("userName", userName).firstResult();
+    public static Uni<User> findByUsername(String username) {
+        return find("username", username).firstResult();
     }
 }

--- a/security/webauthn/src/main/java/io/quarkus/ts/security/webauthn/model/WebAuthnCredential.java
+++ b/security/webauthn/src/main/java/io/quarkus/ts/security/webauthn/model/WebAuthnCredential.java
@@ -55,11 +55,11 @@ public class WebAuthnCredential extends PanacheEntityBase {
     public WebAuthnCredentialRecord toWebAuthnCredentialRecord() {
         return WebAuthnCredentialRecord
                 .fromRequiredPersistedData(
-                        new RequiredPersistedData(user.userName, credID, aaguid, publicKey, publicKeyAlgorithm, counter));
+                        new RequiredPersistedData(user.username, credID, aaguid, publicKey, publicKeyAlgorithm, counter));
     }
 
-    public static Uni<List<WebAuthnCredential>> findByUserName(String userName) {
-        return list("user.userName", userName);
+    public static Uni<List<WebAuthnCredential>> findByUsername(String username) {
+        return list("user.username", username);
     }
 
     public static Uni<WebAuthnCredential> findByCredentialId(String credID) {

--- a/security/webauthn/src/main/java/io/quarkus/ts/security/webauthn/security/MyWebAuthnSetup.java
+++ b/security/webauthn/src/main/java/io/quarkus/ts/security/webauthn/security/MyWebAuthnSetup.java
@@ -19,8 +19,8 @@ public class MyWebAuthnSetup implements WebAuthnUserProvider {
 
     @WithTransaction
     @Override
-    public Uni<List<WebAuthnCredentialRecord>> findByUserName(String userName) {
-        return WebAuthnCredential.findByUserName(userName)
+    public Uni<List<WebAuthnCredentialRecord>> findByUsername(String username) {
+        return WebAuthnCredential.findByUsername(username)
                 .map(list -> list.stream().map(WebAuthnCredential::toWebAuthnCredentialRecord).toList());
     }
 
@@ -36,7 +36,7 @@ public class MyWebAuthnSetup implements WebAuthnUserProvider {
     @Override
     public Uni<Void> store(WebAuthnCredentialRecord credentialRecord) {
         User newUser = new User();
-        newUser.userName = credentialRecord.getUserName();
+        newUser.username = credentialRecord.getUsername();
         WebAuthnCredential credential = new WebAuthnCredential(credentialRecord, newUser);
         return credential.persist()
                 .flatMap(c -> newUser.persist())

--- a/security/webauthn/src/main/resources/META-INF/resources/index.html
+++ b/security/webauthn/src/main/resources/META-INF/resources/index.html
@@ -58,14 +58,14 @@
   <div class="item">
     <h1>Login</h1>
     <p>
-      <input id="userNameLogin" placeholder="User name"/><br/>
+      <input id="usernameLogin" placeholder="User name"/><br/>
       <button id="login">Login</button>
     </p>
   </div>
   <div class="item">
     <h1>Register</h1>
     <p>
-      <input id="userNameRegister" placeholder="User name"/><br/>
+      <input id="usernameRegister" placeholder="User name"/><br/>
       <input id="firstName" placeholder="First name"/><br/>
       <input id="lastName" placeholder="Last name"/><br/>
       <button id="register">Register</button>
@@ -88,11 +88,11 @@
       const loginButton = document.getElementById('login');
 
       loginButton.onclick = () => {
-        var userName = document.getElementById('userNameLogin').value;
+        var username = document.getElementById('usernameLogin').value;
         result.replaceChildren();
-        webAuthn.login({ name: userName })
+        webAuthn.login({ name: username })
           .then(body => {
-            result.append("User: "+userName);
+            result.append("User: "+username);
           })
           .catch(err => {
             result.append("Login failed: "+err);
@@ -103,13 +103,13 @@
       const registerButton = document.getElementById('register');
 
       registerButton.onclick = () => {
-        var userName = document.getElementById('userNameRegister').value;
+        var username = document.getElementById('usernameRegister').value;
         var firstName = document.getElementById('firstName').value;
         var lastName = document.getElementById('lastName').value;
         result.replaceChildren();
-        webAuthn.register({ name: userName, displayName: firstName + " " + lastName })
+        webAuthn.register({ name: username, displayName: firstName + " " + lastName })
           .then(body => {
-            result.append("User: "+userName);
+            result.append("User: "+username);
           })
           .catch(err => {
             result.append("Registration failed: "+err);


### PR DESCRIPTION
### Summary

The https://github.com/quarkusio/quarkus/pull/45132 introduces renaming of `userName` to `username`, I rename our ocurencess as well to be same.

The `REGISTER_CHALLENGE_OPTIONS_URL` not use GET request insted of POST

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)