### PR TITLE
Disable REST Client http tests made synchronous calls affected by issue #48927

### DIFF
--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/HttpVersionAlpnIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/HttpVersionAlpnIT.java
@@ -3,6 +3,7 @@ package io.quarkus.ts.http.restclient.reactive;
 import static io.quarkus.ts.http.restclient.reactive.resources.HttpVersionClientResource.NAME;
 import static org.hamcrest.Matchers.containsString;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -22,6 +23,7 @@ public class HttpVersionAlpnIT {
             .withProperty("quarkus.rest-client.alpn", "true");
 
     @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/48927")
     public void testSyncResponseWithSingleClientOnGlobalClient() {
         app.given()
                 .get("/http2/https-synchronous")
@@ -40,6 +42,7 @@ public class HttpVersionAlpnIT {
     }
 
     @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/48927")
     public void testSyncResponseWithSingleClientOnSingleClient() {
         app.given()
                 .get("/http2/https-synchronous-for-client-with-key")

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/HttpVersionAlpnWithConfigKeyIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/HttpVersionAlpnWithConfigKeyIT.java
@@ -4,6 +4,7 @@ import static io.quarkus.ts.http.restclient.reactive.resources.HttpVersionClient
 import static io.quarkus.ts.http.restclient.reactive.resources.HttpVersionClientResource.WRONG_HTTP_VERSION;
 import static org.hamcrest.Matchers.containsString;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -42,6 +43,7 @@ public class HttpVersionAlpnWithConfigKeyIT {
     }
 
     @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/48927")
     public void testSyncResponseWithSingleClientOnSingleClient() {
         app.given()
                 .get("/http2/https-synchronous-for-client-with-key")

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/HttpVersionIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/HttpVersionIT.java
@@ -3,6 +3,7 @@ package io.quarkus.ts.http.restclient.reactive;
 import static io.quarkus.ts.http.restclient.reactive.resources.HttpVersionClientResource.NAME;
 import static org.hamcrest.Matchers.containsString;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -22,6 +23,7 @@ public class HttpVersionIT {
             .withProperty("quarkus.rest-client.http2", "true");
 
     @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/48927")
     public void testHttpSyncResponseWithSingleClientOnGlobalClient() {
         app.given()
                 .get("/http2/http-synchronous")
@@ -31,6 +33,7 @@ public class HttpVersionIT {
     }
 
     @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/48927")
     public void testHttpsSyncResponseWithSingleClientOnGlobalClient() {
         app.given()
                 .get("/http2/https-synchronous")
@@ -58,6 +61,7 @@ public class HttpVersionIT {
     }
 
     @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/48927")
     public void testHttpSyncResponseWithSingleClientOnSingleClient() {
         app.given()
                 .get("/http2/http-synchronous-for-client-with-key")
@@ -67,6 +71,7 @@ public class HttpVersionIT {
     }
 
     @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/48927")
     public void testHttpsSyncResponseWithSingleClientOnSingleClient() {
         app.given()
                 .get("/http2/https-synchronous-for-client-with-key")

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/HttpVersionWithConfigKeyIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/HttpVersionWithConfigKeyIT.java
@@ -4,6 +4,7 @@ import static io.quarkus.ts.http.restclient.reactive.resources.HttpVersionClient
 import static io.quarkus.ts.http.restclient.reactive.resources.HttpVersionClientResource.WRONG_HTTP_VERSION;
 import static org.hamcrest.Matchers.containsString;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -60,6 +61,7 @@ public class HttpVersionWithConfigKeyIT {
     }
 
     @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/48927")
     public void testHttpSyncResponseWithSingleClientOnSingleClient() {
         app.given()
                 .get("/http2/http-synchronous-for-client-with-key")
@@ -69,6 +71,7 @@ public class HttpVersionWithConfigKeyIT {
     }
 
     @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/48927")
     public void testHttpsSyncResponseWithSingleClientOnSingleClient() {
         app.given()
                 .get("/http2/https-synchronous-for-client-with-key")


### PR DESCRIPTION
### Summary

Our synchronous REST Client calls fail with `IllegalStateException: Response has been closed` due to upstream regressions - https://github.com/quarkusio/quarkus/issues/48927

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)