### PR TITLE
Fix SnappyCompressionIT as KRaft default logs directory has changed when we bumped Kafka version

### DIFF
--- a/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/SnappyCompressionIT.java
+++ b/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/SnappyCompressionIT.java
@@ -40,7 +40,7 @@ public class SnappyCompressionIT {
 
     private static final String BIG_JSON = "/big_json.json";
 
-    private static final String COMMAND_LOG_CONTAINER = "./bin/kafka-run-class.sh kafka.tools.DumpLogSegments --deep-iteration --print-data-log --files /tmp/kraft-combined-logs/test-0/00000000000000000000.log | head";
+    private static final String COMMAND_LOG_CONTAINER = "./bin/kafka-run-class.sh kafka.tools.DumpLogSegments --deep-iteration --print-data-log --files /tmp/default-log-dir/test-0/00000000000000000000.log | head";
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI)
     static final KafkaService kafka = new KafkaService().withProperty("auto.create.topics.enable", "false");


### PR DESCRIPTION
### Summary

Default KRaft logs dir has changed when Kafka version was bumped here https://github.com/quarkus-qe/quarkus-test-framework/pull/1465. This PR fixes SnappyCompressionIT that fails the daily build.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)