### PR TITLE
Change selected modules from using KC dev to prod mode - Part 2

### DIFF
--- a/security/keycloak-oidc-client-basic/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client-basic/src/main/resources/application.properties
@@ -27,3 +27,9 @@ quarkus.oidc-client.admin-user.grant-options.password.password=test-admin-user
 quarkus.oidc-client.jwt-secret.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.jwt-secret.client-id=test-application-client-jwt
 quarkus.oidc-client.jwt-secret.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+
+# Quarkus need set tls registry for oidc-client in addition of oidc for self-sign certs
+quarkus.oidc-client.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}
+quarkus.oidc-client.normal-user.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}
+quarkus.oidc-client.admin-user.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}
+quarkus.oidc-client.jwt-secret.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}

--- a/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/BaseOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/BaseOidcClientSecurityIT.java
@@ -56,7 +56,7 @@ public abstract class BaseOidcClientSecurityIT {
                 .get("/user/issuer")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body(startsWith("user token issued by " + getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri()));
+                .body(startsWith("user token issued by " + getKeycloak().getURI(Protocol.HTTPS).getRestAssuredStyleUri()));
     }
 
     @Test

--- a/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/KeycloakOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/KeycloakOidcClientSecurityIT.java
@@ -13,12 +13,13 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class KeycloakOidcClientSecurityIT extends BaseOidcClientSecurityIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl());
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperties(() -> keycloak.getTlsProperties());
 
     @Override
     protected KeycloakService getKeycloak() {

--- a/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/OpenShiftRhSsoOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/basic/OpenShiftRhSsoOidcClientSecurityIT.java
@@ -16,12 +16,13 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcClientSecurityIT extends BaseOidcClientSecurityIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" }, image = "${rhbk.image}")
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
+            .withProperties(() -> keycloak.getTlsProperties());
 
     @Override
     protected KeycloakService getKeycloak() {

--- a/security/keycloak-oidc-client-extended/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client-extended/src/main/resources/application.properties
@@ -53,3 +53,8 @@ io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.principal.clients
 
 #OpenAPI
 quarkus.smallrye-openapi.store-schema-directory=target/generated/jakarta-rest/
+
+# Quarkus need set tls registry for oidc-client in addition of oidc for self-sign certs
+quarkus.oidc-client.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}
+quarkus.oidc-client.test-user.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}
+quarkus.oidc-client.exchange-token.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractLogoutSinglePageAppFlowIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractLogoutSinglePageAppFlowIT.java
@@ -12,6 +12,7 @@ import java.util.logging.Logger;
 
 import org.htmlunit.SilentCssErrorHandler;
 import org.htmlunit.WebClient;
+import org.htmlunit.WebClientOptions;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.util.Cookie;
@@ -34,8 +35,9 @@ public abstract class AbstractLogoutSinglePageAppFlowIT {
 
     @QuarkusApplication(classes = { LogoutFlow.class, LogoutTenantResolver.class })
     static RestService app = new RestService()
-            .withProperty("keycloak.url", () -> keycloak.getURI(Protocol.HTTP).toString())
-            .withProperties("logout.properties");
+            .withProperty("keycloak.url", () -> keycloak.getURI(Protocol.HTTPS).toString())
+            .withProperties("logout.properties")
+            .withProperties(() -> keycloak.getTlsProperties());
 
     @Test
     public void singlePageAppLogoutFlow() throws IOException {
@@ -61,6 +63,8 @@ public abstract class AbstractLogoutSinglePageAppFlowIT {
 
     private WebClient createWebClient() {
         WebClient webClient = new WebClient();
+        WebClientOptions options = webClient.getOptions();
+        options.setUseInsecureSSL(true);
         webClient.setCssErrorHandler(new SilentCssErrorHandler());
         Logger.getLogger("org.htmlunit.css").setLevel(Level.OFF);
         webClient.getOptions().setRedirectEnabled(true);

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractOidcRestClientIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractOidcRestClientIT.java
@@ -29,7 +29,8 @@ public abstract class AbstractOidcRestClientIT {
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl());
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperties(() -> keycloak.getTlsProperties());
 
     @Test
     public void testRest() {

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BearerFilesystemIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BearerFilesystemIT.java
@@ -47,8 +47,7 @@ public class BearerFilesystemIT {
     private static final String PRIVATE_KEY_FILE = "key.pem";
     private RSAPrivateKey privateKey = null;
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm",
-            "--features=token-exchange" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     private static String tokenFilePath = null;
@@ -56,6 +55,7 @@ public class BearerFilesystemIT {
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperties(() -> keycloak.getTlsProperties())
             // remove OIDC credentials, that are in the application.properties
             // we want to force the app to use JWT token, not default username:password
             .withProperty("quarkus.oidc.credentials.secret", "")
@@ -147,6 +147,7 @@ public class BearerFilesystemIT {
      */
     private String createUserToken() throws Exception {
         return given()
+                .relaxedHTTPSValidation()
                 .param("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
                 .param("client_assertion", createSignedJwt())
                 .param("grant_type", "password")

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/DpopIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/DpopIT.java
@@ -10,6 +10,7 @@ import io.quarkus.test.services.KeycloakContainer;
 
 @QuarkusScenario
 public class DpopIT extends AbstractDpopIT {
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=dpop" })
+    @KeycloakContainer(runKeycloakInProdMode = true, command = { "start", "--import-realm", "--hostname-strict=false",
+            "--features=dpop" })
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 }

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/LogoutSinglePageAppFlowIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/LogoutSinglePageAppFlowIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.KeycloakContainer;
 @QuarkusScenario
 public class LogoutSinglePageAppFlowIT extends AbstractLogoutSinglePageAppFlowIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService("/quarkus-realm.json", REALM_DEFAULT, DEFAULT_REALM_BASE_PATH);
 
 }

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OidcRestClientIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OidcRestClientIT.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.KeycloakContainer;
 @QuarkusScenario
 public class OidcRestClientIT extends AbstractOidcRestClientIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
 }

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenApiStoreSchemaIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenApiStoreSchemaIT.java
@@ -49,12 +49,13 @@ public class OpenApiStoreSchemaIT {
     private static final String EXPECTED_TAGS = "[{\"name\":\"Ping\",\"description\":\"Ping API\"},{\"name\":\"Pong\",\"description\":\"Pong API\"}]";
     private static final String EXPECTED_INFO = "{\"title\":\"security-keycloak-oidc-client-extended API\",\"version\":\"1.0.0-SNAPSHOT\"}";
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
+            .withProperties(keycloak::getTlsProperties);
 
     // QUARKUS-716
     @Test

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftDpopIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftDpopIT.java
@@ -10,6 +10,13 @@ import io.quarkus.test.services.KeycloakContainer;
 
 @OpenShiftScenario
 public class OpenShiftDpopIT extends AbstractDpopIT {
-    @KeycloakContainer(image = "${rhbk.image}", command = { "start-dev", "--import-realm", "--features=dpop" })
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}", command = { "start", "--import-realm",
+            "--hostname-strict=false", "--features=dpop" })
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+
+    @Override
+    protected String getKeycloakRealmUrl() {
+        // RestAssured with openshift KC url need the port otherwise is not able to success TLS handshake
+        return keycloak.getRealmUrl().replace("/realms/test-realm", ":443/realms/test-realm");
+    }
 }

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftOidcRestClientIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftOidcRestClientIT.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.KeycloakContainer;
 @OpenShiftScenario
 public class OpenShiftOidcRestClientIT extends AbstractOidcRestClientIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" }, image = "${rhbk.image}")
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
 }

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftOidcSinglePageAppLogoutFlowIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftOidcSinglePageAppLogoutFlowIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.KeycloakContainer;
 @OpenShiftScenario
 public class OpenShiftOidcSinglePageAppLogoutFlowIT extends AbstractLogoutSinglePageAppFlowIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm" }, image = "${rhbk.image}")
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
     static KeycloakService keycloak = new KeycloakService("/quarkus-realm.json", REALM_DEFAULT, DEFAULT_REALM_BASE_PATH);
 
 }

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/SecurityClaimsIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/SecurityClaimsIT.java
@@ -23,12 +23,13 @@ public class SecurityClaimsIT {
     private static final String CLAIMS_FROM_BEANS_PATH = "/getClaimsFromBeans";
     private static final String CLAIMS_FROM_TOKEN_PATH = "/getClaimsFromToken";
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
+            .withProperties(keycloak::getTlsProperties);
 
     @Test
     public void verifySecuredEndpointIsProtected() {

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/TokenPropagationFilterIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/TokenPropagationFilterIT.java
@@ -24,12 +24,14 @@ import io.restassured.response.Response;
 @QuarkusScenario
 public class TokenPropagationFilterIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    @KeycloakContainer(runKeycloakInProdMode = true, command = { "start", "--import-realm", "--hostname-strict=false",
+            "--features=token-exchange" })
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl);
+            .withProperty("quarkus.oidc.auth-server-url", keycloak::getRealmUrl)
+            .withProperties(keycloak::getTlsProperties);
 
     @Test
     public void usernameTest() {

--- a/security/keycloak-oidc-client-extended/src/test/resources/logout.properties
+++ b/security/keycloak-oidc-client-extended/src/test/resources/logout.properties
@@ -13,6 +13,8 @@ quarkus.oidc.code-flow.logout.post-logout-uri-param=returnTo
 quarkus.oidc.code-flow.logout.extra-params.client_id=${quarkus.oidc.code-flow.client-id}
 quarkus.oidc.code-flow.credentials.secret=B9w9g5x56D7S9fR2j3LqE5reopKgsvFM
 quarkus.oidc.code-flow.application-type=web-app
+# Quarkus need set tls registry for oidc tenant for self-sign certs in addition of setting it for oidc
+quarkus.oidc.code-flow.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}
 
 quarkus.http.auth.permission.unsecured.paths=/code-flow
 quarkus.http.auth.permission.unsecured.policy=permit

--- a/security/keycloak-oidc-client-reactive-basic/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client-reactive-basic/src/main/resources/application.properties
@@ -34,3 +34,9 @@ quarkus.oidc-client.jwt-secret.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKO
 # RestClient
 quarkus.rest-client."io.quarkus.ts.security.keycloak.oidcclient.reactive.headers.RequestHeadersClient".url=http://localhost:${quarkus.http.port}
 quarkus.rest-client."io.quarkus.ts.security.keycloak.oidcclient.reactive.headers.RequestHeadersClient".scope=jakarta.inject.Singleton
+
+# Quarkus need set tls registry for oidc-client in addition of oidc for self-sign certs
+quarkus.oidc-client.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}
+quarkus.oidc-client.normal-user.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}
+quarkus.oidc-client.admin-user.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}
+quarkus.oidc-client.jwt-secret.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}

--- a/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/BaseOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/BaseOidcClientSecurityIT.java
@@ -56,7 +56,7 @@ public abstract class BaseOidcClientSecurityIT {
                 .get("/user/issuer")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body(startsWith("user token issued by " + getKeycloak().getURI(Protocol.HTTP).getRestAssuredStyleUri()));
+                .body(startsWith("user token issued by " + getKeycloak().getURI(Protocol.HTTPS).getRestAssuredStyleUri()));
     }
 
     @Test

--- a/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/KeycloakOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/KeycloakOidcClientSecurityIT.java
@@ -22,12 +22,13 @@ import io.restassured.response.Response;
 @QuarkusScenario
 public class KeycloakOidcClientSecurityIT extends BaseOidcClientSecurityIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl());
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperties(() -> keycloak.getTlsProperties());
 
     @Override
     protected KeycloakService getKeycloak() {

--- a/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/OpenShiftRhSsoOidcClientSecurityIT.java
+++ b/security/keycloak-oidc-client-reactive-basic/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/basic/OpenShiftRhSsoOidcClientSecurityIT.java
@@ -16,12 +16,13 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftRhSsoOidcClientSecurityIT extends BaseOidcClientSecurityIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" }, image = "${rhbk.image}")
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl());
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperties(() -> keycloak.getTlsProperties());
 
     @Override
     protected KeycloakService getKeycloak() {

--- a/security/keycloak-oidc-client-reactive-extended/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/resources/application.properties
@@ -58,3 +58,8 @@ quarkus.log.file.enable=true
 quarkus.log.file.format=%C - %s%n
 #OpenAPI
 quarkus.smallrye-openapi.store-schema-directory=target/generated/jakarta-rest/
+
+# Quarkus need set tls registry for oidc-client in addition of oidc for self-sign certs
+quarkus.oidc-client.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}
+quarkus.oidc-client.test-user.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}
+quarkus.oidc-client.exchange-token.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/AbstractOidcResponseFilterIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/AbstractOidcResponseFilterIT.java
@@ -30,7 +30,8 @@ public abstract class AbstractOidcResponseFilterIT {
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl());
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperties(() -> keycloak.getTlsProperties());
 
     protected AccessTokenResponse createTokenWithoutProfileScope() {
         return keycloak

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/LogoutSinglePageAppFlowIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/LogoutSinglePageAppFlowIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.KeycloakContainer;
 @QuarkusScenario
 public class LogoutSinglePageAppFlowIT extends AbstractLogoutSinglePageAppFlowIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false", "--features=token-exchange" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService("/quarkus-realm.json", REALM_DEFAULT, DEFAULT_REALM_BASE_PATH);
 
 }

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OidcResponseFilterIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OidcResponseFilterIT.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.KeycloakContainer;
 @QuarkusScenario
 public class OidcResponseFilterIT extends AbstractOidcResponseFilterIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
 }

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenApiStoreSchemaIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenApiStoreSchemaIT.java
@@ -49,12 +49,13 @@ public class OpenApiStoreSchemaIT {
     private static final String EXPECTED_TAGS = "[{\"name\":\"Ping\",\"description\":\"Ping API\"},{\"name\":\"Pong\",\"description\":\"Pong API\"}]";
     private static final String EXPECTED_INFO = "{\"title\":\"security-keycloak-oidc-client-reactive-extended API\",\"version\":\"1.0.0-SNAPSHOT\"}";
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl());
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperties(() -> keycloak.getTlsProperties());
 
     // QUARKUS-716
     @Test

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenShiftOidcResponseFilterIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenShiftOidcResponseFilterIT.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.KeycloakContainer;
 @OpenShiftScenario
 public class OpenShiftOidcResponseFilterIT extends AbstractOidcResponseFilterIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" }, image = "${rhbk.image}")
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
 }

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenShiftOidcSinglePageAppLogoutFlowIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenShiftOidcSinglePageAppLogoutFlowIT.java
@@ -9,8 +9,7 @@ import io.quarkus.test.services.KeycloakContainer;
 @OpenShiftScenario
 public class OpenShiftOidcSinglePageAppLogoutFlowIT extends AbstractLogoutSinglePageAppFlowIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--hostname-strict=false",
-            "--features=token-exchange" }, image = "${rhbk.image}")
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
     static KeycloakService keycloak = new KeycloakService("/quarkus-realm.json", REALM_DEFAULT, DEFAULT_REALM_BASE_PATH);
 
 }

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/SecurityClaimsIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/SecurityClaimsIT.java
@@ -23,12 +23,13 @@ public class SecurityClaimsIT {
     private static final String CLAIMS_FROM_BEANS_PATH = "/getClaimsFromBeans";
     private static final String CLAIMS_FROM_TOKEN_PATH = "/getClaimsFromToken";
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl());
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperties(() -> keycloak.getTlsProperties());
 
     @Test
     public void verifySecuredEndpointIsProtected() {

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/TokenPropagationFilterIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/TokenPropagationFilterIT.java
@@ -22,12 +22,14 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class TokenPropagationFilterIT {
 
-    @KeycloakContainer(command = { "start-dev", "--import-realm", "--features=token-exchange" })
+    @KeycloakContainer(runKeycloakInProdMode = true, command = { "start", "--import-realm", "--hostname-strict=false",
+            "--features=token-exchange" })
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl());
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperties(() -> keycloak.getTlsProperties());
 
     @Test
     public void usernameTest() {


### PR DESCRIPTION
### Summary

Changed modules:
1. security/keycloak-oidc-client-basic
2. security/keycloak-oidc-client-extended
3. security/keycloak-oidc-client-reactive-basic
4. security/keycloak-oidc-client-reactive-extended

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [x] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)