### PR TITLE
Avoid SQL application module failures in FIPS-enabled environment as DB2 JDBC driver is not FIPS-compatible

### DIFF
--- a/sql-db/sql-app/pom.xml
+++ b/sql-db/sql-app/pom.xml
@@ -29,10 +29,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jdbc-db2</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-h2</artifactId>
         </dependency>
         <dependency>
@@ -62,6 +58,23 @@
         </dependency>
     </dependencies>
     <profiles>
+        <profile>
+            <id>test-quarkus-jdbc-db2</id>
+            <activation>
+                <!-- quarkus-jdbc-db2 is currently not supported in FIPS-enabled environment -->
+                <!-- TODO: drop this profile once https://github.com/IBM/Db2/issues/43 is fixed and move Quarkus JDBC D2 dependency to others -->
+                <property>
+                    <name>env.FIPS</name>
+                    <value>!fips</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-jdbc-db2</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
         <profile>
             <id>native</id>
             <activation>


### PR DESCRIPTION
### Summary

DB2 tests are not enabled in FIPS-enabled environment, but DB2 JDBC driver presence itself causes issue in FIPS-enabled environment. During native build, following exception is raised:

```
20:14:25,406 INFO  mvn: [2/8] Performing analysis...  []                                                                        (32.3s @ 1.65GB)
20:14:25,411 INFO  mvn:    16,986 reachable types   (82.5% of   20,588 total)
20:14:25,425 INFO  mvn:    28,604 reachable fields  (48.9% of   58,457 total)
20:14:25,468 INFO  mvn:    86,471 reachable methods (50.6% of  170,851 total)
20:14:25,468 INFO  mvn:     6,017 types,   782 fields, and 6,175 methods registered for reflection
20:14:25,470 INFO  mvn: 
20:14:25,471 INFO  mvn: Fatal error: com.oracle.graal.pointsto.util.AnalysisError$ParsingError: Error encountered while parsing com.ibm.db2.jcc.am.b5.a(b5.java:116) 
20:14:25,471 INFO  mvn: Parsing context:
20:14:25,471 INFO  mvn:    at com.ibm.db2.jcc.DB2Driver.acceptsURL(DB2Driver.java:517)
20:14:25,471 INFO  mvn:    at java.sql.DriverManager.getDriver(DriverManager.java:284)
20:14:25,471 INFO  mvn:    at io.agroal.pool.ConnectionFactory.newDriver(ConnectionFactory.java:128)
20:14:25,471 INFO  mvn:    at io.agroal.pool.ConnectionFactory.<init>(ConnectionFactory.java:68)
20:14:25,471 INFO  mvn:    at io.agroal.pool.Poolless.<init>(Poolless.java:87)
20:14:25,471 INFO  mvn:    at io.agroal.pool.DataSource.<init>(DataSource.java:35)
20:14:25,471 INFO  mvn:    at io.quarkus.agroal.runtime.DataSources.createDataSource(DataSources.java:212)
20:14:25,471 INFO  mvn:    at io.quarkus.agroal.runtime.AgroalRecorder$3.apply(AgroalRecorder.java:65)
20:14:25,471 INFO  mvn:    at io.quarkus.agroal.runtime.AgroalRecorder$3.apply(AgroalRecorder.java:60)
20:14:25,471 INFO  mvn:    at java.io.ObjectInputFilter$Config$Global.lambda$checkInput$9(ObjectInputFilter.java:1196)
20:14:25,471 INFO  mvn:    at java.io.ObjectInputFilter$Config$Global$$Lambda/0x00000007c2a5eb88.apply(Unknown Source)
20:14:25,471 INFO  mvn:    at java.lang.String.transform(String.java:4291)
20:14:25,471 INFO  mvn:    at root method.(Unknown Source)
20:14:25,471 INFO  mvn: 
20:14:25,471 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.AnalysisError.parsingError(AnalysisError.java:149)
20:14:25,471 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlow.createFlowsGraph(MethodTypeFlow.java:184)
20:14:25,471 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlow.ensureFlowsGraphCreated(MethodTypeFlow.java:153)
20:14:25,471 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlow.getOrCreateMethodFlowsGraphInfo(MethodTypeFlow.java:111)
20:14:25,471 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.typestate.DefaultStaticInvokeTypeFlow.lambda$update$0(DefaultStaticInvokeTypeFlow.java:75)
20:14:25,471 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.LightImmutableCollection.forEach(LightImmutableCollection.java:90)
20:14:25,471 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.typestate.DefaultStaticInvokeTypeFlow.update(DefaultStaticInvokeTypeFlow.java:74)
20:14:25,471 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.PointsToAnalysis$1.run(PointsToAnalysis.java:491)
20:14:25,471 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.CompletionExecutor.executeCommand(CompletionExecutor.java:187)
20:14:25,471 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.CompletionExecutor.lambda$executeService$0(CompletionExecutor.java:171)
20:14:25,471 INFO  mvn: 	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1423)
20:14:25,471 INFO  mvn: 	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
20:14:25,471 INFO  mvn: 	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
20:14:25,471 INFO  mvn: 	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
20:14:25,471 INFO  mvn: 	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
20:14:25,471 INFO  mvn: 	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
20:14:25,471 INFO  mvn: Caused by: org.graalvm.compiler.java.BytecodeParser$BytecodeParserError: org.graalvm.compiler.debug.GraalError: com.oracle.svm.core.util.UserError$UserException: Class initialization of com.ibm.db2.jcc.am.Connection failed. Use the option 
20:14:25,471 INFO  mvn: 
20:14:25,471 INFO  mvn:     '--initialize-at-run-time=com.ibm.db2.jcc.am.Connection'
20:14:25,471 INFO  mvn: 
20:14:25,471 INFO  mvn:  to explicitly request initialization of this class at run time.
20:14:25,471 INFO  mvn: 	at parsing com.ibm.db2.jcc.am.b5.a(b5.java:50)
20:14:25,471 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.throwParserError(BytecodeParser.java:2553)
20:14:25,471 INFO  mvn: 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.throwParserError(SharedGraphBuilderPhase.java:182)
20:14:25,471 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.iterateBytecodesForBlock(BytecodeParser.java:3434)
20:14:25,471 INFO  mvn: 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.iterateBytecodesForBlock(SharedGraphBuilderPhase.java:751)
20:14:25,471 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.handleBytecodeBlock(BytecodeParser.java:3386)
20:14:25,471 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.processBlock(BytecodeParser.java:3228)
20:14:25,471 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.build(BytecodeParser.java:1137)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.build(SharedGraphBuilderPhase.java:162)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.buildRootMethod(BytecodeParser.java:1029)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.java.GraphBuilderPhase$Instance.run(GraphBuilderPhase.java:101)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SharedGraphBuilderPhase.run(SharedGraphBuilderPhase.java:116)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.run(Phase.java:49)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.BasePhase.apply(BasePhase.java:434)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.apply(Phase.java:42)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.apply(Phase.java:38)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.AnalysisParsedGraph.parseBytecode(AnalysisParsedGraph.java:146)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisMethod.parseGraph(AnalysisMethod.java:895)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisMethod.ensureGraphParsedHelper(AnalysisMethod.java:860)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisMethod.ensureGraphParsed(AnalysisMethod.java:843)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.phases.InlineBeforeAnalysisGraphDecoder.lookupEncodedGraph(InlineBeforeAnalysisGraphDecoder.java:198)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.replacements.PEGraphDecoder.doInline(PEGraphDecoder.java:1211)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.replacements.PEGraphDecoder.tryInline(PEGraphDecoder.java:1194)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.replacements.PEGraphDecoder.trySimplifyInvoke(PEGraphDecoder.java:1049)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.replacements.PEGraphDecoder.handleInvokeWithCallTarget(PEGraphDecoder.java:1001)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.replacements.PEGraphDecoder.handleInvoke(PEGraphDecoder.java:987)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.nodes.GraphDecoder.processNextNode(GraphDecoder.java:921)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.phases.InlineBeforeAnalysisGraphDecoder.processNextNode(InlineBeforeAnalysisGraphDecoder.java:378)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.nodes.GraphDecoder.decode(GraphDecoder.java:650)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.replacements.PEGraphDecoder.decode(PEGraphDecoder.java:892)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.phases.InlineBeforeAnalysis.decodeGraph(InlineBeforeAnalysis.java:76)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.parse(MethodTypeFlowBuilder.java:195)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.apply(MethodTypeFlowBuilder.java:621)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlow.createFlowsGraph(MethodTypeFlow.java:167)
20:14:25,472 INFO  mvn: 	... 14 more
20:14:25,472 INFO  mvn: Caused by: org.graalvm.compiler.debug.GraalError: com.oracle.svm.core.util.UserError$UserException: Class initialization of com.ibm.db2.jcc.am.Connection failed. Use the option 
20:14:25,472 INFO  mvn: 
20:14:25,472 INFO  mvn:     '--initialize-at-run-time=com.ibm.db2.jcc.am.Connection'
20:14:25,472 INFO  mvn: 
20:14:25,472 INFO  mvn:  to explicitly request initialization of this class at run time.
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.AnalysisFuture.setException(AnalysisFuture.java:49)
20:14:25,472 INFO  mvn: 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:322)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.AnalysisFuture.ensureDone(AnalysisFuture.java:63)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisType.ensureOnTypeReachableTaskDone(AnalysisType.java:696)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisType.onReachable(AnalysisType.java:590)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.AtomicUtils.atomicSetAndRun(AtomicUtils.java:49)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisType.lambda$registerAsReachable$8(AnalysisType.java:562)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisType.forAllSuperTypes(AnalysisType.java:676)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisType.forAllSuperTypes(AnalysisType.java:659)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisType.forAllSuperTypes(AnalysisType.java:655)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisType.registerAsReachable(AnalysisType.java:562)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisUniverse.lookupAllowUnresolved(AnalysisUniverse.java:368)
20:14:25,472 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.infrastructure.AnalysisConstantPool.lookupField(AnalysisConstantPool.java:42)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.lookupField(BytecodeParser.java:4343)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.genGetField(BytecodeParser.java:4766)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.processBytecode(BytecodeParser.java:5412)
20:14:25,472 INFO  mvn: 	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.iterateBytecodesForBlock(BytecodeParser.java:3426)
20:14:25,472 INFO  mvn: 	... 44 more
20:14:25,472 INFO  mvn: Caused by: com.oracle.svm.core.util.UserError$UserException: Class initialization of com.ibm.db2.jcc.am.Connection failed. Use the option 
20:14:25,472 INFO  mvn: 
20:14:25,473 INFO  mvn:     '--initialize-at-run-time=com.ibm.db2.jcc.am.Connection'
20:14:25,473 INFO  mvn: 
20:14:25,473 INFO  mvn:  to explicitly request initialization of this class at run time.
20:14:25,473 INFO  mvn: 	at org.graalvm.nativeimage.builder/com.oracle.svm.core.util.UserError.abort(UserError.java:85)
20:14:25,473 INFO  mvn: 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationSupport.ensureClassInitialized(ClassInitializationSupport.java:195)
20:14:25,473 INFO  mvn: 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.AllowAllHostedUsagesClassInitializationSupport.computeInitKindAndMaybeInitializeClass(AllowAllHostedUsagesClassInitializationSupport.java:191)
20:14:25,473 INFO  mvn: 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.AllowAllHostedUsagesClassInitializationSupport.computeInitKindAndMaybeInitializeClass(AllowAllHostedUsagesClassInitializationSupport.java:129)
20:14:25,473 INFO  mvn: 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationSupport.maybeInitializeAtBuildTime(ClassInitializationSupport.java:161)
20:14:25,473 INFO  mvn: 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationSupport.maybeInitializeAtBuildTime(ClassInitializationSupport.java:150)
20:14:25,473 INFO  mvn: 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.SVMHost.onTypeReachable(SVMHost.java:310)
20:14:25,473 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisUniverse.onTypeReachable(AnalysisUniverse.java:699)
20:14:25,473 INFO  mvn: 	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisType.lambda$new$0(AnalysisType.java:310)
20:14:25,473 INFO  mvn: 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
20:14:25,473 INFO  mvn: 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
20:14:25,473 INFO  mvn: 	... 59 more
20:14:25,473 INFO  mvn: Caused by: java.lang.ExceptionInInitializerError
20:14:25,473 INFO  mvn: 	at com.ibm.db2.jcc.am.Connection.<clinit>(Connection.java:704)
20:14:25,473 INFO  mvn: 	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method)
20:14:25,473 INFO  mvn: 	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized(Unsafe.java:1160)
20:14:25,473 INFO  mvn: 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationSupport.ensureClassInitialized(ClassInitializationSupport.java:177)
20:14:25,473 INFO  mvn: 	... 68 more
20:14:25,473 INFO  mvn: Caused by: java.security.ProviderException: sun.security.pkcs11.wrapper.PKCS11Exception: CKR_ATTRIBUTE_VALUE_INVALID
20:14:25,473 INFO  mvn: 	at jdk.crypto.cryptoki/sun.security.pkcs11.P11KeyPairGenerator.generateKeyPair(P11KeyPairGenerator.java:433)
20:14:25,473 INFO  mvn: 	at java.base/java.security.KeyPairGenerator$Delegate.generateKeyPair(KeyPairGenerator.java:728)
20:14:25,473 INFO  mvn: 	at com.ibm.db2.jcc.am.br.a(br.java:155)
20:14:25,473 INFO  mvn: 	at com.ibm.db2.jcc.am.ao.i(ao.java:1029)
20:14:25,473 INFO  mvn: 	at com.ibm.db2.jcc.am.ao.<clinit>(ao.java:979)
20:14:25,473 INFO  mvn: 	... 72 more
20:14:25,473 INFO  mvn: Caused by: sun.security.pkcs11.wrapper.PKCS11Exception: CKR_ATTRIBUTE_VALUE_INVALID
20:14:25,473 INFO  mvn: 	at jdk.crypto.cryptoki/sun.security.pkcs11.wrapper.PKCS11.C_GenerateKeyPair(Native Method)
20:14:25,473 INFO  mvn: 	at jdk.crypto.cryptoki/sun.security.pkcs11.P11KeyPairGenerator.generateKeyPair(P11KeyPairGenerator.java:425)
20:14:25,473 INFO  mvn: 	... 76 more
```

when other tests in this module are run (not the DB2 test which is excluded in FIPS-enabled environment).

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)