### PR TITLE
Add aarch64 tests to nightly build

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -176,3 +176,93 @@ jobs:
         with:
           name: artifacts-latest-windows-native${{ matrix.java }}
           path: artifacts-latest-windows-native${{ matrix.java }}.tar
+  aarch64-linux-build-jvm-latest:
+    name: Daily - Aarch64 - Linux - JVM build - Latest Version
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 17, 21 ]
+        profiles: [ "root-modules,http-modules,security-modules,spring-modules",
+                    "sql-db-modules", "root-modules -pl build/podman/,build/docker -Dtest-ubi8-compatibility",
+                    "messaging-modules,websockets-modules,monitoring-modules,cache-modules,test-tooling-modules,nosql-db-modules"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reclaim Disk Space
+        run: .github/ci-prerequisites.sh
+      - name: Install JDK {{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          check-latest: true
+          cache: 'maven'
+      - uses: ./.github/actions/prepare-quarkus-cli
+      - uses: ./.github/actions/use-docker-mirror
+      - name: Login to Red Hat registry
+        uses: docker/login-action@v3
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.RED_HAT_REGISTRY_USERNAME }}
+          password: ${{ secrets.RED_HAT_REGISTRY_PASSWORD }}
+      - name: Test in JVM mode
+        run: |
+          mvn -fae -V -B --no-transfer-progress -fae clean verify -Daarch64 -P ${{ matrix.profiles }} -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
+      - name: Zip Artifacts
+        if: failure()
+        run: |
+          zip -R artifacts-jvm${{ matrix.java }}.zip '*-reports/*'
+      - name: Archive artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-linux-jvm${{ matrix.java }}
+          path: artifacts-jvm${{ matrix.java }}.zip
+  aarch64-linux-build-native-latest:
+    name: Daily - Aarch64 - Linux - Native build - Latest Version
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 17 ]
+        image: [ "ubi9-quarkus-graalvmce-builder-image:jdk-21", "ubi9-quarkus-mandrel-builder-image:jdk-21", "ubi-quarkus-mandrel-builder-image:jdk-21 -Dtest-ubi8-compatibility" ]
+        profiles: [ "root-modules,websockets-modules,test-tooling-modules,nosql-db-modules",
+                    "http-modules,cache-modules",
+                    "security-modules,spring-modules",
+                    "sql-db-modules -pl env-info,sql-db/hibernate,sql-db/sql-app,sql-db/sql-app-compatibility,sql-db/multiple-pus,sql-db/panache-flyway,sql-db/hibernate-reactive",
+                    "sql-db-modules -pl env-info,sql-db/reactive-rest-data-panache,sql-db/vertx-sql,sql-db/reactive-vanilla,sql-db/hibernate-fulltext-search,sql-db/narayana-transactions",
+                    "messaging-modules,monitoring-modules"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reclaim Disk Space
+        run: .github/ci-prerequisites.sh
+      - name: Install JDK {{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          check-latest: true
+          cache: 'maven'
+      - uses: ./.github/actions/prepare-quarkus-cli
+      - uses: ./.github/actions/use-docker-mirror
+      - name: Login to Red Hat registry
+        uses: docker/login-action@v3
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.RED_HAT_REGISTRY_USERNAME }}
+          password: ${{ secrets.RED_HAT_REGISTRY_PASSWORD }}
+      - name: Test in Native mode
+        run: |
+          mvn -fae -V -B --no-transfer-progress -P ${{ matrix.profiles }} -fae clean verify -Daarch64 -Dnative \
+            -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }} \
+            -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
+      - name: Zip Artifacts
+        if: failure()
+        run: |
+          zip -R artifacts-native${{ matrix.java }}.zip '*-reports/*'
+      - name: Archive artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-linux-native${{ matrix.java }}
+          path: artifacts-native${{ matrix.java }}.zip


### PR DESCRIPTION
### Summary

* Adding aarch64 execution to nightly build on all supported JDKs.

Note: I've added the secrets to this repo, presence of the secrets can be verified without knowing their content.

Example run: https://github.com/mjurc/quarkus-test-suite/actions/runs/13830802718/job/38694453235

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)