### PR TITLE
Fix Docker compose scenarios on Windows with Docker

### DIFF
--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/AbstractSqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/AbstractSqlDatabaseIT.java
@@ -5,6 +5,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 
+import java.util.Map;
+
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import io.restassured.http.ContentType;
+import io.smallrye.common.os.OS;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public abstract class AbstractSqlDatabaseIT {
@@ -175,5 +178,29 @@ public abstract class AbstractSqlDatabaseIT {
                 .statusCode(HttpStatus.SC_NOT_FOUND)
                 .body("code", equalTo(HttpStatus.SC_NOT_FOUND))
                 .body("error", equalTo(String.format("book '%d' not found", VALID_ID)));
+    }
+
+    protected static Map<String, String> getDockerComposeProperties() {
+        if (OS.WINDOWS.isCurrent() && isNotPodman()) {
+            // this helps Docker CLI to discover docker-compos.exe as a plugin
+            // which is installed in 'C:\ProgramData\Docker\cli-plugins\docker-compose.exe'
+            return Map.of("quarkus.compose.devservices.env-variables.PROGRAMDATA", System.getenv("PROGRAMDATA"));
+        }
+        return Map.of();
+    }
+
+    private static boolean isNotPodman() {
+        // this is not as reliable as executing Docker command, but much quicker and sufficient
+        // since our Docker instance will never be a localhost, but it is true for Podman
+        String dockerIp = System.getenv("DOCKER_IP");
+        if (dockerIp != null && dockerIp.contains("localhost")) {
+            return false;
+        }
+        // fallback just in case
+        String dockerHost = System.getenv("DOCKER_HOST");
+        if (dockerHost != null && dockerHost.contains("podman")) {
+            return false;
+        }
+        return !System.getProperty("excludedGroups", "").contains("podman-incompatible");
     }
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMariadbComposeIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMariadbComposeIT.java
@@ -13,6 +13,7 @@ public class DevModeMariadbComposeIT extends AbstractSqlDatabaseIT {
 
     @DevModeQuarkusApplication(properties = "mariadb_app.properties")
     static RestService app = new RestService()
+            .withProperties(AbstractSqlDatabaseIT::getDockerComposeProperties)
             .withProperty("quarkus.compose.devservices.files", "src/main/resources/mariadb-compose-devservices.yml")
             .withProperty("quarkus.compose.devservices.env-variables.IMAGE", "${mariadb.11.image}");
 

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMysqlComposeIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMysqlComposeIT.java
@@ -14,6 +14,7 @@ public class DevModeMysqlComposeIT extends AbstractSqlDatabaseIT {
 
     @DevModeQuarkusApplication(properties = "mysql.properties")
     static RestService app = new RestService()
+            .withProperties(AbstractSqlDatabaseIT::getDockerComposeProperties)
             .withProperty("quarkus.compose.devservices.files", "src/main/resources/mysql-compose-devservices.yml")
             .withProperty("quarkus.compose.devservices.env-variables.IMAGE", "${mysql.upstream.80.image}");
 

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlComposeIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlComposeIT.java
@@ -13,6 +13,7 @@ public class DevModePostgresqlComposeIT extends AbstractSqlDatabaseIT {
 
     @DevModeQuarkusApplication(properties = "postgresql.properties")
     static RestService app = new RestService()
+            .withProperties(AbstractSqlDatabaseIT::getDockerComposeProperties)
             .withProperty("quarkus.compose.devservices.files", "src/main/resources/postgresql-compose-devservices.yml")
             .withProperty("quarkus.compose.devservices.env-variables.IMAGE", "${postgresql.latest.image}");
 


### PR DESCRIPTION
### Summary

Docker CLI seems to detect plugins in `C:\ProgramData\Docker\cli-plugins` and when Quarkus runs Docker compose command, it does not propagate the `PROGRAMDATA` environment variable, which means that the command fails on Windows Server with Docker because there is no `docker-compose.exe`. @rsvoboda is working on reproducing the issue with more traditional setup as our Windows Server Docker machines are using Minikube for Linux containers and have the Docker compose installed with Chocolatey.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)