### PR TITLE
Enable and update disabled reason for pact tests

### DIFF
--- a/test-tooling/pact/src/test/java/io/quarkus/ts/http/pact/ConsumerPactTest.java
+++ b/test-tooling/pact/src/test/java/io/quarkus/ts/http/pact/ConsumerPactTest.java
@@ -3,7 +3,6 @@ package io.quarkus.ts.http.pact;
 import java.util.HashMap;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,7 +18,6 @@ import au.com.dius.pact.core.model.V4Interaction;
 import au.com.dius.pact.core.model.V4Pact;
 import au.com.dius.pact.core.model.annotations.Pact;
 
-@Disabled("https://github.com/quarkiverse/quarkus-pact/issues/191")
 @QuarkusTest
 @Tag("QUARKUS-1024")
 @ExtendWith(PactConsumerTestExt.class)

--- a/test-tooling/pact/src/test/java/io/quarkus/ts/http/pact/ProviderPactTest.java
+++ b/test-tooling/pact/src/test/java/io/quarkus/ts/http/pact/ProviderPactTest.java
@@ -15,7 +15,7 @@ import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvide
 import au.com.dius.pact.provider.junitsupport.Provider;
 import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
 
-@Disabled("https://github.com/quarkiverse/quarkus-pact/issues/191")
+@Disabled("https://github.com/quarkiverse/quarkus-pact/issues/276")
 @QuarkusTest
 @Tag("QUARKUS-1024")
 @Provider("TheProvider")


### PR DESCRIPTION
### Summary

Enabling the pact tests for consumer as they are working.

Update provider pact test disabled reason (as the old one is fixed/ work with Quarkus 3.15)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)