### PR TITLE
Coverage for fix Qute record constructor search with nested type-safe fragment #47001

### DIFF
--- a/qute/reactive/src/main/java/io/quarkus/ts/qute/Application.java
+++ b/qute/reactive/src/main/java/io/quarkus/ts/qute/Application.java
@@ -74,6 +74,13 @@ public class Application {
         return Response.ok(template.data("server", name + " engine")).build();
     }
 
+    @GET
+    @Path("/record-order/test")
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance recordComplexOrderTest() {
+        return new UserTemplates.UserWithOrder(123, "Test User", 789L, true);
+    }
+
     @POST
     @Path("/engine/{name}")
     @Produces(MediaType.TEXT_HTML)

--- a/qute/reactive/src/main/java/io/quarkus/ts/qute/UserTemplates.java
+++ b/qute/reactive/src/main/java/io/quarkus/ts/qute/UserTemplates.java
@@ -1,0 +1,15 @@
+package io.quarkus.ts.qute;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+
+public class UserTemplates {
+    @CheckedTemplate(basePath = "")
+    public static record UserWithOrder(int id, String name, Long orderNumber, boolean isActive) implements TemplateInstance {
+    }
+
+    @CheckedTemplate(basePath = "")
+    public static record UserWithOrder$theFragment(String name, int id) implements TemplateInstance {
+    }
+
+}

--- a/qute/reactive/src/main/resources/templates/UserWithOrder.html
+++ b/qute/reactive/src/main/resources/templates/UserWithOrder.html
@@ -1,0 +1,18 @@
+<div>
+    <p>Id: {id}</p>
+    <p>Name: {name}</p>
+    <p>Order Number: {orderNumber}</p>
+    <p>Is Active: {isActive}</p>
+
+    <hr/>
+    {#fragment id=theFragment}
+    <div class="user-details-complex">
+        <p>Fragment using name then id: User '{name}' has id {id}.</p>
+        <p>All details (from fragment context): Name: {name}, Id: {id}</p>
+    </div>
+    {/fragment}
+    <hr/>
+
+    <h1>Name from Main: {name}</h1>
+    <p>ID from Main: {id}</p>
+</div>

--- a/qute/reactive/src/test/java/io/quarkus/ts/qute/QuteReactiveIT.java
+++ b/qute/reactive/src/test/java/io/quarkus/ts/qute/QuteReactiveIT.java
@@ -11,6 +11,7 @@ import java.util.stream.Stream;
 import jakarta.ws.rs.core.MediaType;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -308,4 +309,19 @@ public class QuteReactiveIT {
                 .statusCode(200)
                 .body(is("io.quarkus.ts.qute.Book$quarkusjacksondeserializer"));
     }
+
+    @Tag("https://github.com/quarkusio/quarkus/pull/47001")
+    @Test
+    void testRecordFragmentParameterOrderNPEFix() {
+        String content = app.given()
+                .get("/record-order/test")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+
+        assertTrue(content.contains("Fragment using name then id: User 'Test User' has id 123"),
+                "Should contain fragment details with name before id");
+    }
+
 }


### PR DESCRIPTION
### Summary

Test coverage for fix implemented in PR [47001](https://github.com/quarkusio/quarkus/pull/47001) related also with [46980](https://github.com/quarkusio/quarkus/issues/46980)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)