### PR TITLE
 Fix wrong creation and resolution of certificate path in `BearerFilesystemIT` on windows

### DIFF
--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BearerFilesystemIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BearerFilesystemIT.java
@@ -51,7 +51,7 @@ public class BearerFilesystemIT {
             "--features=token-exchange" })
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
-    private static String token_file_path = null;
+    private static String tokenFilePath = null;
 
     @QuarkusApplication
     static RestService app = new RestService()
@@ -122,7 +122,8 @@ public class BearerFilesystemIT {
 
     private RSAPrivateKey readPrivateKey() throws Exception {
         if (privateKey == null) {
-            privateKey = readPKCS8PrivateKey(Path.of(getClass().getClassLoader().getResource(PRIVATE_KEY_FILE).getPath()));
+            privateKey = readPKCS8PrivateKey(
+                    new File(getClass().getClassLoader().getResource(PRIVATE_KEY_FILE).getFile()).toPath());
         }
         return privateKey;
     }
@@ -171,13 +172,13 @@ public class BearerFilesystemIT {
     }
 
     public static String getTokenFilePath() {
-        if (token_file_path != null) {
-            return token_file_path;
+        if (tokenFilePath != null) {
+            return tokenFilePath;
         }
         String tmpDir = System.getProperty("java.io.tmpdir");
         String path = RandomStringUtils.insecure().nextAlphanumeric(8) + ".token";
 
-        token_file_path = tmpDir + File.separator + path;
-        return token_file_path;
+        tokenFilePath = Path.of(tmpDir, path).toString();
+        return tokenFilePath;
     }
 }


### PR DESCRIPTION
### Summary

The `Path.of`  failed to create due to `getResource().getPath()` which started always with `\` and created invalid path on windows. This caused `Illegal char <:> at index 2: /C:/Users`.
    
Also the `tokenFilePath` on windows added `\` at the end of tmp directory and when construction of `tokenFilePath` the another file separator was added causing that two separators were placed after each other. E.g. expect the path was `C:\<path>\\abcdefgh.token` but Quarkus log contain `C:\<path>\abcdefgh.token` 

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)