### PR TITLE
Disable tests due to quarkus#50247 (Unable to find datasource '<default>')

### DIFF
--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AnalyticsUtils.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/AnalyticsUtils.java
@@ -36,7 +36,8 @@ public class AnalyticsUtils {
             "quarkus-core",
             "quarkus-grpc",
             "quarkus-hibernate-orm",
-            "quarkus-hibernate-orm-panache",
+            // Enable when https://github.com/quarkusio/quarkus/issues/50247 is fixed
+            //"quarkus-hibernate-orm-panache",
             "quarkus-hibernate-validator",
             "quarkus-infinispan-client",
             "quarkus-jackson",
@@ -64,7 +65,8 @@ public class AnalyticsUtils {
             "quarkus-smallrye-graphql-client",
             "quarkus-smallrye-reactive-streams-operators",
             "quarkus-spring-boot-properties",
-            "quarkus-spring-data-jpa",
+            // Enable when https://github.com/quarkusio/quarkus/issues/50247 is fixed
+            //"quarkus-spring-data-jpa",
             "quarkus-spring-di",
             "quarkus-spring-security",
             "quarkus-undertow",
@@ -73,7 +75,8 @@ public class AnalyticsUtils {
     public static final String[] EXTENSION_SET_B = new String[] {
             "quarkus-avro",
             "quarkus-container-image-openshift",
-            "quarkus-hibernate-orm-rest-data-panache",
+            // Enable when https://github.com/quarkusio/quarkus/issues/50247 is fixed
+            //"quarkus-hibernate-orm-rest-data-panache",
             "quarkus-rest-client-jaxrs",
             "quarkus-jdbc-mariadb",
             "quarkus-jdbc-mssql",
@@ -97,7 +100,8 @@ public class AnalyticsUtils {
             "quarkus-messaging-kafka",
             "quarkus-spring-cache",
             "quarkus-spring-cloud-config-client",
-            "quarkus-spring-data-rest",
+            // Enable when https://github.com/quarkusio/quarkus/issues/50247 is fixed
+            //"quarkus-spring-data-rest",
             "quarkus-spring-scheduled",
             "quarkus-spring-web",
             "quarkus-websockets",

--- a/pom.xml
+++ b/pom.xml
@@ -546,7 +546,8 @@
                 <module>security/bouncycastle-fips</module>
                 <module>security/form-authn</module>
                 <module>security/https</module>
-                <module>security/jpa</module>
+                <!-- TODO enable when https://github.com/quarkusio/quarkus/issues/50247 is fixed-->
+                <!-- <module>security/jpa</module> -->
                 <module>security/jpa-reactive</module>
                 <module>security/jwt</module>
                 <module>security/keycloak</module>

--- a/super-size/many-extensions/pom.xml
+++ b/super-size/many-extensions/pom.xml
@@ -18,10 +18,12 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-elytron-security</artifactId>
         </dependency>
+        <!-- TODO enable when https://github.com/quarkusio/quarkus/issues/50247 is fixed
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-data-jpa</artifactId>
         </dependency>
+        -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes</artifactId>
@@ -100,10 +102,12 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jsonb</artifactId>
         </dependency>
+        <!-- TODO enable when https://github.com/quarkusio/quarkus/issues/50247 is fixed
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-messaging-kafka</artifactId>
         </dependency>
+        -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-metrics</artifactId>
@@ -112,10 +116,12 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-config-yaml</artifactId>
         </dependency>
+        <!-- TODO enable when https://github.com/quarkusio/quarkus/issues/50247 is fixed
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-panache</artifactId>
         </dependency>
+        -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-messaging</artifactId>


### PR DESCRIPTION
### Summary

Disabling tests/module due to https://github.com/quarkusio/quarkus/issues/50247. When the fix is available I'll revert this commit.

The security/jpa module needs to disabled,
otherwise there would need to modification to remove panache.

The super-size/many extension have ony disabled minimal number of extension to preserve maximal matrix for test.

In build-time-analytics only some extensions in set A and B were disabled.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)