### PR TITLE
Build Gradle plugin in CI

### DIFF
--- a/.github/actions/prepare-quarkus-cli/action.yml
+++ b/.github/actions/prepare-quarkus-cli/action.yml
@@ -18,4 +18,15 @@ runs:
         EOF
         chmod +x ./quarkus-dev-cli
         ./quarkus-dev-cli version
+    - name: Build Quarkus Gradle Plugin locally
+      shell: bash
+      run: |
+        echo "Building Gradle plugin locally..."
+        git clone --depth 1 https://github.com/quarkusio/quarkus.git /tmp/quarkus-gradle
+        cd /tmp/quarkus-gradle
+        ./mvnw -Dquickly \
+        -pl devtools/gradle/gradle-application-plugin \
+        -am
+        cd -
+        rm -rf /tmp/quarkus-gradle
 


### PR DESCRIPTION
Build Gradle plugin in CI to avoid the issue https://github.com/quarkusio/quarkus/issues/49595

Context:
Our daily CI job is failing on root-module, the failure is in quarkus-cli about gradle tests, CI is failing consistently, specifically within QuarkusCliCreateJvmApplicationIT.

During the test ```shouldCreateApplicationWithGradleOnJvm``` failed to build, the error message from Gradle was:

```
2025-08-13T04:05:41.1571595Z 04:05:41,144 INFO  FAILURE: Build failed with an exception.
2025-08-13T04:05:41.1573190Z 04:05:41,144 INFO  * What went wrong:
2025-08-13T04:05:41.1581366Z 04:05:41,144 INFO  Could not determine the dependencies of task ':quarkusGenerateAppModel'.
2025-08-13T04:05:41.1582744Z 04:05:41,144 INFO  > Could not resolve all dependencies for configuration ':quarkusProdRuntimeClasspathConfigurationDeployment'.
2025-08-13T04:05:41.1583804Z 04:05:41,144 INFO     > Extending a detachedConfiguration is not allowed
2025-08-13T04:05:41.1585404Z 04:05:41,144 INFO         configuration ':detachedConfiguration1' cannot extend configuration ':quarkusProdRuntimeClasspathConfigurationPlatform'
```


According last comment in the issue  seems the Gradle plugin is not being published to the Sonatype snapshots repository, while the CLI is, so to workaround this, I made the change to build gradle plugin


Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)