### PR TITLE
Reduce the execution time of the daily CI run

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 21 ]
-        profiles: [ "root-modules,http-modules,security-modules,spring-modules",
+        java: [ 21 ]
+        profiles: [ "root-modules", "http-modules,security-modules,spring-modules",
                    "sql-db-modules", "root-modules -pl build/podman/,build/docker -Dtest-ubi8-compatibility",
                    "messaging-modules,websockets-modules,monitoring-modules,cache-modules,test-tooling-modules,nosql-db-modules"]
     steps:
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 17 ]
-        image: [ "ubi9-quarkus-graalvmce-builder-image:jdk-21", "ubi9-quarkus-mandrel-builder-image:jdk-21", "ubi-quarkus-mandrel-builder-image:jdk-21 -Dtest-ubi8-compatibility" ]
+        image: [ "ubi9-quarkus-mandrel-builder-image:jdk-21", "ubi-quarkus-mandrel-builder-image:jdk-21 -Dtest-ubi8-compatibility" ]
         profiles: [ "root-modules,websockets-modules,test-tooling-modules,nosql-db-modules",
                    "http-modules,cache-modules",
                    "security-modules,spring-modules",
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 21 ]
+        java: [ 21 ]
     steps:
       - uses: actions/checkout@v4
       - name: Install JDK {{ matrix.java }}
@@ -183,7 +183,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 17, 21 ]
-        profiles: [ "root-modules,http-modules,security-modules,spring-modules",
+        profiles: [ "root-modules", "http-modules,security-modules,spring-modules",
                     "sql-db-modules", "root-modules -pl build/podman/,build/docker -Dtest-ubi8-compatibility",
                     "messaging-modules,websockets-modules,monitoring-modules,cache-modules,test-tooling-modules,nosql-db-modules"]
     steps:
@@ -225,7 +225,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 17 ]
-        image: [ "ubi9-quarkus-graalvmce-builder-image:jdk-21", "ubi9-quarkus-mandrel-builder-image:jdk-21", "ubi-quarkus-mandrel-builder-image:jdk-21 -Dtest-ubi8-compatibility" ]
+        image: [ "ubi9-quarkus-mandrel-builder-image:jdk-21", "ubi-quarkus-mandrel-builder-image:jdk-21 -Dtest-ubi8-compatibility" ]
         profiles: [ "root-modules,websockets-modules,test-tooling-modules,nosql-db-modules",
                     "http-modules,cache-modules",
                     "security-modules,spring-modules",


### PR DESCRIPTION
### Summary

Reduce the execution time of the daily CI run

 * Drop of ubi9-quarkus-graalvmce-builder-image:jdk-21, Mandrel our main focus
 * Focus on Java 21 in JVM runs, Java 17 is used for compilation in Native runs
 * root-modules as a separate entry in JVM runs, execution time is ~45 minutes, and it grows thanks to the CLI


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)