### PR TITLE
Remove overriding version from strimzi-test-container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,28 +76,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <!--
-                    Override strimzi-test-container version, that is in upstream quarkus-bom
-                    Current version there is 0.109.2 which is not compatible with Kafka which we have in the framework.
-                    This is just a hotfix before strimzi-test-container is bumped in upstream - see https://github.com/quarkusio/quarkus/pull/49949
-                    TODO: remove this dependency once https://github.com/quarkusio/quarkus/pull/49949 is merged
-                    TODO: or strimzi-test-container is bumped otherwise otherwise
-                -->
-                <groupId>io.strimzi</groupId>
-                <artifactId>strimzi-test-container</artifactId>
-                <version>0.112.0</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-avro-serializer</artifactId>
                 <version>${confluent.kafka-avro-serializer.version}</version>


### PR DESCRIPTION
### Summary

After https://github.com/quarkusio/quarkus/pull/50032 is merged upstream, there is no need to override `strimzi-test-container` version in our pom anymore.

I'm not sure if this change is going to be backported to 3.27, which suffers the same problem. So not adding the backport label RN.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)