### PR TITLE
QUARKUS-5658 WS.next + Otel tests

### DIFF
--- a/websockets/websocket-next/pom.xml
+++ b/websockets/websocket-next/pom.xml
@@ -27,5 +27,10 @@
             <artifactId>Java-WebSocket</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-jaeger</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/BaseWebSocketIT.java
+++ b/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/BaseWebSocketIT.java
@@ -9,16 +9,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.HexFormat;
 import java.util.List;
-import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
-import org.java_websocket.client.WebSocketClient;
-import org.java_websocket.handshake.ServerHandshake;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 
@@ -340,57 +336,4 @@ public abstract class BaseWebSocketIT {
         return client;
     }
 
-    public static class Client extends WebSocketClient {
-        private final LinkedBlockingDeque<String> messages = new LinkedBlockingDeque<>();
-        private final LinkedBlockingDeque<ByteBuffer> binaryMessages = new LinkedBlockingDeque<>();
-        private final boolean ignoreJoinMessages;
-
-        public Client(URI serverUri, boolean ignoreJoinMessages) {
-            super(serverUri);
-            this.ignoreJoinMessages = ignoreJoinMessages;
-        }
-
-        public Client(URI serverUri) {
-            super(serverUri);
-            this.ignoreJoinMessages = true;
-        }
-
-        @Override
-        public void onOpen(ServerHandshake serverHandshake) {
-            LOG.debug("New connection opened");
-        }
-
-        @Override
-        public void onMessage(String message) {
-            LOG.debug("Message received: " + message);
-            if (!message.endsWith("joined") || !ignoreJoinMessages) {
-                messages.add(message);
-            }
-        }
-
-        // receive binary message
-        @Override
-        public void onMessage(ByteBuffer bytes) {
-            LOG.debug("Binary message received: " + bytes.toString());
-            binaryMessages.add(bytes);
-        }
-
-        @Override
-        public void onClose(int i, String reason, boolean b) {
-            LOG.debug("WS connection closed for reason: " + reason);
-        }
-
-        @Override
-        public void onError(Exception e) {
-            LOG.error("Websocket Exception thrown: " + e.getMessage(), e);
-        }
-
-        public String waitForAndGetMessage() throws InterruptedException {
-            return messages.poll(2, TimeUnit.SECONDS);
-        }
-
-        public ByteBuffer waitForAndGetBinaryMessage() throws InterruptedException {
-            return binaryMessages.poll(2, TimeUnit.SECONDS);
-        }
-    }
 }

--- a/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/Client.java
+++ b/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/Client.java
@@ -1,0 +1,66 @@
+package io.quarkus.ts.websockets.next;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.jboss.logging.Logger;
+
+public class Client extends WebSocketClient {
+    private static final Logger LOG = Logger.getLogger(Client.class);
+
+    private final LinkedBlockingDeque<String> messages = new LinkedBlockingDeque<>();
+    private final LinkedBlockingDeque<ByteBuffer> binaryMessages = new LinkedBlockingDeque<>();
+    private final boolean ignoreJoinMessages;
+
+    public Client(URI serverUri, boolean ignoreJoinMessages) {
+        super(serverUri);
+        this.ignoreJoinMessages = ignoreJoinMessages;
+    }
+
+    public Client(URI serverUri) {
+        super(serverUri);
+        this.ignoreJoinMessages = true;
+    }
+
+    @Override
+    public void onOpen(ServerHandshake serverHandshake) {
+        LOG.debug("New connection opened");
+    }
+
+    @Override
+    public void onMessage(String message) {
+        LOG.debug("Message received: " + message);
+        if (!message.endsWith("joined") || !ignoreJoinMessages) {
+            messages.add(message);
+        }
+    }
+
+    // receive binary message
+    @Override
+    public void onMessage(ByteBuffer bytes) {
+        LOG.debug("Binary message received: " + bytes.toString());
+        binaryMessages.add(bytes);
+    }
+
+    @Override
+    public void onClose(int i, String reason, boolean b) {
+        LOG.debug("WS connection closed for reason: " + reason);
+    }
+
+    @Override
+    public void onError(Exception e) {
+        LOG.error("Websocket Exception thrown: " + e.getMessage(), e);
+    }
+
+    public String waitForAndGetMessage() throws InterruptedException {
+        return messages.poll(2, TimeUnit.SECONDS);
+    }
+
+    public ByteBuffer waitForAndGetBinaryMessage() throws InterruptedException {
+        return binaryMessages.poll(2, TimeUnit.SECONDS);
+    }
+}

--- a/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/OpenShiftWebSocketsNextOpenTelemetryIT.java
+++ b/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/OpenShiftWebSocketsNextOpenTelemetryIT.java
@@ -1,0 +1,10 @@
+package io.quarkus.ts.websockets.next;
+
+import org.junit.jupiter.api.Tag;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+@Tag("QUARKUS-5658")
+public class OpenShiftWebSocketsNextOpenTelemetryIT extends WebSocketsNextOpenTelemetryIT {
+}

--- a/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/WebSocketsNextMetricsIT.java
+++ b/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/WebSocketsNextMetricsIT.java
@@ -58,11 +58,11 @@ public class WebSocketsNextMetricsIT {
     @Order(1)
     public void serverMessageMetricsTest() throws URISyntaxException, InterruptedException {
         // if the three clients join
-        BaseWebSocketIT.Client aliceClient = createClient("/chat/alice");
+        Client aliceClient = createClient("/chat/alice");
         Thread.sleep(100); // to ensure outgoing "${username} joined" messages are sent in correct sequence
-        BaseWebSocketIT.Client bobClient = createClient("/chat/bob");
+        Client bobClient = createClient("/chat/bob");
         Thread.sleep(100);
-        BaseWebSocketIT.Client charlieClient = createClient("/chat/charlie");
+        Client charlieClient = createClient("/chat/charlie");
         // then client count is three
         thenCounterIs(TOTAL_SERVER_CONNECTIONS_OPEN_FORMAT, 3);
         String helloWorldEnglish = "hello world";
@@ -96,7 +96,7 @@ public class WebSocketsNextMetricsIT {
     @Order(2)
     @Disabled("https://github.com/quarkusio/quarkus/issues/47409")
     public void serverErrorMetricsTest() throws URISyntaxException, InterruptedException {
-        BaseWebSocketIT.Client client = createClient("/failing");
+        Client client = createClient("/failing");
         getServer().logs().assertContains("Error on websocket: Websocket failed to open");
         thenCounterIs(TOTAL_SERVER_CONNECTION_ERRORS_FORMAT, 1);
         client.send("Create an error");
@@ -108,7 +108,7 @@ public class WebSocketsNextMetricsIT {
     @Test
     @Order(3)
     public void clientMessageMetricsTest() throws URISyntaxException, InterruptedException {
-        BaseWebSocketIT.Client client = createClient("/chat/alice");
+        Client client = createClient("/chat/alice");
         // connect server-side client
         given().queryParam("username", "bob").get("/userDataRes/connect"); // "bob joined"
         int inboundClientMessagesTotalBytes = "bob joined".getBytes(StandardCharsets.UTF_8).length;
@@ -155,9 +155,9 @@ public class WebSocketsNextMetricsIT {
         return new URI(getServer().getURI(Protocol.WS).toString()).resolve(with);
     }
 
-    private BaseWebSocketIT.Client createClient(String endpoint)
+    private Client createClient(String endpoint)
             throws URISyntaxException, InterruptedException {
-        BaseWebSocketIT.Client client = new BaseWebSocketIT.Client(getUri(endpoint), false);
+        Client client = new Client(getUri(endpoint), false);
         if (!client.connectBlocking()) {
             LOG.error("Websocket client fail to connect to " + endpoint);
         }

--- a/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/WebSocketsNextOpenTelemetryIT.java
+++ b/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/WebSocketsNextOpenTelemetryIT.java
@@ -1,0 +1,116 @@
+package io.quarkus.ts.websockets.next;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.hamcrest.Matcher;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.JaegerService;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Dependency;
+import io.quarkus.test.services.JaegerContainer;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.response.Response;
+
+@QuarkusScenario
+@Tag("QUARKUS-5658")
+public class WebSocketsNextOpenTelemetryIT {
+
+    private static final Logger LOG = Logger.getLogger(WebSocketsNextOpenTelemetryIT.class);
+    private Response resp;
+
+    @JaegerContainer(useOtlpCollector = true)
+    static final JaegerService jaeger = new JaegerService();
+
+    @QuarkusApplication(dependencies = @Dependency(artifactId = "quarkus-opentelemetry"))
+    static final RestService app = new RestService()
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
+
+    protected RestService getServer() {
+        return app;
+    }
+
+    // {name="OPEN /chat/:username" && resource.service.name="websocket-next"}
+    @Test
+    public void testWebSocketsNextTracing() throws URISyntaxException, InterruptedException {
+        String serviceName = "websocket-next";
+        String openOperationName = "OPEN /chat/:username";
+        String closeOperationName = "CLOSE /chat/:username";
+
+        // client CLOSE trace should link to the OPEN trace via FOLLOWS_FROM reference
+        Client aliceClient = createClient("/chat/alice");
+        aliceClient.send("hello world");
+        aliceClient.close();
+
+        // we use trace ID referred from CLOSE trace to verify OPEN trace
+        await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
+            // there should be one OPEN operation and one CLOSE operation trace
+            retrieveTraces(serviceName, openOperationName);
+            thenNumberOfTraces(is(1));
+            retrieveTraces(serviceName, closeOperationName);
+            thenNumberOfTraces(is(1));
+        });
+
+        // CLOSE trace should have a reference to OPEN trace of FOLLOWS_FROM type
+        Map<String, String> references = given().queryParam("operation", closeOperationName)
+                .queryParam("lookback", "1h")
+                .queryParam("limit", 10)
+                .queryParam("service", serviceName)
+                .get(jaeger.getTraceUrl()).path("data[0].spans[0].references[0]");
+        assertEquals("FOLLOWS_FROM", references.get("refType"));
+        String referenceTraceId = references.get("traceID");
+
+        // assert that the reference traceID equals the OPEN operation traceID
+        String openOperationTraceIds = given().queryParam("operation", openOperationName)
+                .queryParam("lookback", "1h")
+                .queryParam("limit", 10)
+                .queryParam("service", serviceName)
+                .get(jaeger.getTraceUrl()).path("data[0].traceID");
+        assertEquals(referenceTraceId, openOperationTraceIds);
+    }
+
+    private URI getUri(String with) throws URISyntaxException {
+        return new URI(getServer().getURI(Protocol.WS).toString()).resolve(with);
+    }
+
+    private Client createClient(String endpoint)
+            throws URISyntaxException, InterruptedException {
+        Client client = new Client(getUri(endpoint), false);
+        if (!client.connectBlocking()) {
+            LOG.error("Websocket client fail to connect to " + endpoint);
+        }
+        return client;
+    }
+
+    private void retrieveTraces(String serviceName, String operationName) {
+        await().atMost(10, TimeUnit.SECONDS)
+                .pollInterval(Duration.ofSeconds(1))
+                .until(() -> {
+                    resp = given().when()
+                            .queryParam("operation", operationName)
+                            .queryParam("lookback", "1h")
+                            .queryParam("limit", 10)
+                            .queryParam("service", serviceName)
+                            .get(jaeger.getTraceUrl());
+                    return !resp.jsonPath().getList("data.spans").isEmpty();
+                });
+    }
+
+    private void thenNumberOfTraces(Matcher<?> matcher) {
+        resp.then().body("data.size()", matcher);
+    }
+
+}


### PR DESCRIPTION
### Summary

* Adding a test verifying that websocket operations (open/close) are traced by OpenTelemetry, and that the traces refer to eachother.

Issue: https://github.com/quarkusio/quarkus/issues/39143

Code change: https://github.com/quarkusio/quarkus/pull/41956

Documentation: https://quarkus.io/version/main/guides/websockets-next-reference#telemetry

Test plan: https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-5658.md

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)