### PR TITLE
Remove profile.id property and replace it with Enable/DisableDisabled annotation

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DomainSocketIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DomainSocketIT.java
@@ -10,12 +10,12 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.QuarkusApplication;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
@@ -28,7 +28,7 @@ import io.vertx.ext.web.codec.BodyCodec;
 @QuarkusScenario
 @Tag("https://github.com/quarkusio/quarkus/issues/24739")
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Netty Native Transport not supported on Windows, see https://quarkus.io/guides/vertx-reference#native-transport")
-@DisabledIfSystemProperty(named = "profile.id", matches = "native", disabledReason = "Only for JVM mode, error in native mode - https://github.com/quarkusio/quarkus/issues/25928")
+@DisabledOnNative(reason = "Only for JVM mode, error in native mode - https://github.com/quarkusio/quarkus/issues/25928")
 public class DomainSocketIT {
 
     @QuarkusApplication

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
         <quarkiverse.pact.version>1.5.0</quarkiverse.pact.version>
         <smallrye-stork.version>2.7.1</smallrye-stork.version>
         <assertj.version>3.27.3</assertj.version>
-        <profile.id>jvm</profile.id>
         <htmlunit.version>4.10.0</htmlunit.version>
         <!-- Faster build when using -DskipTests -->
         <quarkus.build.skip>${skipTests}</quarkus.build.skip>
@@ -276,7 +275,6 @@
                                 <exclude>${exclude.quarkus.devmode.tests}</exclude>
                             </excludes>
                             <systemPropertyVariables>
-                                <profile.id>${profile.id}</profile.id>
                                 <!-- S2i configuration for OpenShift -->
                                 <quarkus.s2i.base-jvm-image>${quarkus.s2i.base-jvm-image}</quarkus.s2i.base-jvm-image>
                                 <quarkus.s2i.base-native-image>${quarkus.s2i.base-native-image}</quarkus.s2i.base-native-image>
@@ -739,7 +737,6 @@
                 </plugins>
             </build>
             <properties>
-                <profile.id>native</profile.id>
                 <quarkus.native.enabled>true</quarkus.native.enabled>
                 <quarkus.native.container-build>true</quarkus.native.container-build>
                 <quarkus.native.native-image-xmx>5g</quarkus.native.native-image-xmx>

--- a/properties/src/test/java/io/quarkus/ts/properties/bulk/ConfigValueIT.java
+++ b/properties/src/test/java/io/quarkus/ts/properties/bulk/ConfigValueIT.java
@@ -9,6 +9,7 @@ import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 @QuarkusScenario
 public class ConfigValueIT {
@@ -37,10 +38,6 @@ public class ConfigValueIT {
 
     // Clarification: https://github.com/quarkusio/quarkus/issues/27231#issuecomment-1211783882
     private String getExpectedSourceNameValue() {
-        return isNativeExecution() ? "DefaultValuesConfigSource" : "PropertiesConfigSource";
-    }
-
-    private boolean isNativeExecution() {
-        return System.getProperties().contains("native");
+        return QuarkusProperties.isNativeEnabled() ? "DefaultValuesConfigSource" : "PropertiesConfigSource";
     }
 }

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCompletionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCompletionIT.java
@@ -14,7 +14,7 @@ import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 @Tag("QUARKUS-960")
 @Tag("quarkus-cli")
 @QuarkusScenario
-@DisabledOnNative // Only for JVM verification
+@DisabledOnNative(reason = "Only for JVM verification")
 public class QuarkusCliCompletionIT {
 
     static final String EXPECTED_COMPLETION_OUTPUT = "Generates completions for the options and subcommands";

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigEncryptIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigEncryptIT.java
@@ -34,7 +34,7 @@ import io.quarkus.ts.quarkus.cli.config.surefire.EncryptPropertyTest;
 @Tag("QUARKUS-3456")
 @Tag("quarkus-cli")
 @QuarkusScenario
-@DisabledOnNative // Only for JVM verification
+@DisabledOnNative(reason = "Only for JVM verification")
 public class QuarkusCliConfigEncryptIT {
 
     private static QuarkusEncryptConfigCommandBuilder encryptBuilder = null;

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigRemoveIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigRemoveIT.java
@@ -19,7 +19,7 @@ import io.quarkus.ts.quarkus.cli.config.surefire.RemovePropertyTest;
 @Tag("QUARKUS-3456")
 @Tag("quarkus-cli")
 @QuarkusScenario
-@DisabledOnNative // Only for JVM verification
+@DisabledOnNative(reason = "Only for JVM verification")
 public class QuarkusCliConfigRemoveIT {
 
     @Inject

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigSetIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliConfigSetIT.java
@@ -27,7 +27,7 @@ import io.quarkus.ts.quarkus.cli.config.surefire.SetPropertyTest;
 @Tag("QUARKUS-3456")
 @Tag("quarkus-cli")
 @QuarkusScenario
-@DisabledOnNative // Only for JVM verification
+@DisabledOnNative(reason = "Only for JVM verification")
 public class QuarkusCliConfigSetIT {
 
     @Inject

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
@@ -10,7 +10,7 @@ import io.quarkus.test.scenarios.TestQuarkusCli;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 
 @QuarkusScenario
-@DisabledOnNative // Only for JVM verification
+@DisabledOnNative(reason = "Only for JVM verification")
 public class QuarkusCliCreateExtensionIT {
 
     @TestQuarkusCli

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -51,7 +51,7 @@ import io.quarkus.test.utils.FileUtils;
 @Tag("QUARKUS-960")
 @Tag("quarkus-cli")
 @QuarkusScenario
-@DisabledOnNative // Only for JVM verification
+@DisabledOnNative(reason = "Only for JVM verification")
 public class QuarkusCliCreateJvmApplicationIT {
 
     static final String REST_EXTENSION = "quarkus-rest";

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -25,7 +25,7 @@ import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 @Tag("QUARKUS-960")
 @Tag("quarkus-cli")
 @QuarkusScenario
-@DisabledOnNative // Only for JVM verification
+@DisabledOnNative(reason = "Only for JVM verification")
 public class QuarkusCliExtensionsIT {
 
     static final String AGROAL_EXTENSION_NAME = "Agroal - Database connection pool";

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliHelpIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliHelpIT.java
@@ -14,7 +14,7 @@ import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 @Tag("QUARKUS-960")
 @Tag("quarkus-cli")
 @QuarkusScenario
-@DisabledOnNative // Only for JVM verification
+@DisabledOnNative(reason = "Only for JVM verification")
 public class QuarkusCliHelpIT {
 
     static final String HELP_COMMAND = "--help";

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
@@ -18,7 +18,7 @@ import io.quarkus.test.scenarios.annotations.EnabledOnNative;
 @Tag("QUARKUS-960")
 @Tag("quarkus-cli")
 @QuarkusScenario
-@DisabledOnNative // Only for JVM verification
+@DisabledOnNative(reason = "Only for JVM verification")
 public class QuarkusCliSpecialCharsIT {
 
     static final String FOLDER_WITH_SPACES = "s p a c e s";

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliSpecialCharsIT.java
@@ -8,12 +8,12 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.EnabledOnNative;
 
 @Tag("QUARKUS-960")
 @Tag("quarkus-cli")
@@ -29,8 +29,6 @@ public class QuarkusCliSpecialCharsIT {
 
     static final String ARTIFACT_ID = "app";
     static final String EXPECTED_BUILD_OUTPUT = "BUILD SUCCESS";
-    static final String PROFILE_ID = "profile.id";
-    static final String NATIVE = "native";
 
     @Inject
     static QuarkusCliClient cliClient;
@@ -65,31 +63,31 @@ public class QuarkusCliSpecialCharsIT {
     }
 
     @Test
-    @EnabledIfSystemProperty(named = PROFILE_ID, matches = NATIVE)
+    @EnabledOnNative
     public void shouldCreateApplicationOnNativeWithSpaces() {
         assertCreateNativeApplicationAtFolder(FOLDER_WITH_SPACES);
     }
 
     @Test
-    @EnabledIfSystemProperty(named = PROFILE_ID, matches = NATIVE)
+    @EnabledOnNative
     public void shouldCreateApplicationOnNativeWithSpecialChars() {
         assertCreateNativeApplicationAtFolder(FOLDER_WITH_SPECIAL_CHARS);
     }
 
     @Test
-    @EnabledIfSystemProperty(named = PROFILE_ID, matches = NATIVE)
+    @EnabledOnNative
     public void shouldCreateApplicationOnNativeWithDiacritics() {
         assertCreateNativeApplicationAtFolder(FOLDER_WITH_DIACRITICS);
     }
 
     @Test
-    @EnabledIfSystemProperty(named = PROFILE_ID, matches = NATIVE)
+    @EnabledOnNative
     public void shouldCreateApplicationOnNativeWithJapanese() {
         assertCreateNativeApplicationAtFolder(FOLDER_WITH_JAPANESE);
     }
 
     @Test
-    @EnabledIfSystemProperty(named = PROFILE_ID, matches = NATIVE)
+    @EnabledOnNative
     public void shouldCreateApplicationOnNativeWithInternationalization() {
         assertCreateNativeApplicationAtFolder(FOLDER_WITH_INTERNATIONALIZATION);
     }

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliTlsCommandIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliTlsCommandIT.java
@@ -31,7 +31,7 @@ import io.quarkus.ts.quarkus.cli.tls.surefire.TlsCommandTest;
 @Tag("quarkus-cli")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @QuarkusScenario
-@DisabledOnNative // Only for JVM verification
+@DisabledOnNative(reason = "Only for JVM verification")
 public class QuarkusCliTlsCommandIT {
 
     // locations are expected according to the Quarkus docs describes generation target

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliVersionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliVersionIT.java
@@ -18,7 +18,7 @@ import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 @Tag("quarkus-cli")
 @QuarkusScenario
 @DisabledOnQuarkusVersion(version = ".*redhat.*", reason = "Do not run CLI version check on productized bits")
-@DisabledOnNative // Only for JVM verification
+@DisabledOnNative(reason = "Only for JVM verification")
 @DisabledIfSystemProperty(named = "gh-action-disable-on-win", matches = "true", disabledReason = "We setting `-Dfile.encoding=UTF8` on GH windows action. This causing the output the `picked up java_tool_options` which is not expected in this test.") // TODO remove when We test with JDK 21+
 public class QuarkusCliVersionIT {
 

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/AbstractQuarkusCliUpdateIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/AbstractQuarkusCliUpdateIT.java
@@ -27,7 +27,7 @@ import io.quarkus.test.util.QuarkusCLIUtils;
 import io.quarkus.test.utils.AwaitilityUtils;
 
 @QuarkusScenario
-@DisabledOnNative // Only for JVM verification
+@DisabledOnNative(reason = "Only for JVM verification")
 @Tag("quarkus-cli")
 public abstract class AbstractQuarkusCliUpdateIT {
     @Inject


### PR DESCRIPTION
### Summary

The profile.id property was introduced 4 years ago (PR 58). 
Since then the `@EnableOnNative` and `@DisableOnNative` annotation was introduced, so this replacing the `profile.id` for newer method.

The `ConfigValueIT` need to change detection of native mode as it was connected to `profile.id` value.

Also changing the `@DisableOnNative` reason from comment to annotation property. As it will be easier to filter with our new [disabled-tests-inspector](https://github.com/quarkus-qe/quarkus-utilities/tree/main/disabled-tests-inspector)

Maybe the native test in `QuarkusCliSpecialCharsIT` can be removed, as they are skiped, as `@DisableOnNative` annotate the class. I'm leaving them there atm.


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)