### PR TITLE
Use option `properties` instead of method withProperties in reactive REST client tests

### DIFF
--- a/http/rest-client-reactive/src/main/resources/modern.properties
+++ b/http/rest-client-reactive/src/main/resources/modern.properties
@@ -14,3 +14,6 @@ quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG
 quarkus.http.limits.max-body-size=3G
 quarkus.rest-client.read-timeout = 120000
 quarkus.vertx.warning-exception-time=5s
+
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true
+quarkus.otel.enabled=false

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/DevModeIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/DevModeIT.java
@@ -21,9 +21,8 @@ import io.restassured.response.ResponseBody;
 @QuarkusScenario
 public class DevModeIT {
 
-    @DevModeQuarkusApplication
-    static RestService app = new RestService()
-            .withProperties("modern.properties");
+    @DevModeQuarkusApplication(properties = "modern.properties")
+    static RestService app = new RestService();
 
     @Test
     @Tag("https://issues.redhat.com/browse/QUARKUS-5616")

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/LargeFileHandlingIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/LargeFileHandlingIT.java
@@ -43,10 +43,9 @@ public class LargeFileHandlingIT {
         }
     }
 
-    @QuarkusApplication
+    @QuarkusApplication(properties = "modern.properties")
     static RestService app = new RestService()
-            .withProperty("client.filepath", () -> files.toAbsolutePath().toString())
-            .withProperties("modern.properties");
+            .withProperty("client.filepath", () -> files.toAbsolutePath().toString());
 
     @Inject
     public LargeFileHandlingIT() {

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/LocalProxyIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/LocalProxyIT.java
@@ -17,9 +17,8 @@ import io.restassured.response.Response;
 @QuarkusScenario
 public class LocalProxyIT {
 
-    @DevModeQuarkusApplication
+    @DevModeQuarkusApplication(properties = "modern.properties")
     static RestService proxyApp = new RestService()
-            .withProperties("modern.properties")
             .withProperty("quarkus.rest-client.meta-client.enable-local-proxy", "true");
 
     @Test

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
@@ -52,9 +52,8 @@ public class ReactiveRestClientIT {
 
     static final String MALFORMED_URL = "quarkus.rest-client.\"io.quarkus.ts.http.restclient.reactive.MalformedClient\".url";
 
-    @QuarkusApplication
+    @QuarkusApplication(properties = "modern.properties")
     static RestService app = new RestService()
-            .withProperties("modern.properties")
             .withProperty(MALFORMED_URL, () -> mockServer.baseUrl());
 
     @Test

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientProxyIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientProxyIT.java
@@ -22,9 +22,8 @@ public class ReactiveRestClientProxyIT {
             .withProperty("NGINX_ENVSUBST_OUTPUT_DIR", "/etc/nginx")
             .withProperty("_whatever", "resource_with_destination::/etc/nginx/templates/|nginx.conf.template");
 
-    @QuarkusApplication
+    @QuarkusApplication(properties = "proxy.properties")
     static RestService proxyApp = new RestService()
-            .withProperties("proxy.properties")
             .withProperty("quarkus.rest-client.\"io.quarkus.ts.http.restclient.reactive.proxy.ProxyClient\".proxy-user", USER)
             .withProperty("quarkus.rest-client.\"io.quarkus.ts.http.restclient.reactive.proxy.ProxyClient\".proxy-password",
                     PASSWORD)

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/UrlOverrideClientIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/UrlOverrideClientIT.java
@@ -36,17 +36,15 @@ public class UrlOverrideClientIT {
     @JaegerContainer(expectedLog = "\"Health Check state change\",\"status\":\"ready\"")
     static final JaegerService jaeger = new JaegerService();
 
-    @QuarkusApplication()
+    @QuarkusApplication(properties = "urlOverride.properties")
     static RestService app = new RestService()
-            .withProperties("urlOverride.properties")
             .withProperty("quarkus.otel.enabled", "true")
             .withProperty("quarkus.otel.simple", "true")
             .withProperty("quarkus.application.name", MAIN_SERVICE_NAME)
             .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
 
-    @QuarkusApplication()
+    @QuarkusApplication(properties = "urlOverride.properties")
     static RestService app2 = new RestService()
-            .withProperties("urlOverride.properties")
             .withProperty("quarkus.http.ssl-port", "8444")
             .withProperty("ts.quarkus.urlOverride.response", "overridden");
 


### PR DESCRIPTION
### Summary

The property forces framework to use the file as the main properties file; The method adds all properties to CLI.
The user usually wants the former.
This patch affects only tests in rest-client-reactive and only if they they work without any problems after the change.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)