### PR TITLE
[DRAFT] Ensure annotation processor respect depmgmt #2

### DIFF
--- a/hibernate/hibernate-fulltext-search/pom.xml
+++ b/hibernate/hibernate-fulltext-search/pom.xml
@@ -57,6 +57,7 @@
                     <execution>
                         <id>default-compile</id>
                         <configuration>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                             <annotationProcessors>
                                 <annotationProcessor>org.hibernate.search.processor.HibernateSearchProcessor</annotationProcessor>
                             </annotationProcessors>

--- a/hibernate/jakarta-data/pom.xml
+++ b/hibernate/jakarta-data/pom.xml
@@ -74,6 +74,7 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.hibernate.orm</groupId>

--- a/javaee-like-getting-started/pom.xml
+++ b/javaee-like-getting-started/pom.xml
@@ -106,6 +106,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
                 <configuration>
+                    <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.mapstruct</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -248,9 +248,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
-                <configuration>
-                    <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/service-discovery/stork-custom/pom.xml
+++ b/service-discovery/stork-custom/pom.xml
@@ -36,6 +36,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
                 <configuration>
+                    <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.smallrye.stork</groupId>


### PR DESCRIPTION
* Adding configuration to Maven compiler plugin to ensure that annotation processor dependency resolution respects dependency management of the project rather than dependencies of the processor in each project declaring the processor since we run the test suite in different ways and the generated pom and build root changes depending on whether the test is ran from parent module or the individual child test modules.

Follows up on https://github.com/quarkus-qe/quarkus-test-suite/pull/2644/

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)