### PR TITLE
[3.15] Disable OpenShiftBrotli4JIT for IBM execution

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftBrotli4JIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftBrotli4JIT.java
@@ -6,5 +6,6 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkusio/quarkus/issues/43770")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkusio/quarkus/issues/43770")
 public class OpenShiftBrotli4JIT extends Brotli4JHttpIT {
 }


### PR DESCRIPTION
### Summary

The test failing for IBM team. The issue was fixed in 3.20 but is not backported to 3.15 and there is no plan to backport it. So disable this test with same reason as arm.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)