### PR TITLE
Workaround remote dev Windows issue

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/RemoteDevModeHttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/RemoteDevModeHttpAdvancedIT.java
@@ -11,6 +11,8 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.IsRunningCheck;
 import io.quarkus.test.services.RemoteDevModeQuarkusApplication;
+import io.quarkus.test.utils.AwaitilityUtils;
+import io.smallrye.common.os.OS;
 
 @QuarkusScenario
 public class RemoteDevModeHttpAdvancedIT {
@@ -23,12 +25,23 @@ public class RemoteDevModeHttpAdvancedIT {
 
     @Test
     public void serviceShouldBeUpAndRunning() {
-        given().get("/api/hello").then().statusCode(HttpStatus.SC_OK).body("content", is("Hello, World!"));
+        // TODO: drop Windows workaround when https://github.com/quarkusio/quarkus/issues/49434 is fixed
+        if (OS.WINDOWS.isCurrent()) {
+            AwaitilityUtils.untilAsserted(
+                    () -> given().get("/api/hello").then().statusCode(HttpStatus.SC_OK).body("content", is("Hello, World!")));
+        } else {
+            given().get("/api/hello").then().statusCode(HttpStatus.SC_OK).body("content", is("Hello, World!"));
+        }
     }
 
     @Tag("QUARKUS-834")
     @Test
     public void devUiShouldBeNotFound() {
-        app.given().get("/q/dev").then().statusCode(HttpStatus.SC_NOT_FOUND);
+        // TODO: drop Windows workaround when https://github.com/quarkusio/quarkus/issues/49434 is fixed
+        if (OS.WINDOWS.isCurrent()) {
+            AwaitilityUtils.untilAsserted(() -> app.given().get("/q/dev").then().statusCode(HttpStatus.SC_NOT_FOUND));
+        } else {
+            app.given().get("/q/dev").then().statusCode(HttpStatus.SC_NOT_FOUND);
+        }
     }
 }


### PR DESCRIPTION
### Summary

I have reported that remote dev mode behaves bit different on Windows here https://github.com/quarkusio/quarkus/issues/49434, though it may be that things are just slower on Windows, don't know. I think we need to retry as even when the application was ready, it can start reloading.

Tested in `job/quarkus-main-win22-jdk17-baremetal-ts-jvm-podman-monthly/40/`.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)