### PR TITLE
Enable serverErrorMetricsTest as the upstream issue is fixed

### DIFF
--- a/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/WebSocketsNextMetricsIT.java
+++ b/websockets/websocket-next/src/test/java/io/quarkus/ts/websockets/next/WebSocketsNextMetricsIT.java
@@ -14,7 +14,6 @@ import java.nio.charset.StandardCharsets;
 import org.apache.http.HttpStatus;
 import org.awaitility.Awaitility;
 import org.jboss.logging.Logger;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -107,7 +106,6 @@ public class WebSocketsNextMetricsIT {
 
     @Test
     @Order(2)
-    @Disabled("https://github.com/quarkusio/quarkus/issues/47409")
     public void serverErrorMetricsTest() throws URISyntaxException, InterruptedException {
         Client client = createClient("/failing");
         getServer().logs().assertContains("Error on websocket: Websocket failed to open");


### PR DESCRIPTION
### Summary

Enable serverErrorMetricsTest as the upstream issue https://github.com/quarkusio/quarkus/issues/47409 is fixed

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)