### PR TITLE
[3.20] QUARKUS-5668 -  Adding test for ability to exclude URIs from tracing

### DIFF
--- a/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/PartiallyTraceableResource.java
+++ b/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/PartiallyTraceableResource.java
@@ -1,0 +1,39 @@
+package io.quarkus.ts.opentelemetry.reactive;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/partially-traceable-hello")
+public class PartiallyTraceableResource {
+
+    @GET
+    @Path("/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> helloPathParam(@PathParam("name") String name) {
+        return Uni.createFrom().item("Traced hello " + name);
+    }
+
+    @GET
+    @Path("")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> helloQueryParam(@QueryParam("name") String name) {
+        if (name == null || name.isEmpty()) {
+            return Uni.createFrom().item("Untraced hello anonymous");
+        }
+        return Uni.createFrom().item("Traced hello " + name);
+    }
+
+    @GET
+    @Path("/everybody")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> helloEmbedded() {
+        return Uni.createFrom().item("Traced hello to everybody!");
+    }
+
+}

--- a/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/UntraceableResource.java
+++ b/monitoring/opentelemetry-reactive/src/main/java/io/quarkus/ts/opentelemetry/reactive/UntraceableResource.java
@@ -1,0 +1,39 @@
+package io.quarkus.ts.opentelemetry.reactive;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/untraceable-hello")
+public class UntraceableResource {
+
+    @GET
+    @Path("/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> helloPathParam(@PathParam("name") String name) {
+        return Uni.createFrom().item("Untraced hello " + name);
+    }
+
+    @GET
+    @Path("")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> helloQueryParam(@QueryParam("name") String name) {
+        if (name == null || name.isEmpty()) {
+            return Uni.createFrom().item("Untraced hello anonymous");
+        }
+        return Uni.createFrom().item("Untraced hello " + name);
+    }
+
+    @GET
+    @Path("/everybody")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> helloEmbedded() {
+        return Uni.createFrom().item("Untraced hello to everybody!");
+    }
+
+}


### PR DESCRIPTION
### Summary

* Adding test for ability to exclude URIs from tracing.

Jira: https://issues.redhat.com/browse/QUARKUS-5668

Upstream documentation: https://quarkus.io/guides/opentelemetry-tracing#disabling-traces-for-app-endpoints

Code changes:
* https://github.com/quarkusio/quarkus/pull/43885
* https://github.com/quarkusio/quarkus/pull/44724

(cherry picked from commit 84226a2c47533918a7be73e0a1617b494ada3f60)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)