### PR TITLE
[3.15] Quarkus and FW versions bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.15.999-SNAPSHOT</quarkus.platform.version>
-        <quarkus.ide.version>3.15.5</quarkus.ide.version>
+        <quarkus.ide.version>3.15.6</quarkus.ide.version>
         <quarkus.qe.framework.version>1.5.12</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.6.1</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.15.999-SNAPSHOT</quarkus.platform.version>
         <quarkus.ide.version>3.15.6</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.5.12</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.5.13</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.6.1</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.24.1</formatter-maven-plugin.version>


### PR DESCRIPTION
### Summary

Bumps:

Quarkus IDE to 3.15.6 (https://github.com/quarkus-qe/quarkus-test-suite/commit/26765c7c6fb70b72a115cdb11c2c37c798018ef7)

QE FW to 1.5.13 (https://github.com/quarkus-qe/quarkus-test-suite/commit/65f02579a312fc190a3b9f3cd8eb7fbfe2f02697)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)