### PR TITLE
Move spring-data and panache-flyway to quarkus-rest-jackson

### DIFF
--- a/spring/spring-data/pom.xml
+++ b/spring/spring-data/pom.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/SpringDataCompositeEntityIT.java
+++ b/spring/spring-data/src/test/java/io/quarkus/ts/spring/data/primitivetypes/SpringDataCompositeEntityIT.java
@@ -1,11 +1,11 @@
 package io.quarkus.ts.spring.data.primitivetypes;
 
+import static org.apache.http.HttpStatus.SC_OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
-import static org.jboss.resteasy.spi.HttpResponseCodes.SC_OK;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/sql-db/panache-flyway/pom.xml
+++ b/sql-db/panache-flyway/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
### Summary

Upstream PR https://github.com/quarkusio/quarkus/pull/46879 has breaking change, moving panache from resteasy-classic to resteasy-reactive. 

This also covers "spring-data-rest" and "hibernate-orm-rest-data-panache". These are used in our test module "spring-data" and "panache-flyway". This PR update those modules to use quarkus-rest-jackson instead of quarkus-resteasy-jackson to be in sync with quarkus extensions.

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)