### PR TITLE
Explicitly enable all modules to be executed on Windows daily runs

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -112,7 +112,7 @@ jobs:
           # Need to set UTF-8 as otherwise the cp1252 is used on GH windows runner
           # TODO revisit this with Windows 2025 when available or when we move testing to JDK 21+ only
           export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
-          mvn -B --no-transfer-progress -fae clean verify -D"include.quarkus-cli-tests" -D"ts.quarkus.cli.cmd=$(pwd)\quarkus-dev-cli.bat" -D"gh-action-disable-on-win"
+          mvn -B --no-transfer-progress -fae clean verify -D"all-modules" -D"include.quarkus-cli-tests" -D"ts.quarkus.cli.cmd=$(pwd)\quarkus-dev-cli.bat" -D"gh-action-disable-on-win"
       - name: Zip Artifacts
         shell: bash
         if: failure()


### PR DESCRIPTION
### Summary

Explicitly enable all modules to be executed on Windows daily runs

https://github.com/quarkus-qe/quarkus-test-suite/pull/2244 changes introduced `include.quarkus-cli-tests` property in the command which enables `quarkus-cli-tests` profile and thus profiles with `activeByDefault` are not activated

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)