### PR TITLE
Bump Keycloak image to 26.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
                                 <infinispan.image>quay.io/infinispan/server:15.0</infinispan.image>
                                 <infinispan.expected-log>Infinispan Server.*started in</infinispan.expected-log>
                                 <spring.cloud.server.image>quay.io/quarkusqeteam/spring-cloud-config-server:4.1</spring.cloud.server.image>
-                                <keycloak.image>quay.io/keycloak/keycloak:26.0</keycloak.image>
+                                <keycloak.image>quay.io/keycloak/keycloak:26.1</keycloak.image>
                                 <bouncycastle.bctls-fips.version>1.0.12.2</bouncycastle.bctls-fips.version>
                                 <rhbk.image>${rhbk.image}</rhbk.image>
                             </systemPropertyVariables>


### PR DESCRIPTION
### Summary

Bumping Keycloak to 26.1 to align with Quarkus and FW (https://github.com/quarkus-qe/quarkus-test-framework/pull/1558)

The RHBK (`registry.redhat.io/rhbk/keycloak-rhel9:26.0`) don't need to be updated as the latest is used

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)