### PR TITLE
Add test coverage for #47458 Add Metrics and Logs to OTel Capabilities

### DIFF
--- a/monitoring/micrometer-opentelemetry/src/test/java/io/quarkus/ts/monitoring/micrometeropentelemetry/test/DevModeOtelCapabilitiesIT.java
+++ b/monitoring/micrometer-opentelemetry/src/test/java/io/quarkus/ts/monitoring/micrometeropentelemetry/test/DevModeOtelCapabilitiesIT.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.monitoring.micrometeropentelemetry.test;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.ts.monitoring.micrometeropentelemetry.rest.LoggingResource;
+
+@Tag("https://github.com/quarkusio/quarkus/pull/47458")
+@QuarkusScenario
+public class DevModeOtelCapabilitiesIT {
+    @DevModeQuarkusApplication(classes = LoggingResource.class)
+    static final RestService app = new RestService()
+            .withProperty("quarkus.otel.traces.enabled", "false")
+            .withProperty("quarkus.otel.metrics.enabled", "true")
+            .withProperty("quarkus.otel.logs.enabled", "true");
+
+    @Test
+    void testShouldNotContainFailedToExport() {
+        app.given().get("/logging").then().statusCode(200);
+        app.logs().assertDoesNotContain(" Failed to export LogsRequestMarshalers.");
+        app.logs().assertDoesNotContain(" Failed to export MetricsRequestMarshalers.");
+    }
+
+}


### PR DESCRIPTION
### Summary

Test coverage for [#47458](https://github.com/quarkusio/quarkus/pull/47458) 
Original issue in the user comment --> [#47031](https://github.com/quarkusio/quarkus/issues/47031#issuecomment-2781308022)

The test validates that the warning traces `Failed to export LogsRequestMarshalers` and `Failed to export MetricsRequestMarshalers` described by the user here https://github.com/quarkusio/quarkus/issues/47031#issuecomment-2781308022 are not present after the fix.

Mvn command executed for the test:
`mvn clean verify -Dit.test=DevModeOtelCapabilitiesIT -Dreruns=0`

And fail with:
`mvn clean verify -Dquarkus.platform.version=3.21.1 -Dit.test=DevModeOtelCapabilitiesIT -Dreruns=0`

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)