### PR TITLE
[3.20] Use dedicated Maven profile for Hiberante modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,15 +112,16 @@ jobs:
           else
             JVM_MODULES_GROUPS=(
               " -P root-modules,cache-modules,spring-modules,http-modules,test-tooling-modules,messaging-modules,monitoring-modules"
-              " -P security-modules,sql-db-modules,websockets-modules,nosql-db-modules"
+              " -P security-modules,sql-db-modules,websockets-modules,nosql-db-modules,hibernate-modules"
             )
           
             NATIVE_MODULES_GROUPS=(
               " -P root-modules,websockets-modules,test-tooling-modules,nosql-db-modules"
               " -P http-modules,cache-modules"
               " -P security-modules,spring-modules"
-              " -P sql-db-modules -pl env-info,sql-db/hibernate,sql-db/sql-app,sql-db/sql-app-compatibility,sql-db/multiple-pus,sql-db/panache-flyway,sql-db/hibernate-reactive"
-              " -P sql-db-modules -pl env-info,sql-db/reactive-rest-data-panache,sql-db/vertx-sql,sql-db/reactive-vanilla,sql-db/hibernate-fulltext-search,sql-db/narayana-transactions"
+              " -P hibernate-modules"
+              " -P sql-db-modules -pl env-info,sql-db/sql-app,sql-db/sql-app-compatibility,sql-db/multiple-pus,sql-db/panache-flyway"
+              " -P sql-db-modules -pl env-info,sql-db/reactive-rest-data-panache,sql-db/vertx-sql,sql-db/reactive-vanilla,sql-db/narayana-transactions"
               " -P messaging-modules,monitoring-modules"
             )
           

--- a/pom.xml
+++ b/pom.xml
@@ -613,7 +613,7 @@
             </modules>
         </profile>
         <profile>
-            <id>sql-db-modules</id>
+            <id>hibernate-modules</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
                 <property>
@@ -623,16 +623,28 @@
             <modules>
                 <module>env-info</module>
                 <module>sql-db/hibernate</module>
+                <module>sql-db/hibernate-reactive</module>
+                <module>sql-db/hibernate-fulltext-search</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>sql-db-modules</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>all-modules</name>
+                </property>
+            </activation>
+            <modules>
+                <module>env-info</module>
                 <module>sql-db/sql-app</module>
                 <module>sql-db/sql-app-compatibility</module>
                 <module>sql-db/multiple-pus</module>
+                <module>sql-db/vertx-sql</module>
+                <module>sql-db/reactive-vanilla</module>
+                <module>sql-db/narayana-transactions</module>
                 <module>sql-db/panache-flyway</module>
                 <module>sql-db/reactive-rest-data-panache</module>
-                <module>sql-db/vertx-sql</module>
-                <module>sql-db/hibernate-reactive</module>
-                <module>sql-db/reactive-vanilla</module>
-                <module>sql-db/hibernate-fulltext-search</module>
-                <module>sql-db/narayana-transactions</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
### Summary

https://github.com/quarkus-qe/quarkus-test-suite/pull/2617 follow-up because Jenkins job axes has changed and we need to reflect that. I didn't change Hibernate directories to limit changes and keep it simple. Could be slight problem for backports, but considering the pace we are making changes in 3.27/main, I think we would still have to do manual backports.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)