### PR TITLE
Fix OidcMtlsBindingIT on windows due to dynamic SAN

### DIFF
--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/OidcMtlsBindingIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/OidcMtlsBindingIT.java
@@ -15,7 +15,7 @@ public class OidcMtlsBindingIT extends AbstractOidcMtlsBindingIT {
             "--hostname=localhost",
             "--https-client-auth=required", "--https-key-store-file=/etc/server-keystore.p12",
             "--https-trust-store-file=/etc/server-truststore.p12",
-            "--https-trust-store-password=password" }, port = KEYCLOAK_PORT)
+            "--https-trust-store-password=password" }, port = KEYCLOAK_PORT, builder = LocalHostKeycloakContainerManagedResourceBuilder.class)
     static KeycloakService keycloak = newKeycloakInstance(DEFAULT_REALM_FILE, REALM_DEFAULT, DEFAULT_REALM_BASE_PATH)
             .withProperty("HTTPS_KEYSTORE", "resource_with_destination::/etc/|server-keystore.p12")
             .withProperty("HTTPS_TRUSTSTORE", "resource_with_destination::/etc/|server-truststore.p12");


### PR DESCRIPTION
### Summary

In this test the already created keystore/trustore are used. They have predefined SANs which not match windows one (The ip for containers are used there). For mtls this was solved by `LocalHostKeycloakContainerManagedResourceBuilder` but I miss this when creating test coverage for mtls binding. Setting the builder is fixing the issue on windows.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)