### PR TITLE
Drop ineffective @Order annotations in config module and fix non-critical issue reported by the test engine

### DIFF
--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/DevModeConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/DevModeConfigIT.java
@@ -11,7 +11,6 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 import java.util.Base64;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
@@ -33,7 +32,6 @@ public class DevModeConfigIT {
         PropertiesSource.given = app::given;
     }
 
-    @Order(1)
     @Test
     void configProfileDependentSecret() {
         // assert config properties only available with certain config profiles
@@ -48,7 +46,6 @@ public class DevModeConfigIT {
         INJECTED_PROPERTIES.assertSecret(secretKey, secretVal);
     }
 
-    @Order(2)
     @Test
     void changeSecretInRunningApp() {
         var secretKey = BASE64.secretKey(APP_PROPERTIES);

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftBaseConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/OpenShiftBaseConfigIT.java
@@ -15,7 +15,6 @@ import java.util.concurrent.TimeUnit;
 import jakarta.inject.Inject;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -34,7 +33,6 @@ public abstract class OpenShiftBaseConfigIT {
     @Inject
     static OpenShiftClient openshift;
 
-    @Order(1)
     @Test
     public void testSecretKeysHandler() {
         PropertiesSource.given = getApp()::given;
@@ -51,7 +49,6 @@ public abstract class OpenShiftBaseConfigIT {
         INJECTED_CONFIG.assertSecret(secretKey, secretVal);
     }
 
-    @Order(2)
     @Test
     public void configMapEndToEnd() {
         // Simple invocation


### PR DESCRIPTION
### Summary

When config module tests are run, I saw:

```
13:47:33,844 INFO  TestEngine with ID 'junit-jupiter' encountered 2 non-critical issues during test discovery:

(1) [INFO] Ineffective @Order annotation on method 'void io.quarkus.ts.configmap.api.server.DevModeConfigIT.changeSecretInRunningApp()'. It will not be applied because MethodOrderer.OrderAnnotation is not in use. Note that the annotation may be either directly present or meta-present on the method.
    Source: MethodSource [className = 'io.quarkus.ts.configmap.api.server.DevModeConfigIT', methodName = 'changeSecretInRunningApp', methodParameterTypes = '']
            at io.quarkus.ts.configmap.api.server.DevModeConfigIT.changeSecretInRunningApp(SourceFile:0)

(2) [INFO] Ineffective @Order annotation on method 'void io.quarkus.ts.configmap.api.server.DevModeConfigIT.configProfileDependentSecret()'. It will not be applied because MethodOrderer.OrderAnnotation is not in use. Note that the annotation may be either directly present or meta-present on the method.
    Source: MethodSource [className = 'io.quarkus.ts.configmap.api.server.DevModeConfigIT', methodName = 'configProfileDependentSecret', methodParameterTypes = '']
            at io.quarkus.ts.configmap.api.server.DevModeConfigIT.configProfileDependentSecret(SourceFile:0)
```

So I tried to use the `@TestMethodOrder(MethodOrderer.OrderAnnotation.class)` and reversed method execution order. The test still passed, which means that the order is not necessary.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)