### PR TITLE
Make error check more liberal

### DIFF
--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/UrlOverrideClientIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/UrlOverrideClientIT.java
@@ -82,7 +82,7 @@ public class UrlOverrideClientIT {
         // redirect the request to non-existing host which should result in failure to execute the erquest
         Response response = app.given().get("/testUrlOverride/overrideHost/?host=nonExistingHost");
         assertEquals(500, response.statusCode(), "Request should fail with code 500");
-        app.logs().assertContains("UnknownHostException: nonExistingHost");
+        app.logs().assertContains("UnknownHostException", "nonExistingHost");
     }
 
     private void testEndpoints(String defaultEndpoint, String overrideEndpoint) {


### PR DESCRIPTION
### Summary

On Windows the error looks like this:
java.net.UnknownHostException: No such host is known (nonExistingHost)
and on Linux like this:
java.net.UnknownHostException: nonExistingHost
This new check verifies both options

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)