### PR TITLE
Fix build-time analytics module execution failure as we should only set QE FW test properties in the test properties

### DIFF
--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AbstractAnalyticsIT.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AbstractAnalyticsIT.java
@@ -64,7 +64,9 @@ public abstract class AbstractAnalyticsIT {
                 .withStream(null)
                 .withExtraArgs("--no-code", "--no-wrapper")
                 .withExtensions(extensions);
-        return cliClient.createApplication(appName, createApplicationRequest);
+        QuarkusCliRestService cliRestService = cliClient.createApplication(appName, createApplicationRequest);
+        cliRestService.withProperty("quarkus.analytics.disabled", "false");
+        return cliRestService;
     }
 
     protected Result buildApp(Function<String[], Result> buildFunction, String... buildProperties) {

--- a/build-time-analytics/src/test/resources/test.properties
+++ b/build-time-analytics/src/test/resources/test.properties
@@ -1,2 +1,1 @@
 ts.global.generated-service.enabled=false
-ts.global.quarkus.analytics.disabled=false


### PR DESCRIPTION
### Summary

As result of the https://github.com/quarkus-qe/quarkus-test-framework/pull/791 we expect that all QE FW properties are listed as enum constants in `Property`, however in past it was possible to set also Quarkus properties as `ts.global`, which now results in failure. Due to this issue, daily build fails https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/13111089359/job/36575004262 over `[ERROR] java.util.ServiceConfigurationError: org.junit.platform.launcher.TestExecutionListener: Provider io.quarkus.test.listener.QuarkusTestResourceCleaningFilter could not be instantiated`. I have debugged it and found out that everytime `new PropertyLookup` constructor is instantiated in this module, loading of the global configuration fails as no such element.

This is expected to fail until https://github.com/quarkus-qe/quarkus-test-framework/pull/1485 is merged and this PR CI is re-run.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)