### PR TITLE
Test Hibernate Search range aggregations

### DIFF
--- a/hibernate/hibernate-fulltext-search/src/main/java/io/quarkus/ts/hibernate/search/FruitPriceReport.java
+++ b/hibernate/hibernate-fulltext-search/src/main/java/io/quarkus/ts/hibernate/search/FruitPriceReport.java
@@ -1,0 +1,6 @@
+package io.quarkus.ts.hibernate.search;
+
+public record FruitPriceReport(PriceAggregation zeroToTen, PriceAggregation tenToTwenty,
+        PriceAggregation twentyToInfinity) {
+
+}

--- a/hibernate/hibernate-fulltext-search/src/main/java/io/quarkus/ts/hibernate/search/PriceAggregation.java
+++ b/hibernate/hibernate-fulltext-search/src/main/java/io/quarkus/ts/hibernate/search/PriceAggregation.java
@@ -1,0 +1,7 @@
+package io.quarkus.ts.hibernate.search;
+
+public record PriceAggregation(int avg, int min, int max) {
+    public PriceAggregation(double avg, double min, double max) {
+        this((int) avg, (int) min, (int) max);
+    }
+}

--- a/hibernate/hibernate-fulltext-search/src/test/resources/test.properties
+++ b/hibernate/hibernate-fulltext-search/src/test/resources/test.properties
@@ -3,3 +3,5 @@ ts.database.container.delete.image.on.stop=true
 ts.company1.openshift.use-internal-service-as-url=true
 ts.company2.openshift.use-internal-service-as-url=true
 ts.base.openshift.use-internal-service-as-url=true
+# Elastic logs are very noisy, enable them when you need them
+ts.elastic.log.enable=false


### PR DESCRIPTION
### Summary

As part of the https://issues.redhat.com/browse/QUARKUS-6545, Hibernate Search ["release notes"](https://in.relation.to/2025/08/08/hibernate-search-8-1-0-Final/) mentions the aggregation improvements. This PR uses given example and adapts it to our test suite so that we have the improvements covered in JVM, DEV mode, OCP and native. I have casted double digits to int in order to simplify assertions of rounded numbers.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)