### PR TITLE
Fix gRPC DEV UI test failrues

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeGrpcIntegrationReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeGrpcIntegrationReactiveIT.java
@@ -98,7 +98,7 @@ public class DevModeGrpcIntegrationReactiveIT {
                 Page page = browser.newContext().newPage();
                 var grpcServicesViewUrl = app
                         .getURI(Protocol.HTTP)
-                        .withPath("/q/dev-ui/io.quarkus.quarkus-grpc/services")
+                        .withPath("/q/dev-ui/quarkus-grpc/services")
                         .toString();
                 page.navigate(grpcServicesViewUrl);
 

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeGrpcIntegrationIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeGrpcIntegrationIT.java
@@ -96,7 +96,7 @@ public class DevModeGrpcIntegrationIT {
                 Page page = browser.newContext().newPage();
                 var grpcServicesViewUrl = app
                         .getURI(Protocol.HTTP)
-                        .withPath("/q/dev-ui/io.quarkus.quarkus-grpc/services")
+                        .withPath("/q/dev-ui/quarkus-grpc/services")
                         .toString();
                 page.navigate(grpcServicesViewUrl);
 


### PR DESCRIPTION
### Summary

So it seems that extension components are no longer referred to with `io.quarkus` prefix, I can see in Quarkus main project that there is still couple of references to the old paths (just fulltext search "/q/dev-ui/io.quarkus.q", I'll report it), but it is not an issue for actual browsers. However Playwright don't seem to handle redirects well and so both `DevModeGrpcIntegrationReactiveIT` and `DevModeGrpcIntegrationIT` are failing..

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)