### PR TITLE
Misc improvements - GH Actions and QuarkusCliCompletionIT

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -211,13 +211,13 @@ jobs:
       - name: Zip Artifacts
         if: failure()
         run: |
-          zip -R artifacts-jvm${{ matrix.java }}.zip '*-reports/*'
+          zip -R artifacts-linux-aarch64-jvm${{ matrix.java }}.zip '*-reports/*'
       - name: Archive artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-linux-jvm${{ matrix.java }}
-          path: artifacts-jvm${{ matrix.java }}.zip
+          name: artifacts-linux-aarch64-jvm${{ matrix.java }}
+          path: artifacts-linux-aarch64-jvm${{ matrix.java }}.zip
   aarch64-linux-build-native-latest:
     name: Linux AArch64 Native
     runs-on: ubuntu-24.04-arm
@@ -259,10 +259,10 @@ jobs:
       - name: Zip Artifacts
         if: failure()
         run: |
-          zip -R artifacts-native${{ matrix.java }}.zip '*-reports/*'
+          zip -R artifacts-linux-aarch64-native${{ matrix.java }}.zip '*-reports/*'
       - name: Archive artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-linux-native${{ matrix.java }}
-          path: artifacts-native${{ matrix.java }}.zip
+          name: artifacts-linux-aarch64-native${{ matrix.java }}
+          path: artifacts-linux-aarch64-native${{ matrix.java }}.zip

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -2,7 +2,7 @@ name: "Daily Build"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '03 0 * * *'
 jobs:
   linux-build-jvm-latest:
     name: Linux JVM

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCompletionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCompletionIT.java
@@ -17,14 +17,14 @@ import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 @DisabledOnNative(reason = "Only for JVM verification")
 public class QuarkusCliCompletionIT {
 
-    static final String EXPECTED_COMPLETION_OUTPUT = "Generates completions for the options and subcommands";
+    static final String EXPECTED_COMPLETION_OUTPUT = "Generate bash/zsh completion script for quarkus";
 
     @Inject
     static QuarkusCliClient cliClient;
 
     @Test
     public void shouldConfigureCompletion() {
-        QuarkusCliClient.Result result = cliClient.run("completion");
+        QuarkusCliClient.Result result = cliClient.run("completion", "--help");
 
         assertTrue(result.isSuccessful(), "Completion command failed: " + result.getOutput());
         assertTrue(result.getOutput().contains(EXPECTED_COMPLETION_OUTPUT), "Unexpected output: " + result.getOutput());


### PR DESCRIPTION
### Summary
 * Start daily GH Actions 2.5 hours earlier
 * Simplify QuarkusCliCompletionIT to be less log verbose 
   * Completion help command produces 12 lines, completion command produces 3096 lines
 * Use unique archive names for AArch64 runs
   * Artifacts are not archived properly when name collision occurs

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)