### PR TITLE
IBM Z/P Profile update and Disabled OpenShiftMicrometerOpenTelemetryBridgeIT

### DIFF
--- a/monitoring/micrometer-opentelemetry/src/test/java/io/quarkus/ts/monitoring/micrometeropentelemetry/test/OpenShiftMicrometerOpenTelemetryBridgeIT.java
+++ b/monitoring/micrometer-opentelemetry/src/test/java/io/quarkus/ts/monitoring/micrometeropentelemetry/test/OpenShiftMicrometerOpenTelemetryBridgeIT.java
@@ -1,7 +1,8 @@
 package io.quarkus.ts.monitoring.micrometeropentelemetry.test;
 
-import io.quarkus.test.scenarios.OpenShiftScenario;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
 @DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "grafana/otel-lgtm container not available on s390x & ppc64le.")

--- a/monitoring/micrometer-opentelemetry/src/test/java/io/quarkus/ts/monitoring/micrometeropentelemetry/test/OpenShiftMicrometerOpenTelemetryBridgeIT.java
+++ b/monitoring/micrometer-opentelemetry/src/test/java/io/quarkus/ts/monitoring/micrometeropentelemetry/test/OpenShiftMicrometerOpenTelemetryBridgeIT.java
@@ -1,8 +1,10 @@
 package io.quarkus.ts.monitoring.micrometeropentelemetry.test;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @OpenShiftScenario
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "grafana/otel-lgtm container not available on s390x & ppc64le.")
 public class OpenShiftMicrometerOpenTelemetryBridgeIT extends MicrometerOpenTelemetryBridgeIT {
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -922,8 +922,8 @@
                                         <mysql.80.image>registry.redhat.io/rhel8/mysql-80:latest</mysql.80.image>
                                         <mariadb.1011.image>registry.redhat.io/rhel9/mariadb-1011:latest</mariadb.1011.image>
                                         <!-- Kafka  (amq-streams) requires separate properties for image and version -->
-                                        <amq-streams.image>registry.redhat.io/amq-streams/kafka-35-rhel8</amq-streams.image>
-                                        <amq-streams.version>2.6.0</amq-streams.version>
+                                        <amq-streams.image>registry.redhat.io/amq-streams/kafka-38-rhel9</amq-streams.image>
+                                        <amq-streams.version>2.9.1</amq-streams.version>
                                         <mongodb.image>docker.io/library/mongo:4.4.6</mongodb.image>
                                         <infinispan.image>registry.redhat.io/datagrid/datagrid-8-rhel9:1.5-8.5.0.GA</infinispan.image>
                                         <infinispan.expected-log>Red Hat Data Grid.*started in</infinispan.expected-log>


### PR DESCRIPTION
### Summary

- IBM Z/P Profile update: Upgraded AMQ Streams from kafka-35–rhel8 (2.6.0) → kafka-38–rhel9 (2.9.1) in pom.xml.
- Disabled OpenShiftMicrometerOpenTelemetryBridgeIT on IBM Z/P, since the grafana/otel-lgtm container is not available on s390x and ppc64le.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)