### PR TITLE
[3.20] Enable and fix WebSockets Next OIDC module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -709,6 +709,7 @@
                 <module>websockets/quarkus-websockets</module>
                 <module>websockets/websockets-client</module>
                 <module>websockets/websocket-next</module>
+                <module>websockets/websocket-next-oidc</module>
             </modules>
         </profile>
         <profile>

--- a/websockets/websocket-next-oidc/pom.xml
+++ b/websockets/websocket-next-oidc/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>websocket-next-oidc</artifactId>
+    <name>Quarkus QE TS: Websocket Next OIDC</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-websockets-next</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.java-websocket</groupId>
+            <artifactId>Java-WebSocket</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-keycloak</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/websockets/websocket-next-oidc/src/main/java/io/quarkus/ts/websockets/next/endpoints/AdminChatWebSocket.java
+++ b/websockets/websocket-next-oidc/src/main/java/io/quarkus/ts/websockets/next/endpoints/AdminChatWebSocket.java
@@ -3,7 +3,6 @@ package io.quarkus.ts.websockets.next.endpoints;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 
-import io.quarkus.oidc.BearerTokenAuthentication;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.UnauthorizedException;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -12,7 +11,6 @@ import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.WebSocket;
 
 @WebSocket(path = "/adminChat")
-@BearerTokenAuthentication
 public class AdminChatWebSocket {
     @Inject
     SecurityIdentity currentIdentity;

--- a/websockets/websocket-next-oidc/src/main/java/io/quarkus/ts/websockets/next/endpoints/AuthenticatedWebSocket.java
+++ b/websockets/websocket-next-oidc/src/main/java/io/quarkus/ts/websockets/next/endpoints/AuthenticatedWebSocket.java
@@ -2,13 +2,11 @@ package io.quarkus.ts.websockets.next.endpoints;
 
 import jakarta.inject.Inject;
 
-import io.quarkus.oidc.BearerTokenAuthentication;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.WebSocket;
 
 @WebSocket(path = "/bearer")
-@BearerTokenAuthentication
 public class AuthenticatedWebSocket {
     @Inject
     SecurityIdentity currentIdentity;

--- a/websockets/websocket-next-oidc/src/main/resources/application.properties
+++ b/websockets/websocket-next-oidc/src/main/resources/application.properties
@@ -11,3 +11,7 @@ quarkus.websockets-next.server.propagate-subprotocol-headers=true
 # Configure TLS/SSL to use WSS
 quarkus.http.insecure-requests=enabled
 quarkus.tls.trust-all=true
+
+quarkus.http.auth.permission.bearer-auth.auth-mechanism=bearer
+quarkus.http.auth.permission.bearer-auth.paths=/adminChat,/bearer
+quarkus.http.auth.permission.bearer-auth.policy=authenticated

--- a/websockets/websocket-next-oidc/src/test/resources/test-realm-realm.json
+++ b/websockets/websocket-next-oidc/src/test/resources/test-realm-realm.json
@@ -1,0 +1,75 @@
+{
+  "realm": "test-realm",
+  "enabled": true,
+  "sslRequired": "none",
+  "roles": {
+    "realm": [
+      {
+        "name": "user"
+      },
+      {
+        "name": "admin"
+      }
+    ]
+  },
+  "users": [
+    {
+      "username": "albert",
+      "email": "albert@localhost",
+      "firstName": "Albert",
+      "lastName": "User",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "einstein"
+        }
+      ],
+      "clientRoles": {
+        "test-application-client": [
+          "uma_protection"
+        ]
+      },
+      "realmRoles": [
+        "user",
+        "uma_protection"
+      ]
+    },
+    {
+      "username": "charlie",
+      "email": "charlie@localhost",
+      "firstName": "Charlie",
+      "lastName": "Admin",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "random"
+        }
+      ],
+      "clientRoles": {
+        "test-application-client": [
+          "uma_protection"
+        ]
+      },
+      "realmRoles": [
+        "admin",
+        "user",
+        "uma_protection"
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "test-application-client",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "test-application-client-secret"
+    }
+  ]
+}


### PR DESCRIPTION
### Summary

Changes:

- replaces `@BearerAuthentication` (not supported in 3.20) with HTTP permission-based path policy
- enables WebSockets Next OIDC module

The only difference between the `main` and `3.20` branch after this PR will be `@BeareAuthentication` mechanism and 3 configuration properties.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)