### PR TITLE
WebSocketsNextMetricsIT fixes

### DIFF
--- a/websockets/websocket-next/src/main/java/io/quarkus/ts/websockets/next/clients/PingPongClient.java
+++ b/websockets/websocket-next/src/main/java/io/quarkus/ts/websockets/next/clients/PingPongClient.java
@@ -20,9 +20,9 @@ public class PingPongClient {
 
     @OnPongMessage
     void pong(Buffer data) {
-        if (pongsReceived.size() > 2) {
+        pongsReceived.add(System.currentTimeMillis());
+        if (pongsReceived.size() == 3) {
             throw new RuntimeException("You asked for an error, you've got it!");
         }
-        pongsReceived.add(System.currentTimeMillis());
     }
 }

--- a/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/OpenShiftWebSocketsNextMetricsIT.java
+++ b/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/OpenShiftWebSocketsNextMetricsIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.ts.websockets.next;
 
+import org.junit.jupiter.api.Tag;
+
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
+@Tag("QUARKUS-5667")
 public class OpenShiftWebSocketsNextMetricsIT extends WebSocketsNextMetricsIT {
 }

--- a/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/WebSocketsNextMetricsIT.java
+++ b/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/WebSocketsNextMetricsIT.java
@@ -137,7 +137,7 @@ public class WebSocketsNextMetricsIT {
     @Order(4)
     public void clientErrorMetricsTest() throws InterruptedException {
         given().get("/pingPongRes/connect");
-        Thread.sleep(9000); // client pings every two seconds, third pong response produces RTE
+        Thread.sleep(10000); // client pings every two seconds, third pong response produces RTE
         given().get("/pingPongRes/disconnect");
         thenCounterIs(TOTAL_CLIENT_ENDPOINT_ERRORS_FORMAT, 1);
     }

--- a/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/WebSocketsNextMetricsIT.java
+++ b/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/WebSocketsNextMetricsIT.java
@@ -13,6 +13,7 @@ import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
@@ -25,6 +26,7 @@ import io.restassured.response.ValidatableResponse;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @QuarkusScenario
+@Tag("QUARKUS-5667")
 public class WebSocketsNextMetricsIT {
 
     private static final Logger LOG = Logger.getLogger(WebSocketsNextMetricsIT.class);


### PR DESCRIPTION
### Summary

* Add missing tag to WebSockets next Metrics tests
* Since the endpoint produced new exception for every ping after the
  second one, this commit changes the endpoint to produce the exception
  only on the third ping. This removes raciness from the test.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)