### PR TITLE
[3.20] Verify Vert.X duplicated context propagation when Hiberante Reactive session is used with Quarkus REST

### DIFF
--- a/sql-db/hibernate-reactive/src/main/java/io/quarkus/ts/hibernate/reactive/http/GroundedEndpoint.java
+++ b/sql-db/hibernate-reactive/src/main/java/io/quarkus/ts/hibernate/reactive/http/GroundedEndpoint.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.hibernate.reactive.http;
 
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -111,11 +113,12 @@ public class GroundedEndpoint {
                             Book book = new Book();
                             book.setAuthor(author.getId());
                             book.setTitle(name);
-                            return session3.persist(book);
+                            author.getBooks().add(book);
+                            return session3.persist(author);
                         }))).onItem()
                         .transformToUni(ignore -> factory.withSession(session3 -> session3.find(Author.class, author.getId())))
                         .onFailure()
-                        .transform(error -> new WebApplicationException(error.getMessage(), Response.Status.BAD_REQUEST)));
+                        .transform(error -> new WebApplicationException(error.getMessage(), INTERNAL_SERVER_ERROR)));
     }
 
     @GET

--- a/sql-db/hibernate-reactive/src/main/resources/application.properties
+++ b/sql-db/hibernate-reactive/src/main/resources/application.properties
@@ -3,4 +3,4 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.datasource.db-kind=postgresql
 
 # HttpClient config
-SomeApi/mp-rest/url=http://localhost:${quarkus.http.port}
+io.quarkus.ts.hibernate.reactive.http.SomeApi/mp-rest/url=http://localhost:${quarkus.http.port}

--- a/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/AbstractDatabaseHibernateReactiveIT.java
+++ b/sql-db/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/AbstractDatabaseHibernateReactiveIT.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.http.HttpStatus;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -295,6 +296,16 @@ public abstract class AbstractDatabaseHibernateReactiveIT {
                 .get("/library/by-author/Dlugi");
         assertEquals(HttpStatus.SC_OK, author.statusCode());
         assertThat(author.body().asString(), containsString("Slovník"));
+    }
+
+    @Tag("QUARKUS-6475")
+    @Test
+    public void createBookThroughSession() {
+        getApp().given()
+                .get("/hibernate/bookThroughSession/Christie/Marple")
+                .then().statusCode(HttpStatus.SC_OK)
+                .body("name", Matchers.is("Christie"))
+                .body("books.size()", Matchers.is(1));
     }
 
     protected abstract RestService getApp();


### PR DESCRIPTION
### Summary

Verifies https://github.com/quarkusio/quarkus/pull/49163. The Hibernate Reactive session is lost without the fix so request fails, with the fix, response is correct. The endpoint modified in this commit was unused.

- pass: `mvn clean verify -Dit.test=PostgresqlDatabaseHibernateReactiveIT`
- fail: `mvn clean verify -Dquarkus.platform.version=3.20.2 -Dit.test=PostgresqlDatabaseHibernateReactiveIT`

The upstream test coverage doesn't really test it with Hibernate Reactive as we do.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)