### PR TITLE
Enhancement with permission checkers for WebSockets Next

### DIFF
--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websockets/next/endpoints/AuthenticatedChatWebSocket.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websockets/next/endpoints/AuthenticatedChatWebSocket.java
@@ -3,7 +3,11 @@ package io.quarkus.ts.websockets.next.endpoints;
 import jakarta.inject.Inject;
 
 import io.quarkus.security.Authenticated;
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.PermissionChecker;
+import io.quarkus.security.PermissionsAllowed;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.websockets.next.OnError;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.WebSocket;
 
@@ -14,7 +18,20 @@ public class AuthenticatedChatWebSocket {
     SecurityIdentity currentIdentity;
 
     @OnTextMessage(broadcast = true)
+    @PermissionsAllowed("endpoint:invoke")
     public String echo(String message) {
         return currentIdentity.getPrincipal().getName() + ": " + message;
     }
+
+    @OnError
+    String error(ForbiddenException t) {
+        return "forbidden:" + currentIdentity.getPrincipal().getName();
+    }
+
+    @PermissionChecker("endpoint:invoke")
+    boolean canInvokeEndpoint(String message) {
+        String principalName = currentIdentity.getPrincipal().getName();
+        return principalName.equals("alice") || principalName.equals("bob");
+    }
+
 }

--- a/websockets/websocket-next/src/main/resources/application.properties
+++ b/websockets/websocket-next/src/main/resources/application.properties
@@ -6,8 +6,10 @@ quarkus.security.users.embedded.enabled=true
 quarkus.security.users.embedded.plain-text=true
 quarkus.security.users.embedded.users.alice=password
 quarkus.security.users.embedded.users.bob=secret
+quarkus.security.users.embedded.users.tom=boss
 quarkus.security.users.embedded.roles.alice=admin,user
 quarkus.security.users.embedded.roles.bob=user
+quarkus.security.users.embedded.roles.tom=user
 
 quarkus.http.auth.permission.http-upgrade.paths=/propertiesSecured
 quarkus.http.auth.permission.http-upgrade.policy=authenticated

--- a/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/BaseWebSocketIT.java
+++ b/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/BaseWebSocketIT.java
@@ -214,8 +214,16 @@ public abstract class BaseWebSocketIT {
         Client client = createAuthenticatedClient("/authChat", "alice", "password");
         client.send("Hi");
         assertMessage("alice: Hi", client);
+        client.close();
+
+        // directly connect authenticated client which is not passing the checker
+        client = createAuthenticatedClient("/authChat", "tom", "boss");
+        client.send("Hi");
+        assertMessage("forbidden:tom", client);
+        client.close();
 
         // connect server-side client
+        client = createAuthenticatedClient("/authChat", "alice", "password");
         given()
                 .queryParam("username", "bob")
                 .queryParam("password", "secret")


### PR DESCRIPTION
### Summary

Enhancement with permission checkers for WebSockets Next

Primary motivation is native coverage
TP: https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-5859.md

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)