### PR TITLE
Fix QuarkusCliCreateJvmApplicationIT compilation by replacing string property with enum constant after FW changes

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -40,6 +40,7 @@ import io.quarkus.logging.Log;
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
 import io.quarkus.test.bootstrap.QuarkusVersionAwareCliClient;
+import io.quarkus.test.configuration.Configuration;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.TestQuarkusCli;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
@@ -381,7 +382,8 @@ public class QuarkusCliCreateJvmApplicationIT {
             Files.write(pom, content);
         }
         // Start using DEV mode
-        assertEquals(Duration.ofSeconds(2), app.getConfiguration().getAsDuration("startup.timeout", null));
+        assertEquals(Duration.ofSeconds(2),
+                app.getConfiguration().getAsDuration(Configuration.Property.SERVICE_STARTUP_TIMEOUT, null));
         assertThrows(ConditionTimeoutException.class, app::start, "That application shouldn't start!");
         app.logs().assertContains("Type of the artifact is POM, skipping dev goal");
     }


### PR DESCRIPTION
### Summary

Fixing compilation as https://github.com/quarkus-qe/quarkus-test-framework/pull/791 changed expected type to enum.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)