### PR TITLE
Switch PostgreSQL in baremetal tests from 16 to 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <exclude.quarkus.cli.tests>**/QuarkusCli*IT.java</exclude.quarkus.cli.tests>
         <exclude.quarkus.devmode.tests>no</exclude.quarkus.devmode.tests>
         <!-- Docker images used by both surefire and failsafe plugin -->
-        <postgresql.latest.image>docker.io/library/postgres:16</postgresql.latest.image>
+        <postgresql.latest.image>docker.io/library/postgres:17</postgresql.latest.image>
         <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7:latest</mysql.80.image>
         <rhbk.image>registry.redhat.io/rhbk/keycloak-rhel9:26.0</rhbk.image>
         <wiremock-jre8.version>2.35.2</wiremock-jre8.version>
@@ -798,7 +798,7 @@
                                         <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                         <!-- Product Services -->
                                         <rhbk.image>${rhbk.image}</rhbk.image>
-                                        <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10:latest</postgresql.10.image>
+                                        <postgresql.12.image>registry.redhat.io/rhel8/postgresql-12:latest</postgresql.12.image>
                                         <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16:latest</postgresql.latest.image>
                                         <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103:latest</mariadb.103.image>
                                         <mariadb.105.image>registry.redhat.io/rhel9/mariadb-105:latest</mariadb.105.image>
@@ -848,7 +848,7 @@
                                         <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                         <!-- Product Services -->
                                         <rhbk.image>${rhbk.image}</rhbk.image>
-                                        <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10:latest</postgresql.10.image>
+                                        <postgresql.12.image>registry.redhat.io/rhel8/postgresql-12:latest</postgresql.12.image>
                                         <postgresql.dev.svc.latest.image>${postgresql.latest.image}</postgresql.dev.svc.latest.image>
                                         <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16:latest</postgresql.latest.image>
                                         <mysql.80.image>registry.redhat.io/rhel8/mysql-80:latest</mysql.80.image>
@@ -917,7 +917,7 @@
                                         <!-- Product Services -->
                                         <amqbroker.image>registry.redhat.io/amq7/amq-broker-rhel8:7.12</amqbroker.image>
                                         <rhbk.image>${rhbk.image}</rhbk.image>
-                                        <postgresql.10.image>registry.redhat.io/rhel8/postgresql-10:latest</postgresql.10.image>
+                                        <postgresql.12.image>registry.redhat.io/rhel8/postgresql-12:latest</postgresql.12.image>
                                         <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16:latest</postgresql.latest.image>
                                         <mysql.80.image>registry.redhat.io/rhel8/mysql-80:latest</mysql.80.image>
                                         <mariadb.103.image>registry.redhat.io/rhel8/mariadb-103:latest</mariadb.103.image>

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
@@ -24,7 +24,7 @@ public class OpenShiftPostgresqlMultitenantHibernateSearchIT extends AbstractMul
             // Limit resources as Elasticsearch official docker image use half of available RAM
             .withProperty("ES_JAVA_OPTS", "-Xms1g -Xmx1g");
 
-    @Container(image = "${postgresql.10.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.12.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static PostgresqlService database = new PostgresqlService();
 
     @QuarkusApplication

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftPostgresql12HibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftPostgresql12HibernateReactiveIT.java
@@ -11,14 +11,14 @@ import io.quarkus.ts.hibernate.reactive.AbstractDatabaseHibernateReactiveIT;
 
 @OpenShiftScenario
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
-public class OpenShiftPostgresql10HibernateReactiveIT extends AbstractDatabaseHibernateReactiveIT {
+public class OpenShiftPostgresql12HibernateReactiveIT extends AbstractDatabaseHibernateReactiveIT {
 
     private static final String POSTGRES_USER = "quarkus_test";
     private static final String POSTGRES_PASSWORD = "quarkus_test";
     private static final String POSTGRES_DATABASE = "quarkus_test";
     private static final int POSTGRES_PORT = 5432;
 
-    @Container(image = "${postgresql.10.image}", port = POSTGRES_PORT, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.12.image}", port = POSTGRES_PORT, expectedLog = "listening on IPv4 address")
     static PostgresqlService database = new PostgresqlService()
             .withUser(POSTGRES_USER)
             .withPassword(POSTGRES_PASSWORD)

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresql12DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresql12DatabaseIT.java
@@ -10,10 +10,10 @@ import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
-public class OpenShiftPostgresql10DatabaseIT extends AbstractSqlDatabaseIT {
+public class OpenShiftPostgresql12DatabaseIT extends AbstractSqlDatabaseIT {
     static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "${postgresql.10.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.12.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static PostgresqlService database = new PostgresqlService();
 
     @QuarkusApplication


### PR DESCRIPTION
### Summary

Changed motivated by https://issues.redhat.com/browse/QUARKUS-5472, TP https://github.com/quarkus-qe/quarkus-test-plans/pull/220.


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)