### PR TITLE
Refactor and enable Jakarta Data tests

### DIFF
--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/AuthorRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/AuthorRepository.java
@@ -1,7 +1,9 @@
 package io.quarkus.ts.jakarta.data.db;
 
 import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.Repository;
 
+@Repository
 public interface AuthorRepository extends BasicRepository<Author, Long> {
 
 }

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/BookRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/BookRepository.java
@@ -6,10 +6,12 @@ import jakarta.data.Limit;
 import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Repository;
 
 import org.hibernate.StatelessSession;
 import org.hibernate.query.range.Range;
 
+@Repository
 public interface BookRepository extends BasicRepository<Book, Long> {
 
     @OrderBy(io.quarkus.ts.jakarta.data.db._Book.TITLE)

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/Db2AuthorRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/Db2AuthorRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "db2")
-public interface Db2AuthorRepository extends AuthorRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/Db2BookRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/Db2BookRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "db2")
-public interface Db2BookRepository extends BookRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/Db2FruitCrudRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/Db2FruitCrudRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "db2")
-public interface Db2FruitCrudRepository extends FruitCrudRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/Db2FruitRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/Db2FruitRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "db2")
-public interface Db2FruitRepository extends FruitRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/Db2OtherFruitRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/Db2OtherFruitRepository.java
@@ -1,8 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "db2")
-public interface Db2OtherFruitRepository extends OtherFruitRepository {
-
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/FruitCrudRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/FruitCrudRepository.java
@@ -2,7 +2,9 @@ package io.quarkus.ts.jakarta.data.db;
 
 import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
 
+@Repository
 public interface FruitCrudRepository extends CrudRepository<Fruit, Long> {
 
     @Query("SELECT COUNT(this)")

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/FruitRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/FruitRepository.java
@@ -4,10 +4,12 @@ import java.util.List;
 
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
 import jakarta.persistence.EntityManager;
 
 import io.quarkus.ts.jakarta.data.interceptor.MyInterceptorBinding;
 
+@Repository
 public interface FruitRepository {
 
     record View(long count, String names, String ids) {

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MariaDbAuthorRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MariaDbAuthorRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "mariadb")
-public interface MariaDbAuthorRepository extends AuthorRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MariaDbBookRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MariaDbBookRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "mariadb")
-public interface MariaDbBookRepository extends BookRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MariaDbFruitCrudRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MariaDbFruitCrudRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "mariadb")
-public interface MariaDbFruitCrudRepository extends FruitCrudRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MariaDbFruitRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MariaDbFruitRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "mariadb")
-public interface MariaDbFruitRepository extends FruitRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MariaDbOtherFruitRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MariaDbOtherFruitRepository.java
@@ -1,8 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "mariadb")
-public interface MariaDbOtherFruitRepository extends OtherFruitRepository {
-
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MySQLAuthorRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MySQLAuthorRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "mysql")
-public interface MySQLAuthorRepository extends AuthorRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MySQLBookRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MySQLBookRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "mysql")
-public interface MySQLBookRepository extends BookRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MySQLFruitCrudRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MySQLFruitCrudRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "mysql")
-public interface MySQLFruitCrudRepository extends FruitCrudRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MySQLFruitRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MySQLFruitRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "mysql")
-public interface MySQLFruitRepository extends FruitRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MySQLOtherFruitRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/MySQLOtherFruitRepository.java
@@ -1,8 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "mysql")
-public interface MySQLOtherFruitRepository extends OtherFruitRepository {
-
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/OracleAuthorRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/OracleAuthorRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "oracle")
-public interface OracleAuthorRepository extends AuthorRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/OracleBookRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/OracleBookRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "oracle")
-public interface OracleBookRepository extends BookRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/OracleFruitCrudRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/OracleFruitCrudRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "oracle")
-public interface OracleFruitCrudRepository extends FruitCrudRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/OracleFruitRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/OracleFruitRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "oracle")
-public interface OracleFruitRepository extends FruitRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/OracleOtherFruitRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/OracleOtherFruitRepository.java
@@ -1,8 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "oracle")
-public interface OracleOtherFruitRepository extends OtherFruitRepository {
-
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/OtherFruitRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/OtherFruitRepository.java
@@ -6,6 +6,7 @@ import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
+import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
 import jakarta.validation.Valid;
@@ -13,6 +14,7 @@ import jakarta.validation.constraints.Min;
 
 import org.hibernate.annotations.processing.Pattern;
 
+@Repository
 public interface OtherFruitRepository {
 
     @Insert

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/PgAuthorRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/PgAuthorRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "pg")
-public interface PgAuthorRepository extends AuthorRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/PgBookRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/PgBookRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "pg")
-public interface PgBookRepository extends BookRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/PgFruitCrudRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/PgFruitCrudRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "pg")
-public interface PgFruitCrudRepository extends FruitCrudRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/PgFruitRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/PgFruitRepository.java
@@ -1,8 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "pg")
-public interface PgFruitRepository extends FruitRepository {
-
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/PgOtherFruitRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/PgOtherFruitRepository.java
@@ -1,8 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "pg")
-public interface PgOtherFruitRepository extends OtherFruitRepository {
-
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/RepositoryBeansProducer.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/RepositoryBeansProducer.java
@@ -1,0 +1,33 @@
+package io.quarkus.ts.jakarta.data.db;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Produces;
+import jakarta.persistence.EntityManager;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.hibernate.StatelessSession;
+
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.hibernate.orm.PersistenceUnit.PersistenceUnitLiteral;
+
+/**
+ * Redirect Jakarta Data repositories to the currently active named persistence unit.
+ * See also <a href="https://quarkus.io/version/main/guides/hibernate-orm#persistence-unit-active">the documentation</a>.
+ */
+public class RepositoryBeansProducer {
+
+    @Produces
+    @ApplicationScoped
+    public StatelessSession produceStatelessSession(@ConfigProperty(name = "quarkus.profile") String datasource,
+            @Any InjectableInstance<StatelessSession> sessionInstance) {
+        return sessionInstance.select(new PersistenceUnitLiteral(datasource)).get();
+    }
+
+    @Produces
+    @ApplicationScoped
+    public EntityManager produceEntityManager(@ConfigProperty(name = "quarkus.profile") String datasource,
+            @Any InjectableInstance<EntityManager> entityManager) {
+        return entityManager.select(new PersistenceUnitLiteral(datasource)).get();
+    }
+}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/SqlServerAuthorRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/SqlServerAuthorRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "sql-server")
-public interface SqlServerAuthorRepository extends AuthorRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/SqlServerBookRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/SqlServerBookRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "sql-server")
-public interface SqlServerBookRepository extends BookRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/SqlServerFruitCrudRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/SqlServerFruitCrudRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "sql-server")
-public interface SqlServerFruitCrudRepository extends FruitCrudRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/SqlServerFruitRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/SqlServerFruitRepository.java
@@ -1,7 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "sql-server")
-public interface SqlServerFruitRepository extends FruitRepository {
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/SqlServerOtherFruitRepository.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/db/SqlServerOtherFruitRepository.java
@@ -1,8 +1,0 @@
-package io.quarkus.ts.jakarta.data.db;
-
-import jakarta.data.repository.Repository;
-
-@Repository(dataStore = "sql-server")
-public interface SqlServerOtherFruitRepository extends OtherFruitRepository {
-
-}

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/rest/BasicRepositoryResource.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/rest/BasicRepositoryResource.java
@@ -11,26 +11,12 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.hibernate.query.range.Range;
 
-import io.quarkus.arc.InjectableInstance;
 import io.quarkus.ts.jakarta.data.db.Author;
 import io.quarkus.ts.jakarta.data.db.AuthorRepository;
 import io.quarkus.ts.jakarta.data.db.Book;
 import io.quarkus.ts.jakarta.data.db.BookRepository;
-import io.quarkus.ts.jakarta.data.db.Db2AuthorRepository;
-import io.quarkus.ts.jakarta.data.db.Db2BookRepository;
-import io.quarkus.ts.jakarta.data.db.MariaDbAuthorRepository;
-import io.quarkus.ts.jakarta.data.db.MariaDbBookRepository;
-import io.quarkus.ts.jakarta.data.db.MySQLAuthorRepository;
-import io.quarkus.ts.jakarta.data.db.MySQLBookRepository;
-import io.quarkus.ts.jakarta.data.db.OracleAuthorRepository;
-import io.quarkus.ts.jakarta.data.db.OracleBookRepository;
-import io.quarkus.ts.jakarta.data.db.PgAuthorRepository;
-import io.quarkus.ts.jakarta.data.db.PgBookRepository;
-import io.quarkus.ts.jakarta.data.db.SqlServerAuthorRepository;
-import io.quarkus.ts.jakarta.data.db.SqlServerBookRepository;
 
 @Path("/basic-repository")
 public final class BasicRepositoryResource {
@@ -38,27 +24,9 @@ public final class BasicRepositoryResource {
     private final AuthorRepository authorRepository;
     private final BookRepository bookRepository;
 
-    public BasicRepositoryResource(InjectableInstance<AuthorRepository> authorRepositoryInstance,
-            InjectableInstance<BookRepository> bookRepositoryInstance,
-            @ConfigProperty(name = "quarkus.profile") String datasource) {
-        authorRepository = switch (datasource) {
-            case "pg" -> authorRepositoryInstance.select(PgAuthorRepository.class).get();
-            case "mariadb" -> authorRepositoryInstance.select(MariaDbAuthorRepository.class).get();
-            case "mysql" -> authorRepositoryInstance.select(MySQLAuthorRepository.class).get();
-            case "oracle" -> authorRepositoryInstance.select(OracleAuthorRepository.class).get();
-            case "sql-server" -> authorRepositoryInstance.select(SqlServerAuthorRepository.class).get();
-            case "db2" -> authorRepositoryInstance.select(Db2AuthorRepository.class).get();
-            default -> throw new IllegalArgumentException("Unknown datasource: " + datasource);
-        };
-        bookRepository = switch (datasource) {
-            case "pg" -> bookRepositoryInstance.select(PgBookRepository.class).get();
-            case "mariadb" -> bookRepositoryInstance.select(MariaDbBookRepository.class).get();
-            case "mysql" -> bookRepositoryInstance.select(MySQLBookRepository.class).get();
-            case "oracle" -> bookRepositoryInstance.select(OracleBookRepository.class).get();
-            case "sql-server" -> bookRepositoryInstance.select(SqlServerBookRepository.class).get();
-            case "db2" -> bookRepositoryInstance.select(Db2BookRepository.class).get();
-            default -> throw new IllegalArgumentException("Unknown datasource: " + datasource);
-        };
+    BasicRepositoryResource(AuthorRepository authorRepository, BookRepository bookRepository) {
+        this.authorRepository = authorRepository;
+        this.bookRepository = bookRepository;
     }
 
     @Transactional

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/rest/CrudRepositoryResource.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/rest/CrudRepositoryResource.java
@@ -13,35 +13,17 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-import io.quarkus.arc.InjectableInstance;
 import io.quarkus.ts.jakarta.data.db.DayOfWeek;
-import io.quarkus.ts.jakarta.data.db.Db2FruitCrudRepository;
 import io.quarkus.ts.jakarta.data.db.Fruit;
 import io.quarkus.ts.jakarta.data.db.FruitCrudRepository;
-import io.quarkus.ts.jakarta.data.db.MariaDbFruitCrudRepository;
-import io.quarkus.ts.jakarta.data.db.MySQLFruitCrudRepository;
-import io.quarkus.ts.jakarta.data.db.OracleFruitCrudRepository;
-import io.quarkus.ts.jakarta.data.db.PgFruitCrudRepository;
-import io.quarkus.ts.jakarta.data.db.SqlServerFruitCrudRepository;
 
 @Path("/crud-repository")
 public final class CrudRepositoryResource {
 
     private final FruitCrudRepository fruitCrudRepository;
 
-    public CrudRepositoryResource(InjectableInstance<FruitCrudRepository> fruitCrudRepositoryInstance,
-            @ConfigProperty(name = "quarkus.profile") String datasource) {
-        fruitCrudRepository = switch (datasource) {
-            case "pg" -> fruitCrudRepositoryInstance.select(PgFruitCrudRepository.class).get();
-            case "mariadb" -> fruitCrudRepositoryInstance.select(MariaDbFruitCrudRepository.class).get();
-            case "mysql" -> fruitCrudRepositoryInstance.select(MySQLFruitCrudRepository.class).get();
-            case "oracle" -> fruitCrudRepositoryInstance.select(OracleFruitCrudRepository.class).get();
-            case "sql-server" -> fruitCrudRepositoryInstance.select(SqlServerFruitCrudRepository.class).get();
-            case "db2" -> fruitCrudRepositoryInstance.select(Db2FruitCrudRepository.class).get();
-            default -> throw new IllegalArgumentException("Unknown datasource: " + datasource);
-        };
+    CrudRepositoryResource(FruitCrudRepository fruitCrudRepository) {
+        this.fruitCrudRepository = fruitCrudRepository;
     }
 
     @Transactional

--- a/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/rest/RepositoryResource.java
+++ b/hibernate/jakarta-data/src/main/java/io/quarkus/ts/jakarta/data/rest/RepositoryResource.java
@@ -11,24 +11,9 @@ import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-import io.quarkus.arc.InjectableInstance;
-import io.quarkus.ts.jakarta.data.db.Db2FruitRepository;
-import io.quarkus.ts.jakarta.data.db.Db2OtherFruitRepository;
 import io.quarkus.ts.jakarta.data.db.Fruit;
 import io.quarkus.ts.jakarta.data.db.FruitRepository;
-import io.quarkus.ts.jakarta.data.db.MariaDbFruitRepository;
-import io.quarkus.ts.jakarta.data.db.MariaDbOtherFruitRepository;
-import io.quarkus.ts.jakarta.data.db.MySQLFruitRepository;
-import io.quarkus.ts.jakarta.data.db.MySQLOtherFruitRepository;
-import io.quarkus.ts.jakarta.data.db.OracleFruitRepository;
-import io.quarkus.ts.jakarta.data.db.OracleOtherFruitRepository;
 import io.quarkus.ts.jakarta.data.db.OtherFruitRepository;
-import io.quarkus.ts.jakarta.data.db.PgFruitRepository;
-import io.quarkus.ts.jakarta.data.db.PgOtherFruitRepository;
-import io.quarkus.ts.jakarta.data.db.SqlServerFruitRepository;
-import io.quarkus.ts.jakarta.data.db.SqlServerOtherFruitRepository;
 
 @Path("/repository")
 public final class RepositoryResource {
@@ -36,27 +21,9 @@ public final class RepositoryResource {
     private final FruitRepository fruitRepository;
     private final OtherFruitRepository otherFruitRepository;
 
-    public RepositoryResource(InjectableInstance<FruitRepository> fruitRepositoryInstance,
-            InjectableInstance<OtherFruitRepository> otherFruitRepositoryInstance,
-            @ConfigProperty(name = "quarkus.profile") String datasource) {
-        fruitRepository = switch (datasource) {
-            case "pg" -> fruitRepositoryInstance.select(PgFruitRepository.class).get();
-            case "mariadb" -> fruitRepositoryInstance.select(MariaDbFruitRepository.class).get();
-            case "mysql" -> fruitRepositoryInstance.select(MySQLFruitRepository.class).get();
-            case "oracle" -> fruitRepositoryInstance.select(OracleFruitRepository.class).get();
-            case "sql-server" -> fruitRepositoryInstance.select(SqlServerFruitRepository.class).get();
-            case "db2" -> fruitRepositoryInstance.select(Db2FruitRepository.class).get();
-            default -> throw new IllegalArgumentException("Unknown datasource: " + datasource);
-        };
-        otherFruitRepository = switch (datasource) {
-            case "pg" -> otherFruitRepositoryInstance.select(PgOtherFruitRepository.class).get();
-            case "mariadb" -> otherFruitRepositoryInstance.select(MariaDbOtherFruitRepository.class).get();
-            case "mysql" -> otherFruitRepositoryInstance.select(MySQLOtherFruitRepository.class).get();
-            case "oracle" -> otherFruitRepositoryInstance.select(OracleOtherFruitRepository.class).get();
-            case "sql-server" -> otherFruitRepositoryInstance.select(SqlServerOtherFruitRepository.class).get();
-            case "db2" -> otherFruitRepositoryInstance.select(Db2OtherFruitRepository.class).get();
-            default -> throw new IllegalArgumentException("Unknown datasource: " + datasource);
-        };
+    RepositoryResource(FruitRepository fruitRepository, OtherFruitRepository otherFruitRepository) {
+        this.fruitRepository = fruitRepository;
+        this.otherFruitRepository = otherFruitRepository;
     }
 
     @Path("/query-with-record")

--- a/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/Db2JakartaDataIT.java
+++ b/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/Db2JakartaDataIT.java
@@ -1,6 +1,5 @@
 package io.quarkus.ts.jakarta.data;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -14,7 +13,6 @@ import io.quarkus.test.services.QuarkusApplication;
 @Tag("fips-incompatible") // Reported in https://github.com/IBM/Db2/issues/43
 @Tag("podman-incompatible") //TODO: https://github.com/containers/podman/issues/16432
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2020")
-@Disabled("https://github.com/quarkus-qe/quarkus-test-suite/issues/2631")
 public class Db2JakartaDataIT extends AbstractJakartaDataIT {
 
     @Container(image = "${db2.image}", port = 50000, expectedLog = "Setup has completed")

--- a/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/DevModePostgreSqlJakartaDataIT.java
+++ b/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/DevModePostgreSqlJakartaDataIT.java
@@ -1,6 +1,5 @@
 package io.quarkus.ts.jakarta.data;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +11,6 @@ import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.AwaitilityUtils;
 
 @QuarkusScenario
-@Disabled("https://github.com/quarkus-qe/quarkus-test-suite/issues/2631")
 public class DevModePostgreSqlJakartaDataIT extends AbstractJakartaDataIT {
 
     @Container(image = "${postgresql.latest.image}", port = 5432, expectedLog = "listening on IPv4 address")

--- a/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/MariaDbJakartaDataIT.java
+++ b/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/MariaDbJakartaDataIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.jakarta.data;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.bootstrap.MariaDbService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -9,7 +7,6 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-@Disabled("https://github.com/quarkus-qe/quarkus-test-suite/issues/2631")
 public class MariaDbJakartaDataIT extends AbstractJakartaDataIT {
 
     @Container(image = "${mariadb.11.image}", port = 3306, expectedLog = "socket: '.*/mysql.*sock'  port: 3306")

--- a/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/MySqlJakartaDataIT.java
+++ b/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/MySqlJakartaDataIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.jakarta.data;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -9,7 +7,6 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-@Disabled("https://github.com/quarkus-qe/quarkus-test-suite/issues/2631")
 public class MySqlJakartaDataIT extends AbstractJakartaDataIT {
 
     @Container(image = "${mysql.80.image}", port = 3306, expectedLog = "Only MySQL server logs after this point")

--- a/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/OpenShiftPostgreSqlJakartaDataIT.java
+++ b/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/OpenShiftPostgreSqlJakartaDataIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.jakarta.data;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.bootstrap.PostgresqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -9,7 +7,6 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
-@Disabled("https://github.com/quarkus-qe/quarkus-test-suite/issues/2631")
 public class OpenShiftPostgreSqlJakartaDataIT extends AbstractJakartaDataIT {
 
     @Container(image = "${postgresql.latest.image}", port = 5432, expectedLog = "listening on IPv4 address")

--- a/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/OracleJakartaDataIT.java
+++ b/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/OracleJakartaDataIT.java
@@ -1,6 +1,5 @@
 package io.quarkus.ts.jakarta.data;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.OracleService;
@@ -11,7 +10,6 @@ import io.quarkus.test.services.QuarkusApplication;
 
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2022")
 @QuarkusScenario
-@Disabled("https://github.com/quarkus-qe/quarkus-test-suite/issues/2631")
 public class OracleJakartaDataIT extends AbstractJakartaDataIT {
 
     @Container(image = "${oracle.image}", port = 1521, expectedLog = "DATABASE IS READY TO USE!")

--- a/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/PostgreSqlJakartaDataIT.java
+++ b/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/PostgreSqlJakartaDataIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.ts.jakarta.data;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.bootstrap.PostgresqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -9,7 +7,6 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-@Disabled("https://github.com/quarkus-qe/quarkus-test-suite/issues/2631")
 public class PostgreSqlJakartaDataIT extends AbstractJakartaDataIT {
 
     @Container(image = "${postgresql.latest.image}", port = 5432, expectedLog = "listening on IPv4 address")

--- a/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/SqlServerJakartaDataIT.java
+++ b/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/SqlServerJakartaDataIT.java
@@ -1,6 +1,5 @@
 package io.quarkus.ts.jakarta.data;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -13,7 +12,6 @@ import io.quarkus.test.services.SqlServerContainer;
 @Tag("fips-incompatible") // MSSQL works with BC JSSE FIPS which is not native-compatible, we test FIPS elsewhere
 @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2017")
 @QuarkusScenario
-@Disabled("https://github.com/quarkus-qe/quarkus-test-suite/issues/2631")
 public class SqlServerJakartaDataIT extends AbstractJakartaDataIT {
 
     @SqlServerContainer(tlsEnabled = true)


### PR DESCRIPTION
### Summary

Intentional change upstream https://github.com/quarkusio/quarkus/issues/50139 means that THE previous test coverage cannot run. Refactored code relies on documented suggestion in the https://quarkus.io/version/main/guides/hibernate-orm#persistence-unit-active. There are small drawbacks (like less inheritance and not having multiple named PU repos), but anything else will mean more execution time.

Tests enabled in this PR were disabled in https://github.com/quarkus-qe/quarkus-test-suite/pull/2632.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)