### PR TITLE
Rename Quarkus properties from enable to enabled

### DIFF
--- a/http/http-advanced-reactive/src/main/resources/application.properties
+++ b/http/http-advanced-reactive/src/main/resources/application.properties
@@ -19,7 +19,7 @@ quarkus.grpc.clients.reflection-service.host=localhost
 quarkus.grpc.clients.reflection-service.port=${quarkus.http.port}
 quarkus.grpc.server.use-separate-server=false
 # authZ
-quarkus.keycloak.policy-enforcer.enable=true
+quarkus.keycloak.policy-enforcer.enabled=true
 # Non-application endpoints. Required because we are going to force a redirection, otherwise use `/q/*` instead
 quarkus.keycloak.policy-enforcer.paths.health-redirection.path=/api/q/*
 quarkus.keycloak.policy-enforcer.paths.health-redirection.enforcement-mode=DISABLED

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/ContainerRequestFilterReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/ContainerRequestFilterReactiveIT.java
@@ -18,7 +18,7 @@ public class ContainerRequestFilterReactiveIT {
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.enabled", "false")
-            .withProperty("quarkus.keycloak.policy-enforcer.enable", "false")
+            .withProperty("quarkus.keycloak.policy-enforcer.enabled", "false")
             .withProperty("quarkus.keycloak.devservices.enabled", "false")
             .withProperty("pl-container-request-filter.enabled", "true");
 

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeGrpcIntegrationReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeGrpcIntegrationReactiveIT.java
@@ -50,7 +50,7 @@ public class DevModeGrpcIntegrationReactiveIT {
     @DevModeQuarkusApplication(grpc = true)
     static final GrpcService app = (GrpcService) new GrpcService()
             .withProperty("quarkus.oidc.enabled", "false")
-            .withProperty("quarkus.keycloak.policy-enforcer.enable", "false")
+            .withProperty("quarkus.keycloak.policy-enforcer.enabled", "false")
             .withProperty("quarkus.keycloak.devservices.enabled", "false");
 
     @Test

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeHttpIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeHttpIT.java
@@ -13,7 +13,7 @@ public class DevModeHttpIT extends AbstractDevModeIT {
     @DevModeQuarkusApplication(ssl = false)
     static RestService app = new DevModeQuarkusService()
             .withProperty("quarkus.oidc.enabled", "false")
-            .withProperty("quarkus.keycloak.policy-enforcer.enable", "false")
+            .withProperty("quarkus.keycloak.policy-enforcer.enabled", "false")
             .withProperty("quarkus.keycloak.devservices.enabled", "false");
 
     @Override

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeHttpsIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/DevModeHttpsIT.java
@@ -16,7 +16,7 @@ public class DevModeHttpsIT extends AbstractDevModeIT {
     @DevModeQuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, useTlsRegistry = false, configureHttpServer = true))
     static RestService app = new DevModeQuarkusService()
             .withProperty("quarkus.oidc.enabled", "false")
-            .withProperty("quarkus.keycloak.policy-enforcer.enable", "false")
+            .withProperty("quarkus.keycloak.policy-enforcer.enabled", "false")
             .withProperty("quarkus.keycloak.devservices.enabled", "false");
 
     @BeforeEach

--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/RemoteDevModeHttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/RemoteDevModeHttpAdvancedReactiveIT.java
@@ -18,7 +18,7 @@ public class RemoteDevModeHttpAdvancedReactiveIT {
     @RemoteDevModeQuarkusApplication(isRunningCheck = IsRunningCheck.IsBasePathReachableCheck.class)
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.enabled", "false")
-            .withProperty("quarkus.keycloak.policy-enforcer.enable", "false")
+            .withProperty("quarkus.keycloak.policy-enforcer.enabled", "false")
             .withProperty("quarkus.keycloak.devservices.enabled", "false");
 
     @Test

--- a/http/http-advanced/src/main/resources/application.properties
+++ b/http/http-advanced/src/main/resources/application.properties
@@ -16,7 +16,7 @@ quarkus.grpc.clients.hello.host=localhost
 quarkus.grpc.clients.hello.port=${quarkus.http.port}
 quarkus.grpc.server.use-separate-server=false
 # authZ
-quarkus.keycloak.policy-enforcer.enable=true
+quarkus.keycloak.policy-enforcer.enabled=true
 # Non-application endpoints. Required because we are going to force a redirection, otherwise use `/q/*` instead
 quarkus.keycloak.policy-enforcer.paths.health-redirection.path=/api/q/*
 quarkus.keycloak.policy-enforcer.paths.health-redirection.enforcement-mode=DISABLED

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/ContainerRequestFilterIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/ContainerRequestFilterIT.java
@@ -18,7 +18,7 @@ public class ContainerRequestFilterIT {
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.enabled", "false")
-            .withProperty("quarkus.keycloak.policy-enforcer.enable", "false")
+            .withProperty("quarkus.keycloak.policy-enforcer.enabled", "false")
             .withProperty("quarkus.keycloak.devservices.enabled", "false")
             .withProperty("pl-container-request-filter.enabled", "true");
 

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeGrpcIntegrationIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeGrpcIntegrationIT.java
@@ -48,7 +48,7 @@ public class DevModeGrpcIntegrationIT {
     @DevModeQuarkusApplication(grpc = true)
     static final GrpcService app = (GrpcService) new GrpcService()
             .withProperty("quarkus.oidc.enabled", "false")
-            .withProperty("quarkus.keycloak.policy-enforcer.enable", "false")
+            .withProperty("quarkus.keycloak.policy-enforcer.enabled", "false")
             .withProperty("quarkus.keycloak.devservices.enabled", "false");
 
     @Test

--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/RemoteDevModeHttpAdvancedIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/RemoteDevModeHttpAdvancedIT.java
@@ -20,7 +20,7 @@ public class RemoteDevModeHttpAdvancedIT {
     @RemoteDevModeQuarkusApplication(isRunningCheck = IsRunningCheck.IsBasePathReachableCheck.class)
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.enabled", "false")
-            .withProperty("quarkus.keycloak.policy-enforcer.enable", "false")
+            .withProperty("quarkus.keycloak.policy-enforcer.enabled", "false")
             .withProperty("quarkus.keycloak.devservices.enabled", "false");
 
     @Test

--- a/logging/jboss/src/test/resources/accessLogging.properties
+++ b/logging/jboss/src/test/resources/accessLogging.properties
@@ -1,7 +1,7 @@
 quarkus.http.access-log.enabled=true
 quarkus.http.access-log.log-to-file=false
 
-quarkus.log.handler.file.access-log.enable=true
+quarkus.log.handler.file.access-log.enabled=true
 quarkus.log.handler.file.access-log.path=appAccess.log
 quarkus.log.handler.file.access-log.format=%d{yyyy-MM-dd HH:mm:ss}
 quarkus.log.category."io.quarkus.http.access-log".handlers=access-log

--- a/logging/jboss/src/test/resources/default.properties
+++ b/logging/jboss/src/test/resources/default.properties
@@ -9,7 +9,7 @@
 #quarkus.log.min-level=DEBUG
 quarkus.log.level=TRACE
 
-quarkus.log.file.enable=true
+quarkus.log.file.enabled=true
 quarkus.log.file.rotation.file-suffix=.yyyy-MM
 # Max file size value is set to this value to ensure that both backup logs are created
 quarkus.log.file.rotation.max-file-size=100

--- a/logging/thirdparty/src/main/resources/application.properties
+++ b/logging/thirdparty/src/main/resources/application.properties
@@ -9,7 +9,7 @@
 #quarkus.log.min-level=DEBUG
 quarkus.log.level=INFO
 
-%syslog.quarkus.log.syslog.enable=true
+%syslog.quarkus.log.syslog.enabled=true
 %syslog.quarkus.log.syslog.app-name=quarkus
 %syslog.quarkus.log.syslog.format=%-5p %s%n
 %syslog.quarkus.log.syslog.syslog-type=rfc3164

--- a/properties/src/main/resources/application.properties
+++ b/properties/src/main/resources/application.properties
@@ -1,17 +1,17 @@
 # Swagger UI
-quarkus.swagger-ui.enable=true
+quarkus.swagger-ui.enabled=true
 quarkus.swagger-ui.always-include=true
 
 # OpenAPI
-quarkus.smallrye-openapi.enable=true
+quarkus.smallrye-openapi.enabled=true
 
 # GraphQL
 quarkus.smallrye-graphql.ui.always-include=true
-quarkus.smallrye-graphql.ui.enable=true
+quarkus.smallrye-graphql.ui.enabled=true
 
 # Health
 quarkus.smallrye-health.ui.always-include=true
-quarkus.smallrye-health.ui.enable=true
+quarkus.smallrye-health.ui.enabled=true
 
 # Consul
 quarkus.consul-config.enabled=false

--- a/properties/src/test/java/io/quarkus/ts/properties/toggle/ToggleableServices.java
+++ b/properties/src/test/java/io/quarkus/ts/properties/toggle/ToggleableServices.java
@@ -1,10 +1,10 @@
 package io.quarkus.ts.properties.toggle;
 
 public enum ToggleableServices {
-    SWAGGER("Swagger", "/q/swagger-ui", "quarkus.swagger-ui.enable"),
-    OPENAPI("OpenAPI", "/q/openapi", "quarkus.smallrye-openapi.enable"),
-    GRAPHQL("GraphQL", "/q/graphql-ui", "quarkus.smallrye-graphql.ui.enable"),
-    HEALTH("Health", "/q/health-ui", "quarkus.smallrye-health.ui.enable");
+    SWAGGER("Swagger", "/q/swagger-ui", "quarkus.swagger-ui.enabled"),
+    OPENAPI("OpenAPI", "/q/openapi", "quarkus.smallrye-openapi.enabled"),
+    GRAPHQL("GraphQL", "/q/graphql-ui", "quarkus.smallrye-graphql.ui.enabled"),
+    HEALTH("Health", "/q/health-ui", "quarkus.smallrye-health.ui.enabled");
 
     private final String name;
     private final String endpoint;

--- a/security/keycloak-authz-classic/src/main/resources/application.properties
+++ b/security/keycloak-authz-classic/src/main/resources/application.properties
@@ -3,6 +3,6 @@ quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 # tolerate 1 minute of clock skew between the Keycloak server and the application
 quarkus.oidc.token.lifespan-grace=60
-quarkus.keycloak.policy-enforcer.enable=true
+quarkus.keycloak.policy-enforcer.enabled=true
 quarkus.keycloak.policy-enforcer.paths.health.path=/q/*
 quarkus.keycloak.policy-enforcer.paths.health.enforcement-mode=DISABLED

--- a/security/keycloak-authz-reactive/src/main/resources/application.properties
+++ b/security/keycloak-authz-reactive/src/main/resources/application.properties
@@ -3,6 +3,6 @@ quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 # tolerate 1 minute of clock skew between the Keycloak server and the application
 quarkus.oidc.token.lifespan-grace=60
-quarkus.keycloak.policy-enforcer.enable=true
+quarkus.keycloak.policy-enforcer.enabled=true
 quarkus.keycloak.policy-enforcer.paths.health.path=/q/*
 quarkus.keycloak.policy-enforcer.paths.health.enforcement-mode=DISABLED

--- a/security/keycloak-oidc-client-reactive-extended/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/resources/application.properties
@@ -54,7 +54,7 @@ quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=T
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".level=TRACE
 quarkus.log.category."io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.ping.filters.TokenResponseFilter".min-level=TRACE
 quarkus.log.category."io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.ping.filters.TokenResponseFilter".level=TRACE
-quarkus.log.file.enable=true
+quarkus.log.file.enabled=true
 quarkus.log.file.format=%C - %s%n
 #OpenAPI
 quarkus.smallrye-openapi.store-schema-directory=target/generated/jakarta-rest/


### PR DESCRIPTION
### Summary

For 3.26 the enable/enabled properties were unified see https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.26#enable--enabled-in-configuration-properties-gear-white_check_mark

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)