### PR TITLE
Use Red Hat Build of Keycloak for OpenShift tests and thus enable IBM partners to run more Keycloak tests

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHttpAdvancedReactiveIT.java
@@ -4,8 +4,6 @@ import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
@@ -15,10 +13,9 @@ import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x & ppc64le.")
 public class OpenShiftHttpAdvancedReactiveIT extends BaseHttpAdvancedReactiveIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" }, image = "${rhbk.image}")
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureHttpServer = true, useTlsRegistry = false))

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHttpAdvancedIT.java
@@ -4,8 +4,6 @@ import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
@@ -15,10 +13,9 @@ import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x & ppc64le.")
 public class OpenShiftHttpAdvancedIT extends BaseHttpAdvancedIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" }, image = "${rhbk.image}")
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureHttpServer = true, useTlsRegistry = false))

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractLogoutSinglePageAppFlowIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractLogoutSinglePageAppFlowIT.java
@@ -1,0 +1,85 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.util.Cookie;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.LookupService;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.LogoutFlow;
+import io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.LogoutTenantResolver;
+
+public abstract class AbstractLogoutSinglePageAppFlowIT {
+
+    static final String REALM_DEFAULT = "quarkus";
+
+    @LookupService
+    static KeycloakService keycloak;
+
+    @QuarkusApplication(classes = { LogoutFlow.class, LogoutTenantResolver.class })
+    static RestService app = new RestService()
+            .withProperty("keycloak.url", () -> keycloak.getURI(Protocol.HTTP).toString())
+            .withProperties("logout.properties");
+
+    @Test
+    public void singlePageAppLogoutFlow() throws IOException {
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient.getPage(app.getURI(Protocol.HTTP).toString() + "/code-flow");
+
+            HtmlForm form = page.getHtmlElementById("kc-form-login");
+            form.getInputByName("username").type("alice");
+            form.getInputByName("password").type("alice");
+
+            page = form.getButtonByName("login").click();
+
+            assertEquals("alice, cache size: 0", page.getBody().asNormalizedText());
+            assertTrue(isCodeFlowCookiePresent(webClient));
+
+            page = webClient.getPage(app.getURI(Protocol.HTTP).toString() + "/code-flow/logout");
+            assertThat(page.getBody().asNormalizedText(), containsString("You are logged out"));
+            assertFalse(isCodeFlowCookiePresent(webClient));
+            // Clear the post logout cookie
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    private WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        Logger.getLogger("org.htmlunit.css").setLevel(Level.OFF);
+        webClient.getOptions().setRedirectEnabled(true);
+        return webClient;
+    }
+
+    /**
+     * Search for "q_session_code-flow" cookie.
+     * This might be one cookie, or it might be chunked into several ones,
+     * which are named "q_session_code-flow_chunk_1" etc.
+     *
+     * @return True if cookie is present, chunked or not. False otherwise.
+     */
+    private boolean isCodeFlowCookiePresent(WebClient webClient) {
+        for (Cookie cookie : webClient.getCookieManager().getCookies()) {
+            if (cookie.getName().startsWith("q_session_code-flow")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractOidcRestClientIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractOidcRestClientIT.java
@@ -1,0 +1,171 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient;
+
+import static io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.TokenUtils.createToken;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.UUID;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.LookupService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.model.Score;
+import io.restassured.http.ContentType;
+
+public abstract class AbstractOidcRestClientIT {
+
+    static final String PING_ENDPOINT = "/%s-ping";
+    static final String PONG_ENDPOINT = "/%s-pong";
+    static final String WRONG_TOKEN = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    @LookupService
+    static KeycloakService keycloak;
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl());
+
+    @Test
+    public void testRest() {
+        assertPingEndpoints("rest");
+        assertPongEndpoints("rest");
+    }
+
+    @Test
+    public void testReactive() {
+        assertPingEndpoints("reactive");
+        assertPongEndpoints("reactive");
+    }
+
+    @Test
+    public void testAutoAcquireToken() {
+        assertPingEndpoints("auto-acquire-token");
+    }
+
+    @Test
+    public void testTokenPropagation() {
+        assertPingEndpoints("token-propagation");
+    }
+
+    @Test
+    @DisabledOnNative(reason = "Annotation @ClientHeaderParam not working in Native. Reported by https://github.com/quarkusio/quarkus/issues/13660")
+    public void testLookupAuthorization() {
+        assertPingEndpoints("rest-lookup-auth");
+    }
+
+    private void assertPingEndpoints(String endpointPrefix) {
+        String pingEndpoint = String.format(PING_ENDPOINT, endpointPrefix);
+
+        assertPingUnauthorized(pingEndpoint);
+        assertPingUnauthorizedWithWrongToken(pingEndpoint);
+        assertPingPong(pingEndpoint);
+        assertPingPongWithPathParam(pingEndpoint);
+        assertPingPongCreate(pingEndpoint);
+        assertPingPongUpdate(pingEndpoint);
+        assertPingPongDelete(pingEndpoint);
+    }
+
+    private void assertPongEndpoints(String endpointPrefix) {
+        String pongEndpoint = String.format(PONG_ENDPOINT, endpointPrefix);
+
+        assertPongUnauthorized(pongEndpoint);
+        assertPongUnauthorizedWithWrongToken(pongEndpoint);
+        assertPongIsAuthorized(pongEndpoint);
+        assertNotFoundIsAuthorized(pongEndpoint);
+        assertNotFoundUnauthorized(pongEndpoint);
+    }
+
+    private void assertPingUnauthorized(String pingEndpoint) {
+        given()
+                .when().get(pingEndpoint)
+                .then().statusCode(HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    private void assertPingUnauthorizedWithWrongToken(String pingEndpoint) {
+        given().auth().oauth2(WRONG_TOKEN)
+                .when().get(pingEndpoint)
+                .then().statusCode(HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    private void assertPongUnauthorized(String pongEndpoint) {
+        given()
+                .when().get(pongEndpoint)
+                .then().statusCode(HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    private void assertPongUnauthorizedWithWrongToken(String pongEndpoint) {
+        given().auth().oauth2(WRONG_TOKEN)
+                .when().get(pongEndpoint)
+                .then().statusCode(HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    private void assertPongIsAuthorized(String pongEndpoint) {
+        given().auth().oauth2(createToken(keycloak))
+                .when().get(pongEndpoint)
+                .then().statusCode(HttpStatus.SC_OK);
+    }
+
+    private void assertPingPong(String pingEndpoint) {
+        // When calling ping, the rest will invoke also the pong rest endpoint.
+        given()
+                .auth().oauth2(createToken(keycloak))
+                .when().get(pingEndpoint)
+                .then().statusCode(HttpStatus.SC_OK)
+                .body(is("ping pong"));
+    }
+
+    private void assertNotFoundIsAuthorized(String pongEndpoint) {
+        given().auth().oauth2(createToken(keycloak))
+                .when().get(pongEndpoint + "/notFound/id")
+                .then().statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    private void assertNotFoundUnauthorized(String pongEndpoint) {
+        given()
+                .when().get(pongEndpoint + "/notFound/id")
+                .then().statusCode(HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    private void assertPingPongWithPathParam(String pingEndpoint) {
+        final String name = "helloWorld";
+        given().auth().oauth2(createToken(keycloak))
+                .when()
+                .get(pingEndpoint + "/name/" + name)
+                .then().statusCode(HttpStatus.SC_OK).body(containsString("ping pong " + name));
+    }
+
+    private void assertPingPongCreate(String pingEndpoint) {
+        Score score = new Score(15, 30);
+        given().auth().oauth2(createToken(keycloak))
+                .contentType(ContentType.JSON)
+                .body(score)
+                .when()
+                .post(pingEndpoint + "/withBody")
+                .then().statusCode(HttpStatus.SC_OK).body(containsString("ping -> " + score));
+    }
+
+    private void assertPingPongUpdate(String pingEndpoint) {
+        Score score = new Score(15, 30);
+        given().auth().oauth2(createToken(keycloak))
+                .contentType(ContentType.JSON)
+                .body(score)
+                .when()
+                .put(pingEndpoint + "/withBody")
+                .then().statusCode(HttpStatus.SC_OK).body(containsString("ping -> " + score));
+    }
+
+    private void assertPingPongDelete(String pingEndpoint) {
+        given().auth().oauth2(createToken(keycloak))
+                .contentType(ContentType.JSON)
+                .when()
+                .delete(pingEndpoint + "/" + UUID.randomUUID())
+                .then().statusCode(HttpStatus.SC_OK).body(containsString("ping -> true"));
+    }
+
+}

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/LogoutSinglePageAppFlowIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/LogoutSinglePageAppFlowIT.java
@@ -1,88 +1,15 @@
 package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient;
 
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.htmlunit.SilentCssErrorHandler;
-import org.htmlunit.WebClient;
-import org.htmlunit.html.HtmlForm;
-import org.htmlunit.html.HtmlPage;
-import org.htmlunit.util.Cookie;
-import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KeycloakService;
-import io.quarkus.test.bootstrap.Protocol;
-import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.KeycloakContainer;
-import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.LogoutFlow;
-import io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.LogoutTenantResolver;
 
 @QuarkusScenario
-public class LogoutSinglePageAppFlowIT {
-
-    static final String REALM_DEFAULT = "quarkus";
+public class LogoutSinglePageAppFlowIT extends AbstractLogoutSinglePageAppFlowIT {
 
     @KeycloakContainer(command = { "start-dev", "--import-realm" })
     static KeycloakService keycloak = new KeycloakService("/kc-logout-realm.json", REALM_DEFAULT, DEFAULT_REALM_BASE_PATH);
 
-    @QuarkusApplication(classes = { LogoutFlow.class, LogoutTenantResolver.class })
-    static RestService app = new RestService()
-            .withProperty("keycloak.url", () -> keycloak.getURI(Protocol.HTTP).toString())
-            .withProperties("logout.properties");
-
-    @Test
-    public void singlePageAppLogoutFlow() throws IOException {
-        try (final WebClient webClient = createWebClient()) {
-            HtmlPage page = webClient.getPage(app.getURI(Protocol.HTTP).toString() + "/code-flow");
-
-            HtmlForm form = page.getHtmlElementById("kc-form-login");
-            form.getInputByName("username").type("alice");
-            form.getInputByName("password").type("alice");
-
-            page = form.getButtonByName("login").click();
-
-            assertEquals("alice, cache size: 0", page.getBody().asNormalizedText());
-            assertTrue(isCodeFlowCookiePresent(webClient));
-
-            page = webClient.getPage(app.getURI(Protocol.HTTP).toString() + "/code-flow/logout");
-            assertThat(page.getBody().asNormalizedText(), containsString("You are logged out"));
-            assertFalse(isCodeFlowCookiePresent(webClient));
-            // Clear the post logout cookie
-            webClient.getCookieManager().clearCookies();
-        }
-    }
-
-    private WebClient createWebClient() {
-        WebClient webClient = new WebClient();
-        webClient.setCssErrorHandler(new SilentCssErrorHandler());
-        Logger.getLogger("org.htmlunit.css").setLevel(Level.OFF);
-        webClient.getOptions().setRedirectEnabled(true);
-        return webClient;
-    }
-
-    /**
-     * Search for "q_session_code-flow" cookie.
-     * This might be one cookie, or it might be chunked into several ones,
-     * which are named "q_session_code-flow_chunk_1" etc.
-     *
-     * @return True if cookie is present, chunked or not. False otherwise.
-     */
-    private boolean isCodeFlowCookiePresent(WebClient webClient) {
-        for (Cookie cookie : webClient.getCookieManager().getCookies()) {
-            if (cookie.getName().startsWith("q_session_code-flow")) {
-                return true;
-            }
-        }
-        return false;
-    }
 }

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OidcRestClientIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OidcRestClientIT.java
@@ -1,161 +1,17 @@
 package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 
-import java.util.UUID;
-
-import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Test;
-
+import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.model.Score;
-import io.restassured.http.ContentType;
+import io.quarkus.test.services.KeycloakContainer;
 
 @QuarkusScenario
-public class OidcRestClientIT extends BaseOidcIT {
+public class OidcRestClientIT extends AbstractOidcRestClientIT {
 
-    static final String PING_ENDPOINT = "/%s-ping";
-    static final String PONG_ENDPOINT = "/%s-pong";
-    static final String WRONG_TOKEN = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-
-    @Test
-    public void testRest() {
-        assertPingEndpoints("rest");
-        assertPongEndpoints("rest");
-    }
-
-    @Test
-    public void testReactive() {
-        assertPingEndpoints("reactive");
-        assertPongEndpoints("reactive");
-    }
-
-    @Test
-    public void testAutoAcquireToken() {
-        assertPingEndpoints("auto-acquire-token");
-    }
-
-    @Test
-    public void testTokenPropagation() {
-        assertPingEndpoints("token-propagation");
-    }
-
-    @Test
-    @DisabledOnNative(reason = "Annotation @ClientHeaderParam not working in Native. Reported by https://github.com/quarkusio/quarkus/issues/13660")
-    public void testLookupAuthorization() {
-        assertPingEndpoints("rest-lookup-auth");
-    }
-
-    private void assertPingEndpoints(String endpointPrefix) {
-        String pingEndpoint = String.format(PING_ENDPOINT, endpointPrefix);
-
-        assertPingUnauthorized(pingEndpoint);
-        assertPingUnauthorizedWithWrongToken(pingEndpoint);
-        assertPingPong(pingEndpoint);
-        assertPingPongWithPathParam(pingEndpoint);
-        assertPingPongCreate(pingEndpoint);
-        assertPingPongUpdate(pingEndpoint);
-        assertPingPongDelete(pingEndpoint);
-    }
-
-    private void assertPongEndpoints(String endpointPrefix) {
-        String pongEndpoint = String.format(PONG_ENDPOINT, endpointPrefix);
-
-        assertPongUnauthorized(pongEndpoint);
-        assertPongUnauthorizedWithWrongToken(pongEndpoint);
-        assertPongIsAuthorized(pongEndpoint);
-        assertNotFoundIsAuthorized(pongEndpoint);
-        assertNotFoundUnauthorized(pongEndpoint);
-    }
-
-    private void assertPingUnauthorized(String pingEndpoint) {
-        given()
-                .when().get(pingEndpoint)
-                .then().statusCode(HttpStatus.SC_UNAUTHORIZED);
-    }
-
-    private void assertPingUnauthorizedWithWrongToken(String pingEndpoint) {
-        given().auth().oauth2(WRONG_TOKEN)
-                .when().get(pingEndpoint)
-                .then().statusCode(HttpStatus.SC_UNAUTHORIZED);
-    }
-
-    private void assertPongUnauthorized(String pongEndpoint) {
-        given()
-                .when().get(pongEndpoint)
-                .then().statusCode(HttpStatus.SC_UNAUTHORIZED);
-    }
-
-    private void assertPongUnauthorizedWithWrongToken(String pongEndpoint) {
-        given().auth().oauth2(WRONG_TOKEN)
-                .when().get(pongEndpoint)
-                .then().statusCode(HttpStatus.SC_UNAUTHORIZED);
-    }
-
-    private void assertPongIsAuthorized(String pongEndpoint) {
-        given().auth().oauth2(createToken())
-                .when().get(pongEndpoint)
-                .then().statusCode(HttpStatus.SC_OK);
-    }
-
-    private void assertPingPong(String pingEndpoint) {
-        // When calling ping, the rest will invoke also the pong rest endpoint.
-        given()
-                .auth().oauth2(createToken())
-                .when().get(pingEndpoint)
-                .then().statusCode(HttpStatus.SC_OK)
-                .body(is("ping pong"));
-    }
-
-    private void assertNotFoundIsAuthorized(String pongEndpoint) {
-        given().auth().oauth2(createToken())
-                .when().get(pongEndpoint + "/notFound/id")
-                .then().statusCode(HttpStatus.SC_NOT_FOUND);
-    }
-
-    private void assertNotFoundUnauthorized(String pongEndpoint) {
-        given()
-                .when().get(pongEndpoint + "/notFound/id")
-                .then().statusCode(HttpStatus.SC_UNAUTHORIZED);
-    }
-
-    private void assertPingPongWithPathParam(String pingEndpoint) {
-        final String name = "helloWorld";
-        given().auth().oauth2(createToken())
-                .when()
-                .get(pingEndpoint + "/name/" + name)
-                .then().statusCode(HttpStatus.SC_OK).body(containsString("ping pong " + name));
-    }
-
-    private void assertPingPongCreate(String pingEndpoint) {
-        Score score = new Score(15, 30);
-        given().auth().oauth2(createToken())
-                .contentType(ContentType.JSON)
-                .body(score)
-                .when()
-                .post(pingEndpoint + "/withBody")
-                .then().statusCode(HttpStatus.SC_OK).body(containsString("ping -> " + score));
-    }
-
-    private void assertPingPongUpdate(String pingEndpoint) {
-        Score score = new Score(15, 30);
-        given().auth().oauth2(createToken())
-                .contentType(ContentType.JSON)
-                .body(score)
-                .when()
-                .put(pingEndpoint + "/withBody")
-                .then().statusCode(HttpStatus.SC_OK).body(containsString("ping -> " + score));
-    }
-
-    private void assertPingPongDelete(String pingEndpoint) {
-        given().auth().oauth2(createToken())
-                .contentType(ContentType.JSON)
-                .when()
-                .delete(pingEndpoint + "/" + UUID.randomUUID())
-                .then().statusCode(HttpStatus.SC_OK).body(containsString("ping -> true"));
-    }
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
 }

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenApiStoreSchemaIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenApiStoreSchemaIT.java
@@ -1,5 +1,8 @@
 package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -20,12 +23,16 @@ import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.Yaml;
 
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KeycloakContainer;
+import io.quarkus.test.services.QuarkusApplication;
 import io.smallrye.openapi.runtime.io.Format;
 import io.vertx.core.json.JsonObject;
 
 @QuarkusScenario
-public class OpenApiStoreSchemaIT extends BaseOidcIT {
+public class OpenApiStoreSchemaIT {
 
     private static final Logger LOGGER = Logger.getLogger(OpenApiStoreSchemaIT.class.getName());
     private static final String directory = "target/generated/jakarta-rest/";
@@ -41,6 +48,13 @@ public class OpenApiStoreSchemaIT extends BaseOidcIT {
 
     private static final String EXPECTED_TAGS = "[{\"name\":\"Ping\",\"description\":\"Ping API\"},{\"name\":\"Pong\",\"description\":\"Pong API\"}]";
     private static final String EXPECTED_INFO = "{\"title\":\"security-keycloak-oidc-client-extended API\",\"version\":\"1.0.0-SNAPSHOT\"}";
+
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
 
     // QUARKUS-716
     @Test

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftOidcRestClientIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftOidcRestClientIT.java
@@ -1,10 +1,17 @@
 package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 
+import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.KeycloakContainer;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x & ppc64le.")
-public class OpenShiftOidcRestClientIT extends OidcRestClientIT {
+public class OpenShiftOidcRestClientIT extends AbstractOidcRestClientIT {
+
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" }, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+
 }

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftOidcSinglePageAppLogoutFlowIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftOidcSinglePageAppLogoutFlowIT.java
@@ -1,10 +1,15 @@
 package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 
+import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.KeycloakContainer;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "keycloak container not available on s390x & ppc64le.")
-public class OpenShiftOidcSinglePageAppLogoutFlowIT extends LogoutSinglePageAppFlowIT {
+public class OpenShiftOidcSinglePageAppLogoutFlowIT extends AbstractLogoutSinglePageAppFlowIT {
+
+    @KeycloakContainer(command = { "start-dev", "--import-realm" }, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService("/kc-logout-realm.json", REALM_DEFAULT, DEFAULT_REALM_BASE_PATH);
+
 }

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/TokenPropagationFilterIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/TokenPropagationFilterIT.java
@@ -1,5 +1,10 @@
 package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+import static io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.TokenUtils.USER;
+import static io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.TokenUtils.createToken;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 
@@ -8,17 +13,28 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KeycloakContainer;
+import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.response.Response;
 
 @Tag("QUARKUS-3680")
 @QuarkusScenario
-public class TokenPropagationFilterIT extends BaseOidcIT {
+public class TokenPropagationFilterIT {
+
+    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
 
     @Test
     public void usernameTest() {
         given()
-                .auth().oauth2(createToken())
+                .auth().oauth2(createToken(keycloak))
                 .when().get("/token-propagation-filter")
                 .then().statusCode(HttpStatus.SC_OK)
                 .body(containsString(USER));
@@ -27,7 +43,7 @@ public class TokenPropagationFilterIT extends BaseOidcIT {
     @Test
     public void jsonUsernameTest() {
         Response response = given()
-                .auth().oauth2(createToken())
+                .auth().oauth2(createToken(keycloak))
                 .when().get("/json-propagation-filter");
         Assertions.assertEquals(HttpStatus.SC_OK, response.statusCode());
         Assertions.assertEquals(USER, response.body().asString());

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/TokenUtils.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/TokenUtils.java
@@ -1,37 +1,27 @@
 package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient;
 
-import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
-import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
-import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
-
 import org.jboss.logging.Logger;
 
 import io.quarkus.test.bootstrap.KeycloakService;
-import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.services.KeycloakContainer;
-import io.quarkus.test.services.QuarkusApplication;
 
-public abstract class BaseOidcIT {
-    private static final Logger LOG = Logger.getLogger(BaseOidcIT.class);
+final class TokenUtils {
+
+    private static final Logger LOG = Logger.getLogger(TokenUtils.class);
     static final String USER = "test-user";
 
     static final String CLIENT_ID_DEFAULT = "test-application-client";
     static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
-    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
-
-    @QuarkusApplication
-    static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
-
-    protected String createToken() {
-        // we retry and create AuthzClient as we experienced following exception in the past: 'Caused by:
-        // org.apache.http.NoHttpResponseException: keycloak-ts-juwpkvyduk.apps.ocp4-15.dynamic.quarkus:80 failed to respond'
-        return createToken(1);
+    private TokenUtils() {
     }
 
-    private static String createToken(int attemptCount) {
+    static String createToken(KeycloakService keycloak) {
+        // we retry and create AuthzClient as we experienced following exception in the past: 'Caused by:
+        // org.apache.http.NoHttpResponseException: keycloak-ts-juwpkvyduk.apps.ocp4-15.dynamic.quarkus:80 failed to respond'
+        return createToken(1, keycloak);
+    }
+
+    private static String createToken(int attemptCount, KeycloakService keycloak) {
         try {
             return keycloak.createAuthzClient(CLIENT_ID_DEFAULT, CLIENT_SECRET_DEFAULT).obtainAccessToken(USER, USER)
                     .getToken();
@@ -39,9 +29,10 @@ public abstract class BaseOidcIT {
             LOG.error("Attempt #%d to create token failed with exception:".formatted(attemptCount), e);
             if (e.getCause() instanceof org.apache.http.NoHttpResponseException && attemptCount < 3) {
                 LOG.info("Retrying to create token.");
-                return createToken(attemptCount + 1);
+                return createToken(attemptCount + 1, keycloak);
             }
             throw e;
         }
     }
+
 }


### PR DESCRIPTION
### Summary

@ramdr suggested that if we start using the Keycloak image provided  by Red Hat, our IBM partners will be able to run more tests. This PR makes changes similar to what has been done in #2409. 

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)