### PR TITLE
Fix Infinispan Kafka tests by adding SHA-512 SASL mechanism as upstream has changed to support FIPS enabled environment

### DIFF
--- a/messaging/infinispan-grpc-kafka/src/main/resources/infinispan-config.xml
+++ b/messaging/infinispan-grpc-kafka/src/main/resources/infinispan-config.xml
@@ -45,7 +45,7 @@
             <endpoint socket-binding="default" security-realm="default">
                 <hotrod-connector name="hotrod">
                     <authentication>
-                        <sasl mechanisms="PLAIN DIGEST-MD5 BASIC" server-name="infinispan"/>
+                        <sasl mechanisms="PLAIN DIGEST-SHA-512 BASIC" server-name="infinispan"/>
                     </authentication>
                 </hotrod-connector>
                 <rest-connector name="rest">


### PR DESCRIPTION
### Summary

The `InfinispanKafkaSaslSslIT` and `InfinispanKafkaIT` are failing with `Caused by: java.lang.SecurityException: ISPN004031: The selected authentication mechanism 'DIGEST-SHA-512' is not among the supported server mechanisms: [PLAIN, DIGEST-MD5, BASIC]` over changes made in https://github.com/quarkusio/quarkus/pull/45982. The daily build is failing because of this https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/13111089359/job/36575005028. I saw this fix in QE FW https://github.com/quarkus-qe/quarkus-test-framework/pull/1484 so I didn't have to do much thinking. Tested it locally and fixed the issue.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)