### PR TITLE
[3.20] Disable checkThereIsNoTracesAfterRestart due to QUARKUS-6463

### DIFF
--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/DevModeOpenTelemetryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/DevModeOpenTelemetryIT.java
@@ -13,6 +13,7 @@ import java.util.function.Function;
 import org.apache.http.HttpStatus;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -61,6 +62,7 @@ public class DevModeOpenTelemetryIT {
 
     @Test
     @Order(1)
+    @Disabled("https://issues.redhat.com/browse/QUARKUS-6463")
     void checkThereIsNoTracesAfterRestart() {
         String operationName = "GET /hello";
         modifyAppPropertiesAndWait(props -> props.replace(getOtelEnabledProperty(true), getOtelEnabledProperty(false)));


### PR DESCRIPTION
### Summary

Disable checkThereIsNoTracesAfterRestart due to [QUARKUS-6463](https://issues.redhat.com/browse/QUARKUS-6463)

It's not fixed in 3.20 branch and backports yet and I saw the fail in SP testing, better to avoid these false alarms.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)