### PR TITLE
Add coverage for QUARKUS-5714 (Bad validation of Embedded ID)

### DIFF
--- a/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/MyEntity.java
+++ b/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/MyEntity.java
@@ -1,0 +1,37 @@
+package io.quarkus.qe.hibernate.items;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "my_entity")
+public class MyEntity {
+
+    // The name of this property must be (alphabetically) before the name of "data" to trigger the bug.
+    @EmbeddedId
+    private MyEntityId anId;
+
+    private String data;
+
+    public MyEntityId getAnId() {
+        return anId;
+    }
+
+    public void setAnId(MyEntityId anId) {
+        this.anId = anId;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    @Override
+    public String toString() {
+        return "anId=" + anId.getVal() + ", data=" + data;
+    }
+}

--- a/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/MyEntityId.java
+++ b/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/MyEntityId.java
@@ -1,0 +1,24 @@
+package io.quarkus.qe.hibernate.items;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class MyEntityId {
+
+    private long entityId;
+
+    protected MyEntityId() {
+    }
+
+    public MyEntityId(long entityId) {
+        this.entityId = entityId;
+    }
+
+    public long getVal() {
+        return entityId;
+    }
+
+    public void setVal(long entityId) {
+        this.entityId = entityId;
+    }
+}

--- a/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/MyEntityResource.java
+++ b/sql-db/hibernate/src/main/java/io/quarkus/qe/hibernate/items/MyEntityResource.java
@@ -1,0 +1,49 @@
+package io.quarkus.qe.hibernate.items;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;
+
+@Path("entity-creation")
+public class MyEntityResource {
+
+    @Inject
+    @PersistenceUnit("named")
+    EntityManager entityManager;
+
+    @POST
+    @Path("create-and-update")
+    @Transactional
+    public Response createAndUpdateMyEntity(@QueryParam("initData") String initData,
+            @QueryParam("updateData") String updateData, @QueryParam("id") long id) {
+        // Creating entity which will be updated in same transaction.
+        MyEntity entity = new MyEntity();
+        entity.setAnId(new MyEntityId(id));
+        entity.setData(initData);
+        entityManager.persist(entity);
+
+        MyEntityId newIdInstance = new MyEntityId(id);
+        entity.setAnId(newIdInstance);
+        entity.setData(updateData);
+
+        return Response.ok("Entity created and updated!").status(201).build();
+    }
+
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Transactional
+    public MyEntity findEntity(@PathParam("id") long id) {
+        return entityManager.find(MyEntity.class, new MyEntityId(id));
+    }
+}

--- a/sql-db/hibernate/src/test/java/io/quarkus/qe/hibernate/BaseHibernateIT.java
+++ b/sql-db/hibernate/src/test/java/io/quarkus/qe/hibernate/BaseHibernateIT.java
@@ -119,6 +119,27 @@ public abstract class BaseHibernateIT {
                 .body(Matchers.is(AUTHOR));
     }
 
+    @Test
+    @Tag("https://issues.redhat.com/browse/QUARKUS-5714")
+    public void testCreationAndUpdateInOneTransaction() {
+        long id = 10;
+        String initData = "Init data";
+        String updateData = "Updated data";
+        given()
+                .queryParam("id", id)
+                .queryParam("initData", initData)
+                .queryParam("updateData", updateData)
+                .post("/entity-creation/create-and-update")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED);
+
+        given()
+                .get("/entity-creation/" + id)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString(updateData));
+    }
+
     private void givenPostConstructAndPreDestroyAreNotInvoked() {
         assertEquals(FALSE, getPostConstructInvokeResult(), "PostConstruct method has been invoked already");
         assertEquals(FALSE, getPreDestroyInvokeResult(), "PreDestroy method has been invoked already");


### PR DESCRIPTION
### Summary

Coverage for https://issues.redhat.com/browse/QUARKUS-5714

Bad validation of EmbeddedId when creation and update of entity is in one transaction.
For more info see https://hibernate.atlassian.net/browse/HHH-19206

Command to show that this test checking issue `mvn -fae -V -B clean verify -Dreruns=0 -Psql-db-modules -pl sql-db/hibernate  -Dit.test="ProdHibernateIT" -Dquarkus.platform.version=3.15.4`

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)