### PR TITLE
Fix Brotli4j scenarios with S390X and ppc64le architectures tested by our IBM partners

### DIFF
--- a/http/http-advanced-reactive/pom.xml
+++ b/http/http-advanced-reactive/pom.xml
@@ -104,4 +104,24 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>openshift-ibm-z-p</id>
+            <activation>
+                <property>
+                    <name>openshift-ibm-z-p</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.aayushatharva.brotli4j</groupId>
+                    <artifactId>native-linux-s390x</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>com.aayushatharva.brotli4j</groupId>
+                    <artifactId>native-linux-ppc64le</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
### Summary

We also have `native-linux-aarch64` for the same purpose, I used Maven profile because I don't think we should add dependencies we don't use, these things can be activated for example by `arch`, but I used the property we already have.

Tested here: https://jenkins-csb-runtimes-ibmzqe-master.dno.corp.redhat.com/view/RHOAR/job/rhbq-3.x-ocp4-rhel8-rhel9-jdk17-test/jdk=openjdk17,label=quarkus,scenario=http-modules/224/consoleFull 

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)