### PR TITLE
Enable MysqlHandlerIT in FIPS-enabled environment

### DIFF
--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MysqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MysqlHandlerIT.java
@@ -1,14 +1,11 @@
 package io.quarkus.ts.vertx.sql.handlers;
 
-import org.junit.jupiter.api.Tag;
-
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-@Tag("fips-incompatible") // TODO: enable when the https://github.com/eclipse-vertx/vertx-sql-client/issues/1436 is fixed
 @QuarkusScenario
 public class MysqlHandlerIT extends CommonTestCases {
     private static final String DATABASE = "amadeus";


### PR DESCRIPTION
### Summary

This test is now passing, I am investigating others disabled due to the same issue. Tested both manually and using Jenkins, see:

- `{jenkins-url}/view/rhbq-3.20-extended-platform/job/rhbq-3.20-baremetal-ts-jvm/29/jdk=openjdk-17,label=RHEL8_FIPS && large && docker,scenario=databases-modules/testReport/io.quarkus.ts.vertx.sql.handlers/MysqlHandlerIT/`
- `{jenkins-url}/view/rhbq-3.20-extended-platform/job/rhbq-3.20-baremetal-ts-jvm/29/jdk=openjdk-21,label=RHEL8_FIPS && large && docker,scenario=databases-modules/testReport/io.quarkus.ts.vertx.sql.handlers/MysqlHandlerIT/`

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)