### PR TITLE
Test Hibernate Session merge events interception

### DIFF
--- a/hibernate/hibernate-orm/pom.xml
+++ b/hibernate/hibernate-orm/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/hibernate/hibernate-orm/src/main/java/io/quarkus/qe/hibernate/interceptor/SessionEventInterceptor.java
+++ b/hibernate/hibernate-orm/src/main/java/io/quarkus/qe/hibernate/interceptor/SessionEventInterceptor.java
@@ -1,0 +1,38 @@
+package io.quarkus.qe.hibernate.interceptor;
+
+import org.hibernate.Interceptor;
+import org.hibernate.type.Type;
+
+import io.quarkus.hibernate.orm.PersistenceUnitExtension;
+import io.quarkus.qe.hibernate.items.MyEntity;
+
+@PersistenceUnitExtension("named")
+public class SessionEventInterceptor implements Interceptor {
+
+    private volatile MyEntity entity = null;
+    private volatile String changedPropertyName = null;
+    private volatile String originalState = null;
+    private volatile String targetState = null;
+
+    public record MergeData(MyEntity entity, String changedPropertyName, String originalState, String targetState) {
+    }
+
+    @Override
+    public void postMerge(Object source, Object target, Object id, Object[] targetState, Object[] originalState,
+            String[] propertyNames, Type[] propertyTypes) {
+        this.targetState = (String) targetState[0];
+        this.originalState = (String) originalState[0];
+        Interceptor.super.postMerge(source, target, id, targetState, originalState, propertyNames, propertyTypes);
+    }
+
+    @Override
+    public void preMerge(Object entity, Object[] state, String[] propertyNames, Type[] propertyTypes) {
+        this.entity = (MyEntity) entity;
+        this.changedPropertyName = propertyNames[0];
+        Interceptor.super.preMerge(entity, state, propertyNames, propertyTypes);
+    }
+
+    public MergeData getMergeData() {
+        return new MergeData(entity, changedPropertyName, originalState, targetState);
+    }
+}


### PR DESCRIPTION
### Summary

Merge events interception has been identified as one of relevant changes introduced by https://issues.redhat.com/browse/QUARKUS-6545. The feature is still incubating, hence the added test is simple and only asserts principle.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)