### PR TITLE
[3.20] - Enable nativeSerializationTest from websocket-next 

### DIFF
--- a/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/BaseWebSocketIT.java
+++ b/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/BaseWebSocketIT.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 
 public abstract class BaseWebSocketIT {
     private static final Logger LOG = Logger.getLogger(BaseWebSocketIT.class);
@@ -80,7 +79,6 @@ public abstract class BaseWebSocketIT {
     }
 
     @Test
-    @DisabledOnNative(reason = "https://github.com/quarkusio/quarkus/issues/47269")
     public void nativeSerializationTest() throws URISyntaxException, InterruptedException {
         Client client = createClient("/serialization/native");
         assertMessage("{\"type\":\"OPEN\",\"message\":\"Connection opened\",\"payload\":null}", client);


### PR DESCRIPTION
### Summary
Enable nativeSerializationTest from websocket-next for 3.20.1 
In this case, this test was only disabled in our 3.20 branch.
Original issue-->  https://github.com/quarkusio/quarkus/issues/47269 
This was fix in main here--> https://github.com/quarkusio/quarkus/pull/47027 


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)