### PR TITLE
Move daily build after Quarkus upstream

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -2,7 +2,7 @@ name: "Daily Build"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '03 0 * * *'
+    - cron: '30 2 * * *'
 jobs:
   linux-build-jvm-latest:
     name: Linux JVM


### PR DESCRIPTION
### Summary

https://github.com/quarkusio/quarkus/pull/48054 changed when Quarkus project builds and deploys artifacts to the central to midnight. Now, I'd like to postpone our daily build so that we have much higher chance to run our tests with the source code from a day before. This way, we can catch issues early and report them.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)