### PR TITLE
Set explicitly min database version for older db images to fix OCP tests

### DIFF
--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/OpenShiftSpringWebQuteReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/OpenShiftSpringWebQuteReactiveIT.java
@@ -20,7 +20,9 @@ public class OpenShiftSpringWebQuteReactiveIT extends AbstractSpringWebQuteReact
     private static final RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl);
+            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl)
+            // set DB version as we use older version than default version configured at the build time
+            .withProperty("quarkus.datasource.db-version", "10.3");
 
     @Override
     public RestService getApp() {

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/OpenShiftSpringWebRestReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/OpenShiftSpringWebRestReactiveIT.java
@@ -20,7 +20,9 @@ public class OpenShiftSpringWebRestReactiveIT extends AbstractSpringWebRestReact
     private static final RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl);
+            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl)
+            // set DB version as we use older version than default version configured at the build time
+            .withProperty("quarkus.datasource.db-version", "10.3");
 
     @Override
     protected RestService getApp() {

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/OpenShiftSpringWebOpenApiReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/OpenShiftSpringWebOpenApiReactiveIT.java
@@ -23,7 +23,9 @@ public class OpenShiftSpringWebOpenApiReactiveIT extends AbstractSpringWebOpenAp
     private static final RestService app = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
-            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl);
+            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl)
+            // set DB version as we use older version than default version configured at the build time
+            .withProperty("quarkus.datasource.db-version", "10.3");
 
     @Override
     protected RestService getApp() {

--- a/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
+++ b/sql-db/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
@@ -36,7 +36,7 @@ public class OpenShiftPostgresqlMultitenantHibernateSearchIT extends AbstractMul
             .withProperty("quarkus.hibernate-search-orm.elasticsearch.hosts",
                     () -> getElasticSearchConnectionChain(elastic.getURI(Protocol.HTTP)))
             // set DB version as we use older version than default version configured at the build time
-            .withProperty("quarkus.datasource.db-version", "10");
+            .withProperty("quarkus.datasource.db-version", "12");
 
     @Override
     protected RestService getApp() {

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftPostgresql12HibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftPostgresql12HibernateReactiveIT.java
@@ -28,7 +28,9 @@ public class OpenShiftPostgresql12HibernateReactiveIT extends AbstractDatabaseHi
     static RestService app = new RestService().withProperties("postgresql.properties")
             .withProperty("quarkus.datasource.username", POSTGRES_USER)
             .withProperty("quarkus.datasource.password", POSTGRES_PASSWORD)
-            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl);
+            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl)
+            // set DB version as we use older version than default version configured at the build time
+            .withProperty("quarkus.datasource.db-version", "12");
 
     @Override
     protected RestService getApp() {

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresql12DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresql12DatabaseIT.java
@@ -22,5 +22,5 @@ public class OpenShiftPostgresql12DatabaseIT extends AbstractSqlDatabaseIT {
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
             // set DB version as we use older version than default version configured at the build time
-            .withProperty("quarkus.datasource.db-version", "10");
+            .withProperty("quarkus.datasource.db-version", "12");
 }


### PR DESCRIPTION
### Summary

OpenShift tests are failing as Red Hat MariaDB and PostgreSQL images are using older versions than defaults configured at the build time. This is expected failure as [minimum database versions](https://docs.jboss.org/hibernate/orm/7.0/dialect/dialect.html) has changed after upgrade to Hibernate ORM 7.0

Also in Quarkus 3.25 migration guide: https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.25#hibernate-reactive

Our MariaDB `10.3` vs  default `10.5`
Our PostgreSQL `12` vs default `13`

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [x] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)