### PR TITLE
Disable the session header as it's not possible to invoke it

### DIFF
--- a/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/primitivetypes/HttpCommonsHeaders.java
+++ b/spring/spring-data/src/main/java/io/quarkus/ts/spring/data/primitivetypes/HttpCommonsHeaders.java
@@ -28,7 +28,8 @@ public class HttpCommonsHeaders implements ContainerResponseFilter {
     public void filter(ContainerRequestContext requestCtx, ContainerResponseContext responseCtx) {
         MultivaluedMap<String, Object> headers = responseCtx.getHeaders();
         headers.add("x-count", AppConfiguration.getAndIncIndex());
-        headers.add("x-session", sessionIdBean.getSessionId());
+        // TODO enable the session header after the https://github.com/quarkusio/quarkus/issues/45191 is fixed
+        //headers.add("x-session", sessionIdBean.getSessionId());
         headers.add("x-request", requestIdBean.getRequestId());
         headers.add("x-instance", instanceId.getInstanceId());
     }


### PR DESCRIPTION
### Summary

Disable the session header because of the https://github.com/quarkusio/quarkus/issues/45191

ATM don't know how it will work in the future so this is probably best approach to keep the spring-data test running and not disable them as it's affecting most of the test. This should fix daily aswell

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)