### PR TITLE
Fix Docker Compose test cases on Windows with Podman

### DIFF
--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/AbstractSqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/AbstractSqlDatabaseIT.java
@@ -181,26 +181,11 @@ public abstract class AbstractSqlDatabaseIT {
     }
 
     protected static Map<String, String> getDockerComposeProperties() {
-        if (OS.WINDOWS.isCurrent() && isNotPodman()) {
+        if (OS.WINDOWS.isCurrent()) {
             // this helps Docker CLI to discover docker-compos.exe as a plugin
             // which is installed in 'C:\ProgramData\Docker\cli-plugins\docker-compose.exe'
             return Map.of("quarkus.compose.devservices.env-variables.PROGRAMDATA", System.getenv("PROGRAMDATA"));
         }
         return Map.of();
-    }
-
-    private static boolean isNotPodman() {
-        // this is not as reliable as executing Docker command, but much quicker and sufficient
-        // since our Docker instance will never be a localhost, but it is true for Podman
-        String dockerIp = System.getenv("DOCKER_IP");
-        if (dockerIp != null && dockerIp.contains("localhost")) {
-            return false;
-        }
-        // fallback just in case
-        String dockerHost = System.getenv("DOCKER_HOST");
-        if (dockerHost != null && dockerHost.contains("podman")) {
-            return false;
-        }
-        return !System.getProperty("excludedGroups", "").contains("podman-incompatible");
     }
 }


### PR DESCRIPTION
### Summary

I restricted the Docker Compose Windows workaround to Docker as I thought Podman Compose will kick in, but our tests in Jenkins failed, so applying the same workaround as we do for the Docker. Tested in Jenkins run `periodic-builds/job/quarkus-main-win22-jdk17-baremetal-ts-jvm-podman-monthly/38/label=RHEL8 && medium,scenario=databases-modules-1/testReport/io.quarkus.ts.sqldb.sqlapp/`.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)