### PR TITLE
Disable logging for org.htmlunit.css

### DIFF
--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/BaseOidcJwtSecurityIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/BaseOidcJwtSecurityIT.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.http.HttpStatus;
 import org.htmlunit.FailingHttpStatusCodeException;
@@ -34,6 +36,7 @@ public abstract class BaseOidcJwtSecurityIT {
     public void setup() {
         webClient = new WebClient();
         webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        Logger.getLogger("org.htmlunit.css").setLevel(Level.OFF);
         webClient.getOptions().setRedirectEnabled(true);
     }
 

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseMultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseMultiTenantSecurityIT.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.http.HttpStatus;
 import org.htmlunit.SilentCssErrorHandler;
@@ -37,6 +39,7 @@ public abstract class BaseMultiTenantSecurityIT {
     public void setup() {
         webClient = new WebClient();
         webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        Logger.getLogger("org.htmlunit.css").setLevel(Level.OFF);
         webClient.getOptions().setRedirectEnabled(true);
     }
 

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/LogoutSinglePageAppFlowIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/LogoutSinglePageAppFlowIT.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.htmlunit.SilentCssErrorHandler;
 import org.htmlunit.WebClient;
@@ -41,7 +43,6 @@ public class LogoutSinglePageAppFlowIT {
     @Test
     public void singlePageAppLogoutFlow() throws IOException {
         try (final WebClient webClient = createWebClient()) {
-            webClient.getOptions().setRedirectEnabled(true);
             HtmlPage page = webClient.getPage(app.getURI(Protocol.HTTP).toString() + "/code-flow");
 
             HtmlForm form = page.getHtmlElementById("kc-form-login");
@@ -64,6 +65,8 @@ public class LogoutSinglePageAppFlowIT {
     private WebClient createWebClient() {
         WebClient webClient = new WebClient();
         webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        Logger.getLogger("org.htmlunit.css").setLevel(Level.OFF);
+        webClient.getOptions().setRedirectEnabled(true);
         return webClient;
     }
 

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/LogoutSinglePageAppFlowIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/LogoutSinglePageAppFlowIT.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.htmlunit.SilentCssErrorHandler;
 import org.htmlunit.WebClient;
@@ -53,7 +55,6 @@ public class LogoutSinglePageAppFlowIT {
     @Test
     public void singlePageAppLogoutFlow() throws IOException {
         try (final WebClient webClient = createWebClient()) {
-            webClient.getOptions().setRedirectEnabled(true);
             String content = makeHttpPostFormLogin(webClient, "/code-flow", "alice", "alice")
                     .getContentAsString();
 
@@ -91,6 +92,8 @@ public class LogoutSinglePageAppFlowIT {
     private WebClient createWebClient() {
         WebClient webClient = new WebClient();
         webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        Logger.getLogger("org.htmlunit.css").setLevel(Level.OFF);
+        webClient.getOptions().setRedirectEnabled(true);
         return webClient;
     }
 

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/BaseWebappSecurityIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/BaseWebappSecurityIT.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.http.HttpStatus;
 import org.htmlunit.FailingHttpStatusCodeException;
@@ -41,6 +43,7 @@ public abstract class BaseWebappSecurityIT {
     public void setup() {
         webClient = new WebClient();
         webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        Logger.getLogger("org.htmlunit.css").setLevel(Level.OFF);
         webClient.getOptions().setRedirectEnabled(true);
     }
 


### PR DESCRIPTION
### Summary

Disable logging for `org.htmlunit.css`

Removes 1000+ CSSValue warnings (`WARN  CSSValue '0' has to be a 'px', 'em', '%', 'ex', 'ch', 'vw', 'vh', 'vmin', 'vmax', 'rem', 'mm', 'cm', 'Q', or 'pt' value.`), SilentCssErrorHandler doesn't cover this case 
https://github.com/HtmlUnit/htmlunit/blob/4.7.0/src/main/java/org/htmlunit/css/CssStyleSheet.java#L1427

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)