### PR TITLE
Add tests for named DS and PU with hibernate-reactive

### DIFF
--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MultiDatabaseHibernateReactiveIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MultiDatabaseHibernateReactiveIT.java
@@ -1,0 +1,112 @@
+package io.quarkus.ts.hibernate.reactive;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.MySqlService;
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.hibernate.reactive.database.Author;
+import io.quarkus.ts.hibernate.reactive.database.AuthorIdGenerator;
+import io.quarkus.ts.hibernate.reactive.database.AuthorRepository;
+import io.quarkus.ts.hibernate.reactive.database.Book;
+import io.quarkus.ts.hibernate.reactive.database.ISBNConverter;
+import io.quarkus.ts.hibernate.reactive.database.PersonEntity;
+import io.quarkus.ts.hibernate.reactive.http.ApplicationExceptionMapper;
+import io.quarkus.ts.hibernate.reactive.http.BookDescription;
+import io.quarkus.ts.hibernate.reactive.http.GroundedEndpoint;
+import io.quarkus.ts.hibernate.reactive.http.OtherResource;
+import io.quarkus.ts.hibernate.reactive.http.PanacheEndpoint;
+import io.quarkus.ts.hibernate.reactive.http.SomeApi;
+import io.quarkus.ts.hibernate.reactive.http.ValidationResource;
+import io.quarkus.ts.hibernate.reactive.multidbSources.CarResource;
+import io.quarkus.ts.hibernate.reactive.multidbSources.FruitResource;
+import io.quarkus.ts.hibernate.reactive.multidbSources.secondDatabase.Fruit;
+import io.quarkus.ts.hibernate.reactive.multidbSources.thirdDatabase.Car;
+import io.restassured.http.ContentType;
+
+@Tag("QUARKUS-6259")
+@QuarkusScenario
+public class MultiDatabaseHibernateReactiveIT extends AbstractDatabaseHibernateReactiveIT {
+    private static final String SQL_USER = "quarkus_test";
+    private static final String SQL_PASSWORD = "quarkus_test";
+    private static final String SQL_DATABASE = "quarkus_test";
+    private static final int POSTGRES_PORT = 5432;
+    private static final int MYSQL_PORT = 3306;
+
+    @Container(image = "${postgresql.latest.image}", port = POSTGRES_PORT, expectedLog = "listening on IPv4 address")
+    static PostgresqlService postgresql1 = new PostgresqlService()
+            .withUser(SQL_USER)
+            .withPassword(SQL_PASSWORD)
+            .withDatabase(SQL_DATABASE)
+            .withProperty("PGDATA", "/tmp/psql");
+
+    @Container(image = "${postgresql.latest.image}", port = POSTGRES_PORT, expectedLog = "listening on IPv4 address")
+    static PostgresqlService postgresql2 = new PostgresqlService()
+            .withUser(SQL_USER)
+            .withPassword(SQL_PASSWORD)
+            .withDatabase(SQL_DATABASE)
+            .withProperty("PGDATA", "/tmp/psql");
+
+    @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
+    static MySqlService mysql = new MySqlService()
+            .withUser(SQL_USER)
+            .withPassword(SQL_PASSWORD)
+            .withDatabase(SQL_DATABASE);
+
+    @QuarkusApplication(properties = "multidb.properties", classes = { Fruit.class, FruitResource.class, Car.class,
+            CarResource.class,
+            // also include default classes
+            Author.class, AuthorIdGenerator.class, AuthorRepository.class, Book.class, ISBNConverter.class, PersonEntity.class,
+            ApplicationExceptionMapper.class, BookDescription.class, GroundedEndpoint.class, OtherResource.class,
+            PanacheEndpoint.class, SomeApi.class, ValidationResource.class
+    })
+    static RestService app = new RestService()
+            .withProperty("main.url", postgresql1::getReactiveUrl)
+            .withProperty("fruits.url", postgresql2::getReactiveUrl)
+            .withProperty("cars.url", mysql::getReactiveUrl)
+            .withProperty("db.username", SQL_USER)
+            .withProperty("db.password", SQL_PASSWORD);
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+
+    @Test
+    public void getFruits() {
+        /*
+         * Fruits are stored in different persistence-unit that is filled by different import script.
+         * Test that pre-created fruits (imported via SQL script) are in the DB.
+         * Which verifies that the different PU works.
+         */
+        String result = getApp().given().contentType(ContentType.JSON)
+                .get("fruit/getAll")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().body().asString();
+        assertTrue(result.contains("Banana"), "Should return fruit that is pre-created in the database, but was: " + result);
+    }
+
+    @Test
+    public void getCars() {
+        /*
+         * Cars are stored in different persistence-unit that is filled by different import script.
+         * Test that pre-created cars (imported via SQL script) are in the DB.
+         * Which verifies that the different PU works.
+         */
+        String result = getApp().given().contentType(ContentType.JSON)
+                .get("car/getAll")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().body().asString();
+
+        assertTrue(result.contains("Audi"), "Should return car that is pre-created in the database, but was: " + result);
+    }
+}

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/CarResource.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/CarResource.java
@@ -1,0 +1,32 @@
+package io.quarkus.ts.hibernate.reactive.multidbSources;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.ts.hibernate.reactive.multidbSources.thirdDatabase.Car;
+import io.smallrye.mutiny.Uni;
+
+@Path("/car")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class CarResource {
+    @Inject
+    @PersistenceUnit("cars")
+    Mutiny.SessionFactory factory;
+
+    @GET
+    @Path("getAll")
+    public Uni<Response> getAll() {
+        return factory.withSession(session -> session.createNativeQuery("Select * from cars", Car.class)
+                .getResultList()
+                .map(cars -> Response.ok(cars).build()));
+    }
+}

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/FruitResource.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/FruitResource.java
@@ -1,0 +1,32 @@
+package io.quarkus.ts.hibernate.reactive.multidbSources;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.ts.hibernate.reactive.multidbSources.secondDatabase.Fruit;
+import io.smallrye.mutiny.Uni;
+
+@Path("/fruit")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class FruitResource {
+    @Inject
+    @PersistenceUnit("fruits")
+    Mutiny.SessionFactory factory;
+
+    @GET
+    @Path("getAll")
+    public Uni<Response> getAll() {
+        return factory.withSession(session -> session.createNativeQuery("Select * from fruits", Fruit.class)
+                .getResultList()
+                .map(fruits -> Response.ok(fruits).build()));
+    }
+}

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/secondDatabase/Fruit.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/secondDatabase/Fruit.java
@@ -1,0 +1,48 @@
+package io.quarkus.ts.hibernate.reactive.multidbSources.secondDatabase;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Entity
+@Table(name = "fruits")
+/*
+ * This class is for testing multi-database (named datasources and persistence units) tests.
+ * For that, it is required that this entity is in separate package and is not linked to another entity in different PU.
+ */
+public class Fruit {
+    private static final int MAX_NAME_LENGTH = 30;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", unique = true, nullable = false)
+    private Integer id;
+
+    @NotNull
+    @Size(max = MAX_NAME_LENGTH)
+    private String name;
+
+    public Fruit() {
+    }
+
+    public Fruit(String name) {
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public @NotNull @Size(max = MAX_NAME_LENGTH) String getName() {
+        return name;
+    }
+
+    public void setName(@NotNull @Size(max = MAX_NAME_LENGTH) String name) {
+        this.name = name;
+    }
+}

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/thirdDatabase/Car.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/thirdDatabase/Car.java
@@ -1,0 +1,48 @@
+package io.quarkus.ts.hibernate.reactive.multidbSources.thirdDatabase;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Entity
+@Table(name = "cars")
+/*
+ * This class is for testing multi-database (named datasources and persistence units) tests.
+ * For that, it is required that this entity is in separate package and is not linked to another entity in different PU.
+ */
+public class Car {
+    private static final int MAX_NAME_LENGTH = 30;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", unique = true, nullable = false)
+    private Integer id;
+
+    @NotNull
+    @Size(max = MAX_NAME_LENGTH)
+    private String name;
+
+    public Car() {
+    }
+
+    public Car(String name) {
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public @NotNull @Size(max = MAX_NAME_LENGTH) String getName() {
+        return name;
+    }
+
+    public void setName(@NotNull @Size(max = MAX_NAME_LENGTH) String name) {
+        this.name = name;
+    }
+}

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftMultiDatabaseHibernateReactiveIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftMultiDatabaseHibernateReactiveIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.ts.hibernate.reactive.openshift;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.ts.hibernate.reactive.MultiDatabaseHibernateReactiveIT;
+
+@OpenShiftScenario
+public class OpenShiftMultiDatabaseHibernateReactiveIT extends MultiDatabaseHibernateReactiveIT {
+
+}

--- a/hibernate/hibernate-reactive/src/test/resources/multidb.properties
+++ b/hibernate/hibernate-reactive/src/test/resources/multidb.properties
@@ -1,0 +1,44 @@
+# HttpClient config
+io.quarkus.ts.hibernate.reactive.http.SomeApi/mp-rest/url=http://localhost:${quarkus.http.port}
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none
+
+# for whatever reason quarkus requires to have "db-kind" defined for default datasource even though we are not using default datasource
+quarkus.datasource.db-kind=postgresql
+
+# define datasources
+quarkus.datasource."main".reactive.url=${main.url}
+quarkus.datasource."main".db-kind=postgresql
+quarkus.datasource."main".username=${db.username}
+quarkus.datasource."main".password=${db.password}
+
+quarkus.datasource."fruits".reactive=true
+quarkus.datasource."fruits".reactive.url=${fruits.url}
+quarkus.datasource."fruits".db-kind=postgresql
+quarkus.datasource."fruits".username=${db.username}
+quarkus.datasource."fruits".password=${db.password}
+
+quarkus.datasource."cars".reactive=true
+quarkus.datasource."cars".reactive.url=${cars.url}
+quarkus.datasource."cars".db-kind=mysql
+quarkus.datasource."cars".username=${db.username}
+quarkus.datasource."cars".password=${db.password}
+
+# define persistence units
+quarkus.hibernate-orm."cars".datasource=cars
+quarkus.hibernate-orm."cars".packages=io.quarkus.ts.hibernate.reactive.multidbSources.thirdDatabase
+quarkus.hibernate-orm."cars".schema-management.strategy=drop-and-create
+quarkus.hibernate-orm."cars".sql-load-script=multidb_mysql_car_import.sql
+
+quarkus.hibernate-orm."fruits".datasource=fruits
+quarkus.hibernate-orm."fruits".packages=io.quarkus.ts.hibernate.reactive.multidbSources.secondDatabase
+quarkus.hibernate-orm."fruits".schema-management.strategy=drop-and-create
+quarkus.hibernate-orm."fruits".sql-load-script=multidb_postgres_fruit_import.sql
+
+# define default persistence unit
+quarkus.hibernate-orm.datasource=main
+quarkus.hibernate-orm.packages=io.quarkus.ts.hibernate.reactive.database
+quarkus.hibernate-orm.sql-load-script=multidb_postgres_main_import.sql
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+quarkus.hibernate-orm.database.charset=utf-8

--- a/hibernate/hibernate-reactive/src/test/resources/multidb_mysql_car_import.sql
+++ b/hibernate/hibernate-reactive/src/test/resources/multidb_mysql_car_import.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS cars;
+CREATE TABLE cars (id INT NOT NULL AUTO_INCREMENT, name VARCHAR(31) NOT NULL, PRIMARY KEY(id));
+INSERT INTO cars(id,name) VALUES (1, 'BMW');
+INSERT INTO cars(id,name) VALUES (2, 'Audi');
+INSERT INTO cars(id,name) VALUES (3, 'Volkswagen');
+INSERT INTO cars(id,name) VALUES (4, 'Kia');

--- a/hibernate/hibernate-reactive/src/test/resources/multidb_postgres_fruit_import.sql
+++ b/hibernate/hibernate-reactive/src/test/resources/multidb_postgres_fruit_import.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS fruits;
+CREATE TABLE fruits(id SERIAL PRIMARY KEY, name TEXT NOT NULL);
+INSERT INTO fruits(id,name) VALUES (1, 'Apple');
+INSERT INTO fruits(id,name) VALUES (2, 'Banana');
+INSERT INTO fruits(id,name) VALUES (3, 'Orange');

--- a/hibernate/hibernate-reactive/src/test/resources/multidb_postgres_main_import.sql
+++ b/hibernate/hibernate-reactive/src/test/resources/multidb_postgres_main_import.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS authors CASCADE;
+CREATE TABLE authors(id SERIAL PRIMARY KEY, name TEXT NOT NULL);
+INSERT INTO authors(id,name) VALUES (1, 'Homer');
+INSERT INTO authors(id,name) VALUES (2, 'Vern');
+INSERT INTO authors(id,name) VALUES (3, 'Dlugi');
+INSERT INTO authors(id,name) VALUES (4, 'Kahneman');
+DROP TABLE IF EXISTS books CASCADE;
+CREATE TABLE books(id SERIAL PRIMARY KEY, author int references authors(id) , title TEXT NOT NULL, isbn TEXT NULL);
+INSERT INTO books(author, title) VALUES (3, 'Slovník');
+INSERT INTO books(author, title, isbn) VALUES (4, 'Thinking fast and slow', '978-0374275631');
+INSERT INTO books(author, title) VALUES (4, 'Attention and Effort');

--- a/hibernate/hibernate-reactive/src/test/resources/test.properties
+++ b/hibernate/hibernate-reactive/src/test/resources/test.properties
@@ -1,1 +1,5 @@
 ts.database.openshift.use-internal-service-as-url=true
+
+ts.postgresql1.openshift.use-internal-service-as-url=true
+ts.postgresql2.openshift.use-internal-service-as-url=true
+ts.mysql.openshift.use-internal-service-as-url=true


### PR DESCRIPTION
### Summary

Add tests for names datasources and persistence units for Hibernate Reactive as stated in TP https://github.com/quarkus-qe/quarkus-test-plans/pull/255

I'm creating this as a draft, because tests does not work RN because of https://github.com/quarkusio/quarkus/issues/49901. Once that is resolved, tests should start to work properly. (I tried these tests with just one PU which avoids the upstream bug and it works, but breaks the purpose of we are testing here).

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [X] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)