### PR TITLE
Add coverage for QUARKUS-5477 (Add OIDC Client SPI)

### DIFF
--- a/security/keycloak-oidc-client-basic/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/basic/DefaultRoleResource.java
+++ b/security/keycloak-oidc-client-basic/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/basic/DefaultRoleResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.security.keycloak.oidcclient.basic;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.quarkus.security.identity.SecurityIdentity;
+
+@Path("/default")
+@RolesAllowed("default-roles-test-realm")
+public class DefaultRoleResource {
+
+    @Inject
+    SecurityIdentity identity;
+
+    @GET
+    public String get() {
+        return "Hello, user " + identity.getPrincipal().getName();
+    }
+}

--- a/security/keycloak-oidc-client-basic/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/basic/TokenProviderResource.java
+++ b/security/keycloak-oidc-client-basic/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/basic/TokenProviderResource.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.Path;
 
 import io.quarkus.oidc.client.OidcClient;
 import io.quarkus.oidc.client.OidcClients;
+import io.quarkus.oidc.client.spi.TokenProvider;
 
 @Path("/generate-token")
 public class TokenProviderResource {
@@ -14,6 +15,9 @@ public class TokenProviderResource {
 
     @Inject
     OidcClients allOidcClients;
+
+    @Inject
+    TokenProvider tokenProvider;
 
     @GET
     @Path("/client-credentials")
@@ -38,6 +42,12 @@ public class TokenProviderResource {
     @Path("/admin-user-password")
     public String getTokenUsingAdminUserPasswordGrant() {
         return generateToken(allOidcClients.getClient("admin-user"));
+    }
+
+    @GET
+    @Path("/token-provider")
+    public String getTokenUsingTokenProvider() {
+        return tokenProvider.getAccessToken().await().indefinitely();
     }
 
     private String generateToken(OidcClient client) {

--- a/security/keycloak-oidc-client-basic/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client-basic/src/main/resources/application.properties
@@ -3,8 +3,8 @@
 quarkus.oidc.auth-server-url=${KEYCLOAK_HTTP_URL:http://localhost:8180}/auth/realms/test-realm
 quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
-# tolerate 1 minute of clock skew between the Keycloak server and the application
-quarkus.oidc.token.lifespan-grace=60
+# tolerate 5 seconds of clock skew between the Keycloak server and the application
+quarkus.oidc.token.lifespan-grace=5
 # OIDC Client Configuration
 quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.client-id=test-application-client

--- a/security/keycloak-oidc-client-basic/src/test/resources/test-realm-realm.json
+++ b/security/keycloak-oidc-client-basic/src/test/resources/test-realm-realm.json
@@ -1,5 +1,6 @@
 {
   "realm": "test-realm",
+  "accessTokenLifespan": 5,
   "enabled": true,
   "sslRequired": "none",
   "roles": {

--- a/security/keycloak-oidc-client-reactive-basic/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/DefaultRoleResource.java
+++ b/security/keycloak-oidc-client-reactive-basic/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/DefaultRoleResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.basic;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.quarkus.security.identity.SecurityIdentity;
+
+@Path("/default")
+@RolesAllowed("default-roles-test-realm")
+public class DefaultRoleResource {
+
+    @Inject
+    SecurityIdentity identity;
+
+    @GET
+    public String get() {
+        return "Hello, user " + identity.getPrincipal().getName();
+    }
+}

--- a/security/keycloak-oidc-client-reactive-basic/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/TokenProviderResource.java
+++ b/security/keycloak-oidc-client-reactive-basic/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/TokenProviderResource.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.Path;
 
 import io.quarkus.oidc.client.OidcClient;
 import io.quarkus.oidc.client.OidcClients;
+import io.quarkus.oidc.client.spi.TokenProvider;
 
 @Path("/generate-token")
 public class TokenProviderResource {
@@ -14,6 +15,9 @@ public class TokenProviderResource {
 
     @Inject
     OidcClients allOidcClients;
+
+    @Inject
+    TokenProvider tokenProvider;
 
     @GET
     @Path("/client-credentials")
@@ -38,6 +42,12 @@ public class TokenProviderResource {
     @Path("/admin-user-password")
     public String getTokenUsingAdminUserPasswordGrant() {
         return generateToken(allOidcClients.getClient("admin-user"));
+    }
+
+    @GET
+    @Path("/token-provider")
+    public String getTokenUsingTokenProvider() {
+        return tokenProvider.getAccessToken().await().indefinitely();
     }
 
     private String generateToken(OidcClient client) {

--- a/security/keycloak-oidc-client-reactive-basic/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client-reactive-basic/src/main/resources/application.properties
@@ -3,12 +3,15 @@
 quarkus.oidc.auth-server-url=${KEYCLOAK_HTTP_URL:http://localhost:8180}/auth/realms/test-realm
 quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
-# tolerate 1 minute of clock skew between the Keycloak server and the application
-quarkus.oidc.token.lifespan-grace=60
+# tolerate 5 seconds of clock skew between the Keycloak server and the application
+quarkus.oidc.token.lifespan-grace=5
 # OIDC Client Configuration
 quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.client-id=test-application-client
 quarkus.oidc-client.credentials.secret=test-application-client-secret
+quarkus.oidc-client.grant.type=password
+quarkus.oidc-client.grant-options.password.username=test-default-user
+quarkus.oidc-client.grant-options.password.password=test-default-user
 ## Normal User Password
 quarkus.oidc-client.normal-user.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.normal-user.client-id=test-application-client

--- a/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/BaseOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/BaseOidcClientSecurityIT.java
@@ -3,7 +3,10 @@ package io.quarkus.ts.security.keycloak.oidcclient.reactive.basic;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.http.HttpStatus;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -20,7 +23,7 @@ public abstract class BaseOidcClientSecurityIT {
                 .get("/secured")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body(equalTo("Hello, user service-account-test-application-client"));
+                .body(equalTo("Hello, user test-default-user"));
     }
 
     @Test
@@ -89,6 +92,58 @@ public abstract class BaseOidcClientSecurityIT {
     }
 
     @Test
+    public void tokenProviderCheckExpirationAndAccess() throws InterruptedException {
+        String token = TokenProviderMethod.TOKEN_PROVIDER.getToken(getApp());
+
+        getApp().given()
+                .when()
+                .auth().preemptive().oauth2(token)
+                .get("/default")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo("Hello, user test-default-user"));
+
+        // Wait until the token expire the 5s expiration time + 5s set via quarkus.oidc.token.lifespan-grace
+        Awaitility.await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> {
+            getApp().given()
+                    .when()
+                    .auth().preemptive().oauth2(token)
+                    .get("/default")
+                    .then()
+                    .statusCode(HttpStatus.SC_UNAUTHORIZED);
+        });
+
+        // Check if the TokenProvider using refreshed token
+        getApp().given()
+                .when()
+                .auth().preemptive().oauth2(TokenProviderMethod.TOKEN_PROVIDER.getToken(getApp()))
+                .get("/default")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo("Hello, user test-default-user"));
+    }
+
+    @Test
+    public void defaultTokenProviderAdminResource() {
+        getApp().given()
+                .when()
+                .auth().preemptive().oauth2(TokenProviderMethod.TOKEN_PROVIDER.getToken(getApp()))
+                .get("/admin")
+                .then()
+                .statusCode(HttpStatus.SC_FORBIDDEN);
+    }
+
+    @Test
+    public void defaultTokenProviderUserResource() {
+        getApp().given()
+                .when()
+                .auth().preemptive().oauth2(TokenProviderMethod.TOKEN_PROVIDER.getToken(getApp()))
+                .get("/user")
+                .then()
+                .statusCode(HttpStatus.SC_FORBIDDEN);
+    }
+
+    @Test
     public void noUserSecuredResource() {
         getApp().given()
                 .when()
@@ -119,7 +174,8 @@ public abstract class BaseOidcClientSecurityIT {
         CLIENT_CREDENTIALS("client-credentials"),
         JWT("jwt-secret"),
         NORMAL_USER("normal-user-password"),
-        ADMIN_USER("admin-user-password");
+        ADMIN_USER("admin-user-password"),
+        TOKEN_PROVIDER("token-provider");
 
         private final String path;
 

--- a/security/keycloak-oidc-client-reactive-basic/src/test/resources/test-realm-realm.json
+++ b/security/keycloak-oidc-client-reactive-basic/src/test/resources/test-realm-realm.json
@@ -1,5 +1,6 @@
 {
   "realm": "test-realm",
+  "accessTokenLifespan": 5,
   "enabled": true,
   "sslRequired": "none",
   "roles": {
@@ -55,6 +56,28 @@
       "realmRoles": [
         "test-admin-role",
         "test-user-role",
+        "uma_protection"
+      ]
+    },
+    {
+      "username": "test-default-user",
+      "email": "test-default-user@localhost",
+      "firstName": "test-default-user",
+      "lastName": "test-default-user",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test-default-user"
+        }
+      ],
+      "clientRoles": {
+        "test-application-client": [
+          "uma_protection"
+        ]
+      },
+      "realmRoles": [
+        "default-roles-test-realm",
         "uma_protection"
       ]
     }


### PR DESCRIPTION
### Summary

Adding coverage for https://issues.redhat.com/browse/QUARKUS-5477

TP: https://github.com/quarkus-qe/quarkus-test-plans/pull/209

This PR adding the coverage for `TokenProvider`. 

The test are similar in both modules only the `security/keycloak-oidc-client-basic` check the functionality when `quarkus.oidc-client.grant.type` is not set and  the service acount (default) is used.
In case of `security/keycloak-oidc-client-reactive-basic` the default user is created and set `quarkus.oidc-client.grant.type=password` with `grant-options` for default user

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)