### PR TITLE
Fix problem KC uri not include port on OCP

### DIFF
--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/BaseOidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/BaseOidcSecurityIT.java
@@ -202,7 +202,7 @@ public abstract class BaseOidcSecurityIT {
                         "client_id", CLIENT_ID_DEFAULT,
                         "client_secret", CLIENT_SECRET_DEFAULT,
                         "refresh_token", initialRefreshToken))
-                .post(getKeycloak().getRealmUrl() + "/protocol/openid-connect/token");
+                .post(getKeycloakRealmUrl() + "/protocol/openid-connect/token");
 
         // Assert that the old refresh token is no longer valid
         assertEquals(HttpStatus.SC_BAD_REQUEST, refreshGrantResponse.statusCode());
@@ -221,5 +221,9 @@ public abstract class BaseOidcSecurityIT {
 
     protected String getAdminAccessToken() {
         return getTokenCreationResponse(ADMIN_USER, ADMIN_USER).getToken();
+    }
+
+    protected String getKeycloakRealmUrl() {
+        return getKeycloak().getRealmUrl();
     }
 }

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftRhSsoOidcSecurityIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftRhSsoOidcSecurityIT.java
@@ -30,4 +30,10 @@ public class OpenShiftRhSsoOidcSecurityIT extends BaseOidcSecurityIT {
     protected KeycloakService getKeycloak() {
         return keycloak;
     }
+
+    @Override
+    protected String getKeycloakRealmUrl() {
+        // RestAssured with openshift KC url need the port otherwise is not able to success TLS handshake
+        return keycloak.getRealmUrl().replace("/realms", ":443/realms");
+    }
 }


### PR DESCRIPTION
### Summary

CI missed this one problem. Don't know why but on my machine it passing now.

Why RestAssured needs the standard https port is weird but I spot it also with DPoP ocp test.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)