### PR TITLE
Fix and enable Narayana transaction recovery with Oracle database

### DIFF
--- a/sql-db/narayana-transactions/src/test/resources/oracle.properties
+++ b/sql-db/narayana-transactions/src/test/resources/oracle.properties
@@ -4,3 +4,5 @@ quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.datasource.jdbc.telemetry=true
 quarkus.otel.enabled=true
 quarkus.application.name=narayanaTransactions
+# use the second database
+quarkus.datasource.xa-ds-2.jdbc.url=${quarkus.datasource.xa-ds-1.jdbc.url}2


### PR DESCRIPTION
### Summary

I got suggestions in https://github.com/quarkusio/quarkus/issues/35333 to grant rights to the database user to use 2-Phase Commit. Despite the links, I think these suggestions basically match official docs here https://docs.oracle.com/en/database/oracle/oracle-database/23/adfns/xa.html#GUID-91007BAE-9DD3-4993-8220-C3EC8391376B. However I checked and our database user has required permissions. The issue was that Oracle JDBC driver optimizes 2PC and use 1PC if the XA resources points to the same database. Hence this PR creates a new database and makes sure that the transaction recovery is performed on 2 databases.

If you want to check (apart of the object store check which would simply fail if 2PC didn't happen), you can also add:

```
# Show the SQL queries
quarkus.log.category."org.hibernate.SQL".level=TRACE
quarkus.log.category."org.hibernate.SQL".min-level=TRACE

# Show the bound parameter values
quarkus.log.category."org.hibernate.type.descriptor.sql".level=TRACE
quarkus.log.category."org.hibernate.type.descriptor.sql".min-level=TRACE
quarkus.log.category."com.arjuna".min-level=TRACE
quarkus.log.category."com.arjuna".level=TRACE
```

and you will see it happens, I had generated the proof of 2PC from the log (so take it with reservations, but it is just complementary, the test is enough IMO...):

```
Proof of 2PC Usage:

  1. Two XA Resources with PREPARE_OK:

  19:03:01,868 BasicAction::doPrepare() result for action-id (0:ffff0a00008b:8bf1:68ac972f:5c)
  on record id: (0:ffff0a00008b:8bf1:68ac972f:5f) is (TwoPhaseOutcome.PREPARE_OK) node id: 
  (quarkus-qe)

  19:03:01,875 BasicAction::doPrepare() result for action-id (0:ffff0a00008b:8bf1:68ac972f:5c) 
  on record id: (0:ffff0a00008b:8bf1:68ac972f:62) is (TwoPhaseOutcome.PREPARE_OK) node id:
  (quarkus-qe)

  2. Transaction State Persistence (Critical for Recovery):

  19:03:01,875 OutputObjectState::OutputObjectState(0:ffff0a00008b:8bf1:68ac972f:5c,
  /StateManager/BasicAction/TwoPhaseCoordinator/AtomicAction)
  19:03:01,875 BasicAction::save_state ()
  19:03:01,875 StateManager.packHeader for object-id 0:ffff0a00008b:8bf1:68ac972f:5c birth-date
   1756141381853
  19:03:01,875 BasicAction::save_state - next record to pack is a 171 record
  /StateManager/AbstractRecord/XAResourceRecord should save it? = true
  19:03:01,875 Packing a 171 record
  19:03:01,875 BasicAction::save_state - next record to pack is a 171 record 
  /StateManager/AbstractRecord/XAResourceRecord should save it? = true
  19:03:01,875 Packing a 171 record
  19:03:01,875 Packing a NONE_RECORD
  19:03:01,875 Packing action status of ActionStatus.COMMITTING

  3. Full 2PC Protocol (Not 1PC):

  19:03:01,885 BasicAction::phase2Commit() for action-id 0:ffff0a00008b:8bf1:68ac972f:5c
  19:03:01,885 BasicAction::doCommit (XAResourceRecord <
  resource:io.agroal.narayana.BaseXAResource@ea3d9b9, ... >)
  19:03:01,885 XAResourceRecord.topLevelCommit for XAResourceRecord <
  resource:io.agroal.narayana.BaseXAResource@ea3d9b9, ... >

  4. Crash During 2PC Commit Phase:

  19:03:01,885 Crashing the system
```

Regarding changes in the `QuarkusTransactionCallRecoveryService`, I did badly design it, it couldn't work due to how the "callRequireNew" is designed, rollback will result in an exception because commit cannot be executed when we set the rollback only. https://github.com/quarkusio/quarkus/blob/f9d0cfc28ea479c1467c1c106eb482a462a80718/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/QuarkusTransactionImpl.java#L127. My naive idea is that it makes sense that they need to raise exception because then, the original transaction must continue and it cannot be affected by the rollback. So I used the exception handling to achieve the rollback.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)