### PR TITLE
Revert "Disable shouldKeepUsingTheSameQuarkusVersionAfterReload test because of upstream regression"

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -312,7 +312,6 @@ public class QuarkusCliCreateJvmApplicationIT {
 
     @Tag("https://github.com/quarkusio/quarkus/issues/25184")
     @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/47418")
     public void shouldKeepUsingTheSameQuarkusVersionAfterReload() {
         // Generate application using old community version
         QuarkusCliRestService app = cliClient.createApplication("app", defaults()


### PR DESCRIPTION
### Summary

Revert "Disable shouldKeepUsingTheSameQuarkusVersionAfterReload test because of upstream regression"

This reverts commit 002e50b51645cca103e45c2c8291f090824b48ea.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)