### PR TITLE
Replace deprecated Quarkus properties with new one

### DIFF
--- a/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/LoggingInJsonIT.java
+++ b/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/LoggingInJsonIT.java
@@ -102,7 +102,7 @@ public class LoggingInJsonIT {
     }
 
     private void disableJsonFormatLogging() {
-        setPropertyTo("quarkus.log.console.json", Boolean.FALSE.toString());
+        setPropertyTo("quarkus.log.console.json.enabled", Boolean.FALSE.toString());
     }
 
     private void setLogLevelTo(Logger.Level info) {

--- a/security/keycloak-oidc-client-extended/src/test/resources/logout.properties
+++ b/security/keycloak-oidc-client-extended/src/test/resources/logout.properties
@@ -20,7 +20,7 @@ quarkus.http.auth.permission.unsecured.paths=/code-flow
 quarkus.http.auth.permission.unsecured.policy=permit
 quarkus.http.auth.permission.unsecured.methods=GET
 
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 quarkus.http.auth.permission.logout.paths=/code-flow/logout
 quarkus.http.auth.permission.logout.policy=authenticated

--- a/security/keycloak-oidc-client-reactive-extended/src/test/resources/logout.properties
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/resources/logout.properties
@@ -13,7 +13,7 @@ quarkus.http.auth.permission.unsecured.paths=/code-flow
 quarkus.http.auth.permission.unsecured.policy=permit
 quarkus.http.auth.permission.unsecured.methods=GET
 
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 quarkus.http.auth.permission.logout.paths=/code-flow/logout
 quarkus.http.auth.permission.logout.policy=authenticated
@@ -22,4 +22,4 @@ quarkus.oidc.token-cache.max-size=1
 
 # PKCE
 quarkus.oidc.authentication.pkce-required=true
-quarkus.oidc.authentication.pkce-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
+quarkus.oidc.authentication.state-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU


### PR DESCRIPTION
### Summary

These properties was changed in various Quarkus version. With this there should not be any deprecated properties which comes from TS.

See https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.19#other-changes-gear-white_check_mark
and `pkce-secret` missing in migration guide, but it was deprecated around 3.17 (see https://github.com/quarkusio/quarkus/blob/main/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java#L947)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)