### PR TITLE
Updates to address Hibernate 7 update in Quarkus

### DIFF
--- a/sql-db/hibernate-reactive/src/main/java/io/quarkus/ts/hibernate/reactive/database/AuthorIdGenerator.java
+++ b/sql-db/hibernate-reactive/src/main/java/io/quarkus/ts/hibernate/reactive/database/AuthorIdGenerator.java
@@ -1,9 +1,12 @@
 package io.quarkus.ts.hibernate.reactive.database;
 
+import java.util.EnumSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.hibernate.generator.EventType;
+import org.hibernate.generator.EventTypeSets;
 import org.hibernate.reactive.id.ReactiveIdentifierGenerator;
 import org.hibernate.reactive.session.ReactiveConnectionSupplier;
 
@@ -13,6 +16,16 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 public class AuthorIdGenerator implements ReactiveIdentifierGenerator<Integer> {
     private static final int LAST_IMPORTED_ID = 4;
     private final AtomicInteger lastId = new AtomicInteger(LAST_IMPORTED_ID);
+
+    @Override
+    public boolean generatedOnExecution() {
+        return false;
+    }
+
+    @Override
+    public EnumSet<EventType> getEventTypes() {
+        return EventTypeSets.INSERT_ONLY;
+    }
 
     @Override
     public CompletionStage<Integer> generate(ReactiveConnectionSupplier session, Object entity) {

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MsSQLDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MsSQLDatabaseHibernateReactiveIT.java
@@ -1,6 +1,8 @@
 package io.quarkus.ts.hibernate.reactive;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -26,6 +28,12 @@ public class MsSQLDatabaseHibernateReactiveIT extends AbstractDatabaseHibernateR
     @Override
     protected RestService getApp() {
         return app;
+    }
+
+    @Override
+    @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/48476")
+    public void searchWithLimit() {
     }
 
 }

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/PostgresqlDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/PostgresqlDatabaseHibernateReactiveIT.java
@@ -1,5 +1,8 @@
 package io.quarkus.ts.hibernate.reactive;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 import io.quarkus.test.bootstrap.PostgresqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -31,4 +34,11 @@ public class PostgresqlDatabaseHibernateReactiveIT extends AbstractDatabaseHiber
     protected RestService getApp() {
         return app;
     }
+
+    @Override
+    @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/48476")
+    public void searchWithLimit() {
+    }
+
 }


### PR DESCRIPTION
### Summary

* API for ReactiveIdentifierGenerator changed with Hibernate 7.0 (see
  https://github.com/hibernate/hibernate-reactive/issues/1826). This
  commit adds the missing method implementations.
* Disabling tests that detect
  https://github.com/quarkusio/quarkus/issues/48476.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)