### PR TITLE
Test Infinispan cache CDI request context propagation

### DIFF
--- a/cache/infinispan/pom.xml
+++ b/cache/infinispan/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>

--- a/cache/infinispan/src/main/java/io/quarkus/ts/cache/infinispan/BaseServiceWithCache.java
+++ b/cache/infinispan/src/main/java/io/quarkus/ts/cache/infinispan/BaseServiceWithCache.java
@@ -1,6 +1,10 @@
 package io.quarkus.ts.cache.infinispan;
 
+import java.time.Duration;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
 
 import org.infinispan.protostream.GeneratedSchema;
 import org.infinispan.protostream.annotations.Proto;
@@ -10,12 +14,17 @@ import io.quarkus.cache.CacheInvalidate;
 import io.quarkus.cache.CacheInvalidateAll;
 import io.quarkus.cache.CacheKey;
 import io.quarkus.cache.CacheResult;
+import io.quarkus.ts.cache.infinispan.cdi.request.context.RequestContextState;
+import io.smallrye.mutiny.Uni;
 
 public abstract class BaseServiceWithCache {
 
     private static final String CACHE_NAME = "service-cache";
 
     private static final AtomicInteger counter = new AtomicInteger(0);
+
+    @Inject
+    RequestContextState requestContextState;
 
     @CacheResult(cacheName = CACHE_NAME)
     public String getValue() {
@@ -29,7 +38,9 @@ public abstract class BaseServiceWithCache {
 
     @CacheResult(cacheName = CACHE_NAME)
     public ExpensiveResponse getValueWithPrefix(@CacheKey String prefix) {
-        return new ExpensiveResponse(prefix + ": " + counter.getAndIncrement());
+        String result = prefix + ": " + counter.getAndIncrement();
+        requestContextState.setState(result);
+        return new ExpensiveResponse(result);
     }
 
     @CacheInvalidate(cacheName = CACHE_NAME)
@@ -48,5 +59,16 @@ public abstract class BaseServiceWithCache {
 
     @ProtoSchema(includeClasses = { ExpensiveResponse.class })
     interface Schema extends GeneratedSchema {
+    }
+
+    @CacheResult(cacheName = CACHE_NAME)
+    public CompletionStage<ExpensiveResponse> getCompletionStageValueWithPrefix(@CacheKey String prefix) {
+        String result = prefix + ": " + counter.getAndIncrement();
+        requestContextState.setState(result);
+        var expensiveResponse = new ExpensiveResponse(result);
+        return Uni.createFrom().item(expensiveResponse)
+                // delay so that the response is not completed immediately
+                .onItem().delayIt().by(Duration.ofSeconds(2))
+                .subscribeAsCompletionStage();
     }
 }

--- a/cache/infinispan/src/main/java/io/quarkus/ts/cache/infinispan/cdi/request/context/CdiRequestContextResource.java
+++ b/cache/infinispan/src/main/java/io/quarkus/ts/cache/infinispan/cdi/request/context/CdiRequestContextResource.java
@@ -1,0 +1,43 @@
+package io.quarkus.ts.cache.infinispan.cdi.request.context;
+
+import java.util.concurrent.CompletionStage;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.RestQuery;
+
+import io.quarkus.ts.cache.infinispan.RequestScopeService;
+
+@InterceptedRequestContextResponse
+@Path("/cache/cdi-request-context")
+public class CdiRequestContextResource {
+
+    @Inject
+    RequestScopeService requestScopeService;
+
+    @Path("synchronous-response")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public CdiRequestContextResponse getSynchronousResponse(@RestQuery String prefix) {
+        // here respond with the value from the cached method
+        // and JaxRs response filter also enhances this response with the state of CDI request context
+        String cacheOutput = requestScopeService.getValueWithPrefix(prefix).result();
+        return new CdiRequestContextResponse(cacheOutput, null);
+    }
+
+    @Path("async-response")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public CompletionStage<CdiRequestContextResponse> getCompletionStageResponse(@RestQuery String prefix) {
+        // here respond with the value from the cached method
+        // and JaxRs response filter also enhances this response with the state of CDI request context
+        return requestScopeService
+                .getCompletionStageValueWithPrefix(prefix)
+                .thenApply(value -> new CdiRequestContextResponse(value.result(), null));
+    }
+
+}

--- a/cache/infinispan/src/main/java/io/quarkus/ts/cache/infinispan/cdi/request/context/CdiRequestContextResponse.java
+++ b/cache/infinispan/src/main/java/io/quarkus/ts/cache/infinispan/cdi/request/context/CdiRequestContextResponse.java
@@ -1,0 +1,4 @@
+package io.quarkus.ts.cache.infinispan.cdi.request.context;
+
+public record CdiRequestContextResponse(String cacheOutput, String requestContextOutput) {
+}

--- a/cache/infinispan/src/main/java/io/quarkus/ts/cache/infinispan/cdi/request/context/CdiRequestContextResponseFilter.java
+++ b/cache/infinispan/src/main/java/io/quarkus/ts/cache/infinispan/cdi/request/context/CdiRequestContextResponseFilter.java
@@ -1,0 +1,29 @@
+package io.quarkus.ts.cache.infinispan.cdi.request.context;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.container.ContainerResponseContext;
+
+import org.jboss.resteasy.reactive.server.ServerResponseFilter;
+
+public class CdiRequestContextResponseFilter {
+
+    @Inject
+    RequestContextState requestContextState;
+
+    @InterceptedRequestContextResponse
+    @ServerResponseFilter
+    public void filter(ContainerResponseContext responseContext) {
+        String requestContextResponse = requestContextState.getState();
+        final String cacheResponse;
+        if (responseContext.getEntity() instanceof CdiRequestContextResponse response) {
+            cacheResponse = response.cacheOutput();
+        } else {
+            throw new IllegalStateException("Unsupported response type: " + responseContext.getEntity());
+        }
+
+        CdiRequestContextResponse jointResponse = new CdiRequestContextResponse(cacheResponse, requestContextResponse);
+        responseContext.setStatus(200);
+        responseContext.setEntity(jointResponse);
+    }
+
+}

--- a/cache/infinispan/src/main/java/io/quarkus/ts/cache/infinispan/cdi/request/context/InterceptedRequestContextResponse.java
+++ b/cache/infinispan/src/main/java/io/quarkus/ts/cache/infinispan/cdi/request/context/InterceptedRequestContextResponse.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.cache.infinispan.cdi.request.context;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.ws.rs.NameBinding;
+
+@NameBinding
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface InterceptedRequestContextResponse {
+}

--- a/cache/infinispan/src/main/java/io/quarkus/ts/cache/infinispan/cdi/request/context/RequestContextState.java
+++ b/cache/infinispan/src/main/java/io/quarkus/ts/cache/infinispan/cdi/request/context/RequestContextState.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.cache.infinispan.cdi.request.context;
+
+import jakarta.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class RequestContextState {
+
+    /**
+     * We store this "state" in the CDI request context.
+     * If the CDI request context propagation works as expected, then
+     * Jakarta REST filter should be able to retrieve the same state (stored in this field)
+     * as is returned from the cached method.
+     */
+    private volatile String state;
+
+    String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+}


### PR DESCRIPTION
### Summary

This PR adds a test that verifies the https://github.com/quarkusio/quarkus/issues/48196 is fixed. Synchronous response test is enough, I added the completion stage as it seems related.

- PASS: `mvn clean verify InfinispanCacheIT#testCdiRequestContextPropagation`
- FAIL: `mvn clean verify InfinispanCacheIT#testCdiRequestContextPropagation -Dquarkus.platform.version=3.23.3`

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)