### PR TITLE
Enable Hiberante Reactive tests disabled due to #48476 upstream issue

### DIFF
--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MsSQLDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MsSQLDatabaseHibernateReactiveIT.java
@@ -1,8 +1,6 @@
 package io.quarkus.ts.hibernate.reactive;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -28,12 +26,6 @@ public class MsSQLDatabaseHibernateReactiveIT extends AbstractDatabaseHibernateR
     @Override
     protected RestService getApp() {
         return app;
-    }
-
-    @Override
-    @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/48476")
-    public void searchWithLimit() {
     }
 
 }

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/PostgresqlDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/PostgresqlDatabaseHibernateReactiveIT.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.hibernate.reactive;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-
 import io.quarkus.test.bootstrap.PostgresqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -33,12 +30,6 @@ public class PostgresqlDatabaseHibernateReactiveIT extends AbstractDatabaseHiber
     @Override
     protected RestService getApp() {
         return app;
-    }
-
-    @Override
-    @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/48476")
-    public void searchWithLimit() {
     }
 
 }


### PR DESCRIPTION
### Summary

https://github.com/quarkusio/quarkus/issues/48476 is fixed and tests are passing locally on my workstation.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)