### PR TITLE
Remove versioned disable on PortConflictIT

### DIFF
--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/PortConflictIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/PortConflictIT.java
@@ -8,12 +8,10 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.Certificate;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-@DisabledOnQuarkusVersion(version = "3\\.(8|9|10|11|12|13|14)\\..*|3\\.15\\.(0|1)(\\..*)?", reason = "Disabled on Quarkus versions before 3.15.2 due to known port conflict issue https://github.com/quarkusio/quarkus/issues/43373")
 public class PortConflictIT {
 
     static final int COMMON_PORT_HTTP_HTTPS = 50000;


### PR DESCRIPTION
### Summary

* Removing version conditioned disabled on PortConflictIT. The test should fail on versions where the bug is present, and those are out of support now already.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)