### PR TITLE
Fix compilation of security/https module after Vert.x HTTP extension migrated to @ConfigMapping

### DIFF
--- a/security/https/src/test/java/io/quarkus/ts/security/https/enabled/EnabledHttpsSecurityIT.java
+++ b/security/https/src/test/java/io/quarkus/ts/security/https/enabled/EnabledHttpsSecurityIT.java
@@ -14,7 +14,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.Certificate;
 import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 
 @QuarkusScenario
 public class EnabledHttpsSecurityIT {
@@ -26,7 +26,7 @@ public class EnabledHttpsSecurityIT {
             })
     })
     static RestService app = new RestService()
-            .withProperty("quarkus.http.insecure-requests", HttpConfiguration.InsecureRequests.ENABLED.name());
+            .withProperty("quarkus.http.insecure-requests", VertxHttpConfig.InsecureRequests.ENABLED.name());
 
     @Test
     public void https() {

--- a/security/https/src/test/java/io/quarkus/ts/security/https/redirect/RedirectHttpsSecurityIT.java
+++ b/security/https/src/test/java/io/quarkus/ts/security/https/redirect/RedirectHttpsSecurityIT.java
@@ -12,7 +12,7 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Certificate;
 import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.vertx.ext.web.client.WebClientOptions;
 
 @QuarkusScenario
@@ -20,7 +20,7 @@ public class RedirectHttpsSecurityIT {
 
     @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureTruststore = true, configureHttpServer = true, useTlsRegistry = false))
     static RestService app = new RestService()
-            .withProperty("quarkus.http.insecure-requests", HttpConfiguration.InsecureRequests.REDIRECT.name());
+            .withProperty("quarkus.http.insecure-requests", VertxHttpConfig.InsecureRequests.REDIRECT.name());
 
     @Test
     public void https() {


### PR DESCRIPTION
### Summary

This is required because of changes made in the https://github.com/quarkusio/quarkus/pull/45769.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)