### PR TITLE
Add coverage for QUARKUS-5617 (Support for two or more authentications for a single request)

### DIFF
--- a/security/keycloak/pom.xml
+++ b/security/keycloak/pom.xml
@@ -20,6 +20,10 @@
             <artifactId>quarkus-oidc</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-service-keycloak</artifactId>
             <scope>test</scope>

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/MultiMechanismAuthenticationIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/MultiMechanismAuthenticationIT.java
@@ -1,0 +1,123 @@
+package io.quarkus.ts.security.keycloak;
+
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+import static io.restassured.RestAssured.given;
+import static java.util.Base64.getEncoder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KeycloakContainer;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
+
+@QuarkusScenario
+@Tag("QUARKUS-5617")
+public class MultiMechanismAuthenticationIT {
+
+    static final String KC_NORMAL_USER = "test-normal-user";
+    static final String KC_ADMIN_USER = "test-admin-user";
+    static final String BASIC_NORMAL_USER = "user";
+    static final String BASIC_ADMIN_USER = "admin";
+    static final String CLIENT_ID_DEFAULT = "test-application-client";
+    static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
+
+    @KeycloakContainer(command = { "start-dev", "--import-realm" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
+            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT)
+            .withProperties("multi-mechanism.properties");
+
+    @Test
+    public void testAdminBasicAndOidcTogetherOnAdminResource() {
+        given().headers(prepareHeader(KC_ADMIN_USER, BASIC_ADMIN_USER))
+                .when().get("/admin")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testAdminBasicAndOidcTogetherOnUserResource() {
+        given().headers(prepareHeader(KC_ADMIN_USER, BASIC_ADMIN_USER))
+                .when().get("/user")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testUserBasicAndOidcTogetherOnUserResource() {
+        given().headers(prepareHeader(KC_NORMAL_USER, BASIC_NORMAL_USER))
+                .when().get("/user")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testUserBasicAndOidcTogetherOnAdminResource() {
+        given().headers(prepareHeader(KC_NORMAL_USER, BASIC_NORMAL_USER))
+                .when().get("/admin")
+                .then()
+                .statusCode(HttpStatus.SC_FORBIDDEN);
+    }
+
+    @Test
+    public void testAdminOnlyOneMechanism() {
+        given().headers(prepareHeader(null, BASIC_ADMIN_USER))
+                .when().get("/admin")
+                .then()
+                .statusCode(HttpStatus.SC_UNAUTHORIZED);
+
+        given().headers(prepareHeader(KC_ADMIN_USER, null))
+                .when().get("/admin")
+                .then()
+                .statusCode(HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    public void testUserOnlyOneMechanism() {
+        given().headers(prepareHeader(null, BASIC_NORMAL_USER))
+                .when().get("/user")
+                .then()
+                .statusCode(HttpStatus.SC_UNAUTHORIZED);
+
+        given().headers(prepareHeader(KC_NORMAL_USER, null))
+                .when().get("/user")
+                .then()
+                .statusCode(HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    private static Headers prepareHeader(String oidcUser, String basicUser) {
+        List<Header> headers = new ArrayList<>();
+        if (oidcUser != null) {
+            headers.add(new Header("Authorization", "Bearer " + createToken(oidcUser, oidcUser)));
+        }
+        if (basicUser != null) {
+            headers.add(new Header("Authorization", "Basic " + encodeBasicAuthentication(basicUser, basicUser)));
+        }
+        return new Headers(headers);
+    }
+
+    private static String createToken(String username, String password) {
+        return keycloak.createAuthzClient(CLIENT_ID_DEFAULT, CLIENT_SECRET_DEFAULT)
+                .obtainAccessToken(username, password).getToken();
+    }
+
+    private static String encodeBasicAuthentication(String username, String password) {
+        String credentialString = username + ":" + password;
+        return getEncoder().encodeToString(credentialString.getBytes());
+    }
+}

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftMultiMechanismAuthenticationIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftMultiMechanismAuthenticationIT.java
@@ -1,0 +1,10 @@
+package io.quarkus.ts.security.keycloak;
+
+import org.junit.jupiter.api.Tag;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+@Tag("QUARKUS-5617")
+public class OpenShiftMultiMechanismAuthenticationIT extends MultiMechanismAuthenticationIT {
+}

--- a/security/keycloak/src/test/resources/multi-mechanism.properties
+++ b/security/keycloak/src/test/resources/multi-mechanism.properties
@@ -1,0 +1,9 @@
+quarkus.http.auth.inclusive=true
+
+quarkus.http.auth.basic=true
+quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.plain-text=true
+quarkus.security.users.embedded.users.admin=admin
+quarkus.security.users.embedded.users.user=user
+quarkus.security.users.embedded.roles.admin=test-admin-role,test-user-role
+quarkus.security.users.embedded.roles.user=test-user-role


### PR DESCRIPTION
### Summary

TP: https://github.com/quarkus-qe/quarkus-test-plans/pull/217
Jira: https://issues.redhat.com/browse/QUARKUS-5617

Adding tests to check if multiple authentication mechanism are enforced at same time.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)