### PR TITLE
Test OIDC token revocation using OidcProviderClient 

### DIFF
--- a/security/keycloak/src/main/java/io/quarkus/ts/security/keycloak/OidcProviderClientResource.java
+++ b/security/keycloak/src/main/java/io/quarkus/ts/security/keycloak/OidcProviderClientResource.java
@@ -1,0 +1,46 @@
+package io.quarkus.ts.security.keycloak;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import io.quarkus.oidc.AccessTokenCredential;
+import io.quarkus.oidc.OidcProviderClient;
+
+@Path("/oidc-provider-client")
+public class OidcProviderClientResource {
+
+    @Inject
+    OidcProviderClient oidcProviderClient;
+
+    @Inject
+    AccessTokenCredential accessToken;
+
+    @POST
+    @Path("/token/revoke")
+    public String revokeAccessTokens(String refreshToken) {
+        oidcProviderClient.revokeAccessToken(accessToken.getToken()).await().indefinitely();
+        oidcProviderClient.revokeRefreshToken(refreshToken).await().indefinitely();
+        return "Logout, tokens revoked";
+    }
+
+    @POST
+    @Path("/username/from-token")
+    public Response getUsernameFromToken(String accessToken) {
+        return oidcProviderClient.getUserInfo(accessToken)
+                .onItem().transform(userInfo -> Response.ok(userInfo.getPreferredUserName()).build())
+                .onFailure().recoverWithItem(throwable -> Response.status(Response.Status.UNAUTHORIZED)
+                        .entity("Failed to resolve user info: " + throwable.getMessage())
+                        .build())
+                .await().indefinitely();
+    }
+
+    @POST
+    @Path("/token/is-active")
+    public String introspectToken(String passedAccessToken) {
+        return oidcProviderClient.introspectAccessToken(passedAccessToken).await().indefinitely().isActive()
+                ? "active"
+                : "inactive";
+    }
+}

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/BaseOidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/BaseOidcSecurityIT.java
@@ -3,23 +3,30 @@ package io.quarkus.ts.security.keycloak;
 import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.representations.AccessTokenResponse;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.Protocol;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
 
 public abstract class BaseOidcSecurityIT {
 
     static final String NORMAL_USER = "test-normal-user";
     static final String ADMIN_USER = "test-admin-user";
-    static final String REALM_DEFAULT = "test-realm";
     static final String CLIENT_ID_DEFAULT = "test-application-client";
     static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
 
@@ -34,7 +41,7 @@ public abstract class BaseOidcSecurityIT {
     public void normalUserUserResource() {
         given()
                 .when()
-                .auth().oauth2(getToken(NORMAL_USER, NORMAL_USER))
+                .auth().oauth2(getUserAccessToken())
                 .get("/user")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
@@ -45,7 +52,7 @@ public abstract class BaseOidcSecurityIT {
     public void normalUserUserResourceIssuer() {
         given()
                 .when()
-                .auth().oauth2(getToken(NORMAL_USER, NORMAL_USER))
+                .auth().oauth2(getUserAccessToken())
                 .get("/user/issuer")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
@@ -57,7 +64,7 @@ public abstract class BaseOidcSecurityIT {
     public void normalUserAdminResource() {
         given()
                 .when()
-                .auth().oauth2(getToken(NORMAL_USER, NORMAL_USER))
+                .auth().oauth2(getUserAccessToken())
                 .get("/admin")
                 .then()
                 .statusCode(HttpStatus.SC_FORBIDDEN);
@@ -67,7 +74,7 @@ public abstract class BaseOidcSecurityIT {
     public void adminUserUserResource() {
         given()
                 .when()
-                .auth().oauth2(getToken(ADMIN_USER, ADMIN_USER))
+                .auth().oauth2(getAdminAccessToken())
                 .get("/user")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
@@ -78,7 +85,7 @@ public abstract class BaseOidcSecurityIT {
     public void adminUserAdminResource() {
         given()
                 .when()
-                .auth().oauth2(getToken(ADMIN_USER, ADMIN_USER))
+                .auth().oauth2(getAdminAccessToken())
                 .get("/admin")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
@@ -89,7 +96,7 @@ public abstract class BaseOidcSecurityIT {
     public void adminUserAdminResourceIssuer() {
         given()
                 .when()
-                .auth().oauth2(getToken(ADMIN_USER, ADMIN_USER))
+                .auth().oauth2(getAdminAccessToken())
                 .get("/admin/issuer")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
@@ -117,7 +124,7 @@ public abstract class BaseOidcSecurityIT {
 
     @Test
     public void tokenExpirationUserResource() {
-        String token = getToken(NORMAL_USER, NORMAL_USER);
+        String token = getUserAccessToken();
         // According to property `quarkus.oidc.token.lifespan-grace`
         // and the property `accessTokenLifespan` in the keycloak configuration,
         // we need to wait more than 5 seconds for the token expiration.
@@ -131,9 +138,88 @@ public abstract class BaseOidcSecurityIT {
         });
     }
 
+    @Test
+    @Tag("QUARKUS-5653")
+    public void tokenProgrammaticRevocationFlow() {
+        AccessTokenResponse tokenResponse = getTokenCreationResponse(NORMAL_USER, NORMAL_USER);
+        String initialRefreshToken = tokenResponse.getRefreshToken();
+        String initialAccessToken = tokenResponse.getToken();
+
+        // Ensure a refresh token is present
+        assertNotNull(initialRefreshToken, "Refresh token should not be null");
+
+        // Ensure the initial access token is active
+        given()
+                .auth().oauth2(initialAccessToken)
+                .body(initialAccessToken)
+                .post("/oidc-provider-client/token/is-active")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is("active"));
+
+        // Assert that access token can be used to access userinfo
+        given()
+                .auth().oauth2(initialAccessToken)
+                .body(initialAccessToken)
+                .post("/oidc-provider-client/username/from-token")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is(NORMAL_USER));
+
+        // Revoke access and refresh tokens
+        given()
+                .auth().oauth2(initialAccessToken)
+                .body(initialRefreshToken)
+                .post("/oidc-provider-client/token/revoke")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+
+        String newAccessToken = getTokenCreationResponse(NORMAL_USER, NORMAL_USER).getToken();
+
+        // Ensure the initial access token is inactive after revocation
+        given()
+                .auth().oauth2(newAccessToken)
+                .body(initialAccessToken)
+                .post("/oidc-provider-client/token/is-active")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is("inactive"));
+
+        // Access to the protected resource with the old access token should fail
+        given()
+                .auth().oauth2(initialAccessToken)
+                .body(initialAccessToken)
+                .post("/oidc-provider-client/username/from-token")
+                .then()
+                .statusCode(HttpStatus.SC_UNAUTHORIZED);
+
+        // Attempt to use the old refresh token to get a new access token
+        Response refreshGrantResponse = given()
+                .relaxedHTTPSValidation()
+                .contentType(ContentType.URLENC)
+                .formParams(Map.of(
+                        "grant_type", "refresh_token",
+                        "client_id", CLIENT_ID_DEFAULT,
+                        "client_secret", CLIENT_SECRET_DEFAULT,
+                        "refresh_token", initialRefreshToken))
+                .post(getKeycloak().getRealmUrl() + "/protocol/openid-connect/token");
+
+        // Assert that the old refresh token is no longer valid
+        assertEquals(HttpStatus.SC_BAD_REQUEST, refreshGrantResponse.statusCode());
+        assertEquals("invalid_grant", refreshGrantResponse.jsonPath().getString("error"));
+    }
+
     protected abstract KeycloakService getKeycloak();
 
-    private String getToken(String userName, String password) {
-        return authzClient.obtainAccessToken(userName, password).getToken();
+    private AccessTokenResponse getTokenCreationResponse(String username, String password) {
+        return authzClient.obtainAccessToken(username, password);
+    }
+
+    private String getUserAccessToken() {
+        return getTokenCreationResponse(NORMAL_USER, NORMAL_USER).getToken();
+    }
+
+    protected String getAdminAccessToken() {
+        return getTokenCreationResponse(ADMIN_USER, ADMIN_USER).getToken();
     }
 }

--- a/security/keycloak/src/test/resources/test-realm-realm.json
+++ b/security/keycloak/src/test/resources/test-realm-realm.json
@@ -60,6 +60,15 @@
       ]
     }
   ],
+  "clientScopes": [
+    {
+      "name": "openid",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true"
+      }
+    }
+  ],
   "clients": [
     {
       "clientId": "test-application-client",
@@ -107,7 +116,8 @@
         "roles",
         "profile",
         "uma_protection",
-        "email"
+        "email",
+        "openid"
       ],
       "optionalClientScopes": [
         "address",


### PR DESCRIPTION
### Summary

TP: https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-5653.md

`Security event-driven token revocation` cannot be really tested with Keycloak as it automatically revoke tokens during logout process and there is no way to distinguish between KC internal event and manual token revocation.
At least there is a [mock test](https://github.com/quarkusio/quarkus/blob/main/integration-tests/oidc-wiremock-logout/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java) on upstream side

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)