### PR TITLE
Fix SQL application native failures in compatibility module when run in FIPS-enabled environment

### DIFF
--- a/sql-db/sql-app-compatibility/pom.xml
+++ b/sql-db/sql-app-compatibility/pom.xml
@@ -33,10 +33,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jdbc-db2</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-h2</artifactId>
         </dependency>
         <dependency>
@@ -66,6 +62,23 @@
         </dependency>
     </dependencies>
     <profiles>
+        <profile>
+            <id>test-quarkus-jdbc-db2</id>
+            <activation>
+                <!-- quarkus-jdbc-db2 is currently not supported in FIPS-enabled environment -->
+                <!-- TODO: drop this profile once https://github.com/IBM/Db2/issues/43 is fixed and move Quarkus JDBC D2 dependency to others -->
+                <property>
+                    <name>env.FIPS</name>
+                    <value>!fips</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-jdbc-db2</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
         <profile>
             <id>native</id>
             <activation>


### PR DESCRIPTION
### Summary

This is the same thing as I have done in https://github.com/quarkus-qe/quarkus-test-suite/pull/2388, but I didn't realize we run compatibility tests in native mode as well (turns out we run _some_ of them).

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)