### PR TITLE
Set fail-fast to false in CI for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
     timeout-minutes: 240
     needs: [linux-validate-format, prepare-jvm-native-latest-modules-mvn-param]
     strategy:
+      fail-fast: false
       matrix:
         java: [ 17 ]
         module-mvn-args: ${{ fromJSON(needs.prepare-jvm-native-latest-modules-mvn-param.outputs.JVM_MODULES_MAVEN_PARAM) }}
@@ -181,6 +182,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [linux-validate-format, prepare-jvm-native-latest-modules-mvn-param]
     strategy:
+      fail-fast: false
       matrix:
         java: [ 17 ]
         module-mvn-args: ${{ fromJSON(needs.prepare-jvm-native-latest-modules-mvn-param.outputs.NATIVE_MODULES_MAVEN_PARAM) }}
@@ -235,6 +237,7 @@ jobs:
     runs-on: windows-latest
     needs: [linux-validate-format, prepare-jvm-native-latest-modules-mvn-param]
     strategy:
+      fail-fast: false
       matrix:
         java: [ 17 ]
         module-mvn-args: ${{ fromJSON(needs.prepare-jvm-native-latest-modules-mvn-param.outputs.JVM_MODULES_MAVEN_PARAM) }}


### PR DESCRIPTION
### Summary

Similar thing was done in quarkus-qe/quarkus-test-suite#2299
Advantage of this is that we will see all the error on the first run instead of one faster job fail and end all other jobs. Mainly the native part when updating the `pom.xml`.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)