### PR TITLE
Verify Hibernate Validator extension with GraalVM Feature

### DIFF
--- a/http/hibernate-validator/pom.xml
+++ b/http/hibernate-validator/pom.xml
@@ -10,6 +10,10 @@
     <artifactId>http-hibernate-validator</artifactId>
     <packaging>jar</packaging>
     <name>Quarkus QE TS: HTTP: Hibernate Validator</name>
+    <properties>
+        <!-- skipping build mainly to quicken native build as all the test classes require custom build -->
+        <quarkus.build.skip>true</quarkus.build.skip>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/http/hibernate-validator/src/test/java/io/quarkus/ts/http/hibernate/validator/HibernateValidatorGraalVMFeatureValidationIT.java
+++ b/http/hibernate-validator/src/test/java/io/quarkus/ts/http/hibernate/validator/HibernateValidatorGraalVMFeatureValidationIT.java
@@ -1,0 +1,59 @@
+package io.quarkus.ts.http.hibernate.validator;
+
+import java.util.List;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Dependency;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.http.hibernate.validator.sources.GraalVMFeatureResource;
+import io.restassured.http.ContentType;
+
+/**
+ * This test verifies that Quarkus Hibernate Validator extension does not validate data types declared on
+ * 'org.graalvm.nativeimage.hosted.Feature' implementor. More specifically, the {@link GraalVMFeatureResource} method
+ * has formal parameter annotated with the {@link jakarta.validation.Valid} annotation. If the data type of the annotated
+ * parameter has a subclass (or implementor in case of an interface) declared on the GraalVM feature, this resulted
+ * previously in a native build failure, because all the GraalVM features are meant to be built-time only and GraalVM
+ * removes them from the native executable. However, it can't be reproducer so easily because GraalVM does its own
+ * validation and detects if you declare a data type used somewhere else in the same module. That is why for convenience
+ * we use the 'angus-activation' dependency, which GraalVM fails to detect. From this dependency, we only care about
+ * the 'AngusActivationFeature' class.
+ */
+@Tag("https://github.com/quarkusio/quarkus/issues/47033")
+@QuarkusScenario
+public class HibernateValidatorGraalVMFeatureValidationIT {
+
+    @QuarkusApplication(classes = GraalVMFeatureResource.class, dependencies = {
+            @Dependency(artifactId = "quarkus-rest-jackson"),
+            // don't change 'angus-activation' version as when https://github.com/eclipse-ee4j/angus-activation/pull/52
+            // is merged, following releases will not reproduce the issue
+            @Dependency(groupId = "org.eclipse.angus", artifactId = "angus-activation", version = "2.0.2")
+    }, properties = "graalvm-feature-validation.properties")
+    static final RestService app = new RestService();
+
+    @Test
+    public void testHibernateValidationWithGraalVMFeature() {
+        app
+                .given()
+                .contentType(ContentType.JSON)
+                .body(List.of("one", "two", "three", "four", "five"))
+                .post("/graal-vm-feature")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("Number 5 is alive"));
+        app
+                .given()
+                .contentType(ContentType.JSON)
+                .body(List.of("one", "two", "three", "four"))
+                .post("/graal-vm-feature")
+                .then()
+                .statusCode(400)
+                .body(Matchers.not(Matchers.containsString("is alive")))
+                .body(Matchers.containsString("size must be between 5 and 5"));
+    }
+}

--- a/http/hibernate-validator/src/test/java/io/quarkus/ts/http/hibernate/validator/sources/GraalVMFeatureResource.java
+++ b/http/hibernate-validator/src/test/java/io/quarkus/ts/http/hibernate/validator/sources/GraalVMFeatureResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.http.hibernate.validator.sources;
+
+import java.util.ArrayList;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/graal-vm-feature")
+public class GraalVMFeatureResource {
+
+    @Consumes(MediaType.APPLICATION_JSON)
+    @POST
+    public String shortCircuitGreeting(@Valid @Size(min = 5, max = 5) ArrayList<String> list) {
+        return "Number %d is alive".formatted(list.size());
+    }
+
+}

--- a/http/hibernate-validator/src/test/resources/graalvm-feature-validation.properties
+++ b/http/hibernate-validator/src/test/resources/graalvm-feature-validation.properties
@@ -1,0 +1,3 @@
+# index angus-activation so that the Hibernate Validator processor detect its field declaring anonymous ArrayList
+quarkus.index-dependency."dependency-name".group-id=org.eclipse.angus
+quarkus.index-dependency."dependency-name".artifact-id=angus-activation


### PR DESCRIPTION
### Summary

Verifies: https://github.com/quarkusio/quarkus/issues/47033
Supersedes: https://github.com/quarkus-qe/quarkus-test-suite/pull/2457

PASS: `mvn clean verify -Dnative -Dit.test=HibernateValidatorGraalVMFeatureValidationIT -Dquarkus.platform.version=3.20.1`
FAIL: `mvn clean verify -Dnative -Dit.test=HibernateValidatorGraalVMFeatureValidationIT -Dquarkus.platform.version=3.20.0`

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)