### PR TITLE
Grouping PathParams into a custom class and record, Convert Book class to record in `http/rest-client-reactive`

### DIFF
--- a/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/MinMaxResource.java
+++ b/http/http-minimum-reactive/src/main/java/io/quarkus/ts/http/minimum/reactive/MinMaxResource.java
@@ -1,0 +1,64 @@
+package io.quarkus.ts.http.minimum.reactive;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+@Path("/minmax")
+public class MinMaxResource {
+
+    @GET
+    @Path("record/{min}/{max}")
+    public MinMaxRecord recordMinMax(MinMaxRecord params) {
+        return params;
+    }
+
+    @GET
+    @Path("class/{min}/{max}")
+    public MinMaxClass classMinMax(MinMaxClass params) {
+        return params;
+    }
+
+    @GET
+    @Path("method/{min}/{max}")
+    public String methodMinMax(@PathParam("min") String min,
+            @PathParam("max") String max) {
+        return min + " - " + max;
+    }
+
+    public record MinMaxRecord(
+            @PathParam("min") String min,
+            @PathParam("max") String max) {
+    }
+
+    public static class MinMaxClass {
+        @PathParam("min")
+        String min;
+        @PathParam("max")
+        String max;
+
+        public String getMin() {
+            return min;
+        }
+
+        public void setMin(String min) {
+            this.min = min;
+        }
+
+        public String getMax() {
+            return max;
+        }
+
+        public void setMax(String max) {
+            this.max = max;
+        }
+
+        @Override
+        public String toString() {
+            return "MinMax{" +
+                    "min='" + min + '\'' +
+                    ", max='" + max + '\'' +
+                    '}';
+        }
+    }
+}

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpMinimumReactiveIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/HttpMinimumReactiveIT.java
@@ -113,6 +113,24 @@ public class HttpMinimumReactiveIT {
         });
     }
 
+    @Test
+    public void accessingRequestParameters() {
+        givenSpec().get("/api/minmax/method/1/5").then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is("1 - 5"));
+
+        givenSpec().get("/api/minmax/class/1/5").then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("min", is("1"))
+                .body("max", is("5"));
+
+        givenSpec().get("/api/minmax/record/1/5").then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("min", is("1"))
+                .body("max", is("5"));
+
+    }
+
     protected RequestSpecification givenSpec() {
         return app.given();
     }

--- a/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/MinMaxResource.java
+++ b/http/http-minimum/src/main/java/io/quarkus/ts/http/minimum/MinMaxResource.java
@@ -1,0 +1,64 @@
+package io.quarkus.ts.http.minimum;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+@Path("/minmax")
+public class MinMaxResource {
+
+    @GET
+    @Path("record/{min}/{max}")
+    public MinMaxRecord recordMinMax(MinMaxRecord params) {
+        return params;
+    }
+
+    @GET
+    @Path("class/{min}/{max}")
+    public MinMaxClass classMinMax(MinMaxClass params) {
+        return params;
+    }
+
+    @GET
+    @Path("method/{min}/{max}")
+    public String methodMinMax(@PathParam("min") String min,
+            @PathParam("max") String max) {
+        return min + " - " + max;
+    }
+
+    public record MinMaxRecord(
+            @PathParam("min") String min,
+            @PathParam("max") String max) {
+    }
+
+    public static class MinMaxClass {
+        @PathParam("min")
+        String min;
+        @PathParam("max")
+        String max;
+
+        public String getMin() {
+            return min;
+        }
+
+        public void setMin(String min) {
+            this.min = min;
+        }
+
+        public String getMax() {
+            return max;
+        }
+
+        public void setMax(String max) {
+            this.max = max;
+        }
+
+        @Override
+        public String toString() {
+            return "MinMax{" +
+                    "min='" + min + '\'' +
+                    ", max='" + max + '\'' +
+                    '}';
+        }
+    }
+}

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/HttpMinimumIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/HttpMinimumIT.java
@@ -63,6 +63,20 @@ public class HttpMinimumIT {
                 .body("data", is("ok"));
     }
 
+    @Test
+    public void accessingRequestParameters() {
+        givenSpec().get("/api/minmax/method/1/5").then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is("1 - 5"));
+
+        givenSpec().get("/api/minmax/class/1/5").then()
+                .statusCode(HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE);
+
+        givenSpec().get("/api/minmax/record/1/5").then()
+                .statusCode(HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE);
+
+    }
+
     protected RequestSpecification givenSpec() {
         return HTTP_CLIENT_SPEC;
     }

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/json/Book.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/json/Book.java
@@ -1,36 +1,4 @@
 package io.quarkus.ts.http.restclient.reactive.json;
 
-public class Book {
-
-    private String title;
-    private String author;
-
-    public Book() {
-    }
-
-    public Book(String title, String author) {
-        this.title = title;
-        this.author = author;
-    }
-
-    public Book(String title) {
-        this(title, null);
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public String getAuthor() {
-        return author;
-    }
-
-    // TODO: required due to https://github.com/quarkusio/quarkus/issues/46458
-    public void setAuthor(String author) {
-        this.author = author;
-    }
+public record Book(String title, String author) {
 }

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/json/BookAsJsonResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/json/BookAsJsonResource.java
@@ -17,7 +17,7 @@ public class BookAsJsonResource {
 
     @GET
     public Uni<String> get(@PathParam("id") String id) {
-        Map<String, String> body = Map.of("title", "Title in Json: " + id);
+        Map<String, String> body = Map.of("title", "Title in Json: " + id, "author", "");
         return Uni.createFrom().item(Json.encode(body));
     }
 }

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/PlainBookResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/resources/PlainBookResource.java
@@ -160,7 +160,7 @@ public class PlainBookResource {
                 .trustStore(trustStore()) // keep truststore in place to verify QUARKUS-3170
                 .build(BookClient.class)
                 .getBook("The Hobbit: An Unexpected Journey", "J. R. R. Tolkien")
-                .map(Book::getTitle);
+                .map(Book::title);
     }
 
     @POST
@@ -176,7 +176,7 @@ public class PlainBookResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.TEXT_PLAIN)
     public Uni<String> getSequel(Book first) {
-        return Uni.createFrom().item(first.getTitle() + " II");
+        return Uni.createFrom().item(first.title() + " II");
     }
 
     @GET

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
@@ -78,8 +78,8 @@ public class ReactiveRestClientIT {
 
         Book book = books.iterator().next();
 
-        assertEquals("The Wind-Up Bird Chronicle", book.getTitle());
-        assertEquals("Haruki Murakami", book.getAuthor());
+        assertEquals("The Wind-Up Bird Chronicle", book.title());
+        assertEquals("Haruki Murakami", book.author());
     }
 
     @Tag("QUARKUS-1568")
@@ -101,8 +101,8 @@ public class ReactiveRestClientIT {
         for (int i = 0; i < books.size(); i++) {
             var expectedBook = BookRepository.getById(i + 1);
             var actualBook = books.get(i);
-            assertEquals(expectedBook.getTitle(), actualBook.getTitle());
-            assertEquals(expectedBook.getAuthor(), actualBook.getAuthor());
+            assertEquals(expectedBook.title(), actualBook.title());
+            assertEquals(expectedBook.author(), actualBook.author());
         }
     }
 


### PR DESCRIPTION
### Summary

Work for https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-5621.md

It's the first part to cover simple case of grouping parameters in a custom class / Java Record (feature specific to Quarkus REST, not available in Quarkus RESTEasy) and to use Java Record in Rest Client scenario.

 * `http/http-minimum` and `http/http-minimum-reactive`
   * Grouping PathParams into a custom class and record
 * `http/rest-client-reactive`
   * Convert Book class to record

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)