### PR TITLE
Drop Aarch64 workaround for DevModeInfinispanIT

### DIFF
--- a/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/DevModeInfinispanIT.java
+++ b/nosql-db/infinispan/src/test/java/io/quarkus/ts/infinispan/DevModeInfinispanIT.java
@@ -2,44 +2,18 @@ package io.quarkus.ts.infinispan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Map;
-
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
-import io.quarkus.test.utils.FileUtils;
 
 @QuarkusScenario
 public class DevModeInfinispanIT {
 
-    // TODO: drop this Aarch64 workaround when https://issues.redhat.com/browse/QUARKUS-5242 is fixed
-    private static final boolean IS_AARCH64_PLATFORM = Boolean.getBoolean("ts.arm.missing.services.excludes");
-
     @DevModeQuarkusApplication()
-    static RestService service = new RestService()
-            .withProperties(() -> {
-                if (IS_AARCH64_PLATFORM) {
-                    return Map.of("quarkus.infinispan-client.devservices.image-name", "${datagrid.image}");
-                }
-                return Map.of();
-            })
-            .onPreStart(service -> {
-                if (IS_AARCH64_PLATFORM) {
-                    // override default Ryuk used by Infinispan as it doesn't work on Aarch64
-                    RestService restService = (RestService) service;
-                    var testContainersPropsPath = restService
-                            .getServiceFolder()
-                            .resolve("src")
-                            .resolve("main")
-                            .resolve("resources")
-                            .resolve("testcontainers.properties");
-                    FileUtils.copyContentTo("ryuk.container.image=testcontainers/ryuk:0.3.3" + System.lineSeparator(),
-                            testContainersPropsPath);
-                }
-            });
+    static final RestService service = new RestService();
 
     @Test
     void smoke() {


### PR DESCRIPTION
### Summary

This is required to verify https://issues.redhat.com/browse/QUARKUS-5242. I verified the test is fixed using beaker machine.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)