### PR TITLE
Revert "Disable testGrpcDevUIServicesView tests due to regression in upstream"

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeGrpcIntegrationReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeGrpcIntegrationReactiveIT.java
@@ -10,7 +10,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -75,7 +74,6 @@ public class DevModeGrpcIntegrationReactiveIT {
     }
 
     @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/47138")
     public void testGrpcDevUIServicesView() {
         assertOnGrpcServicePage(page -> {
             var grpcSvcView = page.waitForSelector("#page > qwc-grpc-services > vaadin-grid").innerText();

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeGrpcIntegrationIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeGrpcIntegrationIT.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.function.Consumer;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -73,7 +72,6 @@ public class DevModeGrpcIntegrationIT {
     }
 
     @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/47138")
     public void testGrpcDevUIServicesView() {
         assertOnGrpcServicePage(page -> {
             var grpcSvcViewGrid = page.waitForSelector("#page > qwc-grpc-services > vaadin-grid").innerText();


### PR DESCRIPTION
Revert "Disable testGrpcDevUIServicesView tests due to regression in upstream"

https://github.com/quarkusio/quarkus/issues/47138 should be fixed

This reverts commit c9b119b6146b843d5c4a78b8c36ebf880461ef3d.

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)