### PR TITLE
Test coverage for NPE kafka stork #41658

### DIFF
--- a/service-discovery/stork/pom.xml
+++ b/service-discovery/stork/pom.xml
@@ -13,6 +13,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-stork</artifactId>
         </dependency>
         <dependency>
@@ -26,6 +30,15 @@
         <dependency>
             <groupId>io.smallrye.stork</groupId>
             <artifactId>stork-service-discovery-kubernetes</artifactId>
+        </dependency>
+        <!-- https://github.com/quarkusio/quarkus/issues/41658 -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-messaging-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-service-discovery-static-list</artifactId>
         </dependency>
         <!-- https://github.com/quarkusio/quarkus/issues/26927 -->
         <!-- bouncycastle is required by stork-service-discovery-kubernetes in native mode-->
@@ -46,6 +59,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-kafka</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>

--- a/service-discovery/stork/src/main/java/io/quarkus/ts/stork/GreetingResource.java
+++ b/service-discovery/stork/src/main/java/io/quarkus/ts/stork/GreetingResource.java
@@ -1,0 +1,24 @@
+package io.quarkus.ts.stork;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/")
+public class GreetingResource implements IGreetingResource {
+
+    @GET
+    @Path("/greeting")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "Hello from Stork!";
+    }
+
+    @GET
+    @Path("/count")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getMessageCount() {
+        return String.valueOf(PriceConsumer.getCount());
+    }
+}

--- a/service-discovery/stork/src/main/java/io/quarkus/ts/stork/IGreetingResource.java
+++ b/service-discovery/stork/src/main/java/io/quarkus/ts/stork/IGreetingResource.java
@@ -1,0 +1,16 @@
+package io.quarkus.ts.stork;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey = "greeting")
+public interface IGreetingResource {
+    @GET
+    @Path("/greeting")
+    @Produces(MediaType.TEXT_PLAIN)
+    String hello();
+}

--- a/service-discovery/stork/src/main/java/io/quarkus/ts/stork/KafkaPriceProducer.java
+++ b/service-discovery/stork/src/main/java/io/quarkus/ts/stork/KafkaPriceProducer.java
@@ -1,0 +1,22 @@
+package io.quarkus.ts.stork;
+
+import java.time.Duration;
+import java.util.Random;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.mutiny.Multi;
+
+@ApplicationScoped
+public class KafkaPriceProducer {
+
+    private final Random random = new Random();
+
+    @Outgoing("prices-out")
+    public Multi<Double> generate() {
+        return Multi.createFrom().ticks().every(Duration.ofMillis(100))
+                .map(x -> random.nextDouble());
+    }
+}

--- a/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PriceConsumer.java
+++ b/service-discovery/stork/src/main/java/io/quarkus/ts/stork/PriceConsumer.java
@@ -1,0 +1,56 @@
+package io.quarkus.ts.stork;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.logging.Logger;
+
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+
+@ApplicationScoped
+@Path("/price")
+public class PriceConsumer {
+
+    private static final Logger LOG = Logger.getLogger(PriceConsumer.class);
+    private static final AtomicInteger messageCount = new AtomicInteger(0);
+
+    @Inject
+    @RestClient
+    IGreetingResource greetingResource;
+
+    @Incoming("prices")
+    @RunOnVirtualThread
+    @Blocking(ordered = false)
+    public void consume(double price) throws InterruptedException {
+        LOG.info("consume() - Received price: " + price);
+
+        Thread.sleep(1000);
+        try {
+            String result = greetingResource.hello();
+            LOG.info("Greeting result => " + result);
+            messageCount.incrementAndGet();
+        } catch (Exception e) {
+            LOG.error("Error calling greeting service", e);
+        }
+    }
+
+    @GET
+    @Path("/count")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getMessageCount() {
+        return String.valueOf(messageCount.get());
+    }
+
+    public static int getCount() {
+        return messageCount.get();
+    }
+}

--- a/service-discovery/stork/src/main/resources/application.properties
+++ b/service-discovery/stork/src/main/resources/application.properties
@@ -1,1 +1,13 @@
-# application properties should be here
+mp.messaging.incoming.prices.connector=smallrye-kafka
+mp.messaging.outgoing.prices-out.connector=smallrye-kafka
+mp.messaging.incoming.prices.topic=mytopic
+mp.messaging.outgoing.prices-out.topic=mytopic
+
+mp.messaging.incoming.prices.value.deserializer=org.apache.kafka.common.serialization.DoubleDeserializer
+mp.messaging.outgoing.prices-out.value.serializer=org.apache.kafka.common.serialization.DoubleSerializer
+
+
+quarkus.rest-client.greeting.url=stork://greeting-service
+quarkus.stork.greeting-service.service-discovery.type=static
+quarkus.stork.greeting-service.service-discovery.address-list=localhost:${quarkus.http.port}
+quarkus.stork.greeting-service.load-balancer.type=round-robin

--- a/service-discovery/stork/src/test/java/io/quarkus/ts/stork/KafkaWithStorkIT.java
+++ b/service-discovery/stork/src/test/java/io/quarkus/ts/stork/KafkaWithStorkIT.java
@@ -1,0 +1,54 @@
+package io.quarkus.ts.stork;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.KafkaService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KafkaContainer;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.containers.model.KafkaVendor;
+
+@Tag("https://github.com/quarkusio/quarkus/issues/41658")
+@QuarkusScenario
+public class KafkaWithStorkIT {
+
+    private static final Logger testLog = Logger.getLogger(KafkaWithStorkIT.class);
+    private static final String STORK_GET_INSTANCE_NPE_SIGNATURE = "Cannot invoke \"io.smallrye.stork.Stork.getService(String)\" because the return value of \"io.smallrye.stork.Stork.getInstance()\" is null";
+
+    @KafkaContainer(vendor = KafkaVendor.STRIMZI)
+    static final KafkaService kafka = new KafkaService();
+
+    @QuarkusApplication(classes = {
+            IGreetingResource.class, GreetingResource.class, PriceConsumer.class, KafkaPriceProducer.class
+    })
+    static RestService app = new RestService()
+            .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl);
+
+    @Test
+    public void testNoStorkNPEOnGracefulShutdown_LogCheck() {
+        final int expectedMessageCount = 3;
+        await().atMost(Duration.ofSeconds(25))
+                .pollInterval(Duration.ofMillis(500))
+                .until(() -> {
+                    List<String> logs = app.getLogs();
+                    long count = logs.stream()
+                            .filter(line -> line.contains("Received price"))
+                            .count();
+                    return count >= expectedMessageCount;
+                });
+        app.stop();
+        testLog.info("Application shutdown completed.");
+        boolean hasStorkNPE = app.getLogs().stream()
+                .anyMatch(line -> line.contains(STORK_GET_INSTANCE_NPE_SIGNATURE));
+        assertFalse(hasStorkNPE, "Specific NPE Stork.getInstance() should not come up during shutdown");
+    }
+}


### PR DESCRIPTION
### Summary

Adding test coverage for https://github.com/quarkusio/quarkus/issues/41658 which fixes a NPE that occurred during shutdown when using Kafka with Stork-based service discovery
The command where the original NPE from the issue comes up was:
1. `mvn quarkus:dev`
2. press` 's'`
3. Look at the error traces logs

The specific NPE was : 
`Cannot invoke "io.smallrye.stork.Stork.getService(String)" because the return value of "io.smallrye.stork.Stork.getInstance()" is null` and the test validates that the specific Stork NPE no longer occurs during shutdown.

Note: To run this test locally, you need to start Consul first (as some existing classes depend on it):
`$ docker run --rm --name consul -p 8500:8500 -p 8501:8501 consul:1.7 agent -dev -ui -client=0.0.0.0 -bind=0.0.0.0 --https-port=8501
` 
The test reproduces the original scenario by:

1. Setting up a Kafka producer and consumer
2. Using a REST client with Stork URL in the consumer
3. Running the application and processing messages
4. Triggering a shutdown
5. Verifying the specific Stork NPE does not appear in the logs

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)