### PR TITLE
Change selected modules from using KC dev to prod mode

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/HttpAdvancedReactiveIT.java
@@ -14,12 +14,13 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class HttpAdvancedReactiveIT extends BaseHttpAdvancedReactiveIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureHttpServer = true, useTlsRegistry = false))
-    static RestService app = new RestService().withProperty("quarkus.oidc.auth-server-url",
-            keycloak::getRealmUrl);
+    static RestService app = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
+            .withProperties(keycloak::getTlsProperties);
 
     @Override
     protected RestService getApp() {

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/OpenShiftHttpAdvancedReactiveIT.java
@@ -15,12 +15,13 @@ import io.quarkus.test.services.QuarkusApplication;
 @OpenShiftScenario
 public class OpenShiftHttpAdvancedReactiveIT extends BaseHttpAdvancedReactiveIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" }, image = "${rhbk.image}")
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureHttpServer = true, useTlsRegistry = false))
-    static RestService app = new RestService().withProperty("quarkus.oidc.auth-server-url",
-            keycloak::getRealmUrl);
+    static RestService app = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
+            .withProperties(keycloak::getTlsProperties);
 
     @Override
     protected RestService getApp() {

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/HttpAdvancedIT.java
@@ -14,11 +14,13 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class HttpAdvancedIT extends BaseHttpAdvancedIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureHttpServer = true, useTlsRegistry = false))
-    static RestService app = new RestService().withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
+    static RestService app = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
+            .withProperties(keycloak::getTlsProperties);
 
     @Override
     protected RestService getApp() {

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/OpenShiftHttpAdvancedIT.java
@@ -15,11 +15,13 @@ import io.quarkus.test.services.QuarkusApplication;
 @OpenShiftScenario
 public class OpenShiftHttpAdvancedIT extends BaseHttpAdvancedIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" }, image = "${rhbk.image}")
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureHttpServer = true, useTlsRegistry = false))
-    static RestService app = new RestService().withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
+    static RestService app = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
+            .withProperties(keycloak::getTlsProperties);
 
     @Override
     protected RestService getApp() {

--- a/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/BaseMicrometerOidcSecurityIT.java
+++ b/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/BaseMicrometerOidcSecurityIT.java
@@ -29,7 +29,7 @@ public abstract class BaseMicrometerOidcSecurityIT {
     static final String OK_HTTP_CALL_METRIC = HTTP_METRIC + "outcome=\"SUCCESS\",status=\"200\",uri=\"%s\"}";
     static final String UNAUTHORIZED_HTTP_CALL_METRIC = HTTP_METRIC + "outcome=\"CLIENT_ERROR\",status=\"401\",uri=\"%s\"}";
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     private AuthzClient authzClient;

--- a/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/DevMicrometerOidcSecurityIT.java
+++ b/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/DevMicrometerOidcSecurityIT.java
@@ -11,7 +11,8 @@ public class DevMicrometerOidcSecurityIT extends BaseMicrometerOidcSecurityIT {
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
             .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
-            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT);
+            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT)
+            .withProperties(keycloak::getTlsProperties);
 
     @Override
     public RestService getApp() {

--- a/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/ProdMicrometerOidcSecurityIT.java
+++ b/monitoring/micrometer-prometheus-oidc/src/test/java/io/quarkus/ts/micrometer/oidc/ProdMicrometerOidcSecurityIT.java
@@ -11,7 +11,8 @@ public class ProdMicrometerOidcSecurityIT extends BaseMicrometerOidcSecurityIT {
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
             .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
-            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT);
+            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT)
+            .withProperties(keycloak::getTlsProperties);
 
     @Override
     public RestService getApp() {

--- a/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/BaseAuthzSecurityIT.java
+++ b/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/BaseAuthzSecurityIT.java
@@ -46,7 +46,7 @@ public abstract class BaseAuthzSecurityIT {
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body(startsWith("user token issued by " +
-                        getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri()));
+                        getKeycloak().getURI(Protocol.HTTPS).getRestAssuredStyleUri()));
     }
 
     @Test
@@ -90,7 +90,7 @@ public abstract class BaseAuthzSecurityIT {
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body(startsWith("admin token issued by " +
-                        getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri()));
+                        getKeycloak().getURI(Protocol.HTTPS).getRestAssuredStyleUri()));
     }
 
     @Test

--- a/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/KeycloakAuthzSecurityIT.java
+++ b/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/KeycloakAuthzSecurityIT.java
@@ -13,14 +13,15 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class KeycloakAuthzSecurityIT extends BaseAuthzSecurityIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
             .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
-            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT);
+            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT)
+            .withProperties(keycloak::getTlsProperties);
 
     @Override
     protected KeycloakService getKeycloak() {

--- a/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSsoAuthzSecurityIT.java
+++ b/security/keycloak-authz-classic/src/test/java/io/quarkus/ts/security/keycloak/authz/OpenShiftRhSsoAuthzSecurityIT.java
@@ -16,14 +16,15 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoAuthzSecurityIT extends BaseAuthzSecurityIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm" }, image = "${rhbk.image}")
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
             .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
-            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT);
+            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT)
+            .withProperties(keycloak::getTlsProperties);
 
     @Override
     protected KeycloakService getKeycloak() {

--- a/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/BaseAuthzSecurityReactiveIT.java
+++ b/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/BaseAuthzSecurityReactiveIT.java
@@ -64,7 +64,7 @@ public abstract class BaseAuthzSecurityReactiveIT {
     public void normalUserUserResourceIssuer() {
         whenMakeRequestTo(HttpMethod.GET, "/user/issuer", getToken(NORMAL_USER, NORMAL_USER));
         thenStatusCodeIs(HttpStatus.SC_OK);
-        thenBodyStartWith("user token issued by " + getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri());
+        thenBodyStartWith("user token issued by " + getKeycloak().getURI(Protocol.HTTPS).getRestAssuredStyleUri());
     }
 
     @Test
@@ -91,7 +91,7 @@ public abstract class BaseAuthzSecurityReactiveIT {
     public void adminUserAdminResourceIssuer() {
         whenMakeRequestTo(HttpMethod.GET, "/admin/issuer", getToken(ADMIN_USER, ADMIN_USER));
         thenStatusCodeIs(HttpStatus.SC_OK);
-        thenBodyStartWith("admin token issued by " + getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri());
+        thenBodyStartWith("admin token issued by " + getKeycloak().getURI(Protocol.HTTPS).getRestAssuredStyleUri());
     }
 
     @Test

--- a/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/KeycloakAuthzSecurityReactiveIT.java
+++ b/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/KeycloakAuthzSecurityReactiveIT.java
@@ -13,14 +13,15 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class KeycloakAuthzSecurityReactiveIT extends BaseAuthzSecurityReactiveIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
             .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
-            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT);
+            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT)
+            .withProperties(keycloak::getTlsProperties);
 
     @Override
     protected KeycloakService getKeycloak() {

--- a/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/OpenShiftRhSsoAuthzSecurityReactiveIT.java
+++ b/security/keycloak-authz-reactive/src/test/java/io/quarkus/ts/security/keycloak/authz/reactive/OpenShiftRhSsoAuthzSecurityReactiveIT.java
@@ -16,14 +16,15 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoAuthzSecurityReactiveIT extends BaseAuthzSecurityReactiveIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm" }, image = "${rhbk.image}")
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
             .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
-            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT);
+            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT)
+            .withProperties(keycloak::getTlsProperties);
 
     @Override
     protected KeycloakService getKeycloak() {

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/AbstractMultiMechanismAuthenticationIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/AbstractMultiMechanismAuthenticationIT.java
@@ -33,7 +33,8 @@ public abstract class AbstractMultiMechanismAuthenticationIT {
             .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
             .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
             .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT)
-            .withProperties("multi-mechanism.properties");
+            .withProperties("multi-mechanism.properties")
+            .withProperties(() -> keycloak.getTlsProperties());
 
     @Test
     public void testAdminBasicAndOidcTogetherOnAdminResource() {

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/BaseOidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/BaseOidcSecurityIT.java
@@ -57,7 +57,7 @@ public abstract class BaseOidcSecurityIT {
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body(startsWith("user token issued by " +
-                        getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri()));
+                        getKeycloak().getURI(Protocol.HTTPS).getRestAssuredStyleUri()));
     }
 
     @Test
@@ -101,7 +101,7 @@ public abstract class BaseOidcSecurityIT {
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body(startsWith("admin token issued by " +
-                        getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri()));
+                        getKeycloak().getURI(Protocol.HTTPS).getRestAssuredStyleUri()));
     }
 
     @Test

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/KeycloakOidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/KeycloakOidcSecurityIT.java
@@ -13,14 +13,15 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class KeycloakOidcSecurityIT extends BaseOidcSecurityIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
             .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
-            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT);
+            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT)
+            .withProperties(keycloak::getTlsProperties);
 
     @Override
     protected KeycloakService getKeycloak() {

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/MultiMechanismAuthenticationIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/MultiMechanismAuthenticationIT.java
@@ -14,7 +14,7 @@ import io.quarkus.test.services.KeycloakContainer;
 @Tag("QUARKUS-5617")
 public class MultiMechanismAuthenticationIT extends AbstractMultiMechanismAuthenticationIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
 }

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftMultiMechanismAuthenticationIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftMultiMechanismAuthenticationIT.java
@@ -14,7 +14,7 @@ import io.quarkus.test.services.KeycloakContainer;
 @Tag("QUARKUS-5617")
 public class OpenShiftMultiMechanismAuthenticationIT extends AbstractMultiMechanismAuthenticationIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm" }, image = "${rhbk.image}")
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
 }

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftRhSsoOidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftRhSsoOidcSecurityIT.java
@@ -16,14 +16,15 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcSecurityIT extends BaseOidcSecurityIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm" }, image = "${rhbk.image}")
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
             .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
-            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT);
+            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT)
+            .withProperties(keycloak::getTlsProperties);
 
     @Override
     protected KeycloakService getKeycloak() {

--- a/websockets/websocket-next-oidc/src/test/java/io/quarkus/ts/websockets/next/AbstractOidcWebSocketIT.java
+++ b/websockets/websocket-next-oidc/src/test/java/io/quarkus/ts/websockets/next/AbstractOidcWebSocketIT.java
@@ -37,7 +37,8 @@ public abstract class AbstractOidcWebSocketIT {
 
     @QuarkusApplication
     static final RestService server = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl());
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperties(() -> keycloak.getTlsProperties());
 
     @Test
     public void tokenAuthenticatedTest() throws URISyntaxException, InterruptedException {

--- a/websockets/websocket-next-oidc/src/test/java/io/quarkus/ts/websockets/next/OidcWebSocketIT.java
+++ b/websockets/websocket-next-oidc/src/test/java/io/quarkus/ts/websockets/next/OidcWebSocketIT.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.KeycloakContainer;
 @QuarkusScenario
 public class OidcWebSocketIT extends AbstractOidcWebSocketIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
 }

--- a/websockets/websocket-next-oidc/src/test/java/io/quarkus/ts/websockets/next/OpenShiftOidcWebSocketIT.java
+++ b/websockets/websocket-next-oidc/src/test/java/io/quarkus/ts/websockets/next/OpenShiftOidcWebSocketIT.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.KeycloakContainer;
 @OpenShiftScenario
 public class OpenShiftOidcWebSocketIT extends AbstractOidcWebSocketIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" }, image = "${rhbk.image}")
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
 }

--- a/websockets/websocket-next-oidc/src/test/java/io/quarkus/ts/websockets/next/VertxWebSocketClientIT.java
+++ b/websockets/websocket-next-oidc/src/test/java/io/quarkus/ts/websockets/next/VertxWebSocketClientIT.java
@@ -38,12 +38,13 @@ public class VertxWebSocketClientIT {
     private static final String ADMIN_PASSWORD = "random";
     private static Vertx vertx;
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication(ssl = true)
     static final RestService server = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
+            .withProperties(keycloak::getTlsProperties);
 
     @BeforeAll
     static void setup() {

--- a/websockets/websocket-next-oidc/src/test/java/io/quarkus/ts/websockets/next/WebSocketNextBrowserAuthorizationIT.java
+++ b/websockets/websocket-next-oidc/src/test/java/io/quarkus/ts/websockets/next/WebSocketNextBrowserAuthorizationIT.java
@@ -49,14 +49,15 @@ public class WebSocketNextBrowserAuthorizationIT {
     private URILike wsBaseUri;
     private URILike wssBaseUri;
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication(ssl = true, certificates = {
             @Certificate(configureKeystore = true, configureTruststore = true, useTlsRegistry = false, configureHttpServer = true)
     })
     static final RestService server = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
+            .withProperties(keycloak::getTlsProperties);
 
     @BeforeAll
     static void launchBrowser() {


### PR DESCRIPTION
### Summary

Changed modules:
1. http/http-advanced
2. http/http-advanced-reactive
3. monitoring/micrometer-prometheus-oidc
4. security/keycloak
5. security/keycloak-authz-classic
6. security/keycloak-authz-reactive
7. websockets/websocket-next-oidc

Other module will follow, but in them the transition is not that easy. Need to look at them

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [x] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)