### PR TITLE
Update to 3.27 Quarkus branch

### DIFF
--- a/.github/actions/prepare-quarkus-cli/action.yml
+++ b/.github/actions/prepare-quarkus-cli/action.yml
@@ -1,5 +1,5 @@
-name: 'Create Quarkus CLI 3.26.999-SNAPSHOT'
-description: 'Creates Quarkus CLI based on the current Quarkus 3.27 branch (3.26.999-SNAPSHOT version)'
+name: 'Create Quarkus CLI 3.27.999-SNAPSHOT'
+description: 'Creates Quarkus CLI based on the current Quarkus 3.27 branch (3.27.999-SNAPSHOT version)'
 runs:
   using: "composite"
   steps:
@@ -8,13 +8,13 @@ runs:
       run: cp .github/quarkus-snapshots-mvn-settings.xml ~/.m2/settings.xml
     - name: Download Quarkus CLI
       shell: bash
-      run: mvn org.apache.maven.plugins:maven-dependency-plugin:get -Dartifact=io.quarkus:quarkus-cli:3.26.999-SNAPSHOT:jar:runner
+      run: mvn org.apache.maven.plugins:maven-dependency-plugin:get -Dartifact=io.quarkus:quarkus-cli:3.27.999-SNAPSHOT:jar:runner
     - name: Install Quarkus CLI
       shell: bash
       run: |
         cat <<EOF > ./quarkus-dev-cli
         #!/bin/bash
-        java -jar ~/.m2/repository/io/quarkus/quarkus-cli/3.26.999-SNAPSHOT/quarkus-cli-3.26.999-SNAPSHOT-runner.jar "\$@"
+        java -jar ~/.m2/repository/io/quarkus/quarkus-cli/3.27.999-SNAPSHOT/quarkus-cli-3.27.999-SNAPSHOT-runner.jar "\$@"
         EOF
         chmod +x ./quarkus-dev-cli
         ./quarkus-dev-cli version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           check-latest: true
       - name: Build Quarkus 3.27
         run: |
-          git clone -b 3.26 https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
+          git clone -b 3.27 https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
@@ -317,12 +317,12 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Download Quarkus CLI
         shell: bash
-        run: mvn -B --no-transfer-progress org.apache.maven.plugins:maven-dependency-plugin:get -Dartifact=io.quarkus:quarkus-cli:3.26.999-SNAPSHOT:jar:runner
+        run: mvn -B --no-transfer-progress org.apache.maven.plugins:maven-dependency-plugin:get -Dartifact=io.quarkus:quarkus-cli:3.27.999-SNAPSHOT:jar:runner
       - name: Install Quarkus CLI
         run: |
           $quarkusCliFileContent = @"
           @ECHO OFF
-          java -jar %HOMEDRIVE%%HOMEPATH%\.m2\repository\io\quarkus\quarkus-cli\3.26.999-SNAPSHOT\quarkus-cli-3.26.999-SNAPSHOT-runner.jar %*
+          java -jar %HOMEDRIVE%%HOMEPATH%\.m2\repository\io\quarkus\quarkus-cli\3.27.999-SNAPSHOT\quarkus-cli-3.27.999-SNAPSHOT-runner.jar %*
           "@
           New-Item -Path "$(pwd)\quarkus-dev-cli.bat" -ItemType File
           Set-Content -Path "$(pwd)\quarkus-dev-cli.bat" -Value $quarkusCliFileContent

--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AnalyticsUtils.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AnalyticsUtils.java
@@ -6,10 +6,10 @@ import java.util.regex.Pattern;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 public class AnalyticsUtils {
-    private static final String QUARKUS_SNAPSHOT_VERSION = "3.26.999-SNAPSHOT";
+    private static final String QUARKUS_SNAPSHOT_VERSION = "3.27.999-SNAPSHOT";
     // Quarkus reports extensions' versions in the analytics payload as full artifact version.
     // So for 999-SNAPSHOT, it can look like e.g. 999-20230718.203351-1091
-    private static final String QUARKUS_EXTENSION_SNAPSHOT_VERSION_REGEX = "3\\.26\\.999-.*";
+    private static final String QUARKUS_EXTENSION_SNAPSHOT_VERSION_REGEX = "3\\.27\\.999-.*";
     // RHBQ artifacts may differ in the number suffix from a platform version.
     // E.g.: 3.8.0.redhat-00002 vs. 3.8.5.redhat-00003
     private static final String RHBQ_VERSION_REGEX_FORMAT = "%s\\.redhat-\\d{5}";

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/QuickstartIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/QuickstartIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
 @QuarkusScenario
 public class QuickstartIT {
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", branch = "3.27", contextDir = "getting-started", mavenArgs = "-Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
     static final RestService app = new RestService();
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
         <failsafe-plugin.version>3.5.3</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.26.999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>3.27.999-SNAPSHOT</quarkus.platform.version>
         <quarkus.ide.version>3.26.1</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.7.1</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.7.2</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.8.0</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.27.0</formatter-maven-plugin.version>


### PR DESCRIPTION
### Summary

* Updating to 3.27 snapshot of Quarkus dependency
* Updating actions to run with 3.27 Quarkus branch
* Updating to framework 1.7.2 based on Quarkus 3.27
* Making QuickstartsIT use 3.27 branch of quickstarts repository

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)