### PR TITLE
[3.20] Bump Quarkus QE Test Framework to 1.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.20.999-SNAPSHOT</quarkus.platform.version>
         <quarkus.ide.version>3.20.0</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.6.1</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.6.2</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.7.1</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.25.0</formatter-maven-plugin.version>


### PR DESCRIPTION
### Summary

Bumps Quarkus QE Test Framework to 1.6.z, this should fix RHBQ CLI test scenarios.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)