### PR TITLE
Add coverage for QUARKUS-5659 (Use Arc features in datasource extensions for eager startup and active/inactive)

### DIFF
--- a/sql-db/multiple-pus/pom.xml
+++ b/sql-db/multiple-pus/pom.xml
@@ -37,6 +37,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-h2</artifactId>
             <scope>test</scope>
         </dependency>

--- a/sql-db/multiple-pus/src/main/java/io/quarkus/ts/sqldb/multiplepus/FungusResource.java
+++ b/sql-db/multiple-pus/src/main/java/io/quarkus/ts/sqldb/multiplepus/FungusResource.java
@@ -1,10 +1,21 @@
 package io.quarkus.ts.sqldb.multiplepus;
 
+import static jakarta.ws.rs.core.Response.Status.CREATED;
+import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
+
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import io.quarkus.ts.sqldb.multiplepus.model.fungus.Fungus;
 
@@ -16,6 +27,39 @@ public class FungusResource {
     @GET
     public long countAll() {
         return Fungus.count();
+    }
+
+    @POST
+    @Transactional
+    public Response create(@Valid Fungus fungus) {
+        if (fungus.id != null) {
+            throw new ClientErrorException("unexpected ID in request", ValidationExceptionMapper.UNPROCESSABLE_ENTITY);
+        }
+
+        fungus.persist();
+        return Response.ok(fungus).status(CREATED.getStatusCode()).build();
+    }
+
+    @GET
+    @Path("/{id}")
+    public Fungus get(@PathParam("id") Long id) {
+        final Fungus fungus = Fungus.findById(id);
+        if (fungus == null) {
+            throw new NotFoundException("fungus '" + id + "' not found");
+        }
+        return fungus;
+    }
+
+    @DELETE
+    @Path("/{id}")
+    @Transactional
+    public Response delete(@PathParam("id") Long id) {
+        final Fungus fungus = Fungus.findById(id);
+        if (fungus == null) {
+            throw new NotFoundException("Fungus '" + id + "' not found");
+        }
+        fungus.delete();
+        return Response.status(NO_CONTENT.getStatusCode()).build();
     }
 
 }

--- a/sql-db/multiple-pus/src/main/java/io/quarkus/ts/sqldb/multiplepus/producer/DatasourceProducer.java
+++ b/sql-db/multiple-pus/src/main/java/io/quarkus/ts/sqldb/multiplepus/producer/DatasourceProducer.java
@@ -1,0 +1,32 @@
+package io.quarkus.ts.sqldb.multiplepus.producer;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.agroal.DataSource;
+import io.quarkus.arc.InjectableInstance;
+
+public class DatasourceProducer {
+
+    @Inject
+    @DataSource("pg")
+    InjectableInstance<AgroalDataSource> pgDataSourceBean;
+
+    @Inject
+    @DataSource("mariadb")
+    InjectableInstance<AgroalDataSource> mariadbDataSourceBean;
+
+    @Produces
+    @ApplicationScoped
+    public AgroalDataSource dataSource() {
+        if (pgDataSourceBean.getHandle().getBean().isActive()) {
+            return pgDataSourceBean.get();
+        } else if (mariadbDataSourceBean.getHandle().getBean().isActive()) {
+            return mariadbDataSourceBean.get();
+        } else {
+            throw new RuntimeException("No active datasource!");
+        }
+    }
+}

--- a/sql-db/multiple-pus/src/main/java/io/quarkus/ts/sqldb/multiplepus/producer/DatasourceProducerResource.java
+++ b/sql-db/multiple-pus/src/main/java/io/quarkus/ts/sqldb/multiplepus/producer/DatasourceProducerResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.sqldb.multiplepus.producer;
+
+import java.sql.SQLException;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.agroal.api.AgroalDataSource;
+
+@Path("/datasource-producer")
+public class DatasourceProducerResource {
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    @GET
+    public String get() throws SQLException {
+        return dataSource.getConnection().getMetaData().getDatabaseProductName();
+    }
+}

--- a/sql-db/multiple-pus/src/main/resources/application.properties
+++ b/sql-db/multiple-pus/src/main/resources/application.properties
@@ -25,3 +25,9 @@ quarkus.hibernate-orm."fungi".sql-load-script=import-fungi.sql
 quarkus.hibernate-orm."fungi".datasource=vegetables
 quarkus.hibernate-orm."fungi".multitenant=discriminator
 quarkus.hibernate-orm."fungi".packages=io.quarkus.ts.sqldb.multiplepus.model.fungus
+
+# Set db-kind to save time on rebuilding native for tests
+quarkus.datasource."mariadb".db-kind=mariadb
+quarkus.datasource."pg".db-kind=postgresql
+
+quarkus.datasource.metrics.enabled=true

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/AbstractCustomDatasourceProducerIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/AbstractCustomDatasourceProducerIT.java
@@ -1,0 +1,111 @@
+package io.quarkus.ts.sqldb.multiplepus;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.RestService;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public abstract class AbstractCustomDatasourceProducerIT {
+
+    static final int MARIADB_PORT = 3306;
+    static final int POSTGRESQL_PORT = 5432;
+
+    @Test
+    @Order(1)
+    public void noActiveDatasource() {
+        given()
+                .get("/datasource-producer")
+                .then()
+                .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+                .body(containsString("No active datasource!"));
+
+        given()
+                .get("/q/metrics")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(not(containsString("agroal_max_used_count{datasource=")));
+    }
+
+    @Test
+    @Order(2)
+    public void postgresqlActive() {
+        activateDeactivateDatasource(true, false);
+        given()
+                .get("/datasource-producer")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is("PostgreSQL"));
+
+        checkMetricsIfDatasourceIsPresent("pg");
+        checkMetricsIfDatasourceNotPresent("mariadb");
+    }
+
+    @Test
+    @Order(3)
+    public void mariadbActive() {
+        activateDeactivateDatasource(false, true);
+        given()
+                .get("/datasource-producer")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is("MariaDB"));
+
+        checkMetricsIfDatasourceIsPresent("mariadb");
+        checkMetricsIfDatasourceNotPresent("pg");
+    }
+
+    @Test
+    @Order(4)
+    public void bothActiveDatasource() {
+        activateDeactivateDatasource(true, true);
+        // The custom datasource producer return postgres base on the condition logic, the metrics should show both active
+        given()
+                .get("/datasource-producer")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is("PostgreSQL"));
+
+        checkMetricsIfDatasourceIsPresent("mariadb");
+        checkMetricsIfDatasourceIsPresent("pg");
+    }
+
+    /**
+     * Check if the metrics contains active datasource
+     */
+    public void checkMetricsIfDatasourceIsPresent(String datasourceName) {
+        given()
+                .get("/q/metrics")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("agroal_max_used_count{datasource=\"" + datasourceName + "\"}"));
+    }
+
+    /**
+     * Check if the metrics doesn't contain inactive datasource
+     */
+    public void checkMetricsIfDatasourceNotPresent(String datasourceName) {
+        given()
+                .get("/q/metrics")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(not(containsString("agroal_max_used_count{datasource=\"" + datasourceName + "\"}")));
+    }
+
+    public void activateDeactivateDatasource(boolean pgActive, boolean mariadbActive) {
+        getApp().stop();
+        getApp().withProperty("quarkus.datasource.\"pg\".active", String.valueOf(pgActive))
+                .withProperty("quarkus.datasource.\"mariadb\".active", String.valueOf(mariadbActive))
+                .start();
+    }
+
+    protected abstract RestService getApp();
+}

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/AbstractMultiDatabaseActiveInactiveIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/AbstractMultiDatabaseActiveInactiveIT.java
@@ -1,0 +1,236 @@
+package io.quarkus.ts.sqldb.multiplepus;
+
+import static io.quarkus.ts.sqldb.multiplepus.FungiTenantResolver.TENANT_HEADER;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+
+import java.util.Map;
+
+import org.apache.http.HttpStatus;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.ts.sqldb.multiplepus.model.fruit.Fruit;
+import io.quarkus.ts.sqldb.multiplepus.model.fungus.Fungus;
+import io.quarkus.ts.sqldb.multiplepus.model.vegetable.Vegetable;
+import io.restassured.http.ContentType;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public abstract class AbstractMultiDatabaseActiveInactiveIT {
+
+    static final int MARIADB_PORT = 3306;
+    static final int POSTGRESQL_PORT = 5432;
+
+    public static final String INACTIVE_DATASOURCE_ERROR = "Cannot retrieve the EntityManagerFactory/SessionFactory";
+
+    @Test
+    @Order(1)
+    @DisplayName("Check that all named data sources are inactive")
+    public void noActiveDatasource() {
+        checkFruitIsInactive();
+        checkVegetableIsInactive();
+        checkFungusIsInactive();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("Check datasource metrics is not present when all datasources are inactive")
+    public void noActiveDatasourceCheckMetrics() {
+        given()
+                .get("/q/metrics")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(not(containsString("agroal_max_used_count{datasource=")));
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("Check that fruit datasource is active and others are inactive")
+    public void fruitActive() {
+        activateDeactivateDatasource(true, false, false);
+
+        given().get("/fruit")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("", hasSize(7));
+
+        checkVegetableIsInactive();
+        checkFungusIsInactive();
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("Activated datasource (fruit) should be able to make operation")
+    public void createAndDeleteFruit() {
+        Fruit fruit = new Fruit();
+        fruit.name = "Canteloupe";
+
+        int latestFruitId = createRequest(fruit, fruit.name, "/fruit");
+        getByIdRequest(fruit.name, "/fruit/" + latestFruitId);
+        deleteByIdRequest("/fruit/" + latestFruitId);
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("Check datasource metrics is present only for active datasource (fruits)")
+    public void fruitActiveCheckMetrics() {
+        checkMetricsIfDatasourceIsPresent("fruits");
+        checkMetricsIfDatasourceNotPresent("vegetables");
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("Check that fruit datasource is inactive and others are active")
+    public void vegetableAndFungiActive() {
+        activateDeactivateDatasource(false, true, true);
+
+        checkFruitIsInactive();
+
+        given().get("/vegetable")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("", hasSize(7));
+
+        given().get("/fungus")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(Matchers.is("4"));
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("Activated datasource (vegetable) should be able to make operation")
+    public void createAndDeleteVegetable() {
+        Vegetable vegetable = new Vegetable();
+        vegetable.name = "Eggplant";
+
+        int latestVegetableId = createRequest(vegetable, vegetable.name, "/vegetable");
+        getByIdRequest(vegetable.name, "/vegetable/" + latestVegetableId);
+        deleteByIdRequest("/vegetable/" + latestVegetableId);
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("Activated persistence unit name (fungus) should be able to make operation on tenant")
+    public void createAndDeleteFungus() {
+        Fungus fungus = new Fungus();
+        fungus.name = "W. macrospora";
+
+        Map<String, String> headers = Map.of(TENANT_HEADER, "Wynnea");
+
+        int latestFungusId = createRequest(fungus, fungus.name, "/fungus", headers);
+        getByIdRequest(fungus.name, "/fungus/" + latestFungusId, headers);
+        deleteByIdRequest("/fungus/" + latestFungusId, headers);
+    }
+
+    @Test
+    @Order(9)
+    @DisplayName("Check datasource metrics is present only for active datasource (vegatables)")
+    public void vegetableActiveCheckMetrics() {
+        checkMetricsIfDatasourceIsPresent("vegetables");
+        checkMetricsIfDatasourceNotPresent("fruits");
+    }
+
+    public int createRequest(PanacheEntity edibles, String name, String path, Map<String, String> headers) {
+        return given()
+                .contentType(ContentType.JSON)
+                .headers(headers)
+                .body(edibles)
+                .post(path)
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("name", equalTo(name))
+                .extract().path("id");
+    }
+
+    public int createRequest(PanacheEntity edibles, String name, String path) {
+        return createRequest(edibles, name, path, Map.of());
+    }
+
+    public void getByIdRequest(String name, String path, Map<String, String> headers) {
+        given().headers(headers)
+                .get(path)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("name", equalTo(name));
+    }
+
+    public void getByIdRequest(String name, String path) {
+        getByIdRequest(name, path, Map.of());
+    }
+
+    public void deleteByIdRequest(String path, Map<String, String> headers) {
+        given().headers(headers)
+                .delete(path)
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    public void deleteByIdRequest(String path) {
+        deleteByIdRequest(path, Map.of());
+    }
+
+    public void checkFruitIsInactive() {
+        given().get("/fruit")
+                .then()
+                .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+                .body(containsString(INACTIVE_DATASOURCE_ERROR));
+    }
+
+    public void checkVegetableIsInactive() {
+        given().get("/vegetable")
+                .then()
+                .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+                .body(containsString(INACTIVE_DATASOURCE_ERROR));
+    }
+
+    public void checkFungusIsInactive() {
+        given().get("/fungus")
+                .then()
+                .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+                .body(containsString(INACTIVE_DATASOURCE_ERROR));
+    }
+
+    /**
+     * Check if the metrics contains active datasource
+     */
+    public void checkMetricsIfDatasourceIsPresent(String datasourceName) {
+        given()
+                .get("/q/metrics")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("agroal_max_used_count{datasource=\"" + datasourceName + "\"}"));
+    }
+
+    /**
+     * Check if the metrics doesn't contain inactive datasource
+     */
+    public void checkMetricsIfDatasourceNotPresent(String datasourceName) {
+        given()
+                .get("/q/metrics")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(not(containsString("agroal_max_used_count{datasource=\"" + datasourceName + "\"}")));
+    }
+
+    public void activateDeactivateDatasource(boolean fruitActivate, boolean vegetableActivate, boolean fungiActivate) {
+        getApp().stop();
+        getApp().withProperty("quarkus.datasource.\"fruits\".active", String.valueOf(fruitActivate))
+                .withProperty("quarkus.datasource.\"vegetables\".active", String.valueOf(vegetableActivate || fungiActivate))
+                .withProperty("quarkus.hibernate-orm.\"fruits\".active", String.valueOf(fruitActivate))
+                .withProperty("quarkus.hibernate-orm.\"vegetables\".active", String.valueOf(vegetableActivate))
+                .withProperty("quarkus.hibernate-orm.\"fungi\".active", String.valueOf(fungiActivate))
+                .start();
+    }
+
+    protected abstract RestService getApp();
+}

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/CustomDatasourceProducerIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/CustomDatasourceProducerIT.java
@@ -1,0 +1,38 @@
+package io.quarkus.ts.sqldb.multiplepus;
+
+import org.junit.jupiter.api.Tag;
+
+import io.quarkus.test.bootstrap.MariaDbService;
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@Tag("QUARKUS-5659")
+@QuarkusScenario
+public class CustomDatasourceProducerIT extends AbstractCustomDatasourceProducerIT {
+
+    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '/run/mysqld/mysqld.sock'  port: "
+            + MARIADB_PORT)
+    static MariaDbService mariadb = new MariaDbService();
+
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    static PostgresqlService postgresql = new PostgresqlService();
+
+    @QuarkusApplication
+    static RestService app = new RestService().withProperties("datasource-producer.properties")
+            .withProperty("quarkus.datasource.\"mariadb\".username", mariadb::getUser)
+            .withProperty("quarkus.datasource.\"mariadb\".password", mariadb::getPassword)
+            .withProperty("quarkus.datasource.\"mariadb\".jdbc.url", mariadb::getJdbcUrl)
+            .withProperty("quarkus.datasource.\"mariadb\".active", "false")
+            .withProperty("quarkus.datasource.\"pg\".username", postgresql::getUser)
+            .withProperty("quarkus.datasource.\"pg\".password", postgresql::getPassword)
+            .withProperty("quarkus.datasource.\"pg\".jdbc.url", postgresql::getJdbcUrl)
+            .withProperty("quarkus.datasource.\"pg\".active", "false");
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+}

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiDatabaseActiveInactiveIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiDatabaseActiveInactiveIT.java
@@ -1,0 +1,64 @@
+package io.quarkus.ts.sqldb.multiplepus;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.MariaDbService;
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@Tag("QUARKUS-5659")
+@QuarkusScenario
+public class MultiDatabaseActiveInactiveIT extends AbstractMultiDatabaseActiveInactiveIT {
+
+    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '/run/mysqld/mysqld.sock'  port: "
+            + MARIADB_PORT)
+    static MariaDbService mariadb = new MariaDbService();
+
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    static PostgresqlService postgresql = new PostgresqlService();
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("MARIA_DB_USERNAME", mariadb.getUser())
+            .withProperty("MARIA_DB_PASSWORD", mariadb.getPassword())
+            .withProperty("MARIA_DB_JDBC_URL", mariadb::getJdbcUrl)
+            .withProperty("POSTGRESQL_USERNAME", postgresql.getUser())
+            .withProperty("POSTGRESQL_PASSWORD", postgresql.getPassword())
+            .withProperty("POSTGRESQL_JDBC_URL", postgresql::getJdbcUrl)
+            .withProperty("quarkus.datasource.\"fruits\".active", "false")
+            .withProperty("quarkus.datasource.\"vegetables\".active", "false")
+            .withProperty("quarkus.hibernate-orm.\"fruits\".active", "false")
+            .withProperty("quarkus.hibernate-orm.\"vegetables\".active", "false")
+            .withProperty("quarkus.hibernate-orm.\"fungi\".active", "false");
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+
+    @Test
+    @Order(10)
+    @DisplayName("Activate persistence unit name (fungus) with inactive datasource (vegetable)")
+    public void createAndDeleteFungusWhenVegetableDatasourceIsInactive() {
+        getApp().stop();
+        assertThrows(AssertionError.class, () -> {
+            getApp().withProperty("quarkus.datasource.\"fruits\".active", "false")
+                    .withProperty("quarkus.datasource.\"vegetables\".active", "false")
+                    .withProperty("quarkus.hibernate-orm.\"fruits\".active", "false")
+                    .withProperty("quarkus.hibernate-orm.\"vegetables\".active", "false")
+                    .withProperty("quarkus.hibernate-orm.\"fungi\".active", "true")
+                    .start();
+        },
+                "Should not start as the fungi hibernate-orm using same datasource which is inactive.");
+
+        getApp().logs().assertContains("Datasource 'vegetables' was deactivated");
+    }
+}

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftCustomDatasourceProducerIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftCustomDatasourceProducerIT.java
@@ -1,0 +1,39 @@
+package io.quarkus.ts.sqldb.multiplepus;
+
+import org.junit.jupiter.api.Tag;
+
+import io.quarkus.test.bootstrap.MariaDbService;
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@Tag("QUARKUS-5659")
+@OpenShiftScenario
+public class OpenShiftCustomDatasourceProducerIT extends AbstractCustomDatasourceProducerIT {
+
+    @Container(image = "${mariadb.1011.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    static MariaDbService mariadb = new MariaDbService();
+
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    static PostgresqlService postgresql = new PostgresqlService()
+            .withProperty("PGDATA", "/tmp/psql");
+
+    @QuarkusApplication
+    static RestService app = new RestService().withProperties("datasource-producer.properties")
+            .withProperty("quarkus.datasource.\"mariadb\".username", mariadb::getUser)
+            .withProperty("quarkus.datasource.\"mariadb\".password", mariadb::getPassword)
+            .withProperty("quarkus.datasource.\"mariadb\".jdbc.url", mariadb::getJdbcUrl)
+            .withProperty("quarkus.datasource.\"mariadb\".active", "false")
+            .withProperty("quarkus.datasource.\"pg\".username", postgresql::getUser)
+            .withProperty("quarkus.datasource.\"pg\".password", postgresql::getPassword)
+            .withProperty("quarkus.datasource.\"pg\".jdbc.url", postgresql::getJdbcUrl)
+            .withProperty("quarkus.datasource.\"pg\".active", "false")
+            .withProperty("quarkus.datasource.\"mariadb\".db-version", "10.11");
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+}

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiDatabaseActiveInactiveIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiDatabaseActiveInactiveIT.java
@@ -1,0 +1,41 @@
+package io.quarkus.ts.sqldb.multiplepus;
+
+import org.junit.jupiter.api.Tag;
+
+import io.quarkus.test.bootstrap.MariaDbService;
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@Tag("QUARKUS-5659")
+@OpenShiftScenario
+public class OpenShiftMultiDatabaseActiveInactiveIT extends AbstractMultiDatabaseActiveInactiveIT {
+
+    @Container(image = "${mariadb.1011.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    static MariaDbService mariadb = new MariaDbService();
+
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    static PostgresqlService postgresql = new PostgresqlService()
+            .withProperty("PGDATA", "/tmp/psql");
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("MARIA_DB_USERNAME", mariadb.getUser())
+            .withProperty("MARIA_DB_PASSWORD", mariadb.getPassword())
+            .withProperty("MARIA_DB_JDBC_URL", mariadb::getJdbcUrl)
+            .withProperty("POSTGRESQL_USERNAME", postgresql.getUser())
+            .withProperty("POSTGRESQL_PASSWORD", postgresql.getPassword())
+            .withProperty("POSTGRESQL_JDBC_URL", postgresql::getJdbcUrl)
+            .withProperty("quarkus.datasource.\"fruits\".active", "false")
+            .withProperty("quarkus.datasource.\"vegetables\".active", "false")
+            .withProperty("quarkus.hibernate-orm.\"fruits\".active", "false")
+            .withProperty("quarkus.hibernate-orm.\"vegetables\".active", "false")
+            .withProperty("quarkus.hibernate-orm.\"fungi\".active", "false")
+            .withProperty("quarkus.datasource.\"fruits\".db-version", "10.11");
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+}

--- a/sql-db/multiple-pus/src/test/resources/datasource-producer.properties
+++ b/sql-db/multiple-pus/src/test/resources/datasource-producer.properties
@@ -1,0 +1,4 @@
+# The other datasources need to be inactive for testing producer
+quarkus.hibernate-orm."fruits".active=false
+quarkus.hibernate-orm."vegetables".active=false
+quarkus.hibernate-orm."fungi".active=false


### PR DESCRIPTION
### Summary

Adding coverage for QUARKUS-5659.

Jira https://issues.redhat.com/browse/QUARKUS-5659

TP https://github.com/quarkus-qe/quarkus-test-plans/pull/223

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)