### PR TITLE
Remove map in queryParam test + endpoint

### DIFF
--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/PlainBookResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/PlainBookResource.java
@@ -8,7 +8,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import jakarta.enterprise.inject.spi.CDI;
@@ -46,15 +45,6 @@ public class PlainBookResource {
 
     public PlainBookResource(@ConfigProperty(name = "quarkus.http.port") int httpPort) {
         this.baseUri = URI.create("http://localhost:" + httpPort);
-    }
-
-    @GET
-    @Path("/map")
-    @Produces(MediaType.APPLICATION_JSON)
-    public Uni<Book> getByQueryMap(@QueryParam("param") Map<String, String> params) {
-        return Uni.createFrom()
-                .item(new Book(params.get("id"),
-                        params.get("author")));
     }
 
     @GET

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
@@ -15,7 +15,6 @@ import jakarta.ws.rs.core.MediaType;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -90,18 +89,6 @@ public class ReactiveRestClientIT {
                 .get("/client/book/{id}/jsonByBeanParam");
         assertEquals(HttpStatus.SC_OK, response.statusCode());
         assertEquals("Title in Json: 123", response.jsonPath().getString("title"));
-    }
-
-    @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/46816")
-    public void mapInQueryParam() {
-        Response response = app.given()
-                .when()
-                .queryParam("param", "{\"id\":\"Hagakure\",\"author\":\"Tsuramoto\"}")
-                .get("/books/map");
-        assertEquals(HttpStatus.SC_OK, response.statusCode());
-        assertEquals("Hagakure", response.jsonPath().getString("title"));
-        assertEquals("Tsuramoto", response.jsonPath().getString("author"));
     }
 
     @Tag("QUARKUS-2148")


### PR DESCRIPTION
### Summary

Remove test and endpoint for map in queryParam for rest-client-reactive since this is no longed supported, after https://github.com/quarkusio/quarkus/pull/46863

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [X] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)