### PR TITLE
Use ubi-minimal:8.10 instead of 8.6

### DIFF
--- a/build/docker/src/main/docker/Dockerfile-compatibility.native
+++ b/build/docker/src/main/docker/Dockerfile-compatibility.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/getting-started
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/build/podman/src/main/docker/Dockerfile-compatibility.native
+++ b/build/podman/src/main/docker/Dockerfile-compatibility.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/getting-started
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \


### PR DESCRIPTION
### Summary

Use ubi-minimal:8.10 instead of 8.6 as it is the latest 8.x version

https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)