### PR TITLE
Workaround Jakarta Data upsert failures caused by upstream Hibernate ORM bump to Hibernate ORM 7.1.0.CR2

### DIFF
--- a/sql-db/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/rest/BasicRepositoryResource.java
+++ b/sql-db/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/rest/BasicRepositoryResource.java
@@ -66,7 +66,9 @@ public final class BasicRepositoryResource {
     @POST
     public List<Author> saveAll(List<Author> authors) {
         bookRepository.saveAll(authors.stream().flatMap(a -> a.getBooks().stream()).toList());
-        return authorRepository.saveAll(authors);
+        // TODO: switch to the 'authorRepository.saveAll' once https://github.com/quarkusio/quarkus/issues/49593 is fixed
+        bookRepository.session().insertMultiple(authors);
+        return authors;
     }
 
     @Path("/find-annotation-with-limit-and-order-by")
@@ -86,7 +88,8 @@ public final class BasicRepositoryResource {
         var session = bookRepository.session();
         session.fetch(author.getBooks());
         author.getBooks().remove(book);
-        session.update(author);
+        // TODO: replace the next line with session.update(author)
+        //   after https://github.com/quarkusio/quarkus/issues/49593 is fixed
         authorRepository.save(author);
         session.delete(book);
     }

--- a/sql-db/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/AbstractJakartaDataIT.java
+++ b/sql-db/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/AbstractJakartaDataIT.java
@@ -14,6 +14,7 @@ import java.util.function.Supplier;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -477,6 +478,7 @@ public abstract class AbstractJakartaDataIT {
         assertEquals("Title-4", books[0].getTitle());
     }
 
+    @Disabled("https://github.com/quarkusio/quarkus/issues/49593")
     @Order(25)
     @Test
     void testBasicRepositoryDeleteUsingStatelessSessionDirectly() {
@@ -487,6 +489,7 @@ public abstract class AbstractJakartaDataIT {
                 .then().statusCode(204);
     }
 
+    @Disabled("https://github.com/quarkusio/quarkus/issues/49593")
     @Order(26)
     @Test
     void testBasicRepositoryBuiltinFindById() {


### PR DESCRIPTION
### Summary

See https://github.com/quarkusio/quarkus/issues/49593 and the daily build which is constantly failing.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)