### PR TITLE
Add coverage for Agroal bug when the transaction was commited after the timeout

### DIFF
--- a/sql-db/narayana-transactions/src/main/java/io.quarkus.ts.transactions/ClientEntity.java
+++ b/sql-db/narayana-transactions/src/main/java/io.quarkus.ts.transactions/ClientEntity.java
@@ -1,0 +1,61 @@
+package io.quarkus.ts.transactions;
+
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.quarkus.panache.common.Sort;
+
+@Entity(name = "client")
+public class ClientEntity extends PanacheEntity {
+
+    @Column(nullable = false)
+    private String name;
+    @Column(nullable = false)
+    private String lastName;
+    @Column(unique = true, nullable = false, name = "account_number")
+    private String accountNumber;
+
+    public ClientEntity() {
+    }
+
+    public ClientEntity(String name, String lastName, String accountNumber) {
+        this.name = name;
+        this.lastName = lastName;
+        this.accountNumber = accountNumber;
+    }
+
+    public static ClientEntity findClient(String accountNumber) {
+        return find("accountNumber", accountNumber).firstResult();
+    }
+
+    public static List<ClientEntity> getAllclients() {
+        return findAll(Sort.by("name").descending()).list();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public void setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+}

--- a/sql-db/narayana-transactions/src/main/java/io.quarkus.ts.transactions/ClientResource.java
+++ b/sql-db/narayana-transactions/src/main/java/io.quarkus.ts.transactions/ClientResource.java
@@ -1,0 +1,81 @@
+package io.quarkus.ts.transactions;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import io.quarkus.narayana.jta.runtime.TransactionConfiguration;
+
+@Path("/client")
+public class ClientResource {
+
+    @Inject
+    ClientService clientService;
+
+    @POST
+    @Path("/create")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    @TransactionConfiguration(timeout = 1)
+    public Response createClient(ClientEntity client) {
+        clientService.createAccount(client);
+        return Response.ok(client).status(201).build();
+    }
+
+    @POST
+    @Path("/create-manually")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    @TransactionConfiguration(timeout = 1)
+    public Response createClientManually(ClientEntity client) throws InterruptedException {
+        Thread.sleep(2000);
+        clientService.createAccountManually(client);
+        return Response.ok(client).status(201).build();
+    }
+
+    @DELETE
+    @Path("/delete/{account_number}")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    @TransactionConfiguration(timeout = 1)
+    public Response deleteClientManually(@PathParam("account_number") String accountNumber) throws InterruptedException {
+        Thread.sleep(2000);
+        clientService.deleteAccountManually(accountNumber);
+        return Response.ok("Client deleted").status(204).build();
+    }
+
+    @PATCH
+    @Path("/update/{account_number}")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    @TransactionConfiguration(timeout = 1)
+    public Response updateClientManually(@PathParam("account_number") String accountNumber, @QueryParam("name") String newName)
+            throws InterruptedException {
+        Thread.sleep(2000);
+        clientService.updateAccountManually(newName, accountNumber);
+        return Response.ok("Client updated").status(200).build();
+    }
+
+    @Path("/all")
+    @GET
+    public List<ClientEntity> getAccounts() {
+        return clientService.getAllClients();
+    }
+
+    @Path("/{account_number}")
+    @GET
+    public ClientEntity getClientByAccountNumber(@PathParam("account_number") String accountNumber) {
+        return clientService.getAccount(accountNumber);
+    }
+}

--- a/sql-db/narayana-transactions/src/main/java/io.quarkus.ts.transactions/ClientService.java
+++ b/sql-db/narayana-transactions/src/main/java/io.quarkus.ts.transactions/ClientService.java
@@ -1,0 +1,72 @@
+package io.quarkus.ts.transactions;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.agroal.DataSource;
+
+@ApplicationScoped
+public class ClientService {
+
+    @Inject
+    @DataSource("xa-ds-1")
+    AgroalDataSource agroalDataSource;
+
+    public List<ClientEntity> getAllClients() {
+        return ClientEntity.getAllclients();
+    }
+
+    public ClientEntity getAccount(String accountNumber) {
+        return ClientEntity.findClient(accountNumber);
+    }
+
+    public void createAccount(ClientEntity account) {
+        ClientEntity.persist(account);
+    }
+
+    @Transactional(Transactional.TxType.REQUIRED)
+    public void createAccountManually(ClientEntity client) {
+        try (var connection = agroalDataSource.getConnection()) {
+            String prepareStatement = "INSERT INTO client (id, name, lastName, account_number) VALUES (3, ?, ?, ?)";
+            try (var statement = connection.prepareStatement(prepareStatement)) {
+                statement.setString(1, client.getName());
+                statement.setString(2, client.getLastName());
+                statement.setString(3, client.getAccountNumber());
+                statement.execute();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Database operation failed", e);
+        }
+    }
+
+    @Transactional(Transactional.TxType.REQUIRED)
+    public void deleteAccountManually(String accountNumber) {
+        try (var connection = agroalDataSource.getConnection()) {
+            String prepareStatement = "DELETE FROM client WHERE account_number = ?";
+            try (var statement = connection.prepareStatement(prepareStatement)) {
+                statement.setString(1, accountNumber);
+                statement.execute();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Database operation failed", e);
+        }
+    }
+
+    @Transactional(Transactional.TxType.REQUIRED)
+    public void updateAccountManually(String newName, String accountNumber) {
+        try (var connection = agroalDataSource.getConnection()) {
+            String prepareStatement = "UPDATE client SET name = ? WHERE account_number = ?";
+            try (var statement = connection.prepareStatement(prepareStatement)) {
+                statement.setString(1, newName);
+                statement.setString(2, accountNumber);
+                statement.execute();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Database operation failed", e);
+        }
+    }
+}

--- a/sql-db/narayana-transactions/src/main/resources/import.sql
+++ b/sql-db/narayana-transactions/src/main/resources/import.sql
@@ -5,4 +5,7 @@ INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, creat
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('Account_SEQ'), 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (nextval('Account_SEQ'), 'Eduardo', 'Mendoza', 'ES8521006742088984966899', 100, null, CURRENT_TIMESTAMP);
 
+INSERT INTO client (id, name, lastName, account_number) VALUES (100, 'Francisco', 'Quevedo', 'ES8521006742088984966817');
+INSERT INTO client (id, name, lastName, account_number) VALUES (101, 'Eduardo', 'Mendoza', 'ES8521006742088984966899');
+
 CREATE TABLE IF NOT EXISTS recovery_log (id INT);

--- a/sql-db/narayana-transactions/src/test/resources/mariadb_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/mariadb_import.sql
@@ -5,4 +5,7 @@ INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, creat
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Eduardo', 'Mendoza', 'ES8521006742088984966899', 100, null, CURRENT_TIMESTAMP);
 
+INSERT INTO client (id, name, lastName, account_number) VALUES (100, 'Francisco', 'Quevedo', 'ES8521006742088984966817');
+INSERT INTO client (id, name, lastName, account_number) VALUES (101, 'Eduardo', 'Mendoza', 'ES8521006742088984966899');
+
 CREATE TABLE IF NOT EXISTS recovery_log (id INT);

--- a/sql-db/narayana-transactions/src/test/resources/mssql_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/mssql_import.sql
@@ -5,4 +5,7 @@ INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, creat
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR Account_SEQ, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (NEXT VALUE FOR account_SEQ, 'Eduardo', 'Mendoza', 'ES8521006742088984966899', 100, null, CURRENT_TIMESTAMP);
 
+INSERT INTO client (id, name, lastName, account_number) VALUES (100, 'Francisco', 'Quevedo', 'ES8521006742088984966817');
+INSERT INTO client (id, name, lastName, account_number) VALUES (101, 'Eduardo', 'Mendoza', 'ES8521006742088984966899');
+
 CREATE TABLE recovery_log (id INT);

--- a/sql-db/narayana-transactions/src/test/resources/mysql_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/mysql_import.sql
@@ -6,4 +6,7 @@ INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, creat
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) SELECT MAX(id) + 1, 'Eduardo', 'Mendoza', 'ES8521006742088984966899', 100, null, CURRENT_TIMESTAMP FROM account;
 UPDATE account_SEQ SET next_val=(SELECT MAX(id) + 1 FROM account);
 
+INSERT INTO client (id, name, lastName, account_number) VALUES (100, 'Francisco', 'Quevedo', 'ES8521006742088984966817');
+INSERT INTO client (id, name, lastName, account_number) VALUES (101, 'Eduardo', 'Mendoza', 'ES8521006742088984966899');
+
 CREATE TABLE IF NOT EXISTS recovery_log (id INT);

--- a/sql-db/narayana-transactions/src/test/resources/oracle_import.sql
+++ b/sql-db/narayana-transactions/src/test/resources/oracle_import.sql
@@ -5,4 +5,7 @@ INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, creat
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (Account_SEQ.NEXTVAL, 'Francisco', 'Quevedo', 'ES8521006742088984966817', 100, null, CURRENT_TIMESTAMP);
 INSERT INTO account (id, name, lastName, accountNumber, amount, updatedAt, createdAt) VALUES (Account_SEQ.NEXTVAL, 'Eduardo', 'Mendoza', 'ES8521006742088984966899', 100, null, CURRENT_TIMESTAMP);
 
+INSERT INTO client (id, name, lastName, account_number) VALUES (100, 'Francisco', 'Quevedo', 'ES8521006742088984966817');
+INSERT INTO client (id, name, lastName, account_number) VALUES (101, 'Eduardo', 'Mendoza', 'ES8521006742088984966899');
+
 CREATE TABLE IF NOT EXISTS recovery_log (id INT);


### PR DESCRIPTION
### Summary

Coverage for [QUARKUS-5950](https://issues.redhat.com/browse/QUARKUS-5950) and [QUARKUS-5882](https://issues.redhat.com/browse/QUARKUS-5882) which trigger it. Also this was discovered in https://github.com/quarkusio/quarkus/issues/45087

It cover the case where the SQL query was executed after the transaction timeout. The transaction should not be commited in this case. Before the Agroal fix the transaction was commited even after the timeout.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)