### PR TITLE
Test coverage for quarkus-grpc  enum issue in native #47937

### DIFF
--- a/http/grpc/src/main/java/io/quarkus/ts/http/grpc/DemoEnumService.java
+++ b/http/grpc/src/main/java/io/quarkus/ts/http/grpc/DemoEnumService.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.http.grpc;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.grpc.GrpcService;
+import io.quarkus.ts.grpc.demo.Demo;
+import io.quarkus.ts.grpc.demo.EnumTriggerReply;
+import io.quarkus.ts.grpc.demo.EnumTriggerRequest;
+import io.smallrye.mutiny.Uni;
+
+@GrpcService
+public class DemoEnumService implements Demo {
+
+    private static final Logger LOG = Logger.getLogger(DemoEnumService.class);
+
+    @Override
+    public Uni<EnumTriggerReply> triggerEnumError(EnumTriggerRequest request) {
+        return Uni.createFrom().item(request)
+                .invoke(r -> {
+                    LOG.info("Received request: " + r);
+                })
+                .map(msg -> EnumTriggerReply.newBuilder()
+                        .setName(msg.getName())
+                        .setEnum(msg.getEnum())
+                        .build());
+    }
+}

--- a/http/grpc/src/main/proto/demo.proto
+++ b/http/grpc/src/main/proto/demo.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.quarkus.ts.grpc.demo";
+option java_outer_classname = "DemoOuterClass";
+
+package demo;
+
+service Demo {
+  rpc TriggerEnumError (EnumTriggerRequest) returns (EnumTriggerReply) {}
+}
+
+enum DemoEnum {
+  A = 0;
+  B = 1;
+  C = 2;
+}
+
+message EnumTriggerRequest {
+  string name = 1;
+  DemoEnum enum = 2;
+}
+
+message EnumTriggerReply {
+  string name = 1;
+  DemoEnum enum = 2;
+}

--- a/http/grpc/src/test/java/io/quarkus/ts/http/grpc/GrpcEnumIT.java
+++ b/http/grpc/src/test/java/io/quarkus/ts/http/grpc/GrpcEnumIT.java
@@ -1,0 +1,56 @@
+package io.quarkus.ts.http.grpc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.GrpcService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.grpc.demo.DemoEnum;
+import io.quarkus.ts.grpc.demo.DemoGrpc;
+import io.quarkus.ts.grpc.demo.EnumTriggerReply;
+import io.quarkus.ts.grpc.demo.EnumTriggerRequest;
+
+@Tag("https://github.com/quarkusio/quarkus/issues/47936")
+@QuarkusScenario
+public class GrpcEnumIT {
+
+    private static final Logger LOG = Logger.getLogger(GrpcEnumIT.class);
+
+    @QuarkusApplication(grpc = true)
+    static final GrpcService app = new GrpcService();
+
+    @Test
+    public void testClientSideEnumToStringInNativeMode() {
+        EnumTriggerRequest request = EnumTriggerRequest.newBuilder()
+                .setName("test")
+                .setEnum(DemoEnum.B)
+                .build();
+        String requestString = request.toString();
+        LOG.info("Request as string: " + requestString);
+        assertTrue(requestString.contains("name: \"test\""));
+        assertTrue(requestString.contains("enum: B"));
+
+    }
+
+    @Test
+    public void testServerSideEnumLoggingInNativeMode() {
+        try (var channel = app.grpcChannel()) {
+            EnumTriggerRequest request = EnumTriggerRequest.newBuilder()
+                    .setName("logging-test")
+                    .setEnum(DemoEnum.B)
+                    .build();
+
+            EnumTriggerReply response = DemoGrpc.newBlockingStub(channel)
+                    .triggerEnumError(request);
+
+            assertEquals("logging-test", response.getName());
+            assertEquals(DemoEnum.B, response.getEnum());
+
+        }
+    }
+}

--- a/http/grpc/src/test/java/io/quarkus/ts/http/grpc/GrpcTlsSeparateServerIT.java
+++ b/http/grpc/src/test/java/io/quarkus/ts/http/grpc/GrpcTlsSeparateServerIT.java
@@ -3,8 +3,6 @@ package io.quarkus.ts.http.grpc;
 import static io.quarkus.test.services.Certificate.Format.PEM;
 import static io.quarkus.ts.http.grpc.GrpcMutualTlsSeparateServerIT.addEscapes;
 
-import org.junit.jupiter.api.AfterAll;
-
 import io.quarkus.test.bootstrap.CloseableManagedChannel;
 import io.quarkus.test.bootstrap.GrpcService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -37,13 +35,6 @@ public class GrpcTlsSeparateServerIT implements GRPCIT, StreamingHttpIT, Reflect
             webClient = app.mutiny();
         }
         return webClient;
-    }
-
-    @AfterAll
-    static void afterAll() {
-        if (webClient != null) {
-            webClient.close();
-        }
     }
 
     private static String getClientCaCert() {

--- a/http/grpc/src/test/java/io/quarkus/ts/http/grpc/ReflectionHttpIT.java
+++ b/http/grpc/src/test/java/io/quarkus/ts/http/grpc/ReflectionHttpIT.java
@@ -17,6 +17,7 @@ import io.grpc.reflection.v1.FileDescriptorResponse;
 import io.quarkus.ts.grpc.GreeterGrpc;
 import io.quarkus.ts.grpc.HelloWorldProto;
 import io.quarkus.ts.grpc.StreamingGrpc;
+import io.quarkus.ts.grpc.demo.DemoGrpc;
 import io.vertx.mutiny.ext.web.client.WebClient;
 
 public interface ReflectionHttpIT {
@@ -29,14 +30,15 @@ public interface ReflectionHttpIT {
         assertEquals(SC_OK, httpResponse.statusCode());
         GrpcReflectionResponse response = httpResponse.bodyAsJson(GrpcReflectionResponse.class);
 
-        assertEquals(3, response.getServiceCount());
+        assertEquals(4, response.getServiceCount());
 
         List<String> serviceList = response.getServiceList();
 
-        assertEquals(3, serviceList.size());
+        assertEquals(4, serviceList.size());
         assertTrue(serviceList.stream().anyMatch(GreeterGrpc.SERVICE_NAME::equals));
         assertTrue(serviceList.stream().anyMatch(StreamingGrpc.SERVICE_NAME::equals));
         assertTrue(serviceList.stream().anyMatch("grpc.health.v1.Health"::equals));
+        assertTrue(serviceList.stream().anyMatch(DemoGrpc.SERVICE_NAME::equals));
     }
 
     @Test

--- a/http/grpc/src/test/java/io/quarkus/ts/http/grpc/SameServerIT.java
+++ b/http/grpc/src/test/java/io/quarkus/ts/http/grpc/SameServerIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.http.grpc;
 
-import org.junit.jupiter.api.AfterAll;
-
 import io.quarkus.test.bootstrap.CloseableManagedChannel;
 import io.quarkus.test.bootstrap.GrpcService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -29,10 +27,4 @@ public class SameServerIT implements GRPCIT, ReflectionHttpIT, StreamingHttpIT {
         return webClient;
     }
 
-    @AfterAll
-    static void afterAll() {
-        if (webClient != null) {
-            webClient.close();
-        }
-    }
 }

--- a/http/grpc/src/test/java/io/quarkus/ts/http/grpc/SeparateServerIT.java
+++ b/http/grpc/src/test/java/io/quarkus/ts/http/grpc/SeparateServerIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.http.grpc;
 
-import org.junit.jupiter.api.AfterAll;
-
 import io.quarkus.test.bootstrap.CloseableManagedChannel;
 import io.quarkus.test.bootstrap.GrpcService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -31,10 +29,4 @@ public class SeparateServerIT implements GRPCIT, StreamingHttpIT, ReflectionHttp
         return webClient;
     }
 
-    @AfterAll
-    static void afterAll() {
-        if (webClient != null) {
-            webClient.close();
-        }
-    }
 }


### PR DESCRIPTION
This PR adds test coverage for the fix implemented in [#47937](https://github.com/quarkusio/quarkus/pull/47937)
Original Jira issue: https://github.com/quarkusio/quarkus/issues/47936

It will fail in previous versions without the fix if we execute: ` mvn clean verify -Pnative -Dit.test=GrpcEnumNativeIT -Dquarkus.platform.version=3.19.3 -Dreruns=0`

On the other hand, I've removed @ AfterAll method that closed the WebClient. The TF handles WebClient cleanup. The manual cleanup with @ AfterAll was causing issues when the WebClient was shared across the test classes.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)