### PR TITLE
Bump Elastic to 9.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
                                 <amqbroker.1.0x.image>quay.io/artemiscloud/activemq-artemis-broker:1.0.32</amqbroker.1.0x.image>
                                 <redpanda.image>redpandadata/redpanda:v25.2.2</redpanda.image>
                                 <postgresql.latest.image>${postgresql.latest.image}</postgresql.latest.image>
-                                <elastic.9x.image>docker.io/library/elasticsearch:9.1.2</elastic.9x.image>
+                                <elastic.9x.image>docker.io/library/elasticsearch:9.1.4</elastic.9x.image>
                                 <mysql.upstream.80.image>docker.io/library/mysql:8.4</mysql.upstream.80.image>
                                 <mysql.80.image>${mysql.80.image}</mysql.80.image>
                                 <mariadb.11.image>docker.io/library/mariadb:11.8</mariadb.11.image>


### PR DESCRIPTION
### Summary

https://github.com/quarkusio/quarkus/pull/49429 bumped Hibernate Search to 8.1 which [claims to support Elastic 9.1](https://in.relation.to/2025/08/08/hibernate-search-8-1-0-Final/) (though the ticket title is bit confusing https://hibernate.atlassian.net/browse/HSEARCH-5438 but I suppose they won't claim support for each micro). Elastic is now at 9.1.4 in the main https://github.com/quarkusio/quarkus/blob/86d4b6bd6264846f88e8a6c395af37d56847577a/bom/application/pom.xml#L104 and the bump will be backported to 3.27 https://github.com/quarkusio/quarkus/pull/50185. For that reason, I'd like to bump our Elastic version as well.

This change is related to https://issues.redhat.com/browse/QUARKUS-6545.

This change affect only 2 modules (`nosql-db/elasticsearch` and `hibernate/hibernate-fulltext-search`)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)