### PR TITLE
[3.20] Backport for #47245 OpenTelemetry metrics gRPC recovery 

### DIFF
--- a/monitoring/opentelemetry/src/main/java/io/quarkus/ts/opentelemetry/MetricResource.java
+++ b/monitoring/opentelemetry/src/main/java/io/quarkus/ts/opentelemetry/MetricResource.java
@@ -1,0 +1,32 @@
+package io.quarkus.ts.opentelemetry;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+
+@Path("/test-metrics")
+public class MetricResource {
+    private static final Logger LOG = Logger.getLogger(MetricResource.class);
+    private final LongCounter counter;
+
+    public MetricResource(Meter meter) {
+        this.counter = meter.counterBuilder("test_app_counter")
+                .setDescription("test counter for exporter timeout tests")
+                .setUnit("invocations")
+                .build();
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String incrementCounter() {
+        counter.add(1);
+        LOG.info("Test application counter incremented.");
+        return "Counter incremented successfully.";
+    }
+}

--- a/monitoring/opentelemetry/src/main/resources/application.properties
+++ b/monitoring/opentelemetry/src/main/resources/application.properties
@@ -11,4 +11,5 @@ quarkus.grpc.server.use-separate-server=false
 
 quarkus.application.name=pingpong
 quarkus.otel.traces.enabled=true
+quarkus.otel.metrics.enabled=true
 quarkus.log.level=INFO

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryMetricsGrpcExportRecoveryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryMetricsGrpcExportRecoveryIT.java
@@ -1,0 +1,146 @@
+package io.quarkus.ts.opentelemetry;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.logging.Log;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.grpc.common.GrpcMessage;
+import io.vertx.grpc.server.GrpcServer;
+import io.vertx.junit5.VertxExtension;
+
+@Tag("https://github.com/quarkusio/quarkus/pull/47245")
+@QuarkusScenario
+@ExtendWith(VertxExtension.class)
+public class OpenTelemetryMetricsGrpcExportRecoveryIT {
+
+    private static final int METRICS_COLLECTOR_PORT = 9998;
+    private static final int CONFIGURED_TIMEOUT_MS = 3000;
+    private static final int EXPORT_INTERVAL_MS = 5000;
+
+    private static final AtomicBoolean HANG_REQUESTS = new AtomicBoolean(false);
+    private static final AtomicInteger SUCCESSFUL_EXPORTS = new AtomicInteger(0);
+    private static final AtomicInteger HANGING_REQUESTS = new AtomicInteger(0);
+
+    @QuarkusApplication(classes = { MetricResource.class })
+    static final RestService app = new RestService()
+            .withProperty("quarkus.application.name", "metrics-timeout-test")
+            .withProperty("quarkus.otel.metrics.enabled", "true")
+            .withProperty("quarkus.otel.exporter.otlp.metrics.endpoint", "http://localhost:" + METRICS_COLLECTOR_PORT)
+            .withProperty("quarkus.otel.exporter.otlp.metrics.protocol", "grpc")
+            .withProperty("quarkus.otel.metric.export.interval", EXPORT_INTERVAL_MS + "ms")
+            .withProperty("quarkus.otel.exporter.otlp.metrics.timeout", CONFIGURED_TIMEOUT_MS + "ms")
+            .withProperty("quarkus.otel.traces.enabled", "true")
+            .withProperty("quarkus.otel.logs.enabled", "false");
+
+    @Test
+    public void testMetricsExportRecoveryAfterNetworkIssues(Vertx vertx) throws Exception {
+        resetCounters();
+
+        try (AutoCloseable collector = createFakeOtlpCollector(vertx)) {
+            generateMetrics(2);
+
+            await().atMost(20, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertTrue(SUCCESSFUL_EXPORTS.get() > 0,
+                            "Should have at least one successful export"));
+
+            int initialExports = SUCCESSFUL_EXPORTS.get();
+            Log.info("Initial successful exports: %d", initialExports);
+
+            HANG_REQUESTS.set(true);
+
+            generateMetrics(1);
+
+            // Wait for the export to be attempted
+            await().atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertTrue(HANGING_REQUESTS.get() > 0,
+                            "Should have at least one hanging request"));
+
+            Log.info("Hanging requests initiated: %d", HANGING_REQUESTS.get());
+            Thread.sleep(EXPORT_INTERVAL_MS + 2000);
+
+            HANG_REQUESTS.set(false);
+
+            generateMetrics(2);
+
+            // metrics should eventually be exported once network recovers
+            await().atMost(2, TimeUnit.MINUTES)
+                    .untilAsserted(() -> {
+                        int totalExports = SUCCESSFUL_EXPORTS.get();
+                        assertEquals(5, totalExports,
+                                "All 5 generated metrics should be successfully exported after network recovery");
+                    });
+
+            Log.info("Test completed successfully - All metrics were exported despite temporary network issues");
+        }
+    }
+
+    private static AutoCloseable createFakeOtlpCollector(Vertx vertx) {
+        GrpcServer grpcServer = GrpcServer.server(vertx);
+        HttpServer httpServer = vertx.createHttpServer(new HttpServerOptions().setPort(METRICS_COLLECTOR_PORT));
+
+        httpServer.requestHandler(grpcServer).listen(result -> {
+            if (result.succeeded()) {
+                Log.info("Mock OTLP Collector started on port %d", METRICS_COLLECTOR_PORT);
+            }
+        });
+
+        grpcServer.callHandler(request -> {
+            request.messageHandler(message -> {
+                if (HANG_REQUESTS.get()) {
+                    int hangingId = HANGING_REQUESTS.incrementAndGet();
+                    Log.debug("Request %d is hanging (will never respond)", hangingId);
+                } else {
+                    request.response().endMessage(createValidResponse());
+                    SUCCESSFUL_EXPORTS.incrementAndGet();
+                    Log.debug("Request processed successfully. Total exports: %d", SUCCESSFUL_EXPORTS.get());
+                }
+            });
+        });
+
+        return () -> {
+            CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+            httpServer.close(ar -> closeFuture.complete(null));
+            closeFuture.get(5, TimeUnit.SECONDS);
+        };
+    }
+
+    private static GrpcMessage createValidResponse() {
+        return GrpcMessage.message("identity", Buffer.buffer());
+    }
+
+    private void generateMetrics(int count) {
+        for (int i = 0; i < count; i++) {
+            app.given().get("/test-metrics").then().statusCode(HttpStatus.SC_OK);
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+    }
+
+    private void resetCounters() {
+        HANG_REQUESTS.set(false);
+        HANGING_REQUESTS.set(0);
+        SUCCESSFUL_EXPORTS.set(0);
+    }
+}


### PR DESCRIPTION
### Summary

Backport:
- https://github.com/quarkus-qe/quarkus-test-suite/pull/2474

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)