### PR TITLE
Add tag Tag("fips-incompatible") to the test coverage related to Support encrypted pkcs#8

### DIFF
--- a/http/grpc/src/test/java/io/quarkus/ts/http/grpc/GrpcMtlsEncryptedPemTlsRegistryIT.java
+++ b/http/grpc/src/test/java/io/quarkus/ts/http/grpc/GrpcMtlsEncryptedPemTlsRegistryIT.java
@@ -1,8 +1,9 @@
 package io.quarkus.ts.http.grpc;
 
 import static io.quarkus.test.services.Certificate.Format.ENCRYPTED_PEM;
-import static org.junit.Assert.assertEquals;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.GrpcService;
@@ -14,6 +15,7 @@ import io.quarkus.ts.grpc.GreeterGrpc;
 import io.quarkus.ts.grpc.HelloReply;
 import io.quarkus.ts.grpc.HelloRequest;
 
+@Tag("fips-incompatible") // Reported in https://github.com/quarkusio/quarkus/issues/46696
 @QuarkusScenario
 public class GrpcMtlsEncryptedPemTlsRegistryIT {
 
@@ -34,7 +36,7 @@ public class GrpcMtlsEncryptedPemTlsRegistryIT {
         try (var channel = app.securedGrpcChannel()) {
             HelloRequest request = HelloRequest.newBuilder().setName(CLIENT_CN_NAME).build();
             HelloReply response = GreeterGrpc.newBlockingStub(channel).sayHello(request);
-            assertEquals("Hello " + CLIENT_CN_NAME, response.getMessage());
+            Assertions.assertEquals("Hello " + CLIENT_CN_NAME, response.getMessage());
         }
     }
 

--- a/security/https/src/test/java/io/quarkus/ts/security/https/secured/HttpsEncryptedPemIT.java
+++ b/security/https/src/test/java/io/quarkus/ts/security/https/secured/HttpsEncryptedPemIT.java
@@ -4,6 +4,7 @@ import static io.quarkus.ts.security.https.utils.Certificates.CLIENT_CN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -11,6 +12,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Certificate;
 import io.quarkus.test.services.QuarkusApplication;
 
+@Tag("fips-incompatible") // Reported in https://github.com/quarkusio/quarkus/issues/46696
 @QuarkusScenario
 public class HttpsEncryptedPemIT {
     @QuarkusApplication(ssl = true, certificates = @Certificate(format = Certificate.Format.ENCRYPTED_PEM, configureHttpServer = true, clientCertificates = {

--- a/security/https/src/test/java/io/quarkus/ts/security/https/secured/TlsRegistryCertificateReloadingIT.java
+++ b/security/https/src/test/java/io/quarkus/ts/security/https/secured/TlsRegistryCertificateReloadingIT.java
@@ -3,6 +3,7 @@ package io.quarkus.ts.security.https.secured;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -13,6 +14,7 @@ import io.quarkus.test.services.Certificate;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.utils.AwaitilityUtils;
 
+@Tag("fips-incompatible") // Reported in https://github.com/quarkusio/quarkus/issues/46696
 @QuarkusScenario
 public class TlsRegistryCertificateReloadingIT {
 

--- a/security/https/src/test/java/io/quarkus/ts/security/https/secured/TlsRegistryDecryptedKeyIT.java
+++ b/security/https/src/test/java/io/quarkus/ts/security/https/secured/TlsRegistryDecryptedKeyIT.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -12,6 +13,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Certificate;
 import io.quarkus.test.services.QuarkusApplication;
 
+@Tag("fips-incompatible") // Reported in https://github.com/quarkusio/quarkus/issues/46696
 @QuarkusScenario
 public class TlsRegistryDecryptedKeyIT {
     @QuarkusApplication(ssl = true, certificates = @Certificate(format = Certificate.Format.ENCRYPTED_PEM, configureHttpServer = true, clientCertificates = @Certificate.ClientCertificate(cnAttribute = DUMMY_ENTRY_CERT)))


### PR DESCRIPTION
### Summary

Add tag Tag("fips-incompatible") to the test coverage related to Support encrypted pkcs#8

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)