### PR TITLE
Enable MariaDB transaction tests after bump to mariadb-java-client to 3.5.2

### DIFF
--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.transactions;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -36,10 +33,4 @@ public class MariaDbTransactionGeneralUsageIT extends TransactionCommons {
         return TransactionExecutor.QUARKUS_TRANSACTION;
     }
 
-    @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/44160")
-    @Override
-    public void testTransactionRecovery() {
-        // TODO: drop this method when https://github.com/quarkusio/quarkus/issues/44160 is fixed
-    }
 }

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMariaDbTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMariaDbTransactionGeneralUsageIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.transactions;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.MariaDbService;
@@ -39,10 +37,4 @@ public class OpenShiftMariaDbTransactionGeneralUsageIT extends TransactionCommon
         return TransactionExecutor.STATIC_TRANSACTION_MANAGER;
     }
 
-    @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/44160")
-    @Override
-    public void testTransactionRecovery() {
-        // TODO: drop this method when https://github.com/quarkusio/quarkus/issues/44160 is fixed
-    }
 }


### PR DESCRIPTION
### Summary

Enable MariaDB transaction tests after bump to mariadb-java-client to 3.5.2 (https://github.com/quarkusio/quarkus/pull/46221)


Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)