### PR TITLE
[3.15] backport - Migrate to KRaft in kafka operator deployment.

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/resources/amq-streams-operator-kafka-instance.yaml
+++ b/messaging/kafka-streams-reactive-messaging/src/test/resources/amq-streams-operator-kafka-instance.yaml
@@ -1,10 +1,36 @@
 apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: dual-role
+  labels:
+    strimzi.io/cluster: kafka-instance
+spec:
+  replicas: 1
+  roles:
+    - controller
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Mi
+        deleteClaim: true
+        kraftMetadata: shared
+---
+
+apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: kafka-instance
+  annotations:
+    strimzi.io/kraft: enabled
+    strimzi.io/node-pools: enabled
 spec:
   kafka:
-    version: 3.8.0
+    version: 4.0.0
+    metadataVersion: 4.0-IV3
+    strimzi.io/node-pools: enabled
     replicas: 1
     listeners:
       - name: plain
@@ -20,19 +46,6 @@ spec:
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
       log.message.format.version: "3.8-IV0"
-    storage:
-      type: jbod
-      volumes:
-        - id: 0
-          type: persistent-claim
-          size: 100Mi
-          deleteClaim: true
-  zookeeper:
-    replicas: 1
-    storage:
-      type: persistent-claim
-      size: 100Mi
-      deleteClaim: true
   entityOperator:
     topicOperator: {}
     userOperator: {}


### PR DESCRIPTION
### Summary

Backport https://github.com/quarkus-qe/quarkus-test-suite/pull/2539 into 3.15

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [X] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)