### PR TITLE
Fix project compilation by adapting config module to SR Config 3.14.0

### DIFF
--- a/config/src/main/java/io/quarkus/ts/configmap/api/server/secrets/ConfigInterceptorFactory.java
+++ b/config/src/main/java/io/quarkus/ts/configmap/api/server/secrets/ConfigInterceptorFactory.java
@@ -5,12 +5,15 @@ import java.util.Set;
 import io.smallrye.config.ConfigSourceInterceptor;
 import io.smallrye.config.ConfigSourceInterceptorContext;
 import io.smallrye.config.ConfigSourceInterceptorFactory;
+import io.smallrye.config.PropertyName;
 import io.smallrye.config.SecretKeysConfigSourceInterceptor;
 
 public class ConfigInterceptorFactory implements ConfigSourceInterceptorFactory {
     @Override
     public ConfigSourceInterceptor getInterceptor(ConfigSourceInterceptorContext context) {
-        return new SecretKeysConfigSourceInterceptor(Set.of("secret.password", "secrets.custom-factory-crypto-handler",
-                "secrets.custom-factory-base64-handler", "secrets.custom-factory-sha256-handler"));
+        return new SecretKeysConfigSourceInterceptor(Set.of(PropertyName.unprofiled("secret.password"),
+                PropertyName.unprofiled("secrets.custom-factory-crypto-handler"),
+                PropertyName.unprofiled("secrets.custom-factory-base64-handler"),
+                PropertyName.unprofiled("secrets.custom-factory-sha256-handler")));
     }
 }


### PR DESCRIPTION
### Summary

As consequence of the https://github.com/quarkusio/quarkus/pull/50200, this project compilation fails over this change https://github.com/smallrye/smallrye-config/pull/1232/files#diff-c28affa2433e0a2af3d49be70fd146956364c4a2a59600fd60487b6e0a37802c. We use the secret key config source for years now, see https://github.com/quarkus-qe/quarkus-test-suite/pull/886. I'll request that the upstream PR is marked as breaking because the interceptor which has changed is documented https://smallrye.io/smallrye-config/2.13.3/config/secret-keys/#secret-keys.

Update: requested proper label and the migration guide note here https://github.com/quarkusio/quarkus/pull/50200#issuecomment-3324968199

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)