### PR TITLE
Fix MS SQL Server Dev Mode tests on macOS

### DIFF
--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMssqlIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMssqlIT.java
@@ -17,7 +17,7 @@ public class DevModeMssqlIT extends AbstractSqlDatabaseIT {
     static RestService app = new RestService().withProperties("mssql.properties");
 
     @Test
-    public void mmsqlContainerShouldBeStarted() {
-        app.logs().assertContains("Creating container for image: mcr.microsoft.com/mssql/server");
+    public void mssqlContainerShouldBeStarted() {
+        app.logs().assertContains("Creating container for image: mcr.microsoft.com");
     }
 }

--- a/sql-db/sql-app/src/test/resources/container-license-acceptance.txt
+++ b/sql-db/sql-app/src/test/resources/container-license-acceptance.txt
@@ -4,3 +4,4 @@ mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-latest
 mcr.microsoft.com/mssql/rhel/server:2022-latest
 mcr.microsoft.com/mssql/server:2022-latest
+mcr.microsoft.com/azure-sql-edge:latest


### PR DESCRIPTION
### Summary
Fix MS SQL Server Dev Mode tests on macOS

mcr.microsoft.com/azure-sql-edge:latest is used instead of mcr.microsoft.com/mssql/server:2022-latest on macOS

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)