### PR TITLE
Test coverage for #47245 OpenTelemetry metrics gRPC timeout fix validation

### DIFF
--- a/monitoring/opentelemetry/pom.xml
+++ b/monitoring/opentelemetry/pom.xml
@@ -55,6 +55,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-grpc-server</artifactId>
             <scope>test</scope>

--- a/monitoring/opentelemetry/src/main/java/io/quarkus/ts/opentelemetry/MetricResource.java
+++ b/monitoring/opentelemetry/src/main/java/io/quarkus/ts/opentelemetry/MetricResource.java
@@ -1,0 +1,32 @@
+package io.quarkus.ts.opentelemetry;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+
+@Path("/test-metrics")
+public class MetricResource {
+    private static final Logger LOG = Logger.getLogger(MetricResource.class);
+    private final LongCounter counter;
+
+    public MetricResource(Meter meter) {
+        this.counter = meter.counterBuilder("test_app_counter")
+                .setDescription("test counter for exporter timeout tests")
+                .setUnit("invocations")
+                .build();
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String incrementCounter() {
+        counter.add(1);
+        LOG.info("Test application counter incremented.");
+        return "Counter incremented successfully.";
+    }
+}

--- a/monitoring/opentelemetry/src/main/resources/application.properties
+++ b/monitoring/opentelemetry/src/main/resources/application.properties
@@ -11,4 +11,5 @@ quarkus.grpc.server.use-separate-server=false
 
 quarkus.application.name=pingpong
 quarkus.otel.traces.enabled=true
+quarkus.otel.metrics.enabled=true
 quarkus.log.level=INFO

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryMetricsGrpcTimeoutIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryMetricsGrpcTimeoutIT.java
@@ -1,0 +1,143 @@
+package io.quarkus.ts.opentelemetry;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.http.HttpStatus;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.grpc.common.GrpcMessage;
+import io.vertx.grpc.server.GrpcServer;
+import io.vertx.grpc.server.GrpcServerRequest;
+import io.vertx.junit5.VertxExtension;
+
+@Tag("https://github.com/quarkusio/quarkus/pull/47245")
+@QuarkusScenario
+@ExtendWith(VertxExtension.class)
+public class OpenTelemetryMetricsGrpcTimeoutIT {
+
+    private static final Logger LOG = Logger.getLogger(OpenTelemetryMetricsGrpcTimeoutIT.class);
+    private static final long SLOW_RESPONSE_DELAY_MS = 5000L;
+    private static final int METRICS_COLLECTOR_PORT = 9998;
+
+    private static final AtomicBoolean SIMULATE_SLOW_NETWORK = new AtomicBoolean(false);
+    private static final AtomicInteger SUCCESSFUL_EXPORTS = new AtomicInteger(0);
+    private static final AtomicInteger DELAYED_RESPONSES = new AtomicInteger(0);
+
+    @QuarkusApplication(classes = { MetricResource.class })
+    static final RestService app = new RestService()
+            .withProperty("quarkus.application.name", "metrics-timeout-test")
+            .withProperty("quarkus.otel.metrics.enabled", "true")
+            .withProperty("quarkus.otel.exporter.otlp.metrics.endpoint", "http://localhost:" + METRICS_COLLECTOR_PORT)
+            .withProperty("quarkus.otel.exporter.otlp.metrics.protocol", "grpc")
+            .withProperty("quarkus.otel.metric.export.interval", "5s")
+            .withProperty("quarkus.otel.exporter.otlp.metrics.timeout", "3s")
+            .withProperty("quarkus.otel.traces.enabled", "false")
+            .withProperty("quarkus.otel.logs.enabled", "false");
+
+    @Test
+    public void testMetricsExporterRecoversFromSlowNetwork(Vertx vertx) throws Exception {
+        resetCounters();
+
+        try (AutoCloseable collector = createFakeOtlpCollector(vertx)) {
+            generateMetrics(5);
+            await().atMost(30, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertTrue(SUCCESSFUL_EXPORTS.get() > 0, "Normal metrics export should work"));
+
+            int baselineExports = SUCCESSFUL_EXPORTS.get();
+
+            // Simulate slow network
+            SIMULATE_SLOW_NETWORK.set(true);
+            generateMetrics(5);
+            Thread.sleep(8000);
+            assertTrue(DELAYED_RESPONSES.get() > 0, "Some responses should have been delayed");
+
+            // Verify recovery - for validates the timeout fix
+            SIMULATE_SLOW_NETWORK.set(false);
+            generateMetrics(5);
+
+            await().atMost(60, TimeUnit.SECONDS).untilAsserted(() -> {
+                int currentExports = SUCCESSFUL_EXPORTS.get();
+                assertTrue(currentExports > baselineExports,
+                        "Metrics export should recover after network issues");
+            });
+
+            LOG.info("Test PASSED! Metrics exporter recovered successfully.");
+        }
+    }
+
+    private static AutoCloseable createFakeOtlpCollector(Vertx vertx) {
+        GrpcServer grpcServer = GrpcServer.server(vertx);
+        HttpServer httpServer = vertx.createHttpServer(new HttpServerOptions().setPort(METRICS_COLLECTOR_PORT));
+
+        httpServer.requestHandler(grpcServer).listen(result -> {
+            if (result.succeeded()) {
+                LOG.infof("Mock OTLP Collector started on port %d", METRICS_COLLECTOR_PORT);
+            }
+        });
+
+        grpcServer.callHandler(request -> {
+            request.messageHandler(message -> {
+                if (SIMULATE_SLOW_NETWORK.get()) {
+                    DELAYED_RESPONSES.incrementAndGet();
+                    vertx.setTimer(SLOW_RESPONSE_DELAY_MS, timerId -> sendResponseSafely(request, false));
+                } else {
+                    sendResponseSafely(request, true);
+                }
+            });
+        });
+
+        return () -> {
+            CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+            httpServer.close(ar -> closeFuture.complete(null));
+            closeFuture.get(5, TimeUnit.SECONDS);
+        };
+    }
+
+    private static void sendResponseSafely(GrpcServerRequest request, boolean countSuccess) {
+        request.response().endMessage(createValidResponse());
+        if (countSuccess) {
+            SUCCESSFUL_EXPORTS.incrementAndGet();
+        }
+    }
+
+    /**
+     * Creates a valid empty OTLP response indicating successful processing.
+     */
+    private static GrpcMessage createValidResponse() {
+        return GrpcMessage.message("identity", Buffer.buffer());
+    }
+
+    private void generateMetrics(int count) {
+        for (int i = 0; i < count; i++) {
+            app.given().get("/test-metrics").then().statusCode(HttpStatus.SC_OK);
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+    }
+
+    private void resetCounters() {
+        SIMULATE_SLOW_NETWORK.set(false);
+        SUCCESSFUL_EXPORTS.set(0);
+        DELAYED_RESPONSES.set(0);
+    }
+}


### PR DESCRIPTION
### Summary

Test coverage for [#47245](https://github.com/quarkusio/quarkus/pull/47245) 
The test creates a fake OTLP collection that simulates network delays beyond the client timeout to simulate the busy exporter.
Validates that the gRPC timeout fix allows the exporter to recover properly.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)