### PR TITLE
[3.20] Change Quarkus CLI update test to match supported streams

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli38to320UpdateIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli38to320UpdateIT.java
@@ -16,16 +16,16 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
 
 @Tag("quarkus-cli")
-public class QuarkusCli35to315UpdateIT extends AbstractQuarkusCliUpdateIT {
-    private static final DefaultArtifactVersion oldVersion = new DefaultArtifactVersion("3.2");
-    private static final DefaultArtifactVersion newVersion = new DefaultArtifactVersion("3.15");
+public class QuarkusCli38to320UpdateIT extends AbstractQuarkusCliUpdateIT {
+    private static final DefaultArtifactVersion oldVersion = new DefaultArtifactVersion("3.8");
+    private static final DefaultArtifactVersion newVersion = new DefaultArtifactVersion("3.20");
 
-    public QuarkusCli35to315UpdateIT() {
+    public QuarkusCli38to320UpdateIT() {
         super(oldVersion, newVersion);
     }
 
     /**
-     * Test that updating from Quarkus 3.2 to 3.15 correctly transforms
+     * Test that updating from Quarkus 3.8 to 3.20 correctly transforms
      * the 'quarkus-rest-client-reactive-jackson' extension to 'quarkus-rest-client-jackson',
      * and does not incorrectly transform it to 'quarkus-resteasy-client-jackson'.
      * This test addresses a specific issue where the update recipes could apply in the wrong order,


### PR DESCRIPTION
### Summary

We cannot support update from unsupported 3.2 stream, test should be updated to match supported streams at the moment when 3.20 will be released

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)