### PR TITLE
Use older MSSQL image for MssqlHandlerIT due to bug in the newest RHEL-based image

### DIFF
--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MssqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MssqlHandlerIT.java
@@ -14,7 +14,8 @@ import io.quarkus.test.services.SqlServerContainer;
 @QuarkusScenario
 public class MssqlHandlerIT extends CommonTestCases {
 
-    @SqlServerContainer
+    // TODO: use default (newer) image when https://github.com/quarkusio/quarkus/issues/46083 gets fixed
+    @SqlServerContainer(image = "mcr.microsoft.com/mssql/rhel/server:2022-CU16-rhel-9.1")
     static SqlServerService database = new SqlServerService();
 
     @QuarkusApplication


### PR DESCRIPTION
### Summary

Daily build https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/13221313816/job/36906702884 failed in JVM due to https://github.com/quarkusio/quarkus/issues/46083. I have also mentioned that sometimes, failure is not over closed connection in a Flyway migration, but our FW simply prints `MssqlHandlerIT Resource failed to start` without any details like today https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/13232004578. But I can't reproduce that and I think the root cause is the most likely same as in the 46083. I have mentioned one difference, with this old image I can see logged also exception:

```
12:16:00,059 INFO  [app] 12:15:58,738 MSSQL Info {number=3621, state=0, severity=0, message='The statement has been terminated.', serverName='892a39568244', lineNumber=1}
12:16:00,060 INFO  [app] 12:15:58,750 Mutiny had to drop the following exception: io.vertx.mssqlclient.MSSQLException: {number=515, state=2, severity=16, message='Cannot insert the value NULL into column 'nif', table 'msdb.dbo.passenger'; column does not allow nulls. INSERT fails.', serverName='892a39568244', lineNumber=1}
```

but with the newer image, I can't see the exception see:

```
[app] 12:08:51,443 MSSQL Info {number=3621, state=0, severity=0, message='The statement has been terminated.', serverName='380adfe64a8b', lineNumber=1}
```

Anyway, we I can't do anything about that, so unless you know how to fix it, I suggest we switch the image because we haven't seen a green daily build for more than an month.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)