### PR TITLE
[3.20] Disable DevModeKafkaProcessorIT on Windows when run with RHBQ

### DIFF
--- a/messaging/kafka-processor/src/test/java/io/quarkus/ts/messaging/kafka/processor/DevModeKafkaProcessorIT.java
+++ b/messaging/kafka-processor/src/test/java/io/quarkus/ts/messaging/kafka/processor/DevModeKafkaProcessorIT.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnRHBQandWindows;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.ts.messaging.kafka.processor.decorator.HeaderDecorator;
 
+@DisabledOnRHBQandWindows(reason = "QUARKUS-3434")
 @Tag("QUARKUS-5178")
 @QuarkusScenario
 public class DevModeKafkaProcessorIT {


### PR DESCRIPTION
### Summary

Disables `DevModeKafkaProcessorIT` when it is run on Windows with RHBQ as it fails due to known issue. I don't want to do it on the main branch because this failure prompts us to update linked Quarkus ticket when processing new Quarkus streams. However I acknowledge that it is matter of opinion...

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)