### PR TITLE
Disable SpringPropertiesIT in native due to upstream issue

### DIFF
--- a/spring/spring-properties/src/test/java/io/quarkus/ts/spring/properties/SpringPropertiesIT.java
+++ b/spring/spring-properties/src/test/java/io/quarkus/ts/spring/properties/SpringPropertiesIT.java
@@ -8,8 +8,10 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.QuarkusApplication;
 
+@DisabledOnNative(reason = "https://github.com/quarkusio/quarkus/issues/46172")
 @QuarkusScenario
 public class SpringPropertiesIT {
 


### PR DESCRIPTION
### Summary

Not sure when they fix it https://github.com/quarkusio/quarkus/issues/46172, but we need green daily build ASAP, it wasn't green for more than a month, hence disabling the test.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)