### PR TITLE
Initialize org.keycloak.common.util.BouncyIntegration at runtime

### DIFF
--- a/security/keycloak-oidc-client-extended/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client-extended/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# We use org.keycloak:keycloak-authz-client directly and not the keycloak-authorization extension
+quarkus.native.additional-build-args=--initialize-at-run-time=org.keycloak.common.util.BouncyIntegration
+
 # Security
 quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/test-realm
 quarkus.oidc.client-id=test-application-client


### PR DESCRIPTION
### Summary
Initialize org.keycloak.common.util.BouncyIntegration at runtime

We use org.keycloak:keycloak-authz-client directly and not the keycloak-authorization extension 

Fixes daily CI failures, triggered by switch to standalone Keycloak client in Quarkus main

https://github.com/quarkusio/quarkus/blob/main/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakReflectionBuildStep.java#L88

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)