### PR TITLE
Add websocket next tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1215,6 +1215,13 @@ Coverage for sending messages over websockets
 ### `websockets/websockets-client`
 Coverage for sending messages over websockets with only a client library
 
+### `websockets/websocket-next`
+Coverage for sending messages over websocket-next extension
+
+### `websockets/websocket-next-oidc`
+Coverage for sending messages over websocket-next with authentication using OIDC
+
+
 ### `funqy/knative-events`
 
 Verifies [Quarkus Funqy Knative Events](https://quarkus.io/guides/funqy-knative-events) deployed to OpenShift and unit testing using RestAssured works according to the documentation.

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <smallrye-stork.version>2.7.1</smallrye-stork.version>
         <assertj.version>3.27.3</assertj.version>
         <htmlunit.version>4.11.1</htmlunit.version>
+        <java.websocket.version>1.6.0</java.websocket.version>
         <!-- Faster build when using -DskipTests -->
         <quarkus.build.skip>${skipTests}</quarkus.build.skip>
         <!-- S2i configuration -->
@@ -116,6 +117,11 @@
                 <groupId>io.quarkiverse.pact</groupId>
                 <artifactId>quarkus-pact-consumer</artifactId>
                 <version>${quarkiverse.pact.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.java-websocket</groupId>
+                <artifactId>Java-WebSocket</artifactId>
+                <version>${java.websocket.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -700,6 +706,8 @@
                 <module>env-info</module>
                 <module>websockets/quarkus-websockets</module>
                 <module>websockets/websockets-client</module>
+                <module>websockets/websocket-next</module>
+                <module>websockets/websocket-next-oidc</module>
             </modules>
         </profile>
         <profile>

--- a/websockets/websocket-next-oidc/pom.xml
+++ b/websockets/websocket-next-oidc/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>websocket-next-oidc</artifactId>
+    <name>Quarkus QE TS: Websocket Next OIDC</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-websockets-next</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.java-websocket</groupId>
+            <artifactId>Java-WebSocket</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-keycloak</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/websockets/websocket-next-oidc/src/main/java/io/quarkus/ts/websocketNext/endpoints/AdminChatWebSocket.java
+++ b/websockets/websocket-next-oidc/src/main/java/io/quarkus/ts/websocketNext/endpoints/AdminChatWebSocket.java
@@ -1,0 +1,35 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+
+import io.quarkus.oidc.BearerTokenAuthentication;
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.UnauthorizedException;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+
+@WebSocket(path = "/adminChat")
+@BearerTokenAuthentication
+public class AdminChatWebSocket {
+    @Inject
+    SecurityIdentity currentIdentity;
+
+    @RolesAllowed("admin")
+    @OnTextMessage(broadcast = true)
+    public String echo(String message) {
+        return currentIdentity.getPrincipal().getName() + ": " + message;
+    }
+
+    @OnError
+    public String error(ForbiddenException t) {
+        return "forbidden: " + currentIdentity.getPrincipal().getName();
+    }
+
+    @OnError
+    public String error(UnauthorizedException t) {
+        return "forbidden anonymous";
+    }
+}

--- a/websockets/websocket-next-oidc/src/main/java/io/quarkus/ts/websocketNext/endpoints/AuthenticatedWebSocket.java
+++ b/websockets/websocket-next-oidc/src/main/java/io/quarkus/ts/websocketNext/endpoints/AuthenticatedWebSocket.java
@@ -1,0 +1,20 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import jakarta.inject.Inject;
+
+import io.quarkus.oidc.BearerTokenAuthentication;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+
+@WebSocket(path = "/bearer")
+@BearerTokenAuthentication
+public class AuthenticatedWebSocket {
+    @Inject
+    SecurityIdentity currentIdentity;
+
+    @OnTextMessage(broadcast = true)
+    public String echo(String message) {
+        return currentIdentity.getPrincipal().getName() + ": " + message;
+    }
+}

--- a/websockets/websocket-next-oidc/src/main/java/io/quarkus/ts/websocketNext/resources/AuthenticatedChatResource.java
+++ b/websockets/websocket-next-oidc/src/main/java/io/quarkus/ts/websocketNext/resources/AuthenticatedChatResource.java
@@ -1,0 +1,60 @@
+package io.quarkus.ts.websocketNext.resources;
+
+import java.net.URI;
+import java.util.LinkedList;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.resteasy.reactive.RestQuery;
+
+import io.quarkus.websockets.next.BasicWebSocketConnector;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+
+@Path("/authChatRes")
+public class AuthenticatedChatResource {
+    @Inject
+    BasicWebSocketConnector connector;
+    private WebSocketClientConnection connection = null;
+
+    private final URI baseUri;
+
+    private final LinkedList<String> messages = new LinkedList<>();
+
+    public AuthenticatedChatResource(@ConfigProperty(name = "quarkus.http.port") int httpPort) {
+        this.baseUri = URI.create("http://localhost:" + httpPort);
+    }
+
+    @Path("/connect")
+    @GET
+    public void connect(@RestQuery String token) {
+        messages.clear();
+
+        connection = connector
+                .baseUri(baseUri)
+                .path("/bearer")
+                .addHeader("Authorization", "Bearer " + token)
+                .onTextMessage((c, message) -> messages.add(message))
+                .connectAndAwait();
+    }
+
+    @GET
+    @Path("/getLastMessage")
+    public String getLastMessage() {
+        return messages.getLast();
+    }
+
+    @GET
+    @Path("/sendMessage")
+    public void sendMessage(@RestQuery String message) {
+        connection.sendTextAndAwait(message);
+    }
+
+    @GET
+    @Path("/disconnect")
+    public void disconnect() {
+        connection.closeAndAwait();
+    }
+}

--- a/websockets/websocket-next-oidc/src/main/resources/application.properties
+++ b/websockets/websocket-next-oidc/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+quarkus.http.auth.proactive=false
+
+# Configure OIDC (keycloak) server
+quarkus.oidc.auth-server-url=${KEYCLOAK_HTTP_URL:http://localhost:8180}/auth/realms/test-realm
+quarkus.oidc.client-id=test-application-client
+quarkus.oidc.credentials.secret=test-application-client-secret
+# tolerate 1 minute of clock skew between the Keycloak server and the application
+quarkus.oidc.token.lifespan-grace=60

--- a/websockets/websocket-next-oidc/src/test/java/io/quarkuss/ts/websocketNext/OidcWebSocketIT.java
+++ b/websockets/websocket-next-oidc/src/test/java/io/quarkuss/ts/websocketNext/OidcWebSocketIT.java
@@ -1,0 +1,154 @@
+package io.quarkuss.ts.websocketNext;
+
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+import static java.time.Duration.ofSeconds;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KeycloakContainer;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class OidcWebSocketIT {
+    private static final Logger LOG = Logger.getLogger(OidcWebSocketIT.class);
+
+    private static final String ADMIN_USERNAME = "charlie";
+    private static final String ADMIN_PASSWORD = "random";
+    private static final String USER_USERNAME = "albert";
+    private static final String USER_PASSWORD = "einstein";
+
+    static final String CLIENT_ID_DEFAULT = "test-application-client";
+    static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
+
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+
+    @QuarkusApplication
+    static final RestService server = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
+
+    @Test
+    public void tokenAuthenticatedTest() throws URISyntaxException, InterruptedException {
+        Client unauthenticatedClient = new Client(getUri("/bearer"));
+        assertFalse(unauthenticatedClient.connectBlocking(),
+                "Unauthenticated user should not be able to connect to bearer-secured endpoint");
+
+        String token = createToken(USER_USERNAME, USER_PASSWORD);
+        Client albertClient = createTokenAuthenticatedClient("/bearer", token);
+
+        albertClient.send("Hello relativity");
+        assertMessage(USER_USERNAME + ": Hello relativity", albertClient);
+    }
+
+    @Test
+    public void authorizedChatTest() throws URISyntaxException, InterruptedException {
+        // adminChat allows only admins to send messages, but non-admins can listen
+        Client adminClient = createTokenAuthenticatedClient("/adminChat", createToken(ADMIN_USERNAME, ADMIN_PASSWORD));
+        Client userClient = createTokenAuthenticatedClient("/adminChat", createToken(USER_USERNAME, USER_PASSWORD));
+
+        adminClient.send("Howdy");
+        assertMessage(ADMIN_USERNAME + ": Howdy", adminClient, userClient);
+
+        userClient.send("oops");
+        assertMessage("forbidden: " + USER_USERNAME, userClient);
+    }
+
+    @Test
+    public void serverSideClientTest() throws URISyntaxException, InterruptedException {
+        Client userClient = createTokenAuthenticatedClient("/bearer", createToken(USER_USERNAME, USER_PASSWORD));
+
+        String adminToken = createToken(ADMIN_USERNAME, ADMIN_PASSWORD);
+
+        server.given().queryParam("token", adminToken).get("/authChatRes/connect");
+
+        try {
+            // send message via server-side client
+            server.given().queryParam("message", "Hello guys").get("/authChatRes/sendMessage");
+
+            // verify that both direct and server-side client received the message
+            assertMessage(ADMIN_USERNAME + ": Hello guys", userClient);
+            assertEquals(ADMIN_USERNAME + ": Hello guys", server.given().get("/authChatRes/getLastMessage").asString(),
+                    "Server side client should receive last message");
+        } finally {
+            server.given().get("authChatRes/disconnect");
+        }
+    }
+
+    private static URI getUri(String with) throws URISyntaxException {
+        return new URI(server.getURI(Protocol.WS).toString()).resolve(with);
+    }
+
+    private void assertMessage(String expectedMessage, Client... clients) {
+        for (Client client : clients) {
+            Awaitility
+                    .await()
+                    .atMost(ofSeconds(2))
+                    .untilAsserted(() -> assertEquals(expectedMessage, client.waitForAndGetMessage()));
+        }
+    }
+
+    private static String createToken(String username, String password) {
+        return keycloak.createAuthzClient(CLIENT_ID_DEFAULT, CLIENT_SECRET_DEFAULT).obtainAccessToken(username, password)
+                .getToken();
+    }
+
+    private Client createTokenAuthenticatedClient(String endpoint, String token)
+            throws URISyntaxException, InterruptedException {
+        Client client = new Client(getUri(endpoint));
+        client.addHeader("Authorization", "Bearer " + token);
+        if (!client.connectBlocking()) {
+            LOG.error("Websocket client fail to connect");
+        }
+        return client;
+    }
+
+    public static class Client extends WebSocketClient {
+        private final LinkedBlockingDeque<String> messages = new LinkedBlockingDeque<>();
+
+        public Client(URI serverUri) {
+            super(serverUri);
+        }
+
+        @Override
+        public void onOpen(ServerHandshake serverHandshake) {
+            LOG.debug("New connection opened");
+        }
+
+        @Override
+        public void onMessage(String message) {
+            LOG.debug("Message received: " + message);
+            messages.add(message);
+        }
+
+        @Override
+        public void onClose(int i, String reason, boolean b) {
+            LOG.debug("WS connection closed for reason: " + reason);
+        }
+
+        @Override
+        public void onError(Exception e) {
+            LOG.error("Websocket Exception thrown: " + e.getMessage(), e);
+        }
+
+        public String waitForAndGetMessage() throws InterruptedException {
+            return messages.poll(2, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/websockets/websocket-next-oidc/src/test/java/io/quarkuss/ts/websocketNext/OpenShiftOidcWebSocketIT.java
+++ b/websockets/websocket-next-oidc/src/test/java/io/quarkuss/ts/websocketNext/OpenShiftOidcWebSocketIT.java
@@ -1,0 +1,7 @@
+package io.quarkuss.ts.websocketNext;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftOidcWebSocketIT extends OidcWebSocketIT {
+}

--- a/websockets/websocket-next-oidc/src/test/resources/test-realm-realm.json
+++ b/websockets/websocket-next-oidc/src/test/resources/test-realm-realm.json
@@ -1,0 +1,75 @@
+{
+  "realm": "test-realm",
+  "enabled": true,
+  "sslRequired": "none",
+  "roles": {
+    "realm": [
+      {
+        "name": "user"
+      },
+      {
+        "name": "admin"
+      }
+    ]
+  },
+  "users": [
+    {
+      "username": "albert",
+      "email": "albert@localhost",
+      "firstName": "Albert",
+      "lastName": "User",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "einstein"
+        }
+      ],
+      "clientRoles": {
+        "test-application-client": [
+          "uma_protection"
+        ]
+      },
+      "realmRoles": [
+        "user",
+        "uma_protection"
+      ]
+    },
+    {
+      "username": "charlie",
+      "email": "charlie@localhost",
+      "firstName": "Charlie",
+      "lastName": "Admin",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "random"
+        }
+      ],
+      "clientRoles": {
+        "test-application-client": [
+          "uma_protection"
+        ]
+      },
+      "realmRoles": [
+        "admin",
+        "user",
+        "uma_protection"
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "test-application-client",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "test-application-client-secret"
+    }
+  ]
+}

--- a/websockets/websocket-next/pom.xml
+++ b/websockets/websocket-next/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>websocket-next</artifactId>
+    <name>Quarkus QE TS: Websocket Next</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-websockets-next</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.java-websocket</groupId>
+            <artifactId>Java-WebSocket</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/QuarkusQEUpgradeCheck.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/QuarkusQEUpgradeCheck.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.websocketNext;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.websockets.next.HttpUpgradeCheck;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.MultiMap;
+
+@ApplicationScoped
+public class QuarkusQEUpgradeCheck implements HttpUpgradeCheck {
+    @Override
+    public Uni<CheckResult> perform(HttpUpgradeContext ctx) {
+        if (rejectUpgrade(ctx)) {
+            return CheckResult.rejectUpgrade(400);
+        }
+        return CheckResult.permitUpgrade();
+    }
+
+    private boolean rejectUpgrade(HttpUpgradeContext ctx) {
+        MultiMap headers = ctx.httpRequest().headers();
+        return headers.contains("Reject");
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/clients/PingPongClient.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/clients/PingPongClient.java
@@ -1,0 +1,25 @@
+package io.quarkus.ts.websocketNext.clients;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.websockets.next.OnPingMessage;
+import io.quarkus.websockets.next.OnPongMessage;
+import io.quarkus.websockets.next.WebSocketClient;
+import io.vertx.core.buffer.Buffer;
+
+@WebSocketClient(path = "/pingPong")
+public class PingPongClient {
+    public static List<Long> pingsReceived = new ArrayList<>();
+    public static List<Long> pongsReceived = new ArrayList<>();
+
+    @OnPingMessage
+    void ping(Buffer data) {
+        pingsReceived.add(System.currentTimeMillis());
+    }
+
+    @OnPongMessage
+    void pong(Buffer data) {
+        pongsReceived.add(System.currentTimeMillis());
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/clients/UserDataClient.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/clients/UserDataClient.java
@@ -1,0 +1,29 @@
+package io.quarkus.ts.websocketNext.clients;
+
+import jakarta.inject.Inject;
+
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.UserData;
+import io.quarkus.websockets.next.WebSocketClient;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+
+@WebSocketClient(path = "/chat/{username}")
+public class UserDataClient {
+
+    @Inject
+    WebSocketClientConnection connection;
+
+    @OnOpen
+    void open() {
+        connection.userData().put(UserData.TypedKey.forString("username"), connection.pathParam("username"));
+    }
+
+    @OnTextMessage
+    String process(String message) {
+        if (message.endsWith("login")) {
+            return connection.userData().get(UserData.TypedKey.forString("username"));
+        }
+        return null;
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/AdminChatWebsocket.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/AdminChatWebsocket.java
@@ -1,0 +1,33 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.UnauthorizedException;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+
+@WebSocket(path = "adminChat")
+public class AdminChatWebsocket {
+    @Inject
+    SecurityIdentity currentIdentity;
+
+    @RolesAllowed("admin")
+    @OnTextMessage(broadcast = true)
+    public String echo(String message) {
+        return currentIdentity.getPrincipal().getName() + ": " + message;
+    }
+
+    @OnError
+    public String error(ForbiddenException t) {
+        return "forbidden: " + currentIdentity.getPrincipal().getName();
+    }
+
+    @OnError
+    public String error(UnauthorizedException t) {
+        return "forbidden anonymous";
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/AdminOnlyChatWebSocket.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/AdminOnlyChatWebSocket.java
@@ -1,0 +1,33 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.UnauthorizedException;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+
+@WebSocket(path = "/adminOnlyChat")
+@RolesAllowed("admin")
+public class AdminOnlyChatWebSocket {
+    @Inject
+    SecurityIdentity currentIdentity;
+
+    @OnTextMessage(broadcast = true)
+    public String echo(String message) {
+        return currentIdentity.getPrincipal().getName() + ": " + message;
+    }
+
+    @OnError
+    public String error(ForbiddenException t) {
+        return "forbidden: " + currentIdentity.getPrincipal().getName();
+    }
+
+    @OnError
+    public String error(UnauthorizedException t) {
+        return "forbidden anonymous";
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/AuthenticatedChatWebSocket.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/AuthenticatedChatWebSocket.java
@@ -1,0 +1,20 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import jakarta.inject.Inject;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+
+@Authenticated
+@WebSocket(path = "/authChat")
+public class AuthenticatedChatWebSocket {
+    @Inject
+    SecurityIdentity currentIdentity;
+
+    @OnTextMessage(broadcast = true)
+    public String echo(String message) {
+        return currentIdentity.getPrincipal().getName() + ": " + message;
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/ChatWebSocket.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/ChatWebSocket.java
@@ -1,0 +1,39 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import jakarta.inject.Inject;
+
+import io.quarkus.websockets.next.OnBinaryMessage;
+import io.quarkus.websockets.next.OnClose;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketConnection;
+import io.vertx.core.buffer.Buffer;
+
+@WebSocket(path = "/chat/{username}")
+public class ChatWebSocket {
+
+    @Inject
+    WebSocketConnection connection;
+
+    @OnOpen(broadcast = true)
+    public String onOpen() {
+        return connection.pathParam("username") + " joined";
+    }
+
+    @OnClose
+    public void onClose() {
+        String departure = connection.pathParam("username") + " left";
+        connection.broadcast().sendTextAndAwait(departure);
+    }
+
+    @OnTextMessage(broadcast = true)
+    public String onMessage(String message) {
+        return connection.pathParam("username") + ": " + message;
+    }
+
+    @OnBinaryMessage(broadcast = true)
+    public Buffer onBinaryMessage(Buffer message) {
+        return message;
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/ConcurrentBlockingWebSocket.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/ConcurrentBlockingWebSocket.java
@@ -1,0 +1,17 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import io.quarkus.websockets.next.InboundProcessingMode;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+
+@WebSocket(path = "/concurrent", inboundProcessingMode = InboundProcessingMode.CONCURRENT)
+public class ConcurrentBlockingWebSocket {
+
+    @OnTextMessage
+    public String onMessage(String message) throws InterruptedException {
+        if (message.equals("block")) {
+            Thread.sleep(1500);
+        }
+        return message;
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/CustomSerializationWebsocket.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/CustomSerializationWebsocket.java
@@ -1,0 +1,47 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import java.lang.reflect.Type;
+
+import jakarta.inject.Singleton;
+
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.TextMessageCodec;
+import io.quarkus.websockets.next.WebSocket;
+
+@WebSocket(path = "/serialization/custom")
+public class CustomSerializationWebsocket {
+
+    @OnTextMessage(codec = ChatMessageCodec.class)
+    public ChatMessage onMessage(ChatMessage inputMessage) {
+        return new ChatMessage(
+                inputMessage.author,
+                "received: " + inputMessage.message);
+    }
+
+    public record ChatMessage(
+            String author,
+            String message) {
+    }
+
+    @Singleton
+    public static class ChatMessageCodec implements TextMessageCodec<ChatMessage> {
+        @Override
+        public boolean supports(Type type) {
+            return type.equals(ChatMessage.class);
+        }
+
+        @Override
+        public String encode(ChatMessage value) {
+            return value.author + ";" + value.message;
+        }
+
+        @Override
+        public ChatMessage decode(Type type, String value) {
+            String[] input = value.split(";");
+            if (input.length != 2) {
+                throw new RuntimeException("Invalid input string: " + value);
+            }
+            return new ChatMessage(input[0], input[1]);
+        }
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/FailingWebsocket.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/FailingWebsocket.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import io.quarkus.logging.Log;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.smallrye.mutiny.Multi;
+
+@WebSocket(path = "/failing")
+public class FailingWebsocket {
+    @OnOpen()
+    public void onOpen() {
+        throw new RuntimeException("Websocket failed to open");
+    }
+
+    // used to verify that @onError endpoint is called
+    @OnError
+    public void onError(Exception failure) {
+        Log.warn("Error on websocket: " + failure.getMessage());
+    }
+
+    @OnTextMessage
+    public Multi<String> onMessage(String message) {
+        return Multi.createFrom().failure(new RuntimeException(message));
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/NativeSerializationWebsocket.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/NativeSerializationWebsocket.java
@@ -1,0 +1,36 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.vertx.core.json.JsonObject;
+
+@WebSocket(path = "/serialization/native")
+public class NativeSerializationWebsocket {
+
+    public enum MessageType {
+        OPEN,
+        MESSAGE,
+        WRONG
+    }
+
+    public record WSMessage(MessageType type, String message, JsonObject payload) {
+
+    }
+
+    @OnOpen(broadcast = true)
+    public WSMessage onOpen() {
+        return new WSMessage(MessageType.OPEN, "Connection opened", null);
+    }
+
+    @OnTextMessage(broadcast = true)
+    public WSMessage onMessage(WSMessage message) {
+        if (message.type == MessageType.WRONG) {
+            JsonObject jsonOriginMessage = new JsonObject();
+            jsonOriginMessage.put("Original message", message.message);
+
+            return new WSMessage(MessageType.MESSAGE, "Wrong original message", jsonOriginMessage);
+        }
+        return message;
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/ParentWebSocket.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/ParentWebSocket.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+
+@WebSocket(path = "/parent")
+public class ParentWebSocket {
+
+    @OnTextMessage
+    public String onMessage(String message) {
+        return "This is parent webSocket";
+    }
+
+    @WebSocket(path = "/nested")
+    public static class NestedWebSocket {
+        @OnTextMessage
+        public String onMessage(String message) {
+            return "This is nested webSocket";
+        }
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/PingPongWebSocket.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/PingPongWebSocket.java
@@ -1,0 +1,25 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.websockets.next.OnPingMessage;
+import io.quarkus.websockets.next.OnPongMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.vertx.core.buffer.Buffer;
+
+@WebSocket(path = "/pingPong")
+public class PingPongWebSocket {
+    public static List<Long> pingsReceived = new ArrayList<>();
+    public static List<Long> pongsReceived = new ArrayList<>();
+
+    @OnPingMessage
+    void ping(Buffer data) {
+        pingsReceived.add(System.currentTimeMillis());
+    }
+
+    @OnPongMessage
+    void pong(Buffer data) {
+        pongsReceived.add(System.currentTimeMillis());
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/PropertiesSecuredWebSocket.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/PropertiesSecuredWebSocket.java
@@ -1,0 +1,17 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+
+/**
+ * This endpoint should be secured by config in application.properties.
+ * Should only allow authenticated clients
+ */
+@WebSocket(path = "/propertiesSecured")
+public class PropertiesSecuredWebSocket {
+
+    @OnTextMessage(broadcast = true)
+    public String onMessage(String message) {
+        return message;
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/ReactiveWebsocket.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/ReactiveWebsocket.java
@@ -1,0 +1,20 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+@WebSocket(path = "/reactive")
+public class ReactiveWebsocket {
+    @OnOpen(broadcast = true)
+    public Uni<String> onOpen() {
+        return Uni.createFrom().item("Hello");
+    }
+
+    @OnTextMessage(broadcast = true)
+    public Multi<String> onMessage(String message) {
+        return Multi.createFrom().items("Message: ", message);
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/SerialBlockingWebSocket.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/SerialBlockingWebSocket.java
@@ -1,0 +1,17 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import io.quarkus.websockets.next.InboundProcessingMode;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+
+@WebSocket(path = "/serial", inboundProcessingMode = InboundProcessingMode.SERIAL)
+public class SerialBlockingWebSocket {
+
+    @OnTextMessage
+    public String onMessage(String message) throws InterruptedException {
+        if (message.equals("block")) {
+            Thread.sleep(1500);
+        }
+        return message;
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/UserDataWebSocket.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/endpoints/UserDataWebSocket.java
@@ -1,0 +1,34 @@
+package io.quarkus.ts.websocketNext.endpoints;
+
+import jakarta.inject.Inject;
+
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.UserData;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketConnection;
+
+@WebSocket(path = "/userData")
+public class UserDataWebSocket {
+    private static final String MESSAGES_SENT = "MESSAGES_SENT";
+
+    @Inject
+    WebSocketConnection connection;
+
+    @OnOpen()
+    public void onOpen() {
+        connection.userData().put(UserData.TypedKey.forInt(MESSAGES_SENT), 0);
+    }
+
+    @OnTextMessage(broadcast = true)
+    public String onMessage(String message) {
+        int messagesSent = connection.userData().get(UserData.TypedKey.forInt(MESSAGES_SENT));
+
+        if (message.equals("get")) {
+            return "messages sent: " + messagesSent;
+        }
+        messagesSent++;
+        connection.userData().put(UserData.TypedKey.forInt(MESSAGES_SENT), messagesSent);
+        return message;
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/resources/AuthenticatedChatResource.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/resources/AuthenticatedChatResource.java
@@ -1,0 +1,62 @@
+package io.quarkus.ts.websocketNext.resources;
+
+import java.net.URI;
+import java.util.Base64;
+import java.util.LinkedList;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.resteasy.reactive.RestQuery;
+
+import io.quarkus.websockets.next.BasicWebSocketConnector;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+
+@Path("/authChatRes")
+public class AuthenticatedChatResource {
+    @Inject
+    BasicWebSocketConnector connector;
+    private WebSocketClientConnection connection = null;
+
+    private final URI baseUri;
+
+    private final LinkedList<String> messages = new LinkedList<>();
+
+    public AuthenticatedChatResource(@ConfigProperty(name = "quarkus.http.port") int httpPort) {
+        this.baseUri = URI.create("http://localhost:" + httpPort);
+    }
+
+    @Path("/connect")
+    @GET
+    public void connect(@RestQuery String username, @RestQuery String password) {
+        messages.clear();
+
+        String authString = username + ":" + password;
+        connection = connector
+                .baseUri(baseUri)
+                .path("/authChat")
+                .addHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(authString.getBytes()))
+                .onTextMessage((c, message) -> messages.add(message))
+                .connectAndAwait();
+    }
+
+    @GET
+    @Path("/getLastMessage")
+    public String getLastMessage() {
+        return messages.getLast();
+    }
+
+    @GET
+    @Path("/sendMessage")
+    public void sendMessage(@RestQuery String message) {
+        connection.sendTextAndAwait(message);
+    }
+
+    @GET
+    @Path("/disconnect")
+    public void disconnect() {
+        connection.closeAndAwait();
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/resources/PingPongResource.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/resources/PingPongResource.java
@@ -1,0 +1,77 @@
+package io.quarkus.ts.websocketNext.resources;
+
+import java.net.URI;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.ts.websocketNext.clients.PingPongClient;
+import io.quarkus.ts.websocketNext.endpoints.PingPongWebSocket;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.quarkus.websockets.next.WebSocketConnector;
+
+@Path("/pingPongRes")
+public class PingPongResource {
+    @Inject
+    WebSocketConnector<PingPongClient> pingPongConnector;
+
+    WebSocketClientConnection connection = null;
+
+    private final URI baseUri;
+
+    public PingPongResource(@ConfigProperty(name = "quarkus.http.port") int httpPort) {
+        this.baseUri = URI.create("http://localhost:" + httpPort);
+    }
+
+    @GET
+    @Path("/connect")
+    public void connectClient() {
+        //reset ping pong counters
+        PingPongClient.pongsReceived.clear();
+        PingPongClient.pingsReceived.clear();
+
+        PingPongWebSocket.pongsReceived.clear();
+        PingPongWebSocket.pingsReceived.clear();
+
+        connection = pingPongConnector
+                .baseUri(baseUri)
+                .connectAndAwait();
+    }
+
+    @GET
+    @Path("/disconnect")
+    public void disconnectClient() {
+        if (connection != null) {
+            connection.closeAndAwait();
+            connection = null;
+        }
+    }
+
+    @GET
+    @Path("/serverPings")
+    public List<Long> getServerPings() {
+        return PingPongWebSocket.pingsReceived;
+    }
+
+    @GET
+    @Path("/serverPongs")
+    public List<Long> getServerPongs() {
+        return PingPongWebSocket.pongsReceived;
+    }
+
+    @GET
+    @Path("/clientPings")
+    public List<Long> getClientPings() {
+        return PingPongClient.pingsReceived;
+    }
+
+    @GET
+    @Path("/clientPongs")
+    public List<Long> getClientPongs() {
+        return PingPongClient.pongsReceived;
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/resources/TLSChatResource.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/resources/TLSChatResource.java
@@ -1,0 +1,59 @@
+package io.quarkus.ts.websocketNext.resources;
+
+import java.net.URI;
+import java.util.LinkedList;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.resteasy.reactive.RestQuery;
+
+import io.quarkus.websockets.next.BasicWebSocketConnector;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+
+@Path("/tlsChatRes")
+public class TLSChatResource {
+    @Inject
+    BasicWebSocketConnector connector;
+    private WebSocketClientConnection connection = null;
+
+    private final URI baseUri;
+
+    private final LinkedList<String> messages = new LinkedList<>();
+
+    public TLSChatResource(@ConfigProperty(name = "quarkus.http.ssl-port") int httpPort) {
+        this.baseUri = URI.create("https://localhost:" + httpPort);
+    }
+
+    @Path("/connect")
+    @GET
+    public void connect(@RestQuery String username) {
+        messages.clear();
+
+        connection = connector
+                .baseUri(baseUri)
+                .path("/chat/" + username)
+                .onTextMessage((c, message) -> messages.add(message))
+                .connectAndAwait();
+    }
+
+    @GET
+    @Path("/getLastMessage")
+    public String getLastMessage() {
+        return messages.getLast();
+    }
+
+    @GET
+    @Path("/sendMessage")
+    public void sendMessage(@RestQuery String message) {
+        connection.sendTextAndAwait(message);
+    }
+
+    @GET
+    @Path("/disconnect")
+    public void disconnect() {
+        connection.closeAndAwait();
+    }
+}

--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/resources/UserDataResource.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websocketNext/resources/UserDataResource.java
@@ -1,0 +1,42 @@
+package io.quarkus.ts.websocketNext.resources;
+
+import java.net.URI;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.resteasy.reactive.RestQuery;
+
+import io.quarkus.ts.websocketNext.clients.UserDataClient;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.quarkus.websockets.next.WebSocketConnector;
+
+@Path("/userDataRes")
+public class UserDataResource {
+    @Inject
+    WebSocketConnector<UserDataClient> connector;
+    WebSocketClientConnection connection = null;
+
+    private final URI baseUri;
+
+    public UserDataResource(@ConfigProperty(name = "quarkus.http.port") int httpPort) {
+        this.baseUri = URI.create("http://localhost:" + httpPort);
+    }
+
+    @GET
+    @Path("/connect")
+    public void connectClient(@RestQuery String username) {
+        connection = connector
+                .baseUri(baseUri)
+                .pathParam("username", username)
+                .connectAndAwait();
+    }
+
+    @GET
+    @Path("/disconnect")
+    public void disconnect() {
+        connection.closeAndAwait();
+    }
+}

--- a/websockets/websocket-next/src/main/resources/application.properties
+++ b/websockets/websocket-next/src/main/resources/application.properties
@@ -1,0 +1,14 @@
+quarkus.websockets-next.server.auto-ping-interval=1
+quarkus.websockets-next.client.auto-ping-interval=2
+
+quarkus.http.auth.basic=true
+quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.plain-text=true
+quarkus.security.users.embedded.users.alice=password
+quarkus.security.users.embedded.users.bob=secret
+quarkus.security.users.embedded.roles.alice=admin,user
+quarkus.security.users.embedded.roles.bob=user
+
+quarkus.http.auth.permission.http-upgrade.paths=/propertiesSecured
+quarkus.http.auth.permission.http-upgrade.policy=authenticated
+

--- a/websockets/websocket-next/src/main/resources/tls.properties
+++ b/websockets/websocket-next/src/main/resources/tls.properties
@@ -1,0 +1,4 @@
+quarkus.http.insecure-requests=enabled
+
+#Trust store is created dynamically and configured in test
+quarkus.websockets-next.client.tls-configuration-name=tls-client

--- a/websockets/websocket-next/src/test/java/io/quarkuss/ts/websocketNext/BaseWebSocketIT.java
+++ b/websockets/websocket-next/src/test/java/io/quarkuss/ts/websocketNext/BaseWebSocketIT.java
@@ -1,0 +1,396 @@
+package io.quarkuss.ts.websocketNext;
+
+import static io.restassured.RestAssured.given;
+import static java.time.Duration.ofSeconds;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+
+public abstract class BaseWebSocketIT {
+    private static final Logger LOG = Logger.getLogger(BaseWebSocketIT.class);
+
+    protected abstract RestService getServer();
+
+    @Test
+    public void basicTextTest() throws URISyntaxException, InterruptedException {
+        Client client = createClient("/chat/alice", false);
+        client.send("Hello world");
+
+        assertMessage("alice joined", client);
+        assertMessage("alice: Hello world", client);
+    }
+
+    @Test
+    public void basicBinaryTest() throws URISyntaxException, InterruptedException {
+        Client client = createClient("/chat/alice");
+
+        byte[] data = HexFormat.of().parseHex("e04fd020ea3a6910a2d808002b30309d");
+        client.send(data);
+
+        assertArrayEquals(data, client.waitForAndGetBinaryMessage().array(),
+                "Received binary data should be same as send");
+    }
+
+    @Test
+    public void chatTest() throws URISyntaxException, InterruptedException {
+        Client aliceClient = createClient("/chat/alice");
+        Client bobClient = createClient("/chat/bob");
+        Client charlieClient = createClient("/chat/charlie");
+
+        bobClient.send("Hello there");
+        assertMessage("bob: Hello there", aliceClient, bobClient, charlieClient);
+
+        charlieClient.send("Hi bob");
+        assertMessage("charlie: Hi bob", aliceClient, bobClient, charlieClient);
+    }
+
+    @Test
+    public void reactiveTest() throws URISyntaxException, InterruptedException {
+        Client client = createClient("/reactive");
+        assertMessage("Hello", client);
+
+        client.send("Lorem ipsum");
+        assertMessage("Message: ", client);
+        assertMessage("Lorem ipsum", client);
+    }
+
+    @Test
+    public void onErrorEventTest() throws URISyntaxException, InterruptedException {
+        Client client = createClient("/failing");
+        getServer().logs().assertContains("Error on websocket: Websocket failed to open");
+
+        client.send("Random failure");
+        getServer().logs().assertContains("Error on websocket: Random failure");
+    }
+
+    @Test
+    public void nativeSerializationTest() throws URISyntaxException, InterruptedException {
+        Client client = createClient("/serialization/native");
+        assertMessage("{\"type\":\"OPEN\",\"message\":\"Connection opened\",\"payload\":null}", client);
+
+        client.send("{\"type\":\"WRONG\",\"message\":\"oops\",\"payload\":null}");
+        assertMessage(
+                "{\"type\":\"MESSAGE\",\"message\":\"Wrong original message\",\"payload\":{\"Original message\":\"oops\"}}",
+                client);
+    }
+
+    @Test
+    public void customSerializationTest() throws URISyntaxException, InterruptedException {
+        Client client = createClient("/serialization/custom");
+        client.send("bob;hello");
+        assertMessage("bob;received: hello", client);
+    }
+
+    @Test
+    public void concurrencyTest() throws URISyntaxException, InterruptedException {
+        /*
+         * By default, quarkus WS processes messages in serial mode.
+         * Meaning next message will be processed only after first one was finished.
+         * In concurrent mode, messages can be processed in parallel.
+         *
+         * In this test message "block" will always block(wait) in the processing for 1.5 seconds.
+         * In serial mode, it should always wait for it to finish before processing next one.
+         * In concurrent mode, the later message is faster and should arrive first.
+         */
+
+        Client serialClient = createClient("/serial");
+        Client concurentClient = createClient("/concurrent");
+
+        serialClient.send("block");
+        serialClient.send("go");
+        assertMessage("block", serialClient);
+        assertMessage("go", serialClient);
+
+        concurentClient.send("block");
+        concurentClient.send("go");
+        assertMessage("go", concurentClient);
+        assertMessage("block", concurentClient);
+    }
+
+    @Test
+    public void userDataOnServerTest() throws URISyntaxException, InterruptedException {
+        Client client = createClient("/userData");
+
+        client.send("get");
+        assertMessage("messages sent: 0", client);
+
+        client.send("one");
+        assertMessage("one", client);
+        client.send("two");
+        assertMessage("two", client);
+        client.send("three");
+        assertMessage("three", client);
+
+        client.send("get");
+        assertMessage("messages sent: 3", client);
+    }
+
+    @Test
+    public void userDataInClientTest() throws URISyntaxException, InterruptedException {
+        Client client = createClient("/chat/alice");
+        // connect server-side client
+        given().queryParam("username", "bob").get("/userDataRes/connect");
+
+        try {
+            // server-side client will respond to "login" message by sending its username (which is stored in user data)
+            client.send("login");
+            assertMessage("alice: login", client);
+            // first username is set by the chat broker, second one by the server-side client
+            assertMessage("bob: bob", client);
+        } finally {
+            given().get("/userDataRes/disconnect");
+        }
+    }
+
+    @Test
+    public void subWebSocketTest() throws URISyntaxException, InterruptedException {
+        Client parentClient = createClient("/parent");
+        Client nestedClient = createClient("/parent/nested");
+
+        parentClient.send("foo");
+        assertMessage("This is parent webSocket", parentClient);
+
+        nestedClient.send("bar");
+        assertMessage("This is nested webSocket", nestedClient);
+    }
+
+    // verify that custom logic for allowing/rejecting upgrade http-to-websocket works
+    @Test
+    public void httpToWebSocketUpgradeTest() throws URISyntaxException, InterruptedException {
+        Client rejectClient = new Client(getUri("/parent"), true);
+        rejectClient.addHeader("Reject", "");
+        assertFalse(rejectClient.connectBlocking(), "Upgrade from http to websocket should be rejected");
+
+        Client allowClient = new Client(getUri("/parent"), true);
+        assertTrue(allowClient.connectBlocking(), "Upgrade from http to websocket should be allowed");
+    }
+
+    @Test
+    public void pingPongTest() throws InterruptedException {
+        // start websocket client on the server, WS client and server endpoints should start exchanging pings and pongs
+        given().get("/pingPongRes/connect");
+
+        // let them exchange ping pongs for a while
+        Thread.sleep(5000);
+
+        // close the client = stop the ping pong exchange
+        given().get("/pingPongRes/disconnect");
+
+        // assert that pings and pongs arrived in correct time intervals
+        // default config is, that server should send ping every second, client every two seconds
+        assertTimeDifference(getTimes("/pingPongRes/serverPings"), TimeUnit.SECONDS.toMillis(2));
+        assertTimeDifference(getTimes("/pingPongRes/clientPongs"), TimeUnit.SECONDS.toMillis(2));
+
+        assertTimeDifference(getTimes("/pingPongRes/clientPings"), TimeUnit.SECONDS.toMillis(1));
+        assertTimeDifference(getTimes("/pingPongRes/serverPongs"), TimeUnit.SECONDS.toMillis(1));
+    }
+
+    @Test
+    public void authenticatedChatTest() throws URISyntaxException, InterruptedException {
+        // verify that unauthenticated client cannot join the authenticated chat
+        Client anonymousClient = new Client(getUri("/authChat"));
+        assertFalse(anonymousClient.connectBlocking(), "Anonymous connection should fail");
+
+        // directly connect authenticated client and verify sent message
+        Client client = createAuthenticatedClient("/authChat", "alice", "password");
+        client.send("Hi");
+        assertMessage("alice: Hi", client);
+
+        // connect server-side client
+        given()
+                .queryParam("username", "bob")
+                .queryParam("password", "secret")
+                .get("/authChatRes/connect");
+        try {
+            // send message via server-side client
+            given().queryParam("message", "Hello guys").get("/authChatRes/sendMessage");
+
+            // verify that both direct and server-side client received the message
+            assertMessage("bob: Hello guys", client);
+            assertEquals("bob: Hello guys", given().get("/authChatRes/getLastMessage").asString(),
+                    "Server side client should receive last message");
+        } finally {
+            given().get("authChatRes/disconnect");
+        }
+    }
+
+    /**
+     * Test endpoint secured only via config in properties file
+     */
+    @Test
+    public void propertiesAuthenticationTest() throws URISyntaxException, InterruptedException {
+        // verify that unauthenticated client cannot join the properties secured endpoint
+        Client anonymousClient = new Client(getUri("/propertiesSecured"));
+        assertFalse(anonymousClient.connectBlocking(), "Anonymous connection should fail");
+
+        Client authenticatedClient = createAuthenticatedClient("/propertiesSecured", "alice", "password");
+        authenticatedClient.send("hi");
+
+        assertMessage("hi", authenticatedClient);
+    }
+
+    @Test
+    public void authorizedChatTest() throws URISyntaxException, InterruptedException {
+        // adminChat allows only admins to send messages, but anyone can listen
+        // alice has the admin role, so can submit messages to chat
+        Client adminClient = createAuthenticatedClient("/adminChat", "alice", "password");
+        // bob is not admin, so cannot submit messages to chat
+        Client userClient = createAuthenticatedClient("/adminChat", "bob", "secret");
+        // even anonymous client can join and listen, but cannot send messages
+        Client anonymousClient = createClient("/adminChat");
+
+        adminClient.send("Howdy");
+        assertMessage("alice: Howdy", adminClient, userClient, anonymousClient);
+
+        userClient.send("oops");
+        assertMessage("forbidden: bob", userClient);
+
+        anonymousClient.send("trying to send");
+        assertMessage("forbidden anonymous", anonymousClient);
+    }
+
+    @Test
+    public void restrictedChatTest() throws URISyntaxException, InterruptedException {
+        // adminOnlyChat allow only admins to join the chat
+        // alice has the admin role, so can submit messages to chat
+        Client adminClient = createAuthenticatedClient("/adminOnlyChat", "alice", "password");
+
+        adminClient.send("Hello there");
+        assertMessage("alice: Hello there", adminClient);
+
+        Client userClient = new Client(getUri("/adminOnlyChat"));
+        assertFalse(userClient.connectBlocking(), "User's connection to adminOnlyChat should fail");
+    }
+
+    private URI getUri(String with) throws URISyntaxException {
+        return new URI(getServer().getURI(Protocol.WS).toString()).resolve(with);
+    }
+
+    protected void assertMessage(String expectedMessage, Client... clients) {
+        for (Client client : clients) {
+            Awaitility
+                    .await()
+                    .atMost(ofSeconds(2))
+                    .untilAsserted(() -> assertEquals(expectedMessage, client.waitForAndGetMessage()));
+        }
+    }
+
+    private List<Long> getTimes(String url) {
+        return given().get(url).body().jsonPath().getList(".", Long.class);
+    }
+
+    /**
+     * Used for ping & pong times check. Assert that two consecutive timestamps have difference of approximately the given time.
+     */
+    private void assertTimeDifference(List<Long> times, long expectedTimeDifference) {
+        assertTrue(times.size() > 1, "There should be at least two times recorded");
+
+        // add some tolerance to time difference
+        long maxTimeDifference = Double.valueOf(expectedTimeDifference * 1.2).longValue();
+        long minTimeDifference = Double.valueOf(expectedTimeDifference * 0.8).longValue();
+
+        for (int i = 1; i < times.size(); i++) {
+            long timeDifference = times.get(i) - times.get(i - 1);
+            assertTrue(timeDifference < maxTimeDifference,
+                    "Time difference should be less that: " + maxTimeDifference + " but was: " + timeDifference);
+            assertTrue(timeDifference > minTimeDifference,
+                    "Time difference should be more that: " + minTimeDifference + " but was: " + timeDifference);
+        }
+    }
+
+    private Client createClient(String endpoint) throws URISyntaxException, InterruptedException {
+        return createClient(endpoint, true);
+    }
+
+    private Client createAuthenticatedClient(String endpoint, String username, String password)
+            throws URISyntaxException, InterruptedException {
+        Client client = new Client(getUri(endpoint));
+        String authString = username + ":" + password;
+        client.addHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(authString.getBytes()));
+        if (!client.connectBlocking()) {
+            LOG.error("Websocket client fail to connect");
+        }
+        return client;
+    }
+
+    private Client createClient(String endpoint, boolean ignoreJoinMessages) throws URISyntaxException, InterruptedException {
+        Client client = new Client(getUri(endpoint), ignoreJoinMessages);
+        if (!client.connectBlocking()) {
+            LOG.error("Websocket client fail to connect");
+        }
+        return client;
+    }
+
+    public static class Client extends WebSocketClient {
+        private final LinkedBlockingDeque<String> messages = new LinkedBlockingDeque<>();
+        private final LinkedBlockingDeque<ByteBuffer> binaryMessages = new LinkedBlockingDeque<>();
+        private final boolean ignoreJoinMessages;
+
+        public Client(URI serverUri, boolean ignoreJoinMessages) {
+            super(serverUri);
+            this.ignoreJoinMessages = ignoreJoinMessages;
+        }
+
+        public Client(URI serverUri) {
+            super(serverUri);
+            this.ignoreJoinMessages = true;
+        }
+
+        @Override
+        public void onOpen(ServerHandshake serverHandshake) {
+            LOG.debug("New connection opened");
+        }
+
+        @Override
+        public void onMessage(String message) {
+            LOG.debug("Message received: " + message);
+            if (!message.endsWith("joined") || !ignoreJoinMessages) {
+                messages.add(message);
+            }
+        }
+
+        // receive binary message
+        @Override
+        public void onMessage(ByteBuffer bytes) {
+            LOG.debug("Binary message received: " + bytes.toString());
+            binaryMessages.add(bytes);
+        }
+
+        @Override
+        public void onClose(int i, String reason, boolean b) {
+            LOG.debug("WS connection closed for reason: " + reason);
+        }
+
+        @Override
+        public void onError(Exception e) {
+            LOG.error("Websocket Exception thrown: " + e.getMessage(), e);
+        }
+
+        public String waitForAndGetMessage() throws InterruptedException {
+            return messages.poll(2, TimeUnit.SECONDS);
+        }
+
+        public ByteBuffer waitForAndGetBinaryMessage() throws InterruptedException {
+            return binaryMessages.poll(2, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/websockets/websocket-next/src/test/java/io/quarkuss/ts/websocketNext/OpenShiftWebSocketIT.java
+++ b/websockets/websocket-next/src/test/java/io/quarkuss/ts/websocketNext/OpenShiftWebSocketIT.java
@@ -1,0 +1,17 @@
+package io.quarkuss.ts.websocketNext;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@OpenShiftScenario
+public class OpenShiftWebSocketIT extends BaseWebSocketIT {
+
+    @QuarkusApplication
+    protected static final RestService server = new RestService();
+
+    @Override
+    protected RestService getServer() {
+        return server;
+    }
+}

--- a/websockets/websocket-next/src/test/java/io/quarkuss/ts/websocketNext/TlsWebSocketIT.java
+++ b/websockets/websocket-next/src/test/java/io/quarkuss/ts/websocketNext/TlsWebSocketIT.java
@@ -1,0 +1,107 @@
+package io.quarkuss.ts.websocketNext;
+
+import static io.quarkus.test.services.Certificate.Format.PKCS12;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * All TLS related stuff for websocket is moved to separate child class, since it does not work on OCP
+ * TODO: add these tests to OCP once done: https://github.com/quarkus-qe/quarkus-test-framework/issues/1052
+ */
+@QuarkusScenario
+public class TlsWebSocketIT extends BaseWebSocketIT {
+    private static final String TRUST_STORE_PASSWORD = "redhat";
+
+    private static final String CERT_PREFIX = "websocket-next-server";
+
+    @QuarkusApplication(ssl = true, certificates = @Certificate(prefix = CERT_PREFIX, format = PKCS12, configureKeystore = true, configureTruststore = true, password = "redhat", tlsConfigName = "tls-server", configureHttpServer = true))
+    protected static final RestService server = new RestService()
+            .withProperties("tls.properties")
+            .withProperty("quarkus.tls.tls-client.trust-store.p12.path", TlsWebSocketIT::getTrustStoreFilename)
+            .withProperty("quarkus.tls.tls-client.trust-store.p12.password", TRUST_STORE_PASSWORD);
+
+    @Override
+    protected RestService getServer() {
+        return server;
+    }
+
+    @Test
+    public void tlsSecuredTest() throws URISyntaxException, InterruptedException, CertificateException, KeyStoreException,
+            IOException, NoSuchAlgorithmException, KeyManagementException {
+        URI securedURI = new URI(server.getURI(Protocol.WSS).toString()).resolve("/chat/alice");
+
+        // setup SSL context to trust custom certificate
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, new X509TrustManager[] { generateTrustManager() }, null);
+
+        // connect local client
+        Client client = new Client(securedURI);
+        client.setSocketFactory(sslContext.getSocketFactory());
+        client.connectBlocking();
+
+        // connect server-side client
+        server.given().queryParam("username", "bob").get("/tlsChatRes/connect");
+
+        try {
+            // send message from local client and validate both clients got it
+            client.send("Hi");
+            assertMessage("alice: Hi", client);
+            assertEquals("alice: Hi", server.given().get("/tlsChatRes/getLastMessage").asString());
+
+            // send message from server-side client
+            server.given().queryParam("message", "hello").get("/tlsChatRes/sendMessage");
+            assertMessage("bob: hello", client);
+        } finally {
+            // disconnect server-side client
+            server.given().get("/tlsChatRes/disconnect");
+        }
+    }
+
+    private X509TrustManager generateTrustManager()
+            throws KeyStoreException, NoSuchAlgorithmException, IOException, CertificateException {
+        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init((KeyStore) null);
+
+        InputStream myKeys = new FileInputStream(getTrustStoreFilename());
+        KeyStore myTrustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        myTrustStore.load(myKeys, TRUST_STORE_PASSWORD.toCharArray());
+        trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init(myTrustStore);
+
+        X509TrustManager myTrustManager = null;
+        for (TrustManager tm : trustManagerFactory.getTrustManagers()) {
+            if (tm instanceof X509TrustManager x509TrustManager) {
+                myTrustManager = x509TrustManager;
+                break;
+            }
+        }
+        return myTrustManager;
+    }
+
+    private static String getTrustStoreFilename() {
+        return server.getProperty("quarkus.tls.tls-server.trust-store.p12.path").orElseThrow();
+    }
+}


### PR DESCRIPTION
### Summary

Add tests for websocket-next based on test plan https://github.com/quarkus-qe/quarkus-test-plans/pull/201 Tests for permissionChecker and telemetry were omitted as they should be part of other tasks.

I've also omitted test for ping&pong payload validation, because quarkus is always sending static payload-string "ping" and it is IMHO not worth the effort to implement custom WS client just to verify this. As WS client usually don't expose API for this.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [X] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)