### PR TITLE
Switch Playwright browser from Chromium to Firefox in tests

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeGrpcIntegrationReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeGrpcIntegrationReactiveIT.java
@@ -94,7 +94,7 @@ public class DevModeGrpcIntegrationReactiveIT {
 
     private static void assertOnGrpcServicePage(Consumer<Page> assertion) {
         try (Playwright playwright = Playwright.create()) {
-            try (Browser browser = playwright.chromium().launch()) {
+            try (Browser browser = playwright.firefox().launch()) {
                 Page page = browser.newContext().newPage();
                 var grpcServicesViewUrl = app
                         .getURI(Protocol.HTTP)

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeGrpcIntegrationIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeGrpcIntegrationIT.java
@@ -92,7 +92,7 @@ public class DevModeGrpcIntegrationIT {
 
     private static void assertOnGrpcServicePage(Consumer<Page> assertion) {
         try (Playwright playwright = Playwright.create()) {
-            try (Browser browser = playwright.chromium().launch()) {
+            try (Browser browser = playwright.firefox().launch()) {
                 Page page = browser.newContext().newPage();
                 var grpcServicesViewUrl = app
                         .getURI(Protocol.HTTP)

--- a/websockets/websocket-next-oidc/src/test/java/io/quarkus/ts/websockets/next/WebSocketNextBrowserAuthorizationIT.java
+++ b/websockets/websocket-next-oidc/src/test/java/io/quarkus/ts/websockets/next/WebSocketNextBrowserAuthorizationIT.java
@@ -61,7 +61,7 @@ public class WebSocketNextBrowserAuthorizationIT {
     @BeforeAll
     static void launchBrowser() {
         playwright = Playwright.create();
-        browser = playwright.chromium().launch(new BrowserType.LaunchOptions()
+        browser = playwright.firefox().launch(new BrowserType.LaunchOptions()
                 .setHeadless(true));
     }
 


### PR DESCRIPTION
### Summary

Follows up https://github.com/quarkus-qe/quarkus-test-framework/pull/1625

After bumping `com.microsoft.playwright:playwright from 1.52.0 to 1.53.0`, Chromium no longer works with Podman on RHEL8

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)