### PR TITLE
Fix DevModePostgresqlComposeIT on Aarch64

### DIFF
--- a/sql-db/sql-app/src/test/resources/postgresql-compose-devservices.yml
+++ b/sql-db/sql-app/src/test/resources/postgresql-compose-devservices.yml
@@ -13,3 +13,6 @@ services:
       POSTGRES_USER: myuser
       POSTGRES_PASSWORD: mypassword
       POSTGRES_DB: mydb
+      POSTGRESQL_USER: myuser
+      POSTGRESQL_PASSWORD: mypassword
+      POSTGRESQL_DATABASE: mydb


### PR DESCRIPTION
### Summary

Aarch64 is using RH image that expects different environment variables, which is reason why Aarch64 daily build is failing. We have these properties in our PG service already, see https://github.com/quarkus-qe/quarkus-test-framework/blob/main/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/PostgresqlService.java. I have tested this fix on a Beaker machine.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)