### PR TITLE
[3.20] Updating the supported mongodb  image for IBM 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -924,7 +924,7 @@
                                         <!-- Kafka  (amq-streams) requires separate properties for image and version -->
                                         <amq-streams.image>registry.redhat.io/amq-streams/kafka-35-rhel8</amq-streams.image>
                                         <amq-streams.version>2.6.0</amq-streams.version>
-                                        <mongodb.image>docker.io/library/mongo:7.0</mongodb.image>
+                                        <mongodb.image>docker.io/library/mongo:4.4.6</mongodb.image>
                                         <infinispan.image>registry.redhat.io/datagrid/datagrid-8-rhel9:1.5-8.5.0.GA</infinispan.image>
                                         <infinispan.expected-log>Red Hat Data Grid.*started in</infinispan.expected-log>
                                     </systemPropertyVariables>


### PR DESCRIPTION
### Summary

Updating the supported mongodb  image for IBM 

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

Test job 
https://jenkins-csb-runtimes-ibmzqe-master.dno.corp.redhat.com/view/RHOAR/job/rhbq-3.x-ocp4-rhel8-rhel9-jdk17-test/jdk=openjdk17,label=quarkus,scenario=databases-modules/219/console