### PR TITLE
SQLServer2012Dialect replaced by SQLServerDialect

### DIFF
--- a/sql-db/narayana-transactions/src/test/resources/mssql.properties
+++ b/sql-db/narayana-transactions/src/test/resources/mssql.properties
@@ -1,5 +1,5 @@
 quarkus.datasource.db-kind=mssql
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServer2012Dialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServerDialect
 quarkus.hibernate-orm.sql-load-script=mssql_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.datasource.jdbc.additional-jdbc-properties.trustservercertificate=true

--- a/sql-db/reactive-rest-data-panache/src/test/resources/mssql.properties
+++ b/sql-db/reactive-rest-data-panache/src/test/resources/mssql.properties
@@ -1,5 +1,5 @@
 quarkus.datasource.db-kind=mssql
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServer2012Dialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServerDialect
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
 quarkus.datasource.jdbc.additional-jdbc-properties.trustservercertificate=true

--- a/sql-db/sql-app-compatibility/src/test/resources/mssql.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/mssql.properties
@@ -1,5 +1,5 @@
 quarkus.datasource.db-kind=mssql
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServer2012Dialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServerDialect
 quarkus.hibernate-orm.sql-load-script=mssql_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.datasource.jdbc.additional-jdbc-properties.trustservercertificate=true

--- a/sql-db/sql-app/src/test/resources/mssql.properties
+++ b/sql-db/sql-app/src/test/resources/mssql.properties
@@ -1,4 +1,4 @@
 quarkus.datasource.db-kind=mssql
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServer2012Dialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServerDialect
 quarkus.hibernate-orm.sql-load-script=mssql_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create


### PR DESCRIPTION
### Summary

- In Hibernate 7.0 `SQLServer2012Dialect` was replaced with `SQLServerDialect`

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)