### PR TITLE
Test enabling and disabling XA transaction recovery for individual datasources

### DIFF
--- a/sql-db/narayana-transactions/src/main/resources/application.properties
+++ b/sql-db/narayana-transactions/src/main/resources/application.properties
@@ -36,3 +36,7 @@ quarkus.transaction-manager.object-store.table-prefix=quarkus_qe_
 
 # TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
 quarkus.native.monitoring=none
+
+# allows us to assert logging messages related to the transaction recovery
+quarkus.log.category."com.arjuna".level=TRACE
+quarkus.log.category."com.arjuna".min-level=TRACE

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.transactions;
 
+import org.junit.jupiter.api.Tag;
+
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -10,6 +12,7 @@ import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 @QuarkusScenario
 public class MariaDbTransactionGeneralUsageIT extends TransactionCommons {
 
+    private static final String DATASOURCE_JDBC_ENABLE_RECOVERY = "quarkus.datasource.%s.jdbc.enable-recovery";
     static final int MARIADB_PORT = 3306;
 
     @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '.*/mysql.*sock'  port: "
@@ -33,4 +36,21 @@ public class MariaDbTransactionGeneralUsageIT extends TransactionCommons {
         return TransactionExecutor.QUARKUS_TRANSACTION;
     }
 
+    @Tag("QUARKUS-5709")
+    @Override
+    protected void enableTransactionRecovery() {
+        app.withProperty(getDsJdbcEnableRecovery("xa-ds-1"), Boolean.TRUE.toString());
+        app.withProperty(getDsJdbcEnableRecovery("xa-ds-2"), Boolean.TRUE.toString());
+    }
+
+    @Tag("QUARKUS-5709")
+    @Override
+    protected void disableTransactionRecovery() {
+        app.withProperty(getDsJdbcEnableRecovery("xa-ds-1"), Boolean.FALSE.toString());
+        app.withProperty(getDsJdbcEnableRecovery("xa-ds-2"), Boolean.FALSE.toString());
+    }
+
+    private String getDsJdbcEnableRecovery(String datasourceName) {
+        return DATASOURCE_JDBC_ENABLE_RECOVERY.formatted(datasourceName);
+    }
 }


### PR DESCRIPTION
### Summary

Implements the https://github.com/quarkus-qe/quarkus-test-plans/pull/257 test plan. I had to add a check for a logging message in order to assure that the test reliably fails without the `quarkus.datasource.%s.jdbc.enable-recovery` configuration property. It was that or waiting for 10 seconds, so I think the log message is quicker.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)