### PR TITLE
Change default extension in CLI tests to REST

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -28,10 +28,10 @@ import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 @DisabledOnNative(reason = "Only for JVM verification")
 public class QuarkusCliExtensionsIT {
 
-    static final String AGROAL_EXTENSION_NAME = "Agroal - Database connection pool";
-    static final String AGROAL_EXTENSION_ARTIFACT = "quarkus-agroal";
+    static final String REST_EXTENSION_NAME = "REST";
+    static final String REST_EXTENSION_ARTIFACT = "quarkus-rest";
     static final String QUARKUS_BOM = "quarkus-bom";
-    static final String AGROAL_EXTENSION_GUIDE = "https://quarkus.io/guides/datasource";
+    static final String REST_EXTENSION_GUIDE = "https://quarkus.io/guides/rest";
     static final List<String> EXPECTED_PLATFORM_VERSIONS = Arrays.asList("2.0.0.Final", "2.1.0.Final");
     static final ListExtensionRequest NO_STREAM = new ListExtensionRequest(null); // --stream and --platform-bom are not compatible
 
@@ -105,40 +105,40 @@ public class QuarkusCliExtensionsIT {
     }
 
     private void assertListDefaultOptionOutput() {
-        assertTrue(result.getOutput().contains(AGROAL_EXTENSION_NAME)
-                && result.getOutput().contains(AGROAL_EXTENSION_ARTIFACT)
-                && !result.getOutput().contains(AGROAL_EXTENSION_GUIDE),
+        assertTrue(result.getOutput().contains(REST_EXTENSION_NAME)
+                && result.getOutput().contains(REST_EXTENSION_ARTIFACT)
+                && !result.getOutput().contains(REST_EXTENSION_GUIDE),
                 "Default output is unexpected. Output: " + result.getOutput());
     }
 
     private void assertListOriginsOptionOutput() {
         assertTrue(result.getOutput().contains(QUARKUS_BOM)
-                && result.getOutput().contains(AGROAL_EXTENSION_NAME)
-                && result.getOutput().contains(AGROAL_EXTENSION_ARTIFACT)
-                && !result.getOutput().contains(AGROAL_EXTENSION_GUIDE),
+                && result.getOutput().contains(REST_EXTENSION_NAME)
+                && result.getOutput().contains(REST_EXTENSION_ARTIFACT)
+                && !result.getOutput().contains(REST_EXTENSION_GUIDE),
                 "--origins option output is unexpected. Output: " + result.getOutput());
     }
 
     private void assertListNameOptionOutput() {
         // Concise shows only the artifact id
-        assertTrue(result.getOutput().contains(AGROAL_EXTENSION_ARTIFACT)
-                && result.getOutput().contains(AGROAL_EXTENSION_NAME),
+        assertTrue(result.getOutput().contains(REST_EXTENSION_ARTIFACT)
+                && result.getOutput().contains(REST_EXTENSION_NAME),
                 "--name option output is unexpected. Output: " + result.getOutput());
     }
 
     private void assertListConciseOptionOutput() {
         // Concise shows extension name ++ artifact id
-        assertTrue(result.getOutput().contains(AGROAL_EXTENSION_NAME)
-                && result.getOutput().contains(AGROAL_EXTENSION_ARTIFACT)
-                && !result.getOutput().contains(AGROAL_EXTENSION_GUIDE),
+        assertTrue(result.getOutput().contains(REST_EXTENSION_NAME)
+                && result.getOutput().contains(REST_EXTENSION_ARTIFACT)
+                && !result.getOutput().contains(REST_EXTENSION_GUIDE),
                 "--concise option output is unexpected. Output: " + result.getOutput());
     }
 
     private void assertListFullOptionOutput() {
         // Full should show also the origins. Reported by https://github.com/quarkusio/quarkus/issues/18062.
-        assertTrue(result.getOutput().contains(AGROAL_EXTENSION_NAME)
-                && result.getOutput().contains(AGROAL_EXTENSION_ARTIFACT)
-                && result.getOutput().contains(AGROAL_EXTENSION_GUIDE),
+        assertTrue(result.getOutput().contains(REST_EXTENSION_NAME)
+                && result.getOutput().contains(REST_EXTENSION_ARTIFACT)
+                && result.getOutput().contains(REST_EXTENSION_GUIDE),
                 "--full option output is unexpected. Output: " + result.getOutput());
     }
 


### PR DESCRIPTION
### Summary

* Changing the default expected extension in CLI tests to quarkus-rest
  as agroal one changed its long name string in main. This breaks the
  test listing and checking extensions in platform, especially
  considering we run the test against released stream and 999-SNAPSHOT
  in main.

The change in main that breaks the CLI test: https://github.com/quarkusio/quarkus/commit/30d438dcd285cb348403a082222dc30be37abd70#diff-8311ccb2d9df226322aa47cddd87b8da21f4c5dfb00ed67cf80d18f8fa1d5b2aL2

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)