### PR TITLE
Replace deprecated `@AccessToken` import path

### DIFF
--- a/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/ping/clients/TokenPropagationPongClient.java
+++ b/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/ping/clients/TokenPropagationPongClient.java
@@ -12,7 +12,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-import io.quarkus.oidc.token.propagation.AccessToken;
+import io.quarkus.oidc.token.propagation.common.AccessToken;
 import io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.model.Score;
 
 @RegisterRestClient

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/clients/TokenPropagationPongClient.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/clients/TokenPropagationPongClient.java
@@ -12,7 +12,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-import io.quarkus.oidc.token.propagation.AccessToken;
+import io.quarkus.oidc.token.propagation.common.AccessToken;
 import io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.model.Score;
 
 @RegisterRestClient


### PR DESCRIPTION
### Summary

The `io.quarkus.oidc.token.propagation.AccessToken` was deprecated and marked for removal in Quarkus 3.19. Before next LTS we should update it to test what is recommended

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)