### PR TITLE
Add coverage for RunnerClassLoader returnnig resource with `/` if they end with `/`

### DIFF
--- a/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/ResourcesFinderResource.java
+++ b/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/ResourcesFinderResource.java
@@ -1,0 +1,117 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.JarURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+
+@Path("/resource-finder")
+@ApplicationScoped
+public class ResourcesFinderResource {
+
+    @GET
+    @Path("/find")
+    public String findResources(@QueryParam("resourcePath") String resourcePath,
+            @QueryParam("lookupPattern") String lookupPattern) throws URISyntaxException, IOException {
+        ClassLoader classLoader = this.getClass().getClassLoader();
+
+        List<URL> result = new ArrayList<>();
+        Enumeration<URL> resources = classLoader.getResources(resourcePath);
+        while (resources.hasMoreElements()) {
+            URL url = resources.nextElement();
+            if (isJarURL(url)) {
+                getMatchingResourcesInsideJar(url, lookupPattern, result);
+            } else {
+                // This is useful when running Quarkus in dev mode
+                getMatchingResourcesOutsideJar(new File(url.toURI()), lookupPattern, result);
+            }
+        }
+        return result.stream()
+                .map(URL::toString)
+                .collect(Collectors.joining("\n"));
+    }
+
+    /**
+     * Travers over the files inside jar and looking for files which match the pattern
+     * This is simplified PathMatchingResourcePatternResolver#doFindPathMatchingJarResources
+     * from spring which was used in reproducer
+     */
+    private void getMatchingResourcesInsideJar(URL rootDirURL, String lookupPattern, List<URL> result) throws IOException {
+
+        URLConnection con = rootDirURL.openConnection();
+        JarFile jarFile;
+        String rootEntryPath = "";
+
+        if (con instanceof JarURLConnection) {
+            JarURLConnection jarCon = (JarURLConnection) con;
+            jarFile = jarCon.getJarFile();
+            JarEntry jarEntry = jarCon.getJarEntry();
+            rootEntryPath = (jarEntry != null ? jarEntry.getName() : "");
+        } else {
+            jarFile = new JarFile(rootDirURL.getFile());
+        }
+
+        try {
+            if (!rootEntryPath.isEmpty() && !rootEntryPath.endsWith("/")) {
+                rootEntryPath = rootEntryPath + "/";
+            }
+            for (Enumeration<JarEntry> entries = jarFile.entries(); entries.hasMoreElements();) {
+                JarEntry entry = entries.nextElement();
+                String entryPath = entry.getName();
+                if (entryPath.startsWith(rootEntryPath)) {
+                    String relativePath = entryPath.substring(rootEntryPath.length());
+                    if (matchResourceWithPattern(lookupPattern, relativePath)) {
+                        result.add(new URL(rootDirURL, relativePath));
+                    }
+                }
+            }
+        } finally {
+            jarFile.close();
+        }
+    }
+
+    /**
+     * Find resources on classpath when the resources are not inside JAR.
+     * This can be useful when running the dev mode
+     */
+    private void getMatchingResourcesOutsideJar(File dir, String lookupPattern, List<URL> result) throws IOException {
+        for (File content : listDirectory(dir)) {
+            String currPath = content.getAbsolutePath().replace(File.separator, "/");
+            if (content.isDirectory()) {
+                getMatchingResourcesOutsideJar(content, lookupPattern, result);
+            }
+            if (matchResourceWithPattern(dir + lookupPattern, currPath)) {
+                result.add(content.toURI().toURL());
+            }
+        }
+    }
+
+    private static boolean matchResourceWithPattern(String fullPattern, String path) {
+        return path.matches(fullPattern);
+    }
+
+    private static boolean isJarURL(URL rootDirUrl) {
+        return rootDirUrl.getProtocol().equals("jar");
+    }
+
+    protected File[] listDirectory(File dir) {
+        File[] files = dir.listFiles();
+        if (files == null) {
+            return new File[0];
+        }
+        return files;
+    }
+}

--- a/http/http-advanced-reactive/src/main/resources/application.properties
+++ b/http/http-advanced-reactive/src/main/resources/application.properties
@@ -54,6 +54,8 @@ quarkus.keycloak.policy-enforcer.paths.sse.path=/api/sse/*
 quarkus.keycloak.policy-enforcer.paths.sse.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.cheese.path=/api/cheese/*
 quarkus.keycloak.policy-enforcer.paths.cheese.enforcement-mode=DISABLED
+quarkus.keycloak.policy-enforcer.paths.resource-finder.path=/api/resource-finder/*
+quarkus.keycloak.policy-enforcer.paths.resource-finder.enforcement-mode=DISABLED
 quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 # tolerate 1 minute of clock skew between the Keycloak server and the application

--- a/http/http-advanced-reactive/src/main/resources/resource-finder-dir/resource_finder_dir.txt
+++ b/http/http-advanced-reactive/src/main/resources/resource-finder-dir/resource_finder_dir.txt
@@ -1,0 +1,1 @@
+This text file is used to check if RuntimeClassLoader resolve path correctly.

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/ResourceFinderIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/ResourceFinderIT.java
@@ -1,0 +1,54 @@
+package io.quarkus.ts.http.advanced.reactive;
+
+import static org.hamcrest.Matchers.containsString;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+@Tag("https://github.com/quarkusio/quarkus/pull/47378")
+@DisabledOnNative(reason = "Test RuntimeClassLoader is enough in JVM mode")
+public class ResourceFinderIT {
+    private static final String TEXT_FILE_DIRECTORY = "resource-finder-dir/";
+    private static final String EXPECTED_TEXT_FILE_PATH = TEXT_FILE_DIRECTORY + "resource_finder_dir.txt";
+
+    private static final String CLASS_MATCHER = ".*.class";
+    private static final String TEXT_FILE_MATCHER = ".*.txt";
+
+    private static final String expectedClassFilePath = ResourcesFinderResource.class.getName().replace('.', '/');
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperties("oidcdisable.properties");
+
+    @Test
+    public void testIfClassResourceIsPresentOnFullPath() {
+        resourceRequest("io/quarkus/ts/http/advanced/reactive/", CLASS_MATCHER, expectedClassFilePath);
+    }
+
+    @Test
+    public void testIfClassResourceIsPresentOnPartialPath() {
+        resourceRequest("io/quarkus/ts/http/", CLASS_MATCHER, expectedClassFilePath);
+    }
+
+    @Test
+    public void testIfFileResourceIsPresent() {
+        resourceRequest(TEXT_FILE_DIRECTORY, TEXT_FILE_MATCHER, EXPECTED_TEXT_FILE_PATH);
+    }
+
+    private void resourceRequest(String resourcePath, String lookupPattern, String expectedFile) {
+        app.given()
+                .param("resourcePath", resourcePath)
+                .param("lookupPattern", lookupPattern)
+                .get("/api/resource-finder/find")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString(expectedFile));
+    }
+}


### PR DESCRIPTION
### Summary

This adding coverage for https://github.com/quarkusio/quarkus/pull/47378.

It testing if the resources is directory it should be returned with `/`. Otherwise the RunnerClassLoader can point to wrong path. This is more useful for extension as they are likely will be touching classpath then aplication.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)