### PR TITLE
Test creating of Quarkus applications and extensions with the latest released Quarkus version using Quarkus snapshot CLI

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
@@ -2,24 +2,19 @@ package io.quarkus.ts.quarkus.cli;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import jakarta.inject.Inject;
-
-import org.junit.jupiter.api.Test;
-
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliDefaultService;
+import io.quarkus.test.bootstrap.QuarkusVersionAwareCliClient;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.TestQuarkusCli;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 
 @QuarkusScenario
 @DisabledOnNative // Only for JVM verification
 public class QuarkusCliCreateExtensionIT {
 
-    @Inject
-    static QuarkusCliClient cliClient;
-
-    @Test
-    public void shouldCreateAndBuildExtension() {
+    @TestQuarkusCli
+    public void shouldCreateAndBuildExtension(QuarkusVersionAwareCliClient cliClient) {
         // Create extension
         QuarkusCliDefaultService app = cliClient.createExtension("extension-abc");
 


### PR DESCRIPTION
### Summary

Test that Quarkus snapshot CLI can create applications and extensions with the latest released Quarkus versions. More on the motivation here https://github.com/quarkus-qe/quarkus-test-framework/pull/1467. Not all of the tests are switched to use `@TestQuarkusCli` because it adds execution time (even though I only chose JVM tests), so I tried to be reasonable.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)