### PR TITLE
Disable test cleanup

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/BaseHttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/BaseHttpAdvancedReactiveIT.java
@@ -29,7 +29,6 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.htmlunit.util.MimeType.IMAGE_JPEG;
@@ -39,7 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -61,7 +59,6 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.scenarios.annotations.EnabledOnQuarkusVersion;
 import io.quarkus.test.security.certificate.CertificateBuilder;
 import io.restassured.http.Header;
 import io.restassured.response.ValidatableResponse;
@@ -191,24 +188,6 @@ public abstract class BaseHttpAdvancedReactiveIT {
 
         done.await(TIMEOUT_SEC, TimeUnit.SECONDS);
         assertThat(done.getCount(), equalTo(0L));
-    }
-
-    @Test
-    @DisplayName("Non-application endpoint move to /q/")
-    @EnabledOnQuarkusVersion(version = "1\\..*", reason = "Redirection is no longer supported in 2.x")
-    public void nonAppRedirections() {
-        List<String> endpoints = Arrays.asList("/openapi", "/swagger-ui", "/metrics/base", "/metrics/application",
-                "/metrics/vendor", "/metrics", "/health/group", "/health/well", "/health/ready", "/health/live",
-                "/health");
-
-        for (String endpoint : endpoints) {
-            getApp().given().redirects().follow(false).get(ROOT_PATH + endpoint)
-                    .then().statusCode(HttpStatus.SC_MOVED_PERMANENTLY)
-                    .and().header("Location", containsString("/q" + endpoint));
-
-            getApp().given().get(ROOT_PATH + endpoint)
-                    .then().statusCode(in(Arrays.asList(SC_OK, HttpStatus.SC_NO_CONTENT)));
-        }
     }
 
     @Test

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigEncryptIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigEncryptIT.java
@@ -28,10 +28,8 @@ import io.quarkus.test.bootstrap.config.QuarkusEncryptConfigCommandBuilder.Encry
 import io.quarkus.test.bootstrap.config.QuarkusEncryptConfigCommandBuilder.EncryptionKeyOpt;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.ts.quarkus.cli.config.surefire.EncryptPropertyTest;
 
-@DisabledOnQuarkusVersion(version = "3\\.(9|10|11|12)\\..*", reason = "https://github.com/quarkusio/quarkus/pull/41203 merged in 3.13")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class) // remember, this is stateful test as well as stateful cmd builder
 @Tag("QUARKUS-3456")
 @Tag("quarkus-cli")

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigRemoveIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigRemoveIT.java
@@ -13,10 +13,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import io.quarkus.test.bootstrap.config.QuarkusConfigCommand;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.ts.quarkus.cli.config.surefire.RemovePropertyTest;
 
-@DisabledOnQuarkusVersion(version = "3\\.(9|10|11|12)\\..*", reason = "https://github.com/quarkusio/quarkus/pull/41203 merged in 3.13")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class) // remember, this is stateful test as well as stateful cmd builder
 @Tag("QUARKUS-3456")
 @Tag("quarkus-cli")

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigSetIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigSetIT.java
@@ -21,10 +21,8 @@ import io.quarkus.test.bootstrap.config.QuarkusConfigCommand;
 import io.quarkus.test.bootstrap.config.QuarkusSetConfigCommandBuilder.EncryptOption;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.ts.quarkus.cli.config.surefire.SetPropertyTest;
 
-@DisabledOnQuarkusVersion(version = "3\\.(9|10|11|12)\\..*", reason = "https://github.com/quarkusio/quarkus/pull/41203 merged in 3.13")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class) // remember, this is stateful test as well as stateful cmd builder
 @Tag("QUARKUS-3456")
 @Tag("quarkus-cli")

--- a/spring/spring-properties/src/test/java/io/quarkus/ts/spring/properties/SpringPropertiesIT.java
+++ b/spring/spring-properties/src/test/java/io/quarkus/ts/spring/properties/SpringPropertiesIT.java
@@ -8,10 +8,8 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.QuarkusApplication;
 
-@DisabledOnNative(reason = "https://github.com/quarkusio/quarkus/issues/46341")
 @QuarkusScenario
 public class SpringPropertiesIT {
 


### PR DESCRIPTION
### Summary

* Removing the old test from Quarkus 1.x times
* Removing the `DisabledOnQuarkusVersion` for Quarkus CLI config tests as now we are at the Quarkus 3.20 and all of the versions are mentioned are EOL. So I think this is good time to remove it.
* Enable `SpringPropertiesIT` for native as the issue is fixed

Note I plan to add these changes for 3.20 backport. I still looking at some other disabled test but they need more adjustments.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)