### PR TITLE
Use custom yaml with kafka 3.8.0 for AMQ streams operator tests

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/OperatorOpenShiftAmqStreamsKafkaStreamIT.java
@@ -10,8 +10,9 @@ import io.quarkus.test.services.operator.KafkaInstance;
 @OpenShiftScenario
 public class OperatorOpenShiftAmqStreamsKafkaStreamIT extends BaseKafkaStreamTest {
 
+    // TODO: use default KafkaInstance constructor when amq streams operator will support kafka 3.9.0+
     @Operator(name = "amq-streams", source = "redhat-operators")
-    static KafkaInstance kafka = new KafkaInstance();
+    static KafkaInstance kafka = new KafkaInstance("kafka-instance", "/amq-streams-operator-kafka-instance.yaml");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/messaging/kafka-streams-reactive-messaging/src/test/resources/amq-streams-operator-kafka-instance.yaml
+++ b/messaging/kafka-streams-reactive-messaging/src/test/resources/amq-streams-operator-kafka-instance.yaml
@@ -1,0 +1,38 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: kafka-instance
+spec:
+  kafka:
+    version: 3.8.0
+    replicas: 1
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      log.message.format.version: "3.8-IV0"
+    storage:
+      type: jbod
+      volumes:
+        - id: 0
+          type: persistent-claim
+          size: 100Mi
+          deleteClaim: true
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 100Mi
+      deleteClaim: true
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}


### PR DESCRIPTION
### Summary

Latest AMQ streams operator v2.8 [supports Kafka 3.8.0 or less](https://docs.redhat.com/en/documentation/red_hat_streams_for_apache_kafka/2.8/html/release_notes_for_streams_for_apache_kafka_2.8_on_openshift/features-str#kafka_3_8_0_support) while default Kafka version from FW is [3.9.0](https://github.com/quarkus-qe/quarkus-test-framework/pull/1465/files#diff-9d228cf040aec0ac8a0076cf781225a1c21cd68ab05352450d6ff892212d9848)

 This PR brings temporary solution to be able run `OperatorOpenShiftAmqStreamsKafkaStreamIT` tests until new AMQ streams operator version will be out.

FW [OpenShiftStrimziOperatorKafkaWithoutRegistryMessagingIT](https://github.com/quarkus-qe/quarkus-test-framework/blob/b6fc6fcf108ab41c480d4853ad71551f5d189747/examples/kafka/src/test/java/io/quarkus/qe/OpenShiftStrimziOperatorKafkaWithoutRegistryMessagingIT.java#L16) test also use kafka operator (strimzi-kafka-operator). 
Despite the fact that `strimzi-kafka-operator` support Kafka 3.8.0, we don't want to downgrade version for all other tests across FW and TS.

 `OperatorOpenShiftAmqStreamsKafkaStreamIT` is the single tests in our project using AMQ streams operator

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)