### PR TITLE
Stabilize remote DEV cases on Windows

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/RemoteDevModeHttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/RemoteDevModeHttpAdvancedReactiveIT.java
@@ -9,12 +9,13 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.IsRunningCheck;
 import io.quarkus.test.services.RemoteDevModeQuarkusApplication;
 
 @QuarkusScenario
 public class RemoteDevModeHttpAdvancedReactiveIT {
 
-    @RemoteDevModeQuarkusApplication
+    @RemoteDevModeQuarkusApplication(isRunningCheck = IsRunningCheck.IsBasePathReachableCheck.class)
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.enabled", "false")
             .withProperty("quarkus.keycloak.policy-enforcer.enable", "false")

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/RemoteDevModeHttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/RemoteDevModeHttpAdvancedIT.java
@@ -9,12 +9,13 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.IsRunningCheck;
 import io.quarkus.test.services.RemoteDevModeQuarkusApplication;
 
 @QuarkusScenario
 public class RemoteDevModeHttpAdvancedIT {
 
-    @RemoteDevModeQuarkusApplication
+    @RemoteDevModeQuarkusApplication(isRunningCheck = IsRunningCheck.IsBasePathReachableCheck.class)
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.enabled", "false")
             .withProperty("quarkus.keycloak.policy-enforcer.enable", "false")


### PR DESCRIPTION
### Summary

Remote DEV test cases `RemoteDevModeHttpAdvancedReactiveIT` and `RemoteDevModeHttpAdvancedIT` are frequently failing on Windows, I think there may be 2 reasons for that, one is that "is running" check is not reliable and things are slower on Windows. The second is that deleting of service folders is happening while these folders are still used; this part is left alone for now, I am curious how often this will happen if the running check is reliable.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)