### PR TITLE
Use MariaDB 10.11 in FIPS-enabled environment because 11.4 version does not start

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1013,5 +1013,37 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>mariadb-11-fips</id>
+            <activation>
+                <!-- MariaDB 11.4 is not starting in FIPS-enabled environment, use 10.11 as a workaround -->
+                <!-- TODO: drop this profile when https://issues.redhat.com/browse/QUARKUS-5984 is fixed -->
+                <property>
+                    <name>env.FIPS</name>
+                    <value>fips</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <mariadb.11.image>registry.redhat.io/rhel9/mariadb-1011:latest</mariadb.11.image>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/security/jpa/src/test/java/io/quarkus/ts/security/jpa/MariaDbMd5JpaIT.java
+++ b/security/jpa/src/test/java/io/quarkus/ts/security/jpa/MariaDbMd5JpaIT.java
@@ -14,7 +14,7 @@ public class MariaDbMd5JpaIT extends BaseJpaSecurityRealmIT {
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '/run/mysqld/mysqld.sock'  port: "
+    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '.*/mysql.*sock'  port: "
             + MARIADB_PORT)
     static MariaDbService database = new MariaDbService();
 

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/MariaDBConstants.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/MariaDBConstants.java
@@ -4,6 +4,6 @@ public class MariaDBConstants {
     public static final int PORT = 3306;
     public static final String START_LOG = "Only MySQL server logs after this point";
     public static final String IMAGE_103 = "${mariadb.103.image}";
-    public static final String START_LOG_10 = "socket: '/run/mysqld/mysqld.sock'  port: " + PORT;
+    public static final String START_LOG_11 = "socket: '.*/mysql.*sock'  port: " + PORT;
     public static final String IMAGE_11 = "${mariadb.11.image}";
 }

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/SpringWebQuteReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/SpringWebQuteReactiveIT.java
@@ -10,7 +10,7 @@ import io.quarkus.ts.spring.web.reactive.MariaDBConstants;
 @QuarkusScenario
 public class SpringWebQuteReactiveIT extends AbstractSpringWebQuteReactiveIT {
 
-    @Container(image = MariaDBConstants.IMAGE_11, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG_10)
+    @Container(image = MariaDBConstants.IMAGE_11, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG_11)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/SpringWebRestReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/SpringWebRestReactiveIT.java
@@ -10,7 +10,7 @@ import io.quarkus.ts.spring.web.reactive.MariaDBConstants;
 @QuarkusScenario
 public class SpringWebRestReactiveIT extends AbstractSpringWebRestReactiveIT {
 
-    @Container(image = MariaDBConstants.IMAGE_11, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG_10)
+    @Container(image = MariaDBConstants.IMAGE_11, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG_11)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/SpringWebOpenApiReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/SpringWebOpenApiReactiveIT.java
@@ -14,7 +14,7 @@ import io.quarkus.ts.spring.web.reactive.MariaDBConstants;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class SpringWebOpenApiReactiveIT extends AbstractSpringWebOpenApiReactiveIT {
 
-    @Container(image = MariaDBConstants.IMAGE_11, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG_10)
+    @Container(image = MariaDBConstants.IMAGE_11, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG_11)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/MariaDBConstants.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/MariaDBConstants.java
@@ -2,7 +2,7 @@ package io.quarkus.ts.spring.web;
 
 public class MariaDBConstants {
     public static final int PORT = 3306;
-    public static final String START_LOG_10 = "socket: '/run/mysqld/mysqld.sock'  port: " + PORT;
+    public static final String START_LOG_11 = "socket: '.*/mysql.*sock'  port: " + PORT;
     public static final String START_LOG_1011 = "Only MySQL server logs after this point";
     public static final String IMAGE_11 = "${mariadb.11.image}";
     public static final String IMAGE_1011 = "${mariadb.1011.image}";

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/SpringWebQuteIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/SpringWebQuteIT.java
@@ -2,7 +2,7 @@ package io.quarkus.ts.spring.web.bootstrap;
 
 import static io.quarkus.ts.spring.web.MariaDBConstants.IMAGE_11;
 import static io.quarkus.ts.spring.web.MariaDBConstants.PORT;
-import static io.quarkus.ts.spring.web.MariaDBConstants.START_LOG_10;
+import static io.quarkus.ts.spring.web.MariaDBConstants.START_LOG_11;
 
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
@@ -13,7 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class SpringWebQuteIT extends AbstractSpringWebQuteIT {
 
-    @Container(image = IMAGE_11, port = PORT, expectedLog = START_LOG_10)
+    @Container(image = IMAGE_11, port = PORT, expectedLog = START_LOG_11)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/SpringWebRestIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/SpringWebRestIT.java
@@ -2,7 +2,7 @@ package io.quarkus.ts.spring.web.bootstrap;
 
 import static io.quarkus.ts.spring.web.MariaDBConstants.IMAGE_11;
 import static io.quarkus.ts.spring.web.MariaDBConstants.PORT;
-import static io.quarkus.ts.spring.web.MariaDBConstants.START_LOG_10;
+import static io.quarkus.ts.spring.web.MariaDBConstants.START_LOG_11;
 
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
@@ -13,7 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class SpringWebRestIT extends AbstractSpringWebRestIT {
 
-    @Container(image = IMAGE_11, port = PORT, expectedLog = START_LOG_10)
+    @Container(image = IMAGE_11, port = PORT, expectedLog = START_LOG_11)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/openapi/SpringWebOpenApiIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/openapi/SpringWebOpenApiIT.java
@@ -2,7 +2,7 @@ package io.quarkus.ts.spring.web.openapi;
 
 import static io.quarkus.ts.spring.web.MariaDBConstants.IMAGE_11;
 import static io.quarkus.ts.spring.web.MariaDBConstants.PORT;
-import static io.quarkus.ts.spring.web.MariaDBConstants.START_LOG_10;
+import static io.quarkus.ts.spring.web.MariaDBConstants.START_LOG_11;
 
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -17,7 +17,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class SpringWebOpenApiIT extends AbstractSpringWebOpenApiIT {
 
-    @Container(image = IMAGE_11, port = PORT, expectedLog = START_LOG_10)
+    @Container(image = IMAGE_11, port = PORT, expectedLog = START_LOG_11)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/CustomDatasourceProducerIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/CustomDatasourceProducerIT.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class CustomDatasourceProducerIT extends AbstractCustomDatasourceProducerIT {
 
-    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '/run/mysqld/mysqld.sock'  port: "
+    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '.*/mysql.*sock'  port: "
             + MARIADB_PORT)
     static MariaDbService mariadb = new MariaDbService();
 

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiDatabaseActiveInactiveIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiDatabaseActiveInactiveIT.java
@@ -18,7 +18,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class MultiDatabaseActiveInactiveIT extends AbstractMultiDatabaseActiveInactiveIT {
 
-    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '/run/mysqld/mysqld.sock'  port: "
+    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '.*/mysql.*sock'  port: "
             + MARIADB_PORT)
     static MariaDbService mariadb = new MariaDbService();
 

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiplePersistenceIT.java
@@ -12,7 +12,7 @@ public class MultiplePersistenceIT extends AbstractMultiplePersistenceIT {
 
     static final int MARIADB_PORT = 3306;
     static final int POSTGRESQL_PORT = 5432;
-    private static final String MARIADB_START_LOG = "socket: '/run/mysqld/mysqld.sock'  port: " + MARIADB_PORT;
+    private static final String MARIADB_START_LOG = "socket: '.*/mysql.*sock'  port: " + MARIADB_PORT;
 
     @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = MARIADB_START_LOG)
     static MariaDbService mariadb = new MariaDbService();

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
@@ -12,7 +12,7 @@ public class MariaDbTransactionGeneralUsageIT extends TransactionCommons {
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '/run/mysqld/mysqld.sock'  port: "
+    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '.*/mysql.*sock'  port: "
             + MARIADB_PORT)
     static MariaDbService database = new MariaDbService();
 

--- a/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MariaDBPanacheResourceIT.java
+++ b/sql-db/reactive-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MariaDBPanacheResourceIT.java
@@ -11,7 +11,7 @@ public class MariaDBPanacheResourceIT extends AbstractPanacheResourceIT {
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '/run/mysqld/mysqld.sock'  port: "
+    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '.*/mysql.*sock'  port: "
             + MARIADB_PORT)
     static MariaDbService database = new MariaDbService();
 

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MariaDBDatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MariaDBDatabaseIT.java
@@ -11,7 +11,7 @@ public class MariaDBDatabaseIT extends AbstractSqlDatabaseIT {
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '/run/mysqld/mysqld.sock'  port: "
+    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '.*/mysql.*sock'  port: "
             + MARIADB_PORT)
     static MariaDbService database = new MariaDbService();
 

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MariaDBDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MariaDBDatabaseIT.java
@@ -11,7 +11,7 @@ public class MariaDBDatabaseIT extends AbstractSqlDatabaseIT {
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '/run/mysqld/mysqld.sock'  port: "
+    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '.*/mysql.*sock'  port: "
             + MARIADB_PORT)
     static MariaDbService database = new MariaDbService();
 


### PR DESCRIPTION
### Summary

I recently bumped MariaDB to 11.4 https://github.com/quarkus-qe/quarkus-test-suite/pull/2400, but MariaDB 11.4 doesn't start in FIPS-enabled environment https://issues.redhat.com/browse/QUARKUS-5984, so instead of having failing tests or disabling all the tests, I think we should use 10.11 in FIPS-enabled environment.

Tested in `rhbq-3.20-extended-platform/job/rhbq-3.20-baremetal-ts-jvm/18`.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)