### PR TITLE
Adding some improvements in negative tests for OIDC response filter test

### DIFF
--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/TokenRefreshResource.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/TokenRefreshResource.java
@@ -7,10 +7,11 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import org.jboss.logging.Logger;
 
-import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.OidcClientException;
 import io.quarkus.oidc.client.OidcClients;
 import io.quarkus.oidc.client.Tokens;
 import io.smallrye.mutiny.Uni;
@@ -26,9 +27,23 @@ public class TokenRefreshResource {
     @GET
     @Path("/refresh")
     @Produces(MediaType.TEXT_PLAIN)
-    public Uni<String> forceTokenRefresh(@QueryParam("refreshToken") String refreshToken) {
-        OidcClient client = oidcClients.getClient("test-user");
-        return client.refreshTokens(refreshToken).flatMap(this::createTokensString);
+    public Uni<Response> forceTokenRefresh(@QueryParam("refreshToken") String refreshToken) {
+        return oidcClients.getClient("test-user")
+                .refreshTokens(refreshToken)
+                .onItem().transform(tokens -> {
+                    if (!tokensAreInitialized(tokens)) {
+                        return Response.status(500)
+                                .entity("Failed to refresh tokens")
+                                .build();
+                    } else {
+                        LOG.infof("Refreshed AccessToken=%s RefreshToken=%s",
+                                tokens.getAccessToken(), tokens.getRefreshToken());
+                        return Response.ok(tokens.getAccessToken() + " " + tokens.getRefreshToken())
+                                .build();
+                    }
+                })
+                .onFailure(OidcClientException.class)
+                .recoverWithItem(t -> Response.status(500).entity("Invalid token: " + t.getMessage()).build());
     }
 
     private Uni<String> createTokensString(Tokens tokens) {

--- a/security/keycloak-oidc-client-reactive-extended/src/test/resources/test-realm-realm.json
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/resources/test-realm-realm.json
@@ -101,6 +101,21 @@
       "redirectUris": [
         "*"
       ]
+    },
+    {
+      "clientId": "test-application-client-partial",
+      "defaultClientScopes": ["openid"],
+      "enabled": true,
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "test-application-client-partial-secret",
+      "redirectUris": [
+        "*"
+      ]
+
     }
   ]
 }


### PR DESCRIPTION
### Summary

Adding some improvements in negative tests for OIDC response filter test

- Refactored token retrieval in `@BeforeEach`
- Improved negative tests for refresh token and userinfo

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)