### PR TITLE
Bump RHBK version to the latest one and enable ARM tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <!-- Docker images used by both surefire and failsafe plugin -->
         <postgresql.latest.image>docker.io/library/postgres:17</postgresql.latest.image>
         <mysql.80.image>registry.access.redhat.com/rhscl/mysql-80-rhel7:latest</mysql.80.image>
-        <rhbk.image>registry.redhat.io/rhbk/keycloak-rhel9:26.0</rhbk.image>
+        <rhbk.image>registry.redhat.io/rhbk/keycloak-rhel9:26.2</rhbk.image>
         <wiremock-jre8.version>2.35.2</wiremock-jre8.version>
         <build-reporter-maven-extension.version>3.11.1</build-reporter-maven-extension.version>
         <reruns>2</reruns>

--- a/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSsoAuthzSecurityIT.java
+++ b/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSsoAuthzSecurityIT.java
@@ -4,7 +4,6 @@ import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -14,7 +13,6 @@ import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoAuthzSecurityIT extends BaseAuthzSecurityIT {
 

--- a/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/OpenShiftRhSsoAuthzSecurityReactiveIT.java
+++ b/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/OpenShiftRhSsoAuthzSecurityReactiveIT.java
@@ -4,7 +4,6 @@ import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -14,7 +13,6 @@ import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoAuthzSecurityReactiveIT extends BaseAuthzSecurityReactiveIT {
 

--- a/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/OpenShiftRhSsoOidcJwtSecurityIT.java
+++ b/security/keycloak-jwt/src/test/java/io/quarkus/ts/security/keycloak/jwt/OpenShiftRhSsoOidcJwtSecurityIT.java
@@ -4,7 +4,6 @@ import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -14,7 +13,6 @@ import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcJwtSecurityIT extends BaseOidcJwtSecurityIT {
 

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSsoMultiTenantSecurityIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSsoMultiTenantSecurityIT.java
@@ -4,7 +4,6 @@ import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -14,7 +13,6 @@ import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoMultiTenantSecurityIT extends BaseMultiTenantSecurityIT {
 

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSsoStaticMultiTenantUserInfoIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftRhSsoStaticMultiTenantUserInfoIT.java
@@ -5,7 +5,6 @@ import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -14,7 +13,6 @@ import io.quarkus.test.services.KeycloakContainer;
 
 @Tag("QUARKUS-5660")
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoStaticMultiTenantUserInfoIT extends AbstractStaticMultiTenantUserInfoIT {
 

--- a/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/keycloak/oauth2/OpenShiftRhSsoOauth2SecurityIT.java
+++ b/security/keycloak-oauth2/src/test/java/io/quarkus/ts/security/keycloak/oauth2/OpenShiftRhSsoOauth2SecurityIT.java
@@ -4,7 +4,6 @@ import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -14,7 +13,6 @@ import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOauth2SecurityIT extends BaseOauth2SecurityIT {
 

--- a/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/OpenShiftRhSsoOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/OpenShiftRhSsoOidcClientSecurityIT.java
@@ -4,7 +4,6 @@ import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -14,7 +13,6 @@ import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcClientSecurityIT extends BaseOidcClientSecurityIT {
 

--- a/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/OpenShiftRhSsoOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/OpenShiftRhSsoOidcClientSecurityIT.java
@@ -4,7 +4,6 @@ import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -14,7 +13,6 @@ import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcClientSecurityIT extends BaseOidcClientSecurityIT {
 

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/OpenShiftRhSsoWebappSecurityIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/OpenShiftRhSsoWebappSecurityIT.java
@@ -4,7 +4,6 @@ import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -14,7 +13,6 @@ import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoWebappSecurityIT extends BaseWebappSecurityIT {
 

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftRhSsoOidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftRhSsoOidcSecurityIT.java
@@ -4,7 +4,6 @@ import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -14,7 +13,6 @@ import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcSecurityIT extends BaseOidcSecurityIT {
 

--- a/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/OpenShiftRhSsoOidcMtlsIT.java
+++ b/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/OpenShiftRhSsoOidcMtlsIT.java
@@ -6,7 +6,6 @@ import static org.keycloak.representations.idm.CredentialRepresentation.PASSWORD
 import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -21,7 +20,6 @@ Enabling this may require fixing config map names created for resources
  */
 @Disabled("https://github.com/quarkus-qe/quarkus-test-framework/issues/1052")
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/1145")
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcMtlsIT extends KeycloakMtlsAuthN {
 


### PR DESCRIPTION
### Summary
Fixes #1145 

The RHBK 26.2 is first one which fully support ARM64 architecture.
https://catalog.redhat.com/software/containers/rhbk/keycloak-rhel9/64f0add883a29ec473d40906?architecture=arm64&image=687a6ce6590f6e279ac7a826

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [x] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)