### PR TITLE
Update IBM DB2 image to 12.1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@
                                 <mssql.image>mcr.microsoft.com/mssql/rhel/server:2022-latest</mssql.image>
                                 <!-- Oracle image - we aim to use same version as Dev Services for Oracle so that we only download one image -->
                                 <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
-                                <db2.image>docker.io/ibmcom/db2:11.5.8.0</db2.image>
+                                <db2.image>icr.io/db2_community/db2:12.1.0.0</db2.image>
                                 <mongodb.image>docker.io/library/mongo:7.0</mongodb.image>
                                 <redis.image>docker.io/library/redis:7.2</redis.image>
                                 <wiremock.image>docker.io/wiremock/wiremock:3.3.1</wiremock.image>


### PR DESCRIPTION
### Summary

Updating the DB2 image, upstream also moved to this version https://github.com/quarkusio/quarkus/pull/45448. From 11.5.9 the db2 moved to icr.io. 

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)