### PR TITLE
Fix link to Maven snapshot repository in Gradle settings used by Quarkus CLI tests

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -187,7 +187,7 @@ public class QuarkusCliCreateJvmApplicationIT {
         var newFileContent = fileContent.replace("mavenCentral()", """
                 mavenCentral()
                 maven {
-                    url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                    url = uri("https://central.sonatype.com/repository/maven-snapshots/")
                 }
                 """);
         FileUtils.copyContentTo(newFileContent, file.toPath());


### PR DESCRIPTION
### Summary

Our daily builds and pretty much any PR CI that runs full test coverage fails as the latest Quarkus Gradle plugin wasn't reachable. @rsvoboda fixed and documented the issue upstream https://github.com/quarkusio/quarkus/pull/49694 https://github.com/quarkusio/quarkus/pull/49675 and now we need to point to the right repository.

I have reproduced the issue locally, deleted locally built artifact and verified that this fix does the trick for my setup.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)