### PR TITLE
Adding test coverage for QUARKUS-5857 WebSockets Next send authorization headers from web browsers using JS clients

### DIFF
--- a/websockets/websocket-next-oidc/src/main/resources/application.properties
+++ b/websockets/websocket-next-oidc/src/main/resources/application.properties
@@ -6,3 +6,8 @@ quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 # tolerate 1 minute of clock skew between the Keycloak server and the application
 quarkus.oidc.token.lifespan-grace=60
+quarkus.websockets-next.server.supported-subprotocols=bearer-token-carrier
+quarkus.websockets-next.server.propagate-subprotocol-headers=true
+# Configure TLS/SSL to use WSS
+quarkus.http.insecure-requests=enabled
+quarkus.tls.trust-all=true

--- a/websockets/websocket-next-oidc/src/test/java/io/quarkuss/ts/websocketNext/VertxWebSocketClientIT.java
+++ b/websockets/websocket-next-oidc/src/test/java/io/quarkuss/ts/websocketNext/VertxWebSocketClientIT.java
@@ -1,0 +1,149 @@
+package io.quarkuss.ts.websocketNext;
+
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KeycloakContainer;
+import io.quarkus.test.services.QuarkusApplication;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.http.WebSocketConnectOptions;
+
+@QuarkusScenario
+public class VertxWebSocketClientIT {
+    private static final Logger LOGGER = Logger.getLogger(VertxWebSocketClientIT.class);
+    private static final String ADMIN_USERNAME = "charlie";
+    private static final String ADMIN_PASSWORD = "random";
+    private static Vertx vertx;
+
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+
+    @QuarkusApplication(ssl = true)
+    static final RestService server = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
+
+    @BeforeAll
+    static void setup() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (vertx != null) {
+            vertx.close();
+        }
+    }
+
+    private String getBearerToken(String username, String password) {
+        return keycloak.createAuthzClient("test-application-client", "test-application-client-secret")
+                .obtainAccessToken(username, password).getToken();
+    }
+
+    private URI getEndpointUri(String path, Protocol protocol) {
+        try {
+            return new URI(server.getURI(protocol).toString()).resolve(path);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Invalid uri " + e);
+        }
+    }
+
+    @Test
+    void successfulAuthorizationWithHeader() throws InterruptedException {
+        String token = getBearerToken(ADMIN_USERNAME, ADMIN_PASSWORD);
+        URI wsUri = getEndpointUri("/bearer", Protocol.WS);
+
+        WebSocketClient webSocketClient = vertx.createWebSocketClient();
+
+        WebSocketConnectOptions options = new WebSocketConnectOptions()
+                .setHost(wsUri.getHost())
+                .setPort(wsUri.getPort())
+                .setURI(wsUri.getPath())
+                .addHeader("Authorization", "Bearer " + token);
+        CountDownLatch connectionLatch = new CountDownLatch(1);
+        CountDownLatch messageLatch = new CountDownLatch(1);
+        AtomicReference<String> receivedMessage = new AtomicReference<>();
+        List<String> allMessages = new ArrayList<>();
+
+        webSocketClient.connect(options).onComplete(asyncResult -> {
+            if (asyncResult.succeeded()) {
+                WebSocket ws = asyncResult.result();
+                LOGGER.info("WebSocket connection established successfully");
+                connectionLatch.countDown();
+
+                ws.textMessageHandler(message -> {
+                    LOGGER.info("Message received: " + message);
+                    receivedMessage.set(message);
+                    allMessages.add(message);
+                    messageLatch.countDown();
+                    ws.close();
+                });
+
+                ws.writeTextMessage("Test message from Vertx client");
+            } else {
+                LOGGER.error("Error connecting: " + asyncResult.cause().getMessage());
+                connectionLatch.countDown();
+            }
+        });
+
+        assertTrue(connectionLatch.await(5, TimeUnit.SECONDS), "Should establish connection within timeout");
+        assertTrue(messageLatch.await(5, TimeUnit.SECONDS), "Should receive response within timeout");
+
+        String message = receivedMessage.get();
+        assertNotNull(message, "Received message shouldn't be null");
+        assertTrue(message.contains(ADMIN_USERNAME),
+                "Message should contain the authenticated username: " + message);
+    }
+
+    @Test
+    void failedAuthenticationWithoutHeader() throws InterruptedException {
+        URI wsUri = getEndpointUri("/bearer", Protocol.WS);
+
+        WebSocketClient client = vertx.createWebSocketClient();
+
+        WebSocketConnectOptions options = new WebSocketConnectOptions()
+                .setHost(wsUri.getHost())
+                .setPort(wsUri.getPort())
+                .setURI(wsUri.getPath());
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Boolean> connectionSuccess = new AtomicReference<>(false);
+
+        client.connect(options).onComplete(ar -> {
+            if (ar.succeeded()) {
+                LOGGER.warn("Connection unexpectedly established without authorization");
+                connectionSuccess.set(true);
+            } else {
+                LOGGER.info("Connection rejected as expected: " + ar.cause().getMessage());
+                connectionSuccess.set(false);
+            }
+            latch.countDown();
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertFalse(connectionSuccess.get(), "Connection shouldn't be established without authorization");
+    }
+
+}

--- a/websockets/websocket-next-oidc/src/test/java/io/quarkuss/ts/websocketNext/WebSocketNextBrowserAuthorizationIT.java
+++ b/websockets/websocket-next-oidc/src/test/java/io/quarkuss/ts/websocketNext/WebSocketNextBrowserAuthorizationIT.java
@@ -1,0 +1,402 @@
+package io.quarkuss.ts.websocketNext;
+
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.KeycloakContainer;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.URILike;
+
+@QuarkusScenario
+public class WebSocketNextBrowserAuthorizationIT {
+
+    private static final String ADMIN_USERNAME = "charlie";
+    private static final String ADMIN_PASSWORD = "random";
+    private static final String USER_USERNAME = "albert";
+    private static final String USER_PASSWORD = "einstein";
+    private ObjectMapper objectMapper;
+    private static Playwright playwright;
+    private static Browser browser;
+    private BrowserContext browserContext;
+    private Page page;
+    private URILike wsBaseUri;
+    private URILike wssBaseUri;
+
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+
+    @QuarkusApplication(ssl = true, certificates = {
+            @Certificate(configureKeystore = true, configureTruststore = true, useTlsRegistry = false, configureHttpServer = true)
+    })
+    static final RestService server = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
+
+    @BeforeAll
+    static void launchBrowser() {
+        playwright = Playwright.create();
+        browser = playwright.chromium().launch(new BrowserType.LaunchOptions()
+                .setHeadless(true));
+    }
+
+    @BeforeEach
+    void setWsBaseUri() {
+        Browser.NewContextOptions options = new Browser.NewContextOptions()
+                .setIgnoreHTTPSErrors(true);
+        browserContext = browser.newContext(options);
+        page = browserContext.newPage();
+        wsBaseUri = server.getURI(Protocol.WS);
+        wssBaseUri = server.getURI(Protocol.WSS);
+        if (objectMapper == null) {
+            objectMapper = new ObjectMapper();
+        }
+    }
+
+    @AfterEach
+    void teardownEach() {
+        if (browserContext != null) {
+            browserContext.close();
+        }
+    }
+
+    @AfterAll
+    static void closeBrowser() {
+        if (browser != null) {
+            browser.close();
+        }
+        if (playwright != null) {
+            playwright.close();
+        }
+    }
+
+    private String getBearerToken(String username, String password) {
+        return keycloak.createAuthzClient("test-application-client", "test-application-client-secret")
+                .obtainAccessToken(username, password).getToken();
+    }
+
+    private String getEncodedAuthSubprotocol(String username, String password) {
+        String token = getBearerToken(username, password);
+        String subprotocol = "quarkus-http-upgrade#Authorization#Bearer " + token;
+        return URLEncoder.encode(subprotocol, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Convert JavaScript evaluation result to a typed Map using jackson.databind.ObjectMapper
+     */
+    private <T> T evaluateAndConvert(String script, Object[] args, TypeReference<T> typeRef) {
+
+        Object rawResult = page.evaluate(script, args);
+
+        if (rawResult == null) {
+            return null;
+        }
+
+        // Convert the result
+        return objectMapper.convertValue(rawResult, typeRef);
+    }
+
+    @Test
+    void successfulAuthorizationAndSubprotocolNegotiationWSS() {
+        // Encoding is necessary to avoid issues with special characters
+        String encodedSubprotocol = getEncodedAuthSubprotocol(ADMIN_USERNAME, ADMIN_PASSWORD);
+        String wssUrl = wssBaseUri.withPath("/bearer").toString();
+
+        Map<String, Object> result = evaluateAndConvert(
+                """
+                        // This JS function establishes a secure WebSocket connection using 2 subbprotocols 'bearer-token-carrier'
+                        // and the subprotocol with the encoded authorization
+                        ([wssUrl, subprotocol]) => {
+                            return new Promise((resolve, reject) => {
+                                try {
+                                    const ws = new WebSocket(wssUrl, ['bearer-token-carrier', subprotocol]);
+                                    let messages = [];
+                                    ws.onopen = () => {
+                                        // Store the protocol directly when connection opens
+                                        const negotiatedProtocol = ws.protocol;
+                                        console.log("Negotiated protocol:", negotiatedProtocol);
+                                        ws.send('Hello server');
+                                    };
+                                    ws.onmessage = (event) => {
+                                        messages.push(event.data);
+                                        if (messages.length === 1) {
+                                            setTimeout(() => {
+                                                // Include the protocol in the result object
+                                                resolve({
+                                                    status: 'open',
+                                                    messages: messages,
+                                                    protocol: ws.protocol
+                                                });
+                                                ws.close();
+                                            }, 1000);
+                                        }
+                                    };
+                                    ws.onerror = () => resolve({ status: 'error' });
+                                    ws.onclose = (event) => {
+                                        if (messages.length === 0) {
+                                            resolve({ status: 'closed', code: event.code });
+                                        }
+                                    };
+                                } catch(e) {
+                                    reject(e.message);
+                                }
+                            });
+                        }
+                        """,
+                new Object[] { wssUrl, encodedSubprotocol },
+                new TypeReference<>() {
+                });
+
+        assert result != null;
+        assertEquals("open", result.get("status"), "WebSocket connection should be open with valid token");
+
+        // Verify that the correct protocol has been negotiated
+        String negotiatedProtocol = (String) result.get("protocol");
+        assertTrue(negotiatedProtocol != null && !negotiatedProtocol.isEmpty(),
+                "Server should negotiate a protocol");
+        assertEquals("bearer-token-carrier", negotiatedProtocol,
+                "Server should select 'bearer-token-carrier' protocol");
+
+        List<String> messages = objectMapper.convertValue(result.get("messages"), new TypeReference<>() {
+        });
+        assertTrue(messages != null && !messages.isEmpty(), "Should receive at least one message");
+    }
+
+    @Test
+    void successfulAuthorizationWS() {
+        String encodedSubprotocol = getEncodedAuthSubprotocol(ADMIN_USERNAME, ADMIN_PASSWORD);
+        String wsUrl = wsBaseUri.withPath("/bearer").toString();
+
+        Map<String, Object> result = evaluateAndConvert(
+                """
+                        ([wsUrl, subprotocol]) => {
+                            return new Promise((resolve, reject) => {
+                                try {
+                                    const ws = new WebSocket(wsUrl, ['bearer-token-carrier', subprotocol]);
+                                    ws.onopen = () => {
+                                        setTimeout(() => {
+                                            resolve({ status: 'open' });
+                                            ws.close();
+                                        }, 1000);
+                                    };
+                                    ws.onerror = () => resolve({ status: 'error' });
+                                    ws.onclose = (event) => resolve({ status: 'closed', code: event.code });
+                                } catch(e) {
+                                    reject(e.message);
+                                }
+                            });
+                        }
+                        """,
+                new Object[] { wsUrl, encodedSubprotocol },
+                new TypeReference<>() {
+                });
+
+        assert result != null;
+        assertEquals("open", result.get("status"), "WebSocket connection should be open with valid token");
+    }
+
+    @Test
+    void failedAuthorizationWithoutSubprotocolWSS() {
+        String wssUrl = wssBaseUri.withPath("/bearer").toString();
+
+        Map<String, Object> result = evaluateAndConvert(
+                """
+                        (wsUrl) => {
+                                     return new Promise((resolve) => {
+                                           const ws = new WebSocket(wsUrl);
+                                           ws.onopen = () => {
+                                             setTimeout(() => {
+                                               resolve({ status: 'open' });
+                                               ws.close();
+                                             }, 1000);
+                                           };
+                                           ws.onerror = () => {};
+                                           ws.onclose = (closeEvent) => {
+                                             resolve({ status: 'error', code: closeEvent.code });
+                                           }
+                                         });
+                                        }
+                        """,
+                new Object[] { wssUrl },
+                new TypeReference<>() {
+                });
+
+        assert result != null;
+        assertEquals("error", result.get("status"), "Connection should fail without authorization");
+        assertEquals(1006, ((Number) result.get("code")).intValue(), "Expected error code for unauthorized connection");
+
+    }
+
+    @Test
+    void failedAuthenticationWithInvalidToken() {
+        String invalidToken = "invalid_token_format";
+        String wssUrl = wssBaseUri.withPath("/bearer").toString();
+
+        String subprotocol = "quarkus-http-upgrade#Authorization#Bearer " + invalidToken;
+        String encodedSubprotocol = URLEncoder.encode(subprotocol, StandardCharsets.UTF_8);
+
+        Map<String, Object> result = evaluateAndConvert(
+                """
+                        ([wsUrl, subprotocol]) => {
+                            return new Promise((resolve) => {
+                                const ws = new WebSocket(wsUrl, ['bearer-token-carrier', subprotocol]);
+                                ws.onopen = () => {
+                                    setTimeout(() => {
+                                        resolve({ status: 'open' });
+                                        ws.close();
+                                    }, 1000);
+                                };
+                                ws.onerror = () => {};
+                                ws.onclose = (closeEvent) => {
+                                    resolve({ status: 'error', code: closeEvent.code });
+                                };
+                            });
+                        }
+                        """,
+                new Object[] { wssUrl, encodedSubprotocol },
+                new TypeReference<>() {
+                });
+
+        assertEquals("error", result.get("status"), "Connection should fail with invalid token");
+        assertEquals(1006, ((Number) result.get("code")).intValue(), "Expected error code for invalid token");
+
+    }
+
+    @Test
+    void failedAuthorizationUnauthorizedToken() {
+        String encodedSubprotocol = getEncodedAuthSubprotocol(USER_USERNAME, USER_PASSWORD);
+        String wssUrl = wssBaseUri.withPath("/protected").toString();
+
+        Map<String, Object> result = evaluateAndConvert(
+                """
+                        ([wsUrl, subprotocol]) => {
+                            return new Promise((resolve) => {
+                                const ws = new WebSocket(wsUrl, ['bearer-token-carrier', subprotocol]);
+                                ws.onopen = () => {
+                                    setTimeout(() => {
+                                        resolve({ status: 'open' });
+                                        ws.close();
+                                    }, 1000);
+                                };
+                                ws.onerror = () => {};
+                                ws.onclose = (closeEvent) => {
+                                    resolve({ status: 'error', code: closeEvent.code });
+                                };
+                            });
+                        }
+                        """,
+                new Object[] { wssUrl, encodedSubprotocol },
+                new TypeReference<>() {
+                });
+
+        assert result != null;
+        assertEquals("error", result.get("status"), "Connection should fail with unauthorized token");
+        assertEquals(1006, ((Number) result.get("code")).intValue(), "Expected error code for unauthorized token");
+    }
+
+    @Test
+    void verifyCorrectHandlingPostSuccessfulAuthorization() {
+        final int MESSAGE_COUNT = 3;
+        final int TIMEOUT_MS = 5000;
+        String encodedSubprotocol = getEncodedAuthSubprotocol(ADMIN_USERNAME, ADMIN_PASSWORD);
+        String wssUrl = wssBaseUri.withPath("/bearer").toString();
+
+        Map<String, Object> result = evaluateAndConvert(
+                """
+                        // This function tests behavior after successful authorization
+                        // by sending multiple messages to verify stability
+                        ([wsUrl, subprotocol, expectedMessageCount, timeoutMs]) => {
+                            return new Promise((resolve, reject) => {
+                                const messages = [];
+                                let negotiatedProtocol = null;
+                                try {
+                                    const ws = new WebSocket(wsUrl, ['bearer-token-carrier', subprotocol]);
+                                    ws.onopen = () => {
+                                        // Store protocol when connection opens
+                                        negotiatedProtocol = ws.protocol;
+                                        console.log("Negotiated protocol:", negotiatedProtocol);
+                                        // Send multiple messages
+                                        ws.send('Message 1');
+                                        setTimeout(() => ws.send('Message 2'), 500);
+                                        setTimeout(() => ws.send('Message 3'), 1000);
+                                    };
+                                    ws.onmessage = (event) => {
+                                        messages.push(event.data);
+                                        // After the third message, close and resolve
+                                        if (messages.length === expectedMessageCount) {
+                                            setTimeout(() => {
+                                                resolve({
+                                                    status: 'success',
+                                                    messages: messages,
+                                                    protocol: negotiatedProtocol
+                                                });
+                                                ws.close();
+                                            }, 1000);
+                                        }
+                                    };
+                                    ws.onerror = () => reject({ status: 'error', message: 'Connection error' });
+                                    // Set a maximum wait time
+                                    setTimeout(() => {
+                                        if (messages.length < expectedMessageCount) {
+                                            resolve({
+                                                status: 'timeout',
+                                                messages: messages,
+                                                protocol: negotiatedProtocol
+                                            });
+                                            ws.close();
+                                        }
+                                    }, timeoutMs);
+                                } catch(e) {
+                                    reject({ status: 'error', message: e.message });
+                                }
+                            });
+                        }
+                        """,
+                new Object[] { wssUrl, encodedSubprotocol, MESSAGE_COUNT, TIMEOUT_MS },
+                new TypeReference<>() {
+                });
+
+        assert result != null;
+        assertEquals("success", result.get("status"), "WebSocket connection should remain stable after authentication");
+
+        List<String> messages = objectMapper.convertValue(result.get("messages"), new TypeReference<>() {
+        });
+        assertEquals(MESSAGE_COUNT, messages.size(), "Should receive all " + MESSAGE_COUNT + " sent messages");
+
+        for (String message : messages) {
+            assertTrue(message.contains(ADMIN_USERNAME),
+                    "Each message should contain the authenticated username: " + message);
+        }
+
+        // Verify that the negotiated protocol is as expected
+        String negotiatedProtocol = (String) result.get("protocol");
+        assertEquals("bearer-token-carrier", negotiatedProtocol,
+                "Server should select 'bearer-token-carrier' protocol");
+    }
+
+}


### PR DESCRIPTION
### Summary

Test coverage for https://issues.redhat.com/browse/QUARKUS-5857

Test Plan--> https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-5857.md 

This TD implements tests for sending authorization headers from web browsers using JavaScript clients with WebSockets Next. The tests verify that both browser-based with Playwright and programmatic clients can successfully authenticate using Bearer tokens via standard headers and Sec-WebSocket-Protocol.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)