### PR TITLE
Explicit dependency on quarkus-smallrye-stork in Stork modules

### DIFF
--- a/service-discovery/stork-custom/pom.xml
+++ b/service-discovery/stork-custom/pom.xml
@@ -12,8 +12,8 @@
     <name>Quarkus QE TS: Service-discovery: Stork-custom</name>
     <dependencies>
         <dependency>
-            <groupId>io.smallrye.stork</groupId>
-            <artifactId>stork-core</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-stork</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye.stork</groupId>

--- a/service-discovery/stork/pom.xml
+++ b/service-discovery/stork/pom.xml
@@ -12,6 +12,10 @@
     <name>Quarkus QE TS: Service-discovery: Stork</name>
     <dependencies>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-stork</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.stork</groupId>
             <artifactId>stork-service-discovery-consul</artifactId>
         </dependency>


### PR DESCRIPTION
### Summary

Explicit dependency on quarkus-smallrye-stork in Stork modules

Trigger: https://github.com/quarkusio/quarkus/pull/47435 

Quarkus upstream moved away from strong coupling between REST Client and Stork to optional dependency.
Stork modules should depend on `quarkus-smallrye-stork` anyway.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)