### PR TITLE
Grouping parameters in a custom class and Java Records, validation of Java Records

### DIFF
--- a/http/hibernate-validator/src/test/java/io/quarkus/ts/http/hibernate/validator/ResteasyReactiveMoviesResourceIT.java
+++ b/http/hibernate-validator/src/test/java/io/quarkus/ts/http/hibernate/validator/ResteasyReactiveMoviesResourceIT.java
@@ -1,0 +1,108 @@
+package io.quarkus.ts.http.hibernate.validator;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Dependency;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.http.hibernate.validator.sources.MoviesResource;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+
+@QuarkusScenario
+class ResteasyReactiveMoviesResourceIT {
+
+    @QuarkusApplication(classes = MoviesResource.class, dependencies = {
+            @Dependency(artifactId = "quarkus-rest-jackson"),
+            @Dependency(artifactId = "quarkus-smallrye-openapi")
+    })
+    static final RestService app = new RestService();
+
+    @Test
+    void testValidationConstraintsOnOpenAPISchemas() throws JsonProcessingException, InterruptedException {
+        Response response = given().get("/q/openapi");
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        JsonNode body = mapper.readTree(response.body().asString());
+
+        JsonNode director = body.get("components").get("schemas").get("Director");
+        JsonNode movie = body.get("components").get("schemas").get("Movie");
+
+        JsonNode movieId = movie.get("properties").get("id");
+        Assertions.assertEquals("\\S", movieId.get("pattern").asText());
+
+        JsonNode directorName = director.get("properties").get("name");
+        JsonNode directorSurname = director.get("properties").get("surname");
+        Assertions.assertEquals(1, directorName.get("minLength").asInt());
+        Assertions.assertEquals(20, directorName.get("maxLength").asInt());
+        Assertions.assertEquals("\\S", directorName.get("pattern").asText());
+        Assertions.assertEquals(20, directorSurname.get("maxLength").asInt());
+        Assertions.assertEquals("\\S", directorSurname.get("pattern").asText());
+    }
+
+    @Test
+    void getFromMoviesEndpoint() {
+        given()
+                .get("/movies")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id[0]", is("1"))
+                .body("id[1]", is("2"))
+                .body("director[1].name", is("Mary"))
+                .body("id[2]", is("3"))
+                .body("director[2].name", is("Jack"))
+                .body("id[3]", is("4"));
+    }
+
+    @Test
+    void validPostToMoviesEndpoint() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "id": "10",
+                          "director": {
+                            "name": "Jim",
+                            "surname": "White"
+                          },
+                          "released": false
+                        }
+                        """)
+                .post("/movies")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    void invalidPostToMoviesEndpoint() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "id": "10",
+                          "director": {
+                            "name": "",
+                            "surname": "White"
+                          },
+                          "released": false
+                        }
+                        """)
+                .post("/movies")
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(containsString("Name may not be blank"));
+    }
+}

--- a/http/hibernate-validator/src/test/java/io/quarkus/ts/http/hibernate/validator/sources/MoviesResource.java
+++ b/http/hibernate-validator/src/test/java/io/quarkus/ts/http/hibernate/validator/sources/MoviesResource.java
@@ -1,0 +1,52 @@
+package io.quarkus.ts.http.hibernate.validator.sources;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+@Path("/movies")
+public class MoviesResource {
+
+    public record Director(
+            @NotBlank(message = "Name may not be blank") @Size(min = 1, max = 20) String name,
+            @NotBlank(message = "Surname may not be blank") @Size(max = 20) String surname) {
+    }
+
+    public record Movie(
+            @NotBlank(message = "ID may not be blank") String id,
+            @Valid Director director,
+            Boolean released) {
+    }
+
+    private List<Movie> movies = List.of(
+            new Movie("1", new Director("John", "Wick"), true),
+            new Movie("2", new Director("Mary", "Poppins"), false),
+            new Movie("3", new Director("Jack", "Sparrow"), true),
+            new Movie("4", null, false));
+
+    @GET
+    public List<Movie> getMovies() {
+        return movies;
+    }
+
+    @GET
+    @Path("/{id}")
+    public Movie getMovie(@PathParam("id") String id) {
+        return movies
+                .stream()
+                .filter(s -> s.id().equals(id))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Not found"));
+    }
+
+    @POST
+    public Movie addMovie(@Valid Movie movie) {
+        return movie;
+    }
+}

--- a/http/http-advanced-reactive/pom.xml
+++ b/http/http-advanced-reactive/pom.xml
@@ -52,8 +52,8 @@
             <artifactId>quarkus-keycloak-authorization</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
         <dependency>
             <groupId>com.aayushatharva.brotli4j</groupId>

--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/records/CheeseResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/records/CheeseResource.java
@@ -1,0 +1,131 @@
+package io.quarkus.ts.http.advanced.reactive.records;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+import org.jboss.resteasy.reactive.RestCookie;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.RestHeader;
+import org.jboss.resteasy.reactive.RestMatrix;
+import org.jboss.resteasy.reactive.RestPath;
+import org.jboss.resteasy.reactive.RestQuery;
+
+@Path("/cheese")
+public class CheeseResource {
+    @GET
+    @Path("/quarkus/{type}")
+    public String paramQuarkus(ParametersQuarkus p, @RestHeader String headerParam) {
+        return headerParam + "/" + p;
+    }
+
+    @GET
+    @Path("/spec/{type}")
+    public String paramSpec(ParametersSpec p, @HeaderParam("Header-Param") String headerParam) {
+        return headerParam + "/" + p;
+    }
+
+    @GET
+    @Path("/class/{type}")
+    public String paramClass(ParametersClass p, @RestHeader String headerParam) {
+        return headerParam + "/" + p;
+    }
+
+    @POST
+    @Path("/quarkus/{type}")
+    public String paramQuarkusPost(@Valid ParametersQuarkus p, @RestHeader String headerParam) {
+        return headerParam + "/" + p;
+    }
+
+    @POST
+    @Path("/spec/{type}")
+    public String paramSpecPost(@Valid ParametersSpec p, @HeaderParam("Header-Param") String headerParam) {
+        return headerParam + "/" + p;
+    }
+
+    @POST
+    @Path("/class/{type}")
+    public String paramClassPost(@Valid ParametersClass p, @RestHeader String headerParam) {
+        return headerParam + "/" + p;
+    }
+
+    public record ParametersQuarkus(
+            @RestPath String type,
+            @RestMatrix String variant,
+            @RestQuery String age,
+            @NotBlank(message = "Level may not be blank") @RestCookie String level,
+            @RestHeader("X-Cheese-Secret-Handshake") String secretHandshake,
+            @RestForm String smell,
+            AgeRecord ar,
+            AgeClass ac) {
+    }
+
+    public record ParametersSpec(
+            @PathParam("type") String type,
+            @MatrixParam("variant") String variant,
+            @QueryParam("age") String age,
+            @NotBlank(message = "Level may not be blank") @CookieParam("level") @NotBlank String level,
+            @HeaderParam("X-Cheese-Secret-Handshake") String secretHandshake,
+            @FormParam("smell") String smell,
+            AgeRecord ar,
+            AgeClass ac) {
+    }
+
+    public static class ParametersClass {
+        @RestPath
+        String type;
+        @RestMatrix
+        String variant;
+        @RestQuery
+        String age;
+        @NotBlank(message = "Level may not be blank")
+        @RestCookie
+        String level;
+        @RestHeader("X-Cheese-Secret-Handshake")
+        String secretHandshake;
+        @RestForm
+        String smell;
+        @BeanParam
+        AgeRecord ar;
+        @BeanParam
+        AgeClass ac;
+
+        @Override
+        public String toString() {
+            return "ParametersClass{" +
+                    "type=" + type +
+                    ", variant=" + variant +
+                    ", age=" + age +
+                    ", level=" + level +
+                    ", secretHandshake=" + secretHandshake +
+                    ", smell=" + smell +
+                    ", ar=" + ar +
+                    ", ac=" + ac +
+                    '}';
+        }
+    }
+
+    public record AgeRecord(@RestQuery String age) {
+    }
+
+    public static class AgeClass {
+        @RestQuery
+        String age;
+
+        @Override
+        public String toString() {
+            return "AgeClass{" +
+                    "age=" + age +
+                    '}';
+        }
+    }
+}

--- a/http/http-advanced-reactive/src/main/resources/application.properties
+++ b/http/http-advanced-reactive/src/main/resources/application.properties
@@ -52,6 +52,8 @@ quarkus.keycloak.policy-enforcer.paths.intercepted.path=/api/intercepted*
 quarkus.keycloak.policy-enforcer.paths.intercepted.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.sse.path=/api/sse/*
 quarkus.keycloak.policy-enforcer.paths.sse.enforcement-mode=DISABLED
+quarkus.keycloak.policy-enforcer.paths.cheese.path=/api/cheese/*
+quarkus.keycloak.policy-enforcer.paths.cheese.enforcement-mode=DISABLED
 quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 # tolerate 1 minute of clock skew between the Keycloak server and the application


### PR DESCRIPTION
### Summary

Part 2 of work for https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-5621.md
Part 1: https://github.com/quarkus-qe/quarkus-test-suite/pull/2357

`http/http-advanced-reactive`
 * Covering grouping parameters in a custom class and Java Records
   * Quarkus REST specific functionality, not available in Quarkus RESTEasy
 * Covering all the HTTP request parameter annotations 
   * https://quarkus.io/guides/rest#accessing-request-parameters
 * Includes validation of provided parameter

`http/hibernate-validator`
 * Hibernate Validator and Java Records
 * OpenAPI schema checks for the validation rules

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)