### PR TITLE
Add coverage for QUARKUS-5611 (quarkus-oidc-client developer experience)

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,12 @@ Reactive twin of the `security/keycloak-oidc-client-extended`, extends `security
 
 - Verifies Proof Of Key for Code Exchange support for a Keycloak and Red Hat Single Sign-On together with OIDC Single Page Application logout flow
 
+### `security/keycloak-oidc-client-standalone`
+
+Verifies Dev Mode experience using `quarkus-oidc-client` extension without `quarkus-oidc` extension.
+Verifies the logs when using custom and default Keycloak service.
+Verifies that it's possible to get token when using Keycloak Dev service.
+
 ### `securty/oidc-client-mutual-tls`
 
 Verifies OIDC client can be authenticated as part of the `Mutual TLS` (`mTLS`) authentication process

--- a/pom.xml
+++ b/pom.xml
@@ -550,6 +550,7 @@
                 <module>security/keycloak-oidc-client-extended</module>
                 <module>security/keycloak-oidc-client-reactive-basic</module>
                 <module>security/keycloak-oidc-client-reactive-extended</module>
+                <module>security/keycloak-oidc-client-standalone</module>
                 <module>security/vertx-jwt</module>
                 <module>security/oidc-client-mutual-tls</module>
                 <module>security/webauthn</module>

--- a/security/keycloak-oidc-client-standalone/pom.xml
+++ b/security/keycloak-oidc-client-standalone/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>security-keycloak-oidc-client-standalone</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: Security: Keycloak + OIDC Client Standalone</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc-client</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/security/keycloak-oidc-client-standalone/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/standalone/TokenResource.java
+++ b/security/keycloak-oidc-client-standalone/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/standalone/TokenResource.java
@@ -1,0 +1,50 @@
+package io.quarkus.ts.security.keycloak.oidcclient.standalone;
+
+import static java.util.Base64.getUrlDecoder;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.OidcClients;
+import io.quarkus.oidc.client.Tokens;
+
+@Path("/oidc-client-tokens")
+public class TokenResource {
+
+    @Inject
+    OidcClient defaultOidcClient;
+
+    @Inject
+    OidcClients oidcClients;
+
+    @Inject
+    Tokens tokens;
+
+    @GET
+    public String getInjectedToken() {
+        return decodeToken(tokens.getAccessToken());
+    }
+
+    @GET
+    @Path("default-user")
+    public String getTokenOfDefaultUser() {
+        String token = defaultOidcClient.getTokens().await().indefinitely().getAccessToken();
+        return decodeToken(token);
+    }
+
+    @GET
+    @Path("custom-user")
+    public String getTokenOfCustomUser() {
+        String token = oidcClients.getClient("custom-user").getTokens().await().indefinitely().getAccessToken();
+        return decodeToken(token);
+    }
+
+    private String decodeToken(String token) {
+        String[] headerAndPayload = token.split("\\.");
+        String header = new String(getUrlDecoder().decode(headerAndPayload[0]));
+        String payload = new String(getUrlDecoder().decode(headerAndPayload[1]));
+        return header + payload;
+    }
+}

--- a/security/keycloak-oidc-client-standalone/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/standalone/DevModeOidcClientDevServiceUserExperienceIT.java
+++ b/security/keycloak-oidc-client-standalone/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/standalone/DevModeOidcClientDevServiceUserExperienceIT.java
@@ -1,0 +1,43 @@
+package io.quarkus.ts.security.keycloak.oidcclient.standalone;
+
+import static io.quarkus.test.utils.ImageUtil.getImageName;
+import static io.quarkus.test.utils.ImageUtil.getImageVersion;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import com.github.dockerjava.api.model.Image;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.test.utils.DockerUtils;
+
+@Tag("QUARKUS-5611")
+@QuarkusScenario
+public class DevModeOidcClientDevServiceUserExperienceIT {
+
+    private static final String KEYCLOAK_VERSION = getImageVersion("keycloak.image");
+    private static final String KEYCLOAK_IMAGE_NAME = getImageName("keycloak.image");
+    private static final String KEYCLOAK_IMAGE = KEYCLOAK_IMAGE_NAME + ":" + KEYCLOAK_VERSION;
+
+    @DevModeQuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.keycloak.devservices.image-name", "${keycloak.image}");
+
+    @Test
+    public void verifyIfUserIsInformedAboutKeycloakDevServicePullingAndIsStarted() {
+        app.logs().assertContains("Creating container for image: " + KEYCLOAK_IMAGE);
+        app.logs().assertContains("Container " + KEYCLOAK_IMAGE + " is starting:");
+        app.logs().assertContains("Dev Services for Keycloak started");
+    }
+
+    @Test
+    public void verifyKeycloakImage() {
+        Image keycloakImg = DockerUtils.getImage(KEYCLOAK_IMAGE_NAME, KEYCLOAK_VERSION);
+        Assertions.assertFalse(keycloakImg.getId().isEmpty(), String.format("%s:%s not found. "
+                + "Overwriting`quarkus.keycloak.devservices.image-name` default value not worked.",
+                KEYCLOAK_IMAGE, KEYCLOAK_VERSION));
+    }
+}

--- a/security/keycloak-oidc-client-standalone/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/standalone/DevModeOidcClientTokensIT.java
+++ b/security/keycloak-oidc-client-standalone/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/standalone/DevModeOidcClientTokensIT.java
@@ -1,0 +1,60 @@
+package io.quarkus.ts.security.keycloak.oidcclient.standalone;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+
+@Tag("QUARKUS-5611")
+@QuarkusScenario
+public class DevModeOidcClientTokensIT {
+
+    public static String DEFAULT_USER = "bob";
+    public static String CUSTOM_USER = "alice";
+
+    @DevModeQuarkusApplication
+    static RestService app = new RestService()
+            .withProperties("oidc-client.properties");
+
+    @Test
+    public void keycloakContainerShouldStart() {
+        app.logs().assertContains("Creating container for image: quay.io/keycloak/keycloak");
+        app.logs().assertContains("Dev Services for Keycloak started");
+    }
+
+    @Test
+    public void checkTokenUpnIsDefaultUserUsingInjectToken() {
+        given()
+                .when()
+                .get("/oidc-client-tokens")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("\"upn\":\"" + DEFAULT_USER + "\""));
+    }
+
+    @Test
+    public void checkTokenUpnIsDefaultUserUsingInjectOidcClient() {
+        given()
+                .when()
+                .get("/oidc-client-tokens/default-user")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("\"upn\":\"" + DEFAULT_USER + "\""));
+    }
+
+    @Test
+    public void checkTokenUpnIsCustomUser() {
+        given()
+                .when()
+                .get("/oidc-client-tokens/custom-user")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("\"upn\":\"" + CUSTOM_USER + "\""));
+    }
+}

--- a/security/keycloak-oidc-client-standalone/src/test/resources/oidc-client.properties
+++ b/security/keycloak-oidc-client-standalone/src/test/resources/oidc-client.properties
@@ -1,0 +1,13 @@
+default_user=bob
+custom_user=alice
+
+quarkus.oidc-client.grant-options.password.username=${default_user}
+quarkus.oidc-client.grant-options.password.password=${default_user}
+quarkus.oidc-client.grant.type=password
+
+quarkus.oidc-client.custom-user.auth-server-url=${quarkus.oidc-client.auth-server-url}
+quarkus.oidc-client.custom-user.client-id=${quarkus.oidc-client.client-id}
+quarkus.oidc-client.custom-user.credentials.secret=${quarkus.oidc-client.credentials.secret}
+quarkus.oidc-client.custom-user.grant-options.password.username=${custom_user}
+quarkus.oidc-client.custom-user.grant-options.password.password=${custom_user}
+quarkus.oidc-client.custom-user.grant.type=password


### PR DESCRIPTION
### Summary

The coverage checking that `quarkus-oidc-client` can use Keycloak dev services without need for `quarkus-oidc` extension

TP: https://github.com/quarkus-qe/quarkus-test-plans/pull/208

JIRA: https://issues.redhat.com/browse/QUARKUS-5611

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)