### PR TITLE
Disable all monitoring options during native executable build

### DIFF
--- a/security/jpa/src/main/resources/application.properties
+++ b/security/jpa/src/main/resources/application.properties
@@ -8,3 +8,6 @@ quarkus.http.auth.permission.user.policy=user-policy
 
 quarkus.http.auth.permission.admin.paths=/api/admin/*
 quarkus.http.auth.permission.admin.policy=admin-policy
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/hibernate-reactive/src/main/resources/application.properties
+++ b/sql-db/hibernate-reactive/src/main/resources/application.properties
@@ -4,3 +4,6 @@ quarkus.datasource.db-kind=postgresql
 
 # HttpClient config
 SomeApi/mp-rest/url=http://localhost:${quarkus.http.port}
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/jakarta-data/src/main/resources/application.properties
+++ b/sql-db/jakarta-data/src/main/resources/application.properties
@@ -78,3 +78,6 @@ quarkus.datasource.db2.active=false
 quarkus.datasource.db2.username=${db-username}
 quarkus.datasource.db2.password=${db-password}
 quarkus.datasource.db2.jdbc.url=${db-url}
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/narayana-transactions/src/main/resources/application.properties
+++ b/sql-db/narayana-transactions/src/main/resources/application.properties
@@ -33,3 +33,6 @@ quarkus.transaction-manager.object-store.datasource=object-store-ds
 quarkus.transaction-manager.enable-recovery=true
 quarkus.transaction-manager.object-store.create-table=true
 quarkus.transaction-manager.object-store.table-prefix=quarkus_qe_
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/reactive-rest-data-panache/src/main/resources/application.properties
+++ b/sql-db/reactive-rest-data-panache/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/main/resources/application.properties
+++ b/sql-db/sql-app-compatibility/src/main/resources/application.properties
@@ -2,3 +2,6 @@ quarkus.datasource.db-kind=h2
 quarkus.hibernate-orm.database.charset=utf-8
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/test/resources/db2_app.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/db2_app.properties
@@ -4,3 +4,6 @@ quarkus.hibernate-orm.sql-load-script=db2_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-orm.database.orm-compatibility.version=5.6
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/test/resources/h2.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/h2.properties
@@ -7,3 +7,6 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
 
 quarkus.hibernate-orm.database.orm-compatibility.version=5.6
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/test/resources/mariadb_app.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/mariadb_app.properties
@@ -5,3 +5,6 @@ quarkus.hibernate-orm.sql-load-script=mariadb_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-orm.database.orm-compatibility.version=5.6
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/test/resources/mssql.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/mssql.properties
@@ -5,3 +5,6 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.datasource.jdbc.additional-jdbc-properties.trustservercertificate=true
 
 quarkus.hibernate-orm.database.orm-compatibility.version=5.6
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/test/resources/mysql.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/mysql.properties
@@ -5,3 +5,6 @@ quarkus.hibernate-orm.sql-load-script=mariadb_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-orm.database.orm-compatibility.version=5.6
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/test/resources/oracle.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/oracle.properties
@@ -3,3 +3,6 @@ quarkus.hibernate-orm.sql-load-script=oracle_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-orm.database.orm-compatibility.version=5.6
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/test/resources/postgresql.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/postgresql.properties
@@ -3,3 +3,6 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-orm.database.orm-compatibility.version=5.6
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app/src/main/resources/application.properties
+++ b/sql-db/sql-app/src/main/resources/application.properties
@@ -2,3 +2,6 @@ quarkus.datasource.db-kind=h2
 quarkus.hibernate-orm.database.charset=utf-8
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app/src/test/resources/db2_app.properties
+++ b/sql-db/sql-app/src/test/resources/db2_app.properties
@@ -1,3 +1,6 @@
 quarkus.datasource.db-kind=db2
 #quarkus.hibernate-orm.dialect=org.hibernate.dialect.DB2Dialect
 quarkus.hibernate-orm.sql-load-script=db2_import.sql
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app/src/test/resources/h2.properties
+++ b/sql-db/sql-app/src/test/resources/h2.properties
@@ -5,3 +5,6 @@ quarkus.datasource.password=sa
 quarkus.hibernate-orm.database.charset=utf-8
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app/src/test/resources/mariadb_app.properties
+++ b/sql-db/sql-app/src/test/resources/mariadb_app.properties
@@ -1,3 +1,6 @@
 quarkus.datasource.db-kind=mariadb
 quarkus.hibernate-orm.sql-load-script=mariadb_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app/src/test/resources/mssql.properties
+++ b/sql-db/sql-app/src/test/resources/mssql.properties
@@ -2,3 +2,6 @@ quarkus.datasource.db-kind=mssql
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServerDialect
 quarkus.hibernate-orm.sql-load-script=mssql_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app/src/test/resources/mysql.properties
+++ b/sql-db/sql-app/src/test/resources/mysql.properties
@@ -1,3 +1,6 @@
 quarkus.datasource.db-kind=mysql
 quarkus.hibernate-orm.sql-load-script=mysql_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app/src/test/resources/oracle.properties
+++ b/sql-db/sql-app/src/test/resources/oracle.properties
@@ -1,3 +1,6 @@
 quarkus.datasource.db-kind=oracle
 quarkus.hibernate-orm.sql-load-script=oracle_import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/sql-app/src/test/resources/postgresql.properties
+++ b/sql-db/sql-app/src/test/resources/postgresql.properties
@@ -1,3 +1,6 @@
 quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.sql-load-script=import.sql
 quarkus.hibernate-orm.database.generation=drop-and-create
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none

--- a/sql-db/vertx-sql/src/main/resources/application.properties
+++ b/sql-db/vertx-sql/src/main/resources/application.properties
@@ -62,3 +62,6 @@ quarkus.datasource.oracle.reactive.url=oracle:thin:@localhost:1521:amadeus
 ## Flyway
 quarkus.datasource.oracle.jdbc.url=jdbc:oracle:thin:@localhost:1521:amadeus
 quarkus.flyway.oracle.locations=db/migration/oracle,db/migration/common
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none


### PR DESCRIPTION
### Summary

Quarkus now provides option to disable all monitoring options during native image build https://github.com/quarkusio/quarkus/pull/48872 which could help us to work around github.com/quarkusio/quarkus/issues/46890 if I read the situation right and Mandrel team analyzed situation correctly.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)