### PR TITLE
Adding test coverage to support encrypted PEM Keys

### DIFF
--- a/http/grpc/src/test/java/io/quarkus/ts/http/grpc/GrpcMtlsEncryptedPemTlsRegistryIT.java
+++ b/http/grpc/src/test/java/io/quarkus/ts/http/grpc/GrpcMtlsEncryptedPemTlsRegistryIT.java
@@ -1,0 +1,41 @@
+package io.quarkus.ts.http.grpc;
+
+import static io.quarkus.test.services.Certificate.Format.ENCRYPTED_PEM;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.GrpcService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.Certificate.ClientCertificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.grpc.GreeterGrpc;
+import io.quarkus.ts.grpc.HelloReply;
+import io.quarkus.ts.grpc.HelloRequest;
+
+@QuarkusScenario
+public class GrpcMtlsEncryptedPemTlsRegistryIT {
+
+    private static final String CERT_PREFIX = "grpc-mtls-separate-server";
+    private static final String CLIENT_CN_NAME = "mtls-client-name";
+    @QuarkusApplication(grpc = true, ssl = true, certificates = @Certificate(prefix = CERT_PREFIX, clientCertificates = {
+            @ClientCertificate(cnAttribute = CLIENT_CN_NAME) }, format = ENCRYPTED_PEM, configureKeystore = true, configureTruststore = true, tlsConfigName = "mtls-server", configureHttpServer = true))
+    static final GrpcService app = (GrpcService) new GrpcService()
+            .withProperty("quarkus.grpc.server.use-separate-server", "false")
+            .withProperty("quarkus.http.insecure-requests", "disabled")
+            .withProperty("quarkus.http.ssl.client-auth", "request")
+            .withProperty("quarkus.http.auth.permission.perm-1.policy", "authenticated")
+            .withProperty("quarkus.http.auth.permission.perm-1.paths", "*")
+            .withProperty("quarkus.http.auth.permission.perm-1.auth-mechanism", "X509");
+
+    @Test
+    public void testMutualTlsCommunicationWithHelloService() {
+        try (var channel = app.securedGrpcChannel()) {
+            HelloRequest request = HelloRequest.newBuilder().setName(CLIENT_CN_NAME).build();
+            HelloReply response = GreeterGrpc.newBlockingStub(channel).sayHello(request);
+            assertEquals("Hello " + CLIENT_CN_NAME, response.getMessage());
+        }
+    }
+
+}

--- a/security/https/src/main/java/io/quarkus/ts/security/https/TlsRegistryResource.java
+++ b/security/https/src/main/java/io/quarkus/ts/security/https/TlsRegistryResource.java
@@ -1,0 +1,45 @@
+package io.quarkus.ts.security.https;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import io.quarkus.tls.TlsConfiguration;
+import io.quarkus.tls.TlsConfigurationRegistry;
+
+@Path("/tls-registry")
+public class TlsRegistryResource {
+
+    public static final String DUMMY_ENTRY_CERT = "dummy-entry-0";
+
+    @Inject
+    TlsConfigurationRegistry tlsConfigurationRegistry;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String tlsRegistryInspection() throws KeyStoreException, CertificateParsingException {
+        TlsConfiguration tlsConfiguration = tlsConfigurationRegistry.getDefault().orElseThrow();
+
+        KeyStore keyStore = tlsConfiguration.getKeyStore();
+        if (keyStore == null) {
+            throw new WebApplicationException("No KeyStore found in default TLS configuration.",
+                    Response.Status.INTERNAL_SERVER_ERROR);
+        }
+        X509Certificate x509Certificate = (X509Certificate) keyStore.getCertificate(DUMMY_ENTRY_CERT);
+        if (x509Certificate == null) {
+            throw new WebApplicationException("No certificate found with alias " + DUMMY_ENTRY_CERT,
+                    Response.Status.INTERNAL_SERVER_ERROR);
+        }
+        return "Subject X500 : " + x509Certificate.getSubjectX500Principal().getName()
+                + "\nSubject Alternative names (SANs) : " + x509Certificate.getSubjectAlternativeNames();
+    }
+}

--- a/security/https/src/test/java/io/quarkus/ts/security/https/secured/HttpsEncryptedPemIT.java
+++ b/security/https/src/test/java/io/quarkus/ts/security/https/secured/HttpsEncryptedPemIT.java
@@ -1,0 +1,29 @@
+package io.quarkus.ts.security.https.secured;
+
+import static io.quarkus.ts.security.https.utils.Certificates.CLIENT_CN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class HttpsEncryptedPemIT {
+    @QuarkusApplication(ssl = true, certificates = @Certificate(format = Certificate.Format.ENCRYPTED_PEM, configureHttpServer = true, clientCertificates = {
+            @Certificate.ClientCertificate(cnAttribute = CLIENT_CN) }))
+    static final RestService app = new RestService()
+            .withProperty("quarkus.http.insecure-requests", "disabled")
+            .withProperty("quarkus.http.ssl.client-auth", "none");
+
+    @Test
+    public void simpleHttpsCommunicationEncryptedPem() {
+        var response = app.mutinyHttps(CLIENT_CN).get("/hello/simple").sendAndAwait();
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+        assertEquals("Hello, use SSL true", response.bodyAsString(),
+                "Response is not the expected on that endpoint");
+    }
+}

--- a/security/https/src/test/java/io/quarkus/ts/security/https/secured/TlsRegistryCertificateReloadingIT.java
+++ b/security/https/src/test/java/io/quarkus/ts/security/https/secured/TlsRegistryCertificateReloadingIT.java
@@ -1,0 +1,53 @@
+package io.quarkus.ts.security.https.secured;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.security.certificate.CertificateBuilder;
+import io.quarkus.test.security.certificate.ClientCertificateRequest;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.utils.AwaitilityUtils;
+
+@QuarkusScenario
+public class TlsRegistryCertificateReloadingIT {
+
+    private static final String MTLS_PATH = "/secured/mtls";
+    private static final String CERT_PREFIX = "qe-test";
+    private static final String CLIENT_CN_1 = "client-cn-1";
+    private static final String NEW_CLIENT_CN = "my-new-client";
+    private static final String TLS_CONFIG_NAME = "mtls-http";
+
+    @QuarkusApplication(ssl = true, certificates = @Certificate(clientCertificates = {
+            @Certificate.ClientCertificate(cnAttribute = CLIENT_CN_1)
+    }, configureTruststore = true, configureHttpServer = true, configureKeystore = true, prefix = CERT_PREFIX, format = Certificate.Format.ENCRYPTED_PEM, tlsConfigName = "mtls-http"))
+    static final RestService app = new RestService()
+            .withProperty("quarkus.http.ssl.client-auth", "request")
+            .withProperty("quarkus.management.ssl.client-auth", "required")
+            .withProperty("quarkus.http.insecure-requests", "disabled")
+            .withProperty("quarkus.tls." + TLS_CONFIG_NAME + ".reload-period", "2s");
+
+    @Test
+    public void testCertificateReload() {
+        var response = app.mutinyHttps(CLIENT_CN_1).get("/reload-mtls-certificates").sendAndAwait();
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+        assertEquals("Certificates reloaded.", response.bodyAsString());
+
+        var clientReq = new ClientCertificateRequest(NEW_CLIENT_CN, false);
+        app
+                .<CertificateBuilder> getPropertyFromContext(CertificateBuilder.INSTANCE_KEY)
+                .regenerateCertificate(CERT_PREFIX, certRequest -> certRequest.withClientRequests(clientReq));
+
+        AwaitilityUtils.untilAsserted(() -> {
+            var httpResponse = app.mutinyHttps(NEW_CLIENT_CN).get(MTLS_PATH).sendAndAwait();
+            assertEquals(HttpStatus.SC_OK, httpResponse.statusCode());
+            assertEquals("Client certificate: CN=" + NEW_CLIENT_CN, httpResponse.bodyAsString());
+
+        });
+    }
+
+}

--- a/security/https/src/test/java/io/quarkus/ts/security/https/secured/TlsRegistryDecryptedKeyIT.java
+++ b/security/https/src/test/java/io/quarkus/ts/security/https/secured/TlsRegistryDecryptedKeyIT.java
@@ -1,0 +1,33 @@
+package io.quarkus.ts.security.https.secured;
+
+import static io.quarkus.ts.security.https.utils.Certificates.DUMMY_ENTRY_CERT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class TlsRegistryDecryptedKeyIT {
+    @QuarkusApplication(ssl = true, certificates = @Certificate(format = Certificate.Format.ENCRYPTED_PEM, configureHttpServer = true, clientCertificates = @Certificate.ClientCertificate(cnAttribute = DUMMY_ENTRY_CERT)))
+    static final RestService app = new RestService()
+            .withProperty("quarkus.http.insecure-requests", "disabled")
+            .withProperty("quarkus.http.ssl.client-auth", "none");
+
+    @Test
+    public void testInspectDecryptedKey() {
+        var response = app.mutinyHttps(DUMMY_ENTRY_CERT).get("/tls-registry").sendAndAwait();
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+
+        String body = response.bodyAsString();
+        assertTrue(body.contains("Subject X500 : CN=dummy-entry-0"),
+                "Response from /tls-inspection does not contain subject info: " + body);
+        assertTrue(body.contains("localhost") || body.contains(" [[2, localhost], [2, 0.0.0.0]]"),
+                "Response from /tls-inspection does not mention Subject Alternative names (SANs) : localhost or  [[2, localhost], [2, 0.0.0.0]]");
+    }
+}

--- a/security/https/src/test/java/io/quarkus/ts/security/https/utils/Certificates.java
+++ b/security/https/src/test/java/io/quarkus/ts/security/https/utils/Certificates.java
@@ -3,6 +3,7 @@ package io.quarkus.ts.security.https.utils;
 public final class Certificates {
 
     public static final String CLIENT_CN = "client";
+    public static final String DUMMY_ENTRY_CERT = "dummy-entry-0";
     public static final String GUEST_CLIENT_CN = "guest-client";
     public static final String UNKNOWN_CLIENT_CN = "unknown";
     public static final String CLIENT_PASSWORD = "client-password";


### PR DESCRIPTION
### Summary

These tests will be added to cover https://github.com/quarkusio/quarkus/pull/44549 

Jira issue: [QUARKUS-5666](https://issues.redhat.com/browse/QUARKUS-5666)

TP: [TP-QUARKUS-5666](https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-5666.md)

Also we did some TF support --> [1507](https://github.com/quarkus-qe/quarkus-test-framework/pull/1507 )

- Https communication using encrypted Pem, ensure you can communicate with Quarkus REST endpoint using HTTPS (no client-side authentication).
- Certificate reloading, validate with newly generated certificate, it works for encrypted PEMs as well .
- Injecting TLS registry configuration and can see the private key decrypted (so you can see keystore and check some x509 attributes).

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)