### PR TITLE
OIDC logout Clear-Site-Data http header test

### DIFF
--- a/security/keycloak-oidc-client-extended/src/test/resources/logout.properties
+++ b/security/keycloak-oidc-client-extended/src/test/resources/logout.properties
@@ -8,9 +8,11 @@ quarkus.oidc.authentication.scopes=profile,email,phone
 quarkus.oidc.code-flow.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow.client-id=quarkus-web-app
 quarkus.oidc.code-flow.logout.path=/code-flow/logout
+quarkus.oidc.code-flow.logout.frontchannel.path=/code-flow/front-channel-logout
 quarkus.oidc.code-flow.logout.post-logout-path=/code-flow/post-logout
 quarkus.oidc.code-flow.logout.post-logout-uri-param=returnTo
 quarkus.oidc.code-flow.logout.extra-params.client_id=${quarkus.oidc.code-flow.client-id}
+quarkus.oidc.code-flow.logout.clear-site-data=cache,cookies,storage
 quarkus.oidc.code-flow.credentials.secret=B9w9g5x56D7S9fR2j3LqE5reopKgsvFM
 quarkus.oidc.code-flow.application-type=web-app
 # Quarkus need set tls registry for oidc tenant for self-sign certs in addition of setting it for oidc


### PR DESCRIPTION
### Summary

Implement test for OIDC logout HTTP header ClearSiteData setting. According to TP from https://github.com/quarkus-qe/quarkus-test-plans/pull/252.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [X] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)