### PR TITLE
3.27 backports 2

### DIFF
--- a/hibernate/hibernate-offline-startup/README.MD
+++ b/hibernate/hibernate-offline-startup/README.MD
@@ -1,0 +1,27 @@
+# Hibernate Offline Startup
+
+Tests are motivated by the [QUARKUS-3363](https://issues.redhat.com/browse/QUARKUS-3363) and planned in the [test plan](https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-3363.MD).
+
+## Challenges
+
+* Hibernate multitenancy types:
+    * MariaDB and MySQL are testing the database-based multitenancy since they don’t support the schema.
+    * SQL Server is also testing the database-based multitenancy, even though it does support schema, the default schema is “dbo”, and when Hibernate attempts to change the schema, the driver reports that as an unsupported action. It should be possible to switch schemes by changing a user's credentials with their own default schema, but I couldn’t make it work.
+    * PostgreSQL is testing schema-based multitenancy.
+    * Oracle supports schemes; however, configuring Oracle to create schemas is challenging. Granting users admin rights or every possible right to the individual schema passed; however, when Hibernate succeeded in creating the schema and tried to create sequences in the schema, it always failed on permissions. I think we can’t do both: ask Hibernate to create the schema while also preparing schema permissions beforehand. Therefore, we leverage the fact that the Oracle image supports creating multiple databases and use individual schemas named after the user.
+* Credentials propagation; in our customer case, database credentials were obtained dynamically from incoming requests after the database started; also, Quarkus documentation mentions a scenario where the database pod is not available during the Quarkus application startup. We have disabled pooling so that every database query means a new connection that requires credentials and testing:
+    * ability to send credentials before any database requests (using Hibernate tenant resolver and credentials provider)
+    * ability to send credentials and with the same request query database (using Hibernate tenant resolver and credentials provider)
+    * ability to create a connection “manually” while accessing credentials from the incoming HTTP request
+* Fixed ports are required so that we can start Quarkus with a JDBC URL that is not available:
+    * OCP pods expose the same ports as we specify in the @Container annotation; therefore, we can use a hardcoded internal service URL with a fixed port
+    * Bare-metal tests use Test Containers, which try to discourage fixed ports (the setter method is protected) due to the fact that they can cause issues with the remote Docker host; we should not introduce this feature to our framework. Therefore, a new resource manager is created in this module. On Windows, the remote Docker host is ported to the localhost so that hardcoded JDBC URLs work.
+    * Nginx would allow us to start the database with a dynamic port and redirect it to the port we specify in the Quarkus configuration. I have tried Nginx to only permit traffic once we need it, but its resolver expects to resolve network aliases to their IPs on startup. I didn’t find a configuration that worked for both Docker and Podman. It also required more code for provisioning test containers with the shared network.
+* DB2 and privileged mode
+    * In other test modules, we configure the privileged mode for DB2 in the scope of the DB2 service (AKA field is called db2, hence we only configure it for the service called db2). However, we look up the database by a service name in the test parent, so I could not use a different name for the DB2 service. Hence, the privileged mode is configured when the DB2 image is recognized instead.
+* OpenTelemetry JDBC Instrumentation
+    * We create a schema using the Hibernate ORM SchemaManager, which is not supported for multitenancy (but works like a charm...). However, if we disable telemetry for the req_scope_credentials datasource and keep it for the app_scope_credentials datasource while both datasources are used by the same Hibernate persistence unit, traces for both schemes generation are present. I have tried to create a reproducer with supported scenarios and couldn’t. Therefore, we test telemetry for all tenants (datasources) resolved for the default persistence unit.
+* Detection of build-time configuration properties for forced dependencies
+    * Current mechanism used by our framework to detect build-time properties relies on a classpath during the testing framework bootstrap. Thus, we either need to hardcode a list of build-time properties for these dependencies in our framework or put the build-time properties in our application.properties file. That’s the reason for having the `quarkus.hibernate-orm.dialect.mariadb.bytes-per-character` configuration property defined for all the test classes.
+* CDI Request Context
+    * Due to the https://github.com/quarkusio/quarkus/issues/50154, test that should verify credentials propagation using CDI Request Context is storing state in static variables. This would not work in a concurrent environment.

--- a/hibernate/hibernate-offline-startup/pom.xml
+++ b/hibernate/hibernate-offline-startup/pom.xml
@@ -10,14 +10,41 @@
     <artifactId>hibernate-offline-startup</artifactId>
     <name>Quarkus QE TS: Hibernate modules: Hibernate Offline Startup</name>
     <packaging>jar</packaging>
+    <properties>
+        <!-- tests require custom builds -->
+        <quarkus.build.skip>true</quarkus.build.skip>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-context-propagation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-database</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-jaeger</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/defaults/orm/Article.java
+++ b/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/defaults/orm/Article.java
@@ -1,0 +1,40 @@
+package io.quarkus.ts.hibernate.startup.offline.pu.defaults.orm;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class Article {
+
+    private Long id;
+
+    private String name;
+
+    public Article() {
+    }
+
+    public Article(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Id
+    @GeneratedValue
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/defaults/orm/CustomCredentialsProvider.java
+++ b/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/defaults/orm/CustomCredentialsProvider.java
@@ -1,0 +1,50 @@
+package io.quarkus.ts.hibernate.startup.offline.pu.defaults.orm;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+
+import io.quarkus.credentials.CredentialsProvider;
+import io.quarkus.logging.Log;
+
+@ApplicationScoped
+public class CustomCredentialsProvider implements CredentialsProvider {
+
+    private record UsernameAndPassword(String username, String password) {
+    }
+
+    private final Map<String, UsernameAndPassword> providerToCredentials = new ConcurrentHashMap<>();
+    private final RequestScopedData requestScopedData;
+
+    CustomCredentialsProvider(RequestScopedData requestScopedData) {
+        this.requestScopedData = requestScopedData;
+    }
+
+    // TODO: drop the activation when https://github.com/quarkusio/quarkus/issues/50154 is fixed
+    @ActivateRequestContext
+    @Override
+    public Map<String, String> getCredentials(String credentialsProviderName) {
+        if (requestScopedData.foundCredentials()) {
+            Log.debug("Retrieved credentials from the CDI request scope");
+            return Map.of(
+                    CredentialsProvider.USER_PROPERTY_NAME, requestScopedData.getUser(),
+                    CredentialsProvider.PASSWORD_PROPERTY_NAME, requestScopedData.getPassword());
+        }
+        if (providerToCredentials.containsKey(credentialsProviderName)) {
+            UsernameAndPassword credentials = providerToCredentials.get(credentialsProviderName);
+            Log.debug("Found credentials for " + credentialsProviderName);
+            return Map.of(
+                    CredentialsProvider.USER_PROPERTY_NAME, credentials.username,
+                    CredentialsProvider.PASSWORD_PROPERTY_NAME, credentials.password);
+        } else {
+            Log.debug("Found no credentials for " + credentialsProviderName);
+        }
+        return Map.of();
+    }
+
+    public void storeCredentials(String provider, String username, String password) {
+        providerToCredentials.put(provider, new UsernameAndPassword(username, password));
+    }
+}

--- a/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/defaults/orm/CustomTenantResolver.java
+++ b/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/defaults/orm/CustomTenantResolver.java
@@ -1,0 +1,40 @@
+package io.quarkus.ts.hibernate.startup.offline.pu.defaults.orm;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.UriInfo;
+
+import io.quarkus.hibernate.orm.PersistenceUnitExtension;
+import io.quarkus.hibernate.orm.runtime.tenant.TenantResolver;
+import io.quarkus.logging.Log;
+
+@PersistenceUnitExtension
+@RequestScoped
+public class CustomTenantResolver implements TenantResolver {
+
+    @Inject
+    UriInfo uriInfo;
+
+    @Inject
+    RequestScopedData requestScopedData;
+
+    @Override
+    public String getDefaultTenantId() {
+        return resolveTenantIdInternal();
+    }
+
+    @Override
+    public String resolveTenantId() {
+        return resolveTenantIdInternal();
+    }
+
+    private String resolveTenantIdInternal() {
+        requestScopedData.loadCredentials();
+        String tenant = uriInfo.getPathParameters().getFirst("tenant");
+        if (tenant != null && !tenant.isEmpty()) {
+            Log.debug("Resolved tenant " + tenant);
+            return tenant;
+        }
+        throw new IllegalStateException("Tenant not found");
+    }
+}

--- a/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/defaults/orm/RequestScopedData.java
+++ b/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/defaults/orm/RequestScopedData.java
@@ -1,0 +1,35 @@
+package io.quarkus.ts.hibernate.startup.offline.pu.defaults.orm;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+
+import io.vertx.ext.web.RoutingContext;
+
+@RequestScoped
+public final class RequestScopedData {
+
+    // TODO: make this member variables instead when https://github.com/quarkusio/quarkus/issues/50154 is fixed
+    //      or get the credentials directly from the RoutingContext instead
+    private static volatile String user;
+    private static volatile String password;
+
+    @Inject
+    RoutingContext routingContext;
+
+    void loadCredentials() {
+        user = routingContext.request().getHeader("username");
+        password = routingContext.request().getHeader("password");
+    }
+
+    String getUser() {
+        return user;
+    }
+
+    String getPassword() {
+        return password;
+    }
+
+    boolean foundCredentials() {
+        return password != null && !password.isEmpty();
+    }
+}

--- a/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/defaults/rest/DatabaseManagementResource.java
+++ b/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/defaults/rest/DatabaseManagementResource.java
@@ -1,0 +1,46 @@
+package io.quarkus.ts.hibernate.startup.offline.pu.defaults.rest;
+
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.hibernate.relational.SchemaManager;
+import org.jboss.resteasy.reactive.RestPath;
+
+import io.quarkus.ts.hibernate.startup.offline.pu.defaults.orm.CustomCredentialsProvider;
+
+@Path("/default-pu/database-management/{tenant}/")
+public class DatabaseManagementResource {
+
+    public record DatabaseCredentials(String username, String password) {
+    }
+
+    @Inject
+    SchemaManager schemaManager;
+
+    @Inject
+    CustomCredentialsProvider customCredentialsProvider;
+
+    @ConfigProperty(name = "fixed-default-schema")
+    Optional<String> fixedDefaultSchema;
+
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("store-app-scoped-credentials")
+    @POST
+    public void storeApplicationScopedCredentials(@RestPath String tenant, DatabaseCredentials credentials) {
+        customCredentialsProvider.storeCredentials(tenant, credentials.username, credentials.password);
+    }
+
+    @Path("create-schema")
+    @POST
+    public void createSchema(@RestPath String tenant) {
+        String schema = fixedDefaultSchema.orElse(tenant);
+        schemaManager.forSchema(schema).create(true);
+    }
+
+}

--- a/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/defaults/rest/NewspapersResource.java
+++ b/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/defaults/rest/NewspapersResource.java
@@ -1,0 +1,61 @@
+package io.quarkus.ts.hibernate.startup.offline.pu.defaults.rest;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnit;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.jboss.resteasy.reactive.RestPath;
+
+import io.quarkus.ts.hibernate.startup.offline.pu.defaults.orm.Article;
+
+@Path("/default-pu/newspapers/{tenant}/")
+public class NewspapersResource {
+
+    @Inject
+    EntityManager entityManager;
+
+    @Inject
+    @PersistenceUnit
+    SessionFactory sessionFactory;
+
+    @GET
+    @Path("/article/count")
+    public long count() {
+        return (long) entityManager
+                .createQuery("select count(*) from Article")
+                .getSingleResultOrNull();
+    }
+
+    @Produces(MediaType.APPLICATION_JSON)
+    @GET
+    @Path("/article/{id}")
+    public Article getArticle(@RestPath Long id) {
+        return entityManager.find(Article.class, id);
+    }
+
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Transactional
+    @POST
+    @Path("/article")
+    public Long createArticle(Article article) {
+        entityManager.persist(article);
+        return article.getId();
+    }
+
+    @Path("/dialect/max-varchar-length")
+    @GET
+    public int getMaxVarcharLength() {
+        var dialect = (MariaDBDialect) sessionFactory.unwrap(SessionFactoryImplementor.class).getJdbcServices().getDialect();
+        return dialect.getMaxVarcharLength();
+    }
+}

--- a/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/ownconnection/orm/Article.java
+++ b/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/ownconnection/orm/Article.java
@@ -1,0 +1,39 @@
+package io.quarkus.ts.hibernate.startup.offline.pu.ownconnection.orm;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class Article {
+
+    private Long id;
+
+    private String name;
+
+    public Article() {
+    }
+
+    public Article(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Id
+    @GeneratedValue
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/ownconnection/orm/CustomTenantConnectionResolver.java
+++ b/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/ownconnection/orm/CustomTenantConnectionResolver.java
@@ -1,0 +1,122 @@
+package io.quarkus.ts.hibernate.startup.offline.pu.ownconnection.orm;
+
+import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Named;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.service.UnknownUnwrapTypeException;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.supplier.AgroalConnectionFactoryConfigurationSupplier;
+import io.agroal.api.configuration.supplier.AgroalConnectionPoolConfigurationSupplier;
+import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
+import io.agroal.api.security.SimplePassword;
+import io.quarkus.hibernate.orm.PersistenceUnitExtension;
+import io.quarkus.hibernate.orm.runtime.tenant.TenantConnectionResolver;
+import io.vertx.ext.web.RoutingContext;
+
+import javax.sql.DataSource;
+
+@ApplicationScoped
+@PersistenceUnitExtension("own_connection_provider")
+public class CustomTenantConnectionResolver implements TenantConnectionResolver {
+
+    private final AgroalDataSource dataSource;
+
+    CustomTenantConnectionResolver(@Named("own_connection_provider") AgroalDataSource dataSource,
+            RoutingContext routingContext) {
+        this.dataSource = createDatasource(dataSource, routingContext);
+    }
+
+    @Override
+    public ConnectionProvider resolve(String tenantId) {
+        return new CustomConnectionProvider();
+    }
+
+    private static String getPassword(RoutingContext routingContext) {
+        var password = routingContext.request().getHeader("connection-password");
+        return password == null ? "" : password;
+    }
+
+    private static String getUsername(RoutingContext routingContext) {
+        var username = routingContext.request().getHeader("connection-user");
+        return username == null ? "" : username;
+    }
+
+    private static AgroalDataSource createDatasource(AgroalDataSource dataSource, RoutingContext routingContext) {
+        var existingConfig = dataSource.getConfiguration();
+        try {
+            return AgroalDataSource.from(new AgroalDataSourceConfigurationSupplier()
+                    .dataSourceImplementation(existingConfig.dataSourceImplementation())
+                    .metricsEnabled(existingConfig.metricsEnabled())
+                    .connectionPoolConfiguration(
+                            new AgroalConnectionPoolConfigurationSupplier(existingConfig.connectionPoolConfiguration())
+                                    .connectionFactoryConfiguration(
+                                            connectionFactory -> new AgroalConnectionFactoryConfigurationSupplier(
+                                                    connectionFactory.get())
+                                                    .credential(new SimplePassword("") {
+                                                        @Override
+                                                        public Properties asProperties() {
+                                                            var properties = new Properties();
+                                                            properties.setProperty(USER_PROPERTY_NAME,
+                                                                    getUsername(routingContext));
+                                                            properties.setProperty(PASSWORD_PROPERTY_NAME,
+                                                                    getPassword(routingContext));
+                                                            return properties;
+                                                        }
+                                                    }))));
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private final class CustomConnectionProvider implements ConnectionProvider {
+        @Override
+        public Connection getConnection() throws SQLException {
+            var connection = dataSource.getConnection();
+            String schema = ConfigProvider.getConfig()
+                    .getOptionalValue("fixed-default-schema", String.class)
+                    .orElse("own_connection_provider");
+            connection.setSchema(schema);
+            return connection;
+        }
+
+        @Override
+        public void closeConnection(Connection connection) throws SQLException {
+            connection.close();
+        }
+
+        @Override
+        public boolean supportsAggressiveRelease() {
+            return true;
+        }
+
+        @Override
+        public boolean isUnwrappableAs(Class<?> unwrapType) {
+            return ConnectionProvider.class.equals(unwrapType) ||
+                    DataSource.class.isAssignableFrom(unwrapType) ||
+                    AgroalDataSource.class.isAssignableFrom(unwrapType);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> T unwrap(Class<T> unwrapType) {
+            if (ConnectionProvider.class.equals(unwrapType)) {
+                return (T) this;
+            } else if (DataSource.class.isAssignableFrom(unwrapType)
+                    || AgroalDataSource.class.isAssignableFrom(unwrapType)) {
+                return (T) dataSource;
+            } else {
+                throw new UnknownUnwrapTypeException(unwrapType);
+            }
+        }
+    }
+}

--- a/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/ownconnection/orm/CustomTenantResolver.java
+++ b/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/ownconnection/orm/CustomTenantResolver.java
@@ -1,0 +1,20 @@
+package io.quarkus.ts.hibernate.startup.offline.pu.ownconnection.orm;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.orm.PersistenceUnitExtension;
+import io.quarkus.hibernate.orm.runtime.tenant.TenantResolver;
+
+@ApplicationScoped
+@PersistenceUnitExtension("own_connection_provider")
+public class CustomTenantResolver implements TenantResolver {
+    @Override
+    public String getDefaultTenantId() {
+        return "own_connection_provider";
+    }
+
+    @Override
+    public String resolveTenantId() {
+        return "own_connection_provider";
+    }
+}

--- a/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/ownconnection/rest/DatabaseManagementResource.java
+++ b/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/ownconnection/rest/DatabaseManagementResource.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.hibernate.startup.offline.pu.ownconnection.rest;
+
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.hibernate.relational.SchemaManager;
+import org.jboss.resteasy.reactive.RestPath;
+
+@Path("/own-connection-provider-pu/database-management/{tenant}/")
+public class DatabaseManagementResource {
+
+    @Named("own_connection_provider")
+    @Inject
+    SchemaManager schemaManager;
+
+    @ConfigProperty(name = "fixed-default-schema")
+    Optional<String> fixedDefaultSchema;
+
+    @Path("create-schema")
+    @POST
+    public void createSchema(@RestPath String tenant) {
+        String schema = fixedDefaultSchema.orElse(tenant);
+        schemaManager.forSchema(schema).create(true);
+    }
+
+}

--- a/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/ownconnection/rest/NewspapersResource.java
+++ b/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/pu/ownconnection/rest/NewspapersResource.java
@@ -1,0 +1,49 @@
+package io.quarkus.ts.hibernate.startup.offline.pu.ownconnection.rest;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.RestPath;
+
+import io.quarkus.ts.hibernate.startup.offline.pu.ownconnection.orm.Article;
+
+@Path("/own-connection-provider-pu/newspapers/{tenant}/")
+public class NewspapersResource {
+
+    @Named("own_connection_provider")
+    @Inject
+    EntityManager entityManager;
+
+    @GET
+    @Path("/article/count")
+    public long count() {
+        return (long) entityManager
+                .createQuery("select count(*) from Article")
+                .getSingleResultOrNull();
+    }
+
+    @Produces(MediaType.APPLICATION_JSON)
+    @GET
+    @Path("/article/{id}")
+    public Article getArticle(@RestPath Long id) {
+        return entityManager.find(Article.class, id);
+    }
+
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Transactional
+    @POST
+    @Path("/article")
+    public Long createArticle(Article article) {
+        entityManager.persist(article);
+        return article.getId();
+    }
+
+}

--- a/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/rest/PingResource.java
+++ b/hibernate/hibernate-offline-startup/src/main/java/io/quarkus/ts/hibernate/startup/offline/rest/PingResource.java
@@ -1,0 +1,35 @@
+package io.quarkus.ts.hibernate.startup.offline.rest;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("ping")
+public class PingResource {
+
+    @ConfigProperty(name = "quarkus.hibernate-orm.database.start-offline")
+    boolean startOffline;
+
+    @Inject
+    EntityManager entityManager;
+
+    @Path("start-offline")
+    @GET
+    public String startOffline() {
+        return "pong: " + startOffline;
+    }
+
+    @Path("database/{tenant}")
+    @GET
+    public String database() {
+        return "pong: " + databaseOnline();
+    }
+
+    private boolean databaseOnline() {
+        return entityManager.createQuery("select 1").getSingleResult().equals(1);
+    }
+
+}

--- a/hibernate/hibernate-offline-startup/src/main/resources/application.properties
+++ b/hibernate/hibernate-offline-startup/src/main/resources/application.properties
@@ -1,0 +1,30 @@
+# default connection provider
+jdbc-url=must-be-replaced-during-runtime
+quarkus.hibernate-orm.database.start-offline=true
+quarkus.hibernate-orm.multitenant=SCHEMA
+quarkus.hibernate-orm.datasource=app_scope_credentials
+quarkus.hibernate-orm.packages=io.quarkus.ts.hibernate.startup.offline.pu.defaults.orm
+quarkus.datasource.app_scope_credentials.credentials-provider=app_scope_credentials
+quarkus.datasource.app_scope_credentials.jdbc.url=${jdbc-url}
+quarkus.datasource.app_scope_credentials.db-kind=${quarkus.datasource.db-kind}
+quarkus.datasource.app_scope_credentials.reactive=false
+quarkus.datasource.req_scope_credentials.credentials-provider=req_scope_credentials
+quarkus.datasource.req_scope_credentials.jdbc.url=${jdbc-url}
+quarkus.datasource.req_scope_credentials.db-kind=${quarkus.datasource.db-kind}
+quarkus.datasource.req_scope_credentials.reactive=false
+## ensure each request use a new connection so that we test resolving credentials work
+quarkus.datasource.app_scope_credentials.jdbc.pooling-enabled=false
+quarkus.datasource.req_scope_credentials.jdbc.pooling-enabled=false
+# own connection provider
+quarkus.hibernate-orm.own_connection_provider.database.start-offline=true
+quarkus.hibernate-orm.own_connection_provider.multitenant=${quarkus.hibernate-orm.multitenant}
+quarkus.hibernate-orm.own_connection_provider.datasource=own_connection_provider
+quarkus.hibernate-orm.own_connection_provider.packages=io.quarkus.ts.hibernate.startup.offline.pu.ownconnection.orm
+quarkus.datasource.own_connection_provider.jdbc.url=${jdbc-url}
+quarkus.datasource.own_connection_provider.db-kind=${quarkus.datasource.db-kind}
+quarkus.datasource.own_connection_provider.reactive=false
+## ensure each request use a new connection so that we test resolving credentials work
+quarkus.datasource.own_connection_provider.jdbc.pooling-enabled=false
+
+# must be here as the MariaDB JDBC driver is a forced dependency so the FW doesn't recognize this is a build-time property
+quarkus.hibernate-orm.dialect.mariadb.bytes-per-character=3

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/AbstractHibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/AbstractHibernateOfflineStartupIT.java
@@ -1,0 +1,192 @@
+package io.quarkus.ts.hibernate.startup.offline.test;
+
+import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.DatabaseService;
+import io.quarkus.test.bootstrap.LookupService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.ts.hibernate.startup.offline.pu.defaults.orm.Article;
+import io.quarkus.ts.hibernate.startup.offline.pu.defaults.rest.DatabaseManagementResource.DatabaseCredentials;
+import io.restassured.http.ContentType;
+
+public abstract class AbstractHibernateOfflineStartupIT {
+
+    static final String ONLINE_STARTUP_FAILED_MESSAGE = "Could not retrieve the database version to check it is at least";
+
+    @LookupService
+    static DatabaseService<?> db;
+
+    @LookupService
+    static RestService app;
+
+    @Test
+    void testApplicationScopedCredentialsOnFirstRequest() {
+        final String tenant = "app_scope_credentials";
+        startDbIfNotRunning();
+        // upload application scoped credentials
+        app.given()
+                .contentType(ContentType.JSON)
+                .pathParam("tenant", tenant)
+                .body(new DatabaseCredentials(db.getUser(), db.getPassword()))
+                .post("/default-pu/database-management/{tenant}/store-app-scoped-credentials")
+                .then()
+                .statusCode(204);
+        // create database scheme
+        // awaitility are used because the very first request needs database ready
+        untilAsserted(() -> app.given()
+                .pathParam("tenant", tenant)
+                .post("/default-pu/database-management/{tenant}/create-schema")
+                .then()
+                .statusCode(204));
+
+        // make sure that the tenant schema is empty
+        app.given()
+                .pathParam("tenant", tenant)
+                .get("/default-pu/newspapers/{tenant}/article/count")
+                .then()
+                .statusCode(200)
+                .body(is("0"));
+        // creates Article entity instance
+        final String articleName = "My %s article".formatted(tenant);
+        Long entityId = Long.parseLong(app.given()
+                .contentType(ContentType.JSON)
+                .pathParam("tenant", tenant)
+                .body(new Article(null, articleName))
+                .post("/default-pu/newspapers/{tenant}/article")
+                .then()
+                .statusCode(200)
+                .extract().asString());
+        // retrieves Article entity and asserts it
+        app.given()
+                .pathParam("id", entityId)
+                .pathParam("tenant", tenant)
+                .get("/default-pu/newspapers/{tenant}/article/{id}")
+                .then()
+                .statusCode(200)
+                .body("id", is(entityId.intValue()))
+                .body("name", is(articleName));
+    }
+
+    @Test
+    void testRequestScopedCredentialsOnFirstRequest() {
+        final String tenant = "req_scope_credentials";
+        startDbIfNotRunning();
+        // create database scheme
+        // awaitility are used because the very first request needs database ready
+        untilAsserted(() -> app.given()
+                .pathParam("tenant", tenant)
+                .header("username", db.getUser())
+                .header("password", db.getPassword())
+                .post("/default-pu/database-management/{tenant}/create-schema")
+                .then()
+                .statusCode(204));
+
+        // make sure that the tenant schema is empty
+        app.given()
+                .pathParam("tenant", tenant)
+                .header("username", db.getUser())
+                .header("password", db.getPassword())
+                .get("/default-pu/newspapers/{tenant}/article/count")
+                .then()
+                .statusCode(200)
+                .body(is("0"));
+        // no credentials must mean no connection
+        app.given()
+                .pathParam("tenant", tenant)
+                .get("/default-pu/newspapers/{tenant}/article/count")
+                .then()
+                .statusCode(500);
+        // creates Article entity instance
+        final String articleName = "My %s article".formatted(tenant);
+        Long entityId = Long.parseLong(app.given()
+                .contentType(ContentType.JSON)
+                .pathParam("tenant", tenant)
+                .header("username", db.getUser())
+                .header("password", db.getPassword())
+                .body(new Article(null, articleName))
+                .post("/default-pu/newspapers/{tenant}/article")
+                .then()
+                .statusCode(200)
+                .extract().asString());
+        // retrieves Article entity and asserts it
+        app.given()
+                .pathParam("id", entityId)
+                .pathParam("tenant", tenant)
+                .header("username", db.getUser())
+                .header("password", db.getPassword())
+                .get("/default-pu/newspapers/{tenant}/article/{id}")
+                .then()
+                .statusCode(200)
+                .body("id", is(entityId.intValue()))
+                .body("name", is(articleName));
+    }
+
+    @Test
+    void testProgrammaticallyResolveConnection() {
+        final String tenant = "own_connection_provider";
+        startDbIfNotRunning();
+        // create database scheme
+        // awaitility are used because the very first request needs database ready
+        untilAsserted(() -> app.given()
+                .pathParam("tenant", tenant)
+                .header("connection-user", db.getUser())
+                .header("connection-password", db.getPassword())
+                .post("/own-connection-provider-pu/database-management/{tenant}/create-schema")
+                .then()
+                .statusCode(204));
+
+        // no credentials must mean no result
+        app.given()
+                .pathParam("tenant", tenant)
+                .get("/own-connection-provider-pu/newspapers/{tenant}/article/count")
+                .then()
+                .statusCode(500);
+
+        // make sure that the tenant schema is empty
+        app.given()
+                .pathParam("tenant", tenant)
+                .header("connection-user", db.getUser())
+                .header("connection-password", db.getPassword())
+                .get("/own-connection-provider-pu/newspapers/{tenant}/article/count")
+                .then()
+                .statusCode(200)
+                .body(is("0"));
+        // creates Article entity instance
+        final String articleName = "My %s article".formatted(tenant);
+        Long entityId = Long.parseLong(app.given()
+                .contentType(ContentType.JSON)
+                .pathParam("tenant", tenant)
+                .header("connection-user", db.getUser())
+                .header("connection-password", db.getPassword())
+                .body(new Article(null, articleName))
+                .post("/own-connection-provider-pu/newspapers/{tenant}/article")
+                .then()
+                .statusCode(200)
+                .extract().asString());
+        // retrieves Article entity and asserts it
+        app.given()
+                .pathParam("id", entityId)
+                .pathParam("tenant", tenant)
+                .header("connection-user", db.getUser())
+                .header("connection-password", db.getPassword())
+                .get("/own-connection-provider-pu/newspapers/{tenant}/article/{id}")
+                .then()
+                .statusCode(200)
+                .body("id", is(entityId.intValue()))
+                .body("name", is(articleName));
+    }
+
+    protected static void startDbIfNotRunning() {
+        if (!db.isRunning()) {
+            testApplicationDidNotUseDatabase();
+            db.start();
+        }
+    }
+
+    private static void testApplicationDidNotUseDatabase() {
+        app.logs().assertDoesNotContain(ONLINE_STARTUP_FAILED_MESSAGE);
+    }
+}

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/Db2HibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/Db2HibernateOfflineStartupIT.java
@@ -1,0 +1,28 @@
+package io.quarkus.ts.hibernate.startup.offline.test;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+import io.quarkus.test.bootstrap.Db2Service;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.Dependency;
+import io.quarkus.test.services.QuarkusApplication;
+
+// note: it is unclear if this test requires more work to pass until the linked issue is fixed
+@Disabled("https://github.com/quarkusio/quarkus/issues/50209")
+@Tag("fips-incompatible") // Reported in https://github.com/IBM/Db2/issues/43
+@Tag("podman-incompatible") //TODO: https://github.com/containers/podman/issues/16432
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2020")
+@QuarkusScenario
+public class Db2HibernateOfflineStartupIT extends AbstractHibernateOfflineStartupIT {
+
+    @Container(image = "${db2.image}", port = 50000, expectedLog = "Setup has completed", builder = FixedPortResourceBuilder.class)
+    static final Db2Service db = new Db2Service().setAutoStart(false);
+
+    @QuarkusApplication(dependencies = @Dependency(artifactId = "quarkus-jdbc-db2"))
+    static final RestService app = new RestService()
+            .withProperty("jdbc-url", "jdbc:db2://localhost:50000/mydb");
+}

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/DevModeHibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/DevModeHibernateOfflineStartupIT.java
@@ -1,0 +1,83 @@
+package io.quarkus.ts.hibernate.startup.offline.test;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.DevModeQuarkusService;
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.logging.Log;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.Dependency;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.test.utils.AwaitilityUtils;
+import io.quarkus.ts.hibernate.startup.offline.pu.defaults.rest.DatabaseManagementResource;
+import io.restassured.http.ContentType;
+
+@QuarkusScenario
+public class DevModeHibernateOfflineStartupIT extends AbstractHibernateOfflineStartupIT {
+
+    private static final String APPLICATION_PROPERTIES = "src/main/resources/application.properties";
+
+    @Container(image = "${postgresql.latest.image}", port = 5432, expectedLog = "listening on IPv4 address", builder = FixedPortResourceBuilder.class)
+    static final PostgresqlService db = new PostgresqlService().setAutoStart(false);
+
+    @DevModeQuarkusApplication(dependencies = @Dependency(artifactId = "quarkus-jdbc-postgresql"))
+    static final DevModeQuarkusService app = (DevModeQuarkusService) new DevModeQuarkusService()
+            .withProperty("jdbc-url", "jdbc:postgresql://localhost:5432/mydb");
+
+    @Test
+    void testHotReload() {
+        // when all the test methods are run, this is not executed in the current execution order
+        // but if run independently, we need to run this first in order to assert that offline startup worked
+        startDbIfNotRunning();
+
+        // stop database, turn off the offline startup and expect a failure
+        Log.info("Stopping database");
+        db.stop();
+        Log.info("Turning off the offline startup feature");
+        app.modifyFile(APPLICATION_PROPERTIES, props -> props.replace("quarkus.hibernate-orm.database.start-offline=true",
+                "quarkus.hibernate-orm.database.start-offline=false"));
+        Log.info("Waiting for application to get ready");
+        AwaitilityUtils
+                .untilAsserted(() -> app.given().get("/ping/start-offline").then().statusCode(200).body(is("pong: false")));
+        // this should happen due to validation on startup
+        // however until the https://github.com/quarkusio/quarkus/issues/50210 is fixed, it can always happen
+        app.logs().assertContains("Could not obtain connection to query JDBC database");
+
+        // now test recovery when the offline startup is re-enabled
+        Log.info("Enabling the offline startup feature");
+        app.modifyFile(APPLICATION_PROPERTIES, props -> props.replace("quarkus.hibernate-orm.database.start-offline=false",
+                "quarkus.hibernate-orm.database.start-offline=true"));
+        Log.info("Waiting for application to get ready");
+        AwaitilityUtils
+                .untilAsserted(() -> app.given().get("/ping/start-offline").then().statusCode(200).body(is("pong: true")));
+        final String tenant = "app_scope_credentials";
+        // upload application scoped credentials
+        app.given()
+                .contentType(ContentType.JSON)
+                .pathParam("tenant", tenant)
+                .body(new DatabaseManagementResource.DatabaseCredentials(db.getUser(), db.getPassword()))
+                .post("/default-pu/database-management/{tenant}/store-app-scoped-credentials")
+                .then()
+                .statusCode(204);
+        // check that database is not available
+        app.given()
+                .pathParam("tenant", tenant)
+                .get("/ping/database/{tenant}")
+                .then().statusCode(500);
+        // by now we already asserted that prior to the disabled offline startup, this message wasn't logged
+        app.logs().assertContains(ONLINE_STARTUP_FAILED_MESSAGE);
+
+        Log.info("Starting database to test the offline startup feature");
+        db.start();
+        AwaitilityUtils.untilAsserted(() -> app.given()
+                .pathParam("tenant", tenant)
+                .get("/ping/database/{tenant}")
+                .then()
+                .statusCode(200)
+                .body(is("pong: true")));
+    }
+
+}

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/FixedPortResourceBuilder.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/FixedPortResourceBuilder.java
@@ -1,0 +1,110 @@
+package io.quarkus.ts.hibernate.startup.offline.test;
+
+import java.lang.annotation.Annotation;
+import java.util.function.Supplier;
+
+import org.apache.commons.lang3.StringUtils;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.SelinuxContext;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+
+import io.quarkus.test.bootstrap.LocalhostManagedResource;
+import io.quarkus.test.bootstrap.ManagedResource;
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.configuration.Configuration;
+import io.quarkus.test.configuration.PropertyLookup;
+import io.quarkus.test.logging.Log;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.Mount;
+import io.quarkus.test.services.containers.ContainerManagedResourceBuilder;
+import io.quarkus.test.services.containers.GenericDockerContainerManagedResource;
+import io.quarkus.test.utils.DockerUtils;
+import io.smallrye.common.os.OS;
+
+public final class FixedPortResourceBuilder extends ContainerManagedResourceBuilder {
+
+    private ServiceContext context;
+    private Mount[] mounts;
+
+    @Override
+    public ServiceContext getContext() {
+        return context;
+    }
+
+    @Override
+    public ManagedResource build(ServiceContext context) {
+        this.context = context;
+        var managedResource = new FixedPortManagedResource(this, () -> mounts);
+        if (OS.WINDOWS.isCurrent()) {
+            return new LocalhostManagedResource(managedResource);
+        }
+        return managedResource;
+    }
+
+    @Override
+    public void init(Annotation annotation) {
+        super.init(annotation);
+        Container metadata = (Container) annotation;
+        mounts = metadata.mounts();
+    }
+
+    private static final class FixedPortManagedResource extends GenericDockerContainerManagedResource {
+
+        private static final PropertyLookup DB2_IMAGE_PROPERTY = new PropertyLookup("db2.image");
+        private final FixedPortResourceBuilder model;
+        private final Supplier<Mount[]> mounts;
+
+        private FixedPortManagedResource(FixedPortResourceBuilder model, Supplier<Mount[]> mounts) {
+            super(model);
+            this.model = model;
+            this.mounts = mounts;
+        }
+
+        @Override
+        protected GenericContainer<?> initContainer() {
+            var container = new FixedPortContainer(model.getImage());
+
+            container.setFixedPort(model.getPort());
+
+            if (StringUtils.isNotBlank(model.getExpectedLog())) {
+                container.waitingFor(new LogMessageWaitStrategy().withRegEx(".*" + model.getExpectedLog() + ".*\\s"));
+            }
+
+            if (model.getCommand() != null && model.getCommand().length > 0) {
+                container.withCommand(model.getCommand());
+            }
+
+            if (isDb2Image()
+                    || model.getContext().getOwner().getConfiguration().isTrue(Configuration.Property.PRIVILEGED_MODE)) {
+                Log.info(model.getContext().getOwner(), "Running container on Privileged mode");
+                container.setPrivilegedMode(true);
+            }
+
+            container.withCreateContainerCmdModifier(cmd -> cmd.withName(DockerUtils.generateDockerContainerName()));
+
+            if (mounts.get() != null) {
+                for (var mount : mounts.get()) {
+                    Log.info(model.getContext().getOwner(), "Mounting " + mount.from() + " to " + mount.to());
+                    container.withClasspathResourceMapping(mount.from(), mount.to(), BindMode.READ_ONLY, SelinuxContext.SHARED);
+                }
+            }
+
+            return container;
+        }
+
+        private boolean isDb2Image() {
+            return DB2_IMAGE_PROPERTY.get().equals(model.getImage());
+        }
+    }
+
+    private static final class FixedPortContainer extends GenericContainer<FixedPortContainer> {
+        public FixedPortContainer(String dockerImageName) {
+            super(dockerImageName);
+        }
+
+        private void setFixedPort(int port) {
+            addFixedExposedPort(port, port);
+        }
+    }
+}

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/HibernateReactiveOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/HibernateReactiveOfflineStartupIT.java
@@ -1,0 +1,47 @@
+package io.quarkus.ts.hibernate.startup.offline.test;
+
+import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
+import static io.quarkus.ts.hibernate.startup.offline.test.AbstractHibernateOfflineStartupIT.ONLINE_STARTUP_FAILED_MESSAGE;
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.Dependency;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.hibernate.startup.offline.test.reactive.ReactiveArticle;
+import io.quarkus.ts.hibernate.startup.offline.test.reactive.ReactiveDatasourceCredentialProvider;
+import io.quarkus.ts.hibernate.startup.offline.test.reactive.ReactiveResource;
+
+@QuarkusScenario
+public class HibernateReactiveOfflineStartupIT {
+
+    @Container(image = "${postgresql.latest.image}", port = 5432, expectedLog = "listening on IPv4 address", builder = FixedPortResourceBuilder.class)
+    static final PostgresqlService db = new PostgresqlService().setAutoStart(false);
+
+    @QuarkusApplication(dependencies = {
+            @Dependency(artifactId = "quarkus-reactive-pg-client")
+    }, properties = "hibernate-reactive.properties", classes = {
+            ReactiveResource.class,
+            ReactiveArticle.class,
+            ReactiveDatasourceCredentialProvider.class
+    })
+    static final RestService app = new RestService();
+
+    @Test
+    void testOfflineStartup() {
+        app.logs().assertDoesNotContain(ONLINE_STARTUP_FAILED_MESSAGE);
+        db.start();
+        untilAsserted(() -> app.given().post("/reactive/create-table").then().statusCode(204));
+        ReactiveArticle article = new ReactiveArticle();
+        article.setId(6L);
+        article.setName("Test Article");
+        app.given().body(article).contentType(JSON).post("/reactive/article").then().statusCode(204);
+        app.given().pathParam("id", article.getId()).get("/reactive/article/{id}").then().statusCode(200).body("name",
+                is(article.getName()));
+    }
+}

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/MariaDBHibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/MariaDBHibernateOfflineStartupIT.java
@@ -1,0 +1,44 @@
+package io.quarkus.ts.hibernate.startup.offline.test;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.MariaDbService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.Dependency;
+import io.quarkus.test.services.Mount;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class MariaDBHibernateOfflineStartupIT extends AbstractHibernateOfflineStartupIT {
+
+    @Container(image = "${mariadb.11.image}", expectedLog = "socket: '.*/mysql.*sock'  port: 3306", mounts = {
+            @Mount(from = "mysql-init.sql", to = "/docker-entrypoint-initdb.d/init.sql")
+    }, port = 3306, builder = FixedPortResourceBuilder.class)
+    static final MariaDbService db = new MariaDbService().setAutoStart(false);
+
+    @QuarkusApplication(dependencies = @Dependency(artifactId = "quarkus-jdbc-mariadb"))
+    static final RestService app = new RestService()
+            .withProperty("jdbc-url", "jdbc:mariadb://localhost:3306")
+            .withProperty("quarkus.hibernate-orm.multitenant", "DATABASE")
+            .withProperty("quarkus.datasource.app_scope_credentials.jdbc.url", "${jdbc-url}/app_scope_db")
+            .withProperty("quarkus.datasource.req_scope_credentials.jdbc.url", "${jdbc-url}/req_scope_db")
+            .withProperty("quarkus.datasource.own_connection_provider.jdbc.url", "${jdbc-url}/own_conn_db");
+
+    @Test
+    void testDialectTuning() {
+        final String tenant = "req_scope_credentials";
+        app.given()
+                .pathParam("tenant", tenant)
+                .header("username", db.getUser())
+                .header("password", db.getPassword())
+                .get("/default-pu/newspapers/{tenant}/dialect/max-varchar-length")
+                .then()
+                .statusCode(200)
+                // (65,535 bytes - 2 bytes) / (3 max bytes) ~= 21844
+                .body(is("21844"));
+    }
+}

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/MySqlDBHibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/MySqlDBHibernateOfflineStartupIT.java
@@ -1,0 +1,28 @@
+package io.quarkus.ts.hibernate.startup.offline.test;
+
+import io.quarkus.test.bootstrap.MySqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.Dependency;
+import io.quarkus.test.services.Mount;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class MySqlDBHibernateOfflineStartupIT extends AbstractHibernateOfflineStartupIT {
+
+    @Container(image = "${mysql.80.image}", expectedLog = "Only MySQL server logs after this point", mounts = {
+            @Mount(from = "mysql-init.sql", to = "/tmp/init.sql"),
+            @Mount(from = "mysql-my-conf.config", to = "/etc/my.cnf.d/my.cnf")
+    }, port = 3306, builder = FixedPortResourceBuilder.class)
+    static final MySqlService db = new MySqlService().setAutoStart(false);
+
+    @QuarkusApplication(dependencies = @Dependency(artifactId = "quarkus-jdbc-mysql"))
+    static final RestService app = new RestService()
+            .withProperty("jdbc-url", "jdbc:mysql://localhost:3306")
+            .withProperty("quarkus.hibernate-orm.multitenant", "DATABASE")
+            .withProperty("quarkus.datasource.app_scope_credentials.jdbc.url", "${jdbc-url}/app_scope_db")
+            .withProperty("quarkus.datasource.req_scope_credentials.jdbc.url", "${jdbc-url}/req_scope_db")
+            .withProperty("quarkus.datasource.own_connection_provider.jdbc.url", "${jdbc-url}/own_conn_db");
+
+}

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/OpenShiftMariaDBHibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/OpenShiftMariaDBHibernateOfflineStartupIT.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.hibernate.startup.offline.test;
+
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import io.quarkus.test.bootstrap.MariaDbService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.Dependency;
+import io.quarkus.test.services.Mount;
+import io.quarkus.test.services.QuarkusApplication;
+
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
+@OpenShiftScenario
+public class OpenShiftMariaDBHibernateOfflineStartupIT extends AbstractHibernateOfflineStartupIT {
+
+    @Container(image = "${mariadb.1011.image}", expectedLog = "socket: '.*/mysql.*sock'  port: 3306", mounts = {
+            @Mount(from = "mysql-init.sql", to = "/tmp/init.sql"),
+            @Mount(from = "mysql-my-conf.config", to = "/etc/my.cnf.d/custom.cnf")
+    }, port = 3306)
+    static final MariaDbService db = new MariaDbService().setAutoStart(false);
+
+    @QuarkusApplication(dependencies = @Dependency(artifactId = "quarkus-jdbc-mariadb"))
+    static final RestService app = new RestService()
+            .withProperty("jdbc-url", "jdbc:mariadb://db:3306")
+            .withProperty("quarkus.hibernate-orm.multitenant", "DATABASE")
+            .withProperty("quarkus.datasource.app_scope_credentials.jdbc.url", "${jdbc-url}/app_scope_db")
+            .withProperty("quarkus.datasource.req_scope_credentials.jdbc.url", "${jdbc-url}/req_scope_db")
+            .withProperty("quarkus.datasource.own_connection_provider.jdbc.url", "${jdbc-url}/own_conn_db");
+
+}

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/OpenShiftMySqlDBHibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/OpenShiftMySqlDBHibernateOfflineStartupIT.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.hibernate.startup.offline.test;
+
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import io.quarkus.test.bootstrap.MySqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.Dependency;
+import io.quarkus.test.services.Mount;
+import io.quarkus.test.services.QuarkusApplication;
+
+@EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
+@OpenShiftScenario
+public class OpenShiftMySqlDBHibernateOfflineStartupIT extends AbstractHibernateOfflineStartupIT {
+
+    @Container(image = "${mysql.80.image}", expectedLog = "Only MySQL server logs after this point", mounts = {
+            @Mount(from = "mysql-init.sql", to = "/tmp/init.sql"),
+            @Mount(from = "mysql-my-conf.config", to = "/etc/my.cnf.d/custom.cnf")
+    }, port = 3306)
+    static final MySqlService db = new MySqlService().setAutoStart(false);
+
+    @QuarkusApplication(dependencies = @Dependency(artifactId = "quarkus-jdbc-mysql"))
+    static final RestService app = new RestService()
+            .withProperty("jdbc-url", "jdbc:mysql://db:3306")
+            .withProperty("quarkus.hibernate-orm.multitenant", "DATABASE")
+            .withProperty("quarkus.datasource.app_scope_credentials.jdbc.url", "${jdbc-url}/app_scope_db")
+            .withProperty("quarkus.datasource.req_scope_credentials.jdbc.url", "${jdbc-url}/req_scope_db")
+            .withProperty("quarkus.datasource.own_connection_provider.jdbc.url", "${jdbc-url}/own_conn_db");
+
+}

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/OpenShiftPostgreSqlHibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/OpenShiftPostgreSqlHibernateOfflineStartupIT.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.hibernate.startup.offline.test;
+
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.Dependency;
+import io.quarkus.test.services.QuarkusApplication;
+
+@OpenShiftScenario
+public class OpenShiftPostgreSqlHibernateOfflineStartupIT extends AbstractHibernateOfflineStartupIT {
+
+    @Container(image = "${postgresql.latest.image}", port = 5432, expectedLog = "listening on IPv4 address")
+    static final PostgresqlService db = new PostgresqlService()
+            .setAutoStart(false)
+            .withProperty("PGDATA", "/tmp/psql");
+
+    @QuarkusApplication(dependencies = @Dependency(artifactId = "quarkus-jdbc-postgresql"))
+    static final RestService app = new RestService()
+            .withProperty("jdbc-url", "jdbc:postgresql://db:5432/mydb");
+}

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/OpenTelemetryHibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/OpenTelemetryHibernateOfflineStartupIT.java
@@ -1,0 +1,67 @@
+package io.quarkus.ts.hibernate.startup.offline.test;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.JaegerService;
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.Dependency;
+import io.quarkus.test.services.JaegerContainer;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.utils.AwaitilityUtils;
+import io.restassured.response.Response;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class) // using order only to test the traces last
+@QuarkusScenario
+public class OpenTelemetryHibernateOfflineStartupIT extends AbstractHibernateOfflineStartupIT {
+
+    @JaegerContainer(expectedLog = "\"Health Check state change\",\"status\":\"ready\"")
+    static final JaegerService jaeger = new JaegerService();
+
+    @Container(image = "${postgresql.latest.image}", port = 5432, expectedLog = "listening on IPv4 address", builder = FixedPortResourceBuilder.class)
+    static final PostgresqlService db = new PostgresqlService().setAutoStart(false);
+
+    @QuarkusApplication(dependencies = {
+            @Dependency(artifactId = "quarkus-jdbc-postgresql"),
+            @Dependency(artifactId = "quarkus-opentelemetry")
+    })
+    static final RestService app = new RestService()
+            .withProperty("quarkus.application.name", "app")
+            .withProperty("quarkus.datasource.app_scope_credentials.jdbc.telemetry", "true")
+            .withProperty("quarkus.datasource.req_scope_credentials.jdbc.telemetry", "true")
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
+            .withProperty("jdbc-url", "jdbc:postgresql://localhost:5432/mydb");
+
+    @Order(Integer.MAX_VALUE) // run last so that JDBC traces produced by other test methods are ready
+    @Test
+    void testJdbcTraces() {
+        AwaitilityUtils.untilAsserted(() -> {
+            var response = thenRetrieveTraces();
+            var operationNames = response.jsonPath().getList("data.spans.operationName.flatten()", String.class);
+            assertThat(operationNames).contains("SELECT mydb.Article").contains("INSERT mydb.Article");
+            var tagValues = response.jsonPath().getList("data.flatten().spans.flatten().tags.flatten().value");
+            assertThat(tagValues)
+                    .contains("create schema req_scope_credentials")
+                    .contains("create schema app_scope_credentials");
+        });
+    }
+
+    private static Response thenRetrieveTraces() {
+        return given().when()
+                .queryParam("lookback", "1h")
+                .queryParam("limit", 10000)
+                .queryParam("service", "app")
+                .get(jaeger.getTraceUrl())
+                .then().statusCode(200)
+                .extract().response();
+    }
+
+}

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/OracleHibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/OracleHibernateOfflineStartupIT.java
@@ -1,0 +1,29 @@
+package io.quarkus.ts.hibernate.startup.offline.test;
+
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+import io.quarkus.test.bootstrap.OracleService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.Dependency;
+import io.quarkus.test.services.QuarkusApplication;
+
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2022")
+@QuarkusScenario
+public class OracleHibernateOfflineStartupIT extends AbstractHibernateOfflineStartupIT {
+
+    @Container(image = "${oracle.image}", port = 1521, expectedLog = "DATABASE IS READY TO USE!", builder = FixedPortResourceBuilder.class)
+    static final OracleService db = new OracleService().withDatabase("APP_SCOPE_DB,REQ_SCOPE_DB,OWN_CONN_DB")
+            .setAutoStart(false);
+
+    @QuarkusApplication(dependencies = @Dependency(artifactId = "quarkus-jdbc-oracle"))
+    static final RestService app = new RestService()
+            .withProperty("jdbc-url", "jdbc:oracle:thin:@localhost:1521")
+            .withProperty("fixed-default-schema", db.getUser().toUpperCase())
+            .withProperty("quarkus.hibernate-orm.multitenant", "DATABASE")
+            .withProperty("quarkus.datasource.app_scope_credentials.jdbc.url", "${jdbc-url}/APP_SCOPE_DB")
+            .withProperty("quarkus.datasource.req_scope_credentials.jdbc.url", "${jdbc-url}/REQ_SCOPE_DB")
+            .withProperty("quarkus.datasource.own_connection_provider.jdbc.url", "${jdbc-url}/OWN_CONN_DB");
+
+}

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/SqlServerHibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/SqlServerHibernateOfflineStartupIT.java
@@ -1,0 +1,63 @@
+package io.quarkus.ts.hibernate.startup.offline.test;
+
+import static io.quarkus.test.services.containers.DockerContainerManagedResource.DOCKER_INNER_CONTAINER;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.testcontainers.containers.GenericContainer;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.bootstrap.SqlServerService;
+import io.quarkus.test.logging.Log;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.Dependency;
+import io.quarkus.test.services.QuarkusApplication;
+
+@Tag("fips-incompatible") // MSSQL works with BC JSSE FIPS which is not native-compatible, we test FIPS elsewhere
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2017")
+@QuarkusScenario
+public class SqlServerHibernateOfflineStartupIT extends AbstractHibernateOfflineStartupIT {
+
+    private static final String JDBC_URL = "jdbc:sqlserver://localhost:1433;databaseName=%s;encrypt=false;";
+
+    @Container(image = "${mssql.image}", port = 1433, expectedLog = "Service Broker manager has started", builder = FixedPortResourceBuilder.class)
+    static final SqlServerService db = new SqlServerService().setAutoStart(false).onPostStart(service -> {
+        SqlServerService self = (SqlServerService) service;
+        String[] commands = {
+                "CREATE DATABASE app_scope_credentials_db",
+                "CREATE DATABASE req_scope_credentials_db",
+                "CREATE DATABASE own_connection_provider_db"
+        };
+        for (String command : commands) {
+            try {
+                var result = self
+                        .<GenericContainer<?>> getPropertyFromContext(DOCKER_INNER_CONTAINER)
+                        .execInContainer(
+                                "/opt/mssql-tools18/bin/sqlcmd", "-C", "-S", "localhost", "-U", self.getUser(),
+                                "-P", self.getPassword(), "-Q", command);
+                Log.debug(self, "Command execution result is: %s", result);
+                if (result.getStderr() != null && !result.getStderr().isBlank()) {
+                    Log.error("Failed to execute command: " + result.getStderr());
+                }
+            } catch (IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    });
+
+    @QuarkusApplication(dependencies = @Dependency(artifactId = "quarkus-jdbc-mssql"))
+    static final RestService app = new RestService()
+            .withProperty("quarkus.hibernate-orm.multitenant", "DATABASE")
+            .withProperty("fixed-default-schema", "dbo")
+            .withProperty("quarkus.datasource.app_scope_credentials.jdbc.url", getJdbcUrl("app_scope_credentials_db"))
+            .withProperty("quarkus.datasource.req_scope_credentials.jdbc.url", getJdbcUrl("req_scope_credentials_db"))
+            .withProperty("quarkus.datasource.own_connection_provider.jdbc.url", getJdbcUrl("own_connection_provider_db"));
+
+    private static String getJdbcUrl(String dbName) {
+        return JDBC_URL.formatted(dbName);
+    }
+}

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/reactive/ReactiveArticle.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/reactive/ReactiveArticle.java
@@ -1,0 +1,34 @@
+package io.quarkus.ts.hibernate.startup.offline.test.reactive;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Table(name = "article")
+@Entity
+public class ReactiveArticle {
+
+    private Long id;
+
+    private String name;
+
+    public ReactiveArticle() {
+    }
+
+    @Id
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/reactive/ReactiveDatasourceCredentialProvider.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/reactive/ReactiveDatasourceCredentialProvider.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.hibernate.startup.offline.test.reactive;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.Dependent;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.credentials.CredentialsProvider;
+
+@Dependent
+public class ReactiveDatasourceCredentialProvider implements CredentialsProvider {
+
+    private final Map<String, String> credentials;
+
+    ReactiveDatasourceCredentialProvider(@ConfigProperty(name = "db.username") String username,
+            @ConfigProperty(name = "db.password") String password) {
+        credentials = Map.of(
+                CredentialsProvider.USER_PROPERTY_NAME, username,
+                CredentialsProvider.PASSWORD_PROPERTY_NAME, password);
+    }
+
+    @Override
+    public Map<String, String> getCredentials(String credentialsProviderName) {
+        return credentials;
+    }
+}

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/reactive/ReactiveResource.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/reactive/ReactiveResource.java
@@ -1,0 +1,46 @@
+package io.quarkus.ts.hibernate.startup.offline.test.reactive;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("reactive")
+public class ReactiveResource {
+
+    private final Mutiny.SessionFactory sessionFactory;
+
+    ReactiveResource(Mutiny.SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+
+    @Path("create-table")
+    @POST
+    public Uni<Void> createTable() {
+        return sessionFactory.withSession(session -> session
+                .createNativeQuery("CREATE TABLE article(id BIGSERIAL PRIMARY KEY, name VARCHAR(250))")
+                .executeUpdate())
+                .replaceWithVoid();
+    }
+
+    @Path("/article")
+    @POST
+    public Uni<Void> createArticle(ReactiveArticle article) {
+        return sessionFactory.withTransaction(session -> session.persist(article));
+    }
+
+    @Produces(APPLICATION_JSON)
+    @Path("/article/{id}")
+    @GET
+    public Uni<ReactiveArticle> getArticleById(@PathParam("id") Long id) {
+        return sessionFactory.withStatelessSession(statelessSession -> statelessSession.get(ReactiveArticle.class, id));
+    }
+
+}

--- a/hibernate/hibernate-offline-startup/src/test/resources/hibernate-reactive.properties
+++ b/hibernate/hibernate-offline-startup/src/test/resources/hibernate-reactive.properties
@@ -1,0 +1,6 @@
+quarkus.datasource.reactive.url=postgresql://localhost:5432/mydb
+quarkus.datasource.jdbc=false
+quarkus.datasource.credentials-provider=reactive_ds_provider
+quarkus.hibernate-orm.database.start-offline=true
+db.username=user
+db.password=user

--- a/hibernate/hibernate-offline-startup/src/test/resources/mysql-init.sql
+++ b/hibernate/hibernate-offline-startup/src/test/resources/mysql-init.sql
@@ -1,0 +1,6 @@
+CREATE DATABASE IF NOT EXISTS app_scope_db;
+CREATE DATABASE IF NOT EXISTS req_scope_db;
+CREATE DATABASE IF NOT EXISTS own_conn_db;
+GRANT ALL PRIVILEGES ON app_scope_db.* TO 'user'@'%';
+GRANT ALL PRIVILEGES ON req_scope_db.* TO 'user'@'%';
+GRANT ALL PRIVILEGES ON own_conn_db.* TO 'user'@'%';

--- a/hibernate/hibernate-offline-startup/src/test/resources/mysql-my-conf.config
+++ b/hibernate/hibernate-offline-startup/src/test/resources/mysql-my-conf.config
@@ -1,0 +1,2 @@
+[mysqld]
+init-file=/tmp/init.sql

--- a/hibernate/hibernate-orm/pom.xml
+++ b/hibernate/hibernate-orm/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/hibernate/hibernate-orm/src/main/java/io/quarkus/qe/hibernate/interceptor/SessionEventInterceptor.java
+++ b/hibernate/hibernate-orm/src/main/java/io/quarkus/qe/hibernate/interceptor/SessionEventInterceptor.java
@@ -1,0 +1,38 @@
+package io.quarkus.qe.hibernate.interceptor;
+
+import org.hibernate.Interceptor;
+import org.hibernate.type.Type;
+
+import io.quarkus.hibernate.orm.PersistenceUnitExtension;
+import io.quarkus.qe.hibernate.items.MyEntity;
+
+@PersistenceUnitExtension("named")
+public class SessionEventInterceptor implements Interceptor {
+
+    private volatile MyEntity entity = null;
+    private volatile String changedPropertyName = null;
+    private volatile String originalState = null;
+    private volatile String targetState = null;
+
+    public record MergeData(MyEntity entity, String changedPropertyName, String originalState, String targetState) {
+    }
+
+    @Override
+    public void postMerge(Object source, Object target, Object id, Object[] targetState, Object[] originalState,
+            String[] propertyNames, Type[] propertyTypes) {
+        this.targetState = (String) targetState[0];
+        this.originalState = (String) originalState[0];
+        Interceptor.super.postMerge(source, target, id, targetState, originalState, propertyNames, propertyTypes);
+    }
+
+    @Override
+    public void preMerge(Object entity, Object[] state, String[] propertyNames, Type[] propertyTypes) {
+        this.entity = (MyEntity) entity;
+        this.changedPropertyName = propertyNames[0];
+        Interceptor.super.preMerge(entity, state, propertyNames, propertyTypes);
+    }
+
+    public MergeData getMergeData() {
+        return new MergeData(entity, changedPropertyName, originalState, targetState);
+    }
+}

--- a/hibernate/hibernate-reactive/src/main/java/io/quarkus/ts/hibernate/reactive/database/XmlValidatedCustomer.java
+++ b/hibernate/hibernate-reactive/src/main/java/io/quarkus/ts/hibernate/reactive/database/XmlValidatedCustomer.java
@@ -1,0 +1,24 @@
+package io.quarkus.ts.hibernate.reactive.database;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class XmlValidatedCustomer {
+
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    public String name;
+    public String email;
+
+    public XmlValidatedCustomer() {
+    }
+
+    public XmlValidatedCustomer(String name, String email) {
+        this.name = name;
+        this.email = email;
+    }
+}

--- a/hibernate/hibernate-reactive/src/main/resources/META-INF/validation.xml
+++ b/hibernate/hibernate-reactive/src/main/resources/META-INF/validation.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration https://jakarta.ee/xml/ns/validation/validation-configuration-3.1.xsd" version="3.1">
+    <constraint-mapping>META-INF/validation/constraints-customer.xml</constraint-mapping>
+</validation-config>

--- a/hibernate/hibernate-reactive/src/main/resources/META-INF/validation/constraints-customer.xml
+++ b/hibernate/hibernate-reactive/src/main/resources/META-INF/validation/constraints-customer.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<constraint-mappings xmlns="https://jakarta.ee/xml/ns/validation/mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping https://jakarta.ee/xml/ns/validation/validation-mapping-3.1.xsd" version="3.1">
+    <bean class="io.quarkus.ts.hibernate.reactive.database.XmlValidatedCustomer">
+        <field name="name">
+            <constraint annotation="jakarta.validation.constraints.NotNull"/>
+            <constraint annotation="jakarta.validation.constraints.Size">
+                <element name="min">3</element>
+                <element name="max">50</element>
+            </constraint>
+        </field>
+        <field name="email">
+            <constraint annotation="jakarta.validation.constraints.Email"/>
+        </field>
+    </bean>
+</constraint-mappings>

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/AbstractHibernateValidatorIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/AbstractHibernateValidatorIT.java
@@ -47,5 +47,34 @@ public abstract class AbstractHibernateValidatorIT {
                 .body("correctMaxLength", equalTo(true));
     }
 
+    @Tag("QUARKUS-6262")
+    @Test
+    public void validationXmlInvalidCustomerEmail() {
+        getApp().given()
+                .when().put("/validation/xml/customer/Vick/not-an-email")
+                .then()
+                .statusCode(SC_BAD_REQUEST)
+                .body(containsString("XML constraint violation"));
+    }
+
+    @Tag("QUARKUS-6262")
+    @Test
+    public void validationXmlInvalidCustomerName() {
+        getApp().given()
+                .when().put("/validation/xml/customer/No/customer@example.com")
+                .then()
+                .statusCode(SC_BAD_REQUEST)
+                .body(containsString("XML constraint violation"));
+    }
+
+    @Tag("QUARKUS-6262")
+    @Test
+    public void validationXmlValidCustomer() {
+        getApp().given()
+                .when().put("/validation/xml/customer/Bjorn/brojn@example.com")
+                .then()
+                .statusCode(SC_CREATED);
+    }
+
     protected abstract RestService getApp();
 }

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MultiDatabaseHibernateReactiveIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MultiDatabaseHibernateReactiveIT.java
@@ -18,6 +18,7 @@ import io.quarkus.ts.hibernate.reactive.database.AuthorRepository;
 import io.quarkus.ts.hibernate.reactive.database.Book;
 import io.quarkus.ts.hibernate.reactive.database.ISBNConverter;
 import io.quarkus.ts.hibernate.reactive.database.PersonEntity;
+import io.quarkus.ts.hibernate.reactive.database.XmlValidatedCustomer;
 import io.quarkus.ts.hibernate.reactive.http.ApplicationExceptionMapper;
 import io.quarkus.ts.hibernate.reactive.http.BookDescription;
 import io.quarkus.ts.hibernate.reactive.http.GroundedEndpoint;
@@ -65,7 +66,7 @@ public class MultiDatabaseHibernateReactiveIT extends AbstractDatabaseHibernateR
             // also include default classes
             Author.class, AuthorIdGenerator.class, AuthorRepository.class, Book.class, ISBNConverter.class, PersonEntity.class,
             ApplicationExceptionMapper.class, BookDescription.class, GroundedEndpoint.class, OtherResource.class,
-            PanacheEndpoint.class, SomeApi.class, ValidationResource.class
+            PanacheEndpoint.class, SomeApi.class, ValidationResource.class, XmlValidatedCustomer.class
     })
     static RestService app = new RestService()
             .withProperty("main.url", postgresql1::getReactiveUrl)

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MultiDatabaseHibernateReactiveIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MultiDatabaseHibernateReactiveIT.java
@@ -1,0 +1,112 @@
+package io.quarkus.ts.hibernate.reactive;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.MySqlService;
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.hibernate.reactive.database.Author;
+import io.quarkus.ts.hibernate.reactive.database.AuthorIdGenerator;
+import io.quarkus.ts.hibernate.reactive.database.AuthorRepository;
+import io.quarkus.ts.hibernate.reactive.database.Book;
+import io.quarkus.ts.hibernate.reactive.database.ISBNConverter;
+import io.quarkus.ts.hibernate.reactive.database.PersonEntity;
+import io.quarkus.ts.hibernate.reactive.http.ApplicationExceptionMapper;
+import io.quarkus.ts.hibernate.reactive.http.BookDescription;
+import io.quarkus.ts.hibernate.reactive.http.GroundedEndpoint;
+import io.quarkus.ts.hibernate.reactive.http.OtherResource;
+import io.quarkus.ts.hibernate.reactive.http.PanacheEndpoint;
+import io.quarkus.ts.hibernate.reactive.http.SomeApi;
+import io.quarkus.ts.hibernate.reactive.http.ValidationResource;
+import io.quarkus.ts.hibernate.reactive.multidbSources.CarResource;
+import io.quarkus.ts.hibernate.reactive.multidbSources.FruitResource;
+import io.quarkus.ts.hibernate.reactive.multidbSources.secondDatabase.Fruit;
+import io.quarkus.ts.hibernate.reactive.multidbSources.thirdDatabase.Car;
+import io.restassured.http.ContentType;
+
+@Tag("QUARKUS-6259")
+@QuarkusScenario
+public class MultiDatabaseHibernateReactiveIT extends AbstractDatabaseHibernateReactiveIT {
+    private static final String SQL_USER = "quarkus_test";
+    private static final String SQL_PASSWORD = "quarkus_test";
+    private static final String SQL_DATABASE = "quarkus_test";
+    private static final int POSTGRES_PORT = 5432;
+    private static final int MYSQL_PORT = 3306;
+
+    @Container(image = "${postgresql.latest.image}", port = POSTGRES_PORT, expectedLog = "listening on IPv4 address")
+    static PostgresqlService postgresql1 = new PostgresqlService()
+            .withUser(SQL_USER)
+            .withPassword(SQL_PASSWORD)
+            .withDatabase(SQL_DATABASE)
+            .withProperty("PGDATA", "/tmp/psql");
+
+    @Container(image = "${postgresql.latest.image}", port = POSTGRES_PORT, expectedLog = "listening on IPv4 address")
+    static PostgresqlService postgresql2 = new PostgresqlService()
+            .withUser(SQL_USER)
+            .withPassword(SQL_PASSWORD)
+            .withDatabase(SQL_DATABASE)
+            .withProperty("PGDATA", "/tmp/psql");
+
+    @Container(image = "${mysql.80.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
+    static MySqlService mysql = new MySqlService()
+            .withUser(SQL_USER)
+            .withPassword(SQL_PASSWORD)
+            .withDatabase(SQL_DATABASE);
+
+    @QuarkusApplication(properties = "multidb.properties", classes = { Fruit.class, FruitResource.class, Car.class,
+            CarResource.class,
+            // also include default classes
+            Author.class, AuthorIdGenerator.class, AuthorRepository.class, Book.class, ISBNConverter.class, PersonEntity.class,
+            ApplicationExceptionMapper.class, BookDescription.class, GroundedEndpoint.class, OtherResource.class,
+            PanacheEndpoint.class, SomeApi.class, ValidationResource.class
+    })
+    static RestService app = new RestService()
+            .withProperty("main.url", postgresql1::getReactiveUrl)
+            .withProperty("fruits.url", postgresql2::getReactiveUrl)
+            .withProperty("cars.url", mysql::getReactiveUrl)
+            .withProperty("db.username", SQL_USER)
+            .withProperty("db.password", SQL_PASSWORD);
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+
+    @Test
+    public void getFruits() {
+        /*
+         * Fruits are stored in different persistence-unit that is filled by different import script.
+         * Test that pre-created fruits (imported via SQL script) are in the DB.
+         * Which verifies that the different PU works.
+         */
+        String result = getApp().given().contentType(ContentType.JSON)
+                .get("fruit/getAll")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().body().asString();
+        assertTrue(result.contains("Banana"), "Should return fruit that is pre-created in the database, but was: " + result);
+    }
+
+    @Test
+    public void getCars() {
+        /*
+         * Cars are stored in different persistence-unit that is filled by different import script.
+         * Test that pre-created cars (imported via SQL script) are in the DB.
+         * Which verifies that the different PU works.
+         */
+        String result = getApp().given().contentType(ContentType.JSON)
+                .get("car/getAll")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().body().asString();
+
+        assertTrue(result.contains("Audi"), "Should return car that is pre-created in the database, but was: " + result);
+    }
+}

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MySQLHibernateValidatorDisabledIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MySQLHibernateValidatorDisabledIT.java
@@ -57,6 +57,33 @@ public class MySQLHibernateValidatorDisabledIT {
         assertEquals("Column allows NULL values", responseBody);
     }
 
+    @Tag("QUARKUS-6262")
+    @Test
+    public void validationXmlAcceptInvalidCustomerEmail() {
+        getApp().given()
+                .when().put("/validation/xml/customer/Vick/not-an-email")
+                .then()
+                .statusCode(SC_CREATED);
+    }
+
+    @Tag("QUARKUS-6262")
+    @Test
+    public void validationXmlAcceptInvalidCustomerName() {
+        getApp().given()
+                .when().put("/validation/xml/customer/No/customer@example.com")
+                .then()
+                .statusCode(SC_CREATED);
+    }
+
+    @Tag("QUARKUS-6262")
+    @Test
+    public void validationXmlValidCustomer() {
+        getApp().given()
+                .when().put("/validation/xml/customer/Bjorn/brojn@example.com")
+                .then()
+                .statusCode(SC_CREATED);
+    }
+
     public RestService getApp() {
         return app;
     }

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/OracleHibernateValidatorDdlModeIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/OracleHibernateValidatorDdlModeIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.hibernate.reactive;
 
+import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 
 import org.junit.jupiter.api.Tag;
@@ -41,6 +42,24 @@ public class OracleHibernateValidatorDdlModeIT extends AbstractHibernateValidato
         getApp().given().put("/validation/person/InvalidNameWithMoreThanThirtyChars").then()
                 // DDL mode applies constraints to table, but error is thrown on Oracle side, not Hibernate
                 .statusCode(SC_INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    @Override
+    public void validationXmlInvalidCustomerEmail() {
+        getApp().given()
+                .when().put("/validation/xml/customer/Al/not-an-email")
+                .then()
+                .statusCode(SC_CREATED);
+    }
+
+    @Test
+    @Override
+    public void validationXmlInvalidCustomerName() {
+        getApp().given()
+                .when().put("/validation/xml/customer/No/customer@example.com")
+                .then()
+                .statusCode(SC_CREATED);
     }
 
     public RestService getApp() {

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/CarResource.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/CarResource.java
@@ -1,0 +1,32 @@
+package io.quarkus.ts.hibernate.reactive.multidbSources;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.ts.hibernate.reactive.multidbSources.thirdDatabase.Car;
+import io.smallrye.mutiny.Uni;
+
+@Path("/car")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class CarResource {
+    @Inject
+    @PersistenceUnit("cars")
+    Mutiny.SessionFactory factory;
+
+    @GET
+    @Path("getAll")
+    public Uni<Response> getAll() {
+        return factory.withSession(session -> session.createNativeQuery("Select * from cars", Car.class)
+                .getResultList()
+                .map(cars -> Response.ok(cars).build()));
+    }
+}

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/FruitResource.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/FruitResource.java
@@ -1,0 +1,32 @@
+package io.quarkus.ts.hibernate.reactive.multidbSources;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.ts.hibernate.reactive.multidbSources.secondDatabase.Fruit;
+import io.smallrye.mutiny.Uni;
+
+@Path("/fruit")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class FruitResource {
+    @Inject
+    @PersistenceUnit("fruits")
+    Mutiny.SessionFactory factory;
+
+    @GET
+    @Path("getAll")
+    public Uni<Response> getAll() {
+        return factory.withSession(session -> session.createNativeQuery("Select * from fruits", Fruit.class)
+                .getResultList()
+                .map(fruits -> Response.ok(fruits).build()));
+    }
+}

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/secondDatabase/Fruit.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/secondDatabase/Fruit.java
@@ -1,0 +1,48 @@
+package io.quarkus.ts.hibernate.reactive.multidbSources.secondDatabase;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Entity
+@Table(name = "fruits")
+/*
+ * This class is for testing multi-database (named datasources and persistence units) tests.
+ * For that, it is required that this entity is in separate package and is not linked to another entity in different PU.
+ */
+public class Fruit {
+    private static final int MAX_NAME_LENGTH = 30;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", unique = true, nullable = false)
+    private Integer id;
+
+    @NotNull
+    @Size(max = MAX_NAME_LENGTH)
+    private String name;
+
+    public Fruit() {
+    }
+
+    public Fruit(String name) {
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public @NotNull @Size(max = MAX_NAME_LENGTH) String getName() {
+        return name;
+    }
+
+    public void setName(@NotNull @Size(max = MAX_NAME_LENGTH) String name) {
+        this.name = name;
+    }
+}

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/thirdDatabase/Car.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/multidbSources/thirdDatabase/Car.java
@@ -1,0 +1,48 @@
+package io.quarkus.ts.hibernate.reactive.multidbSources.thirdDatabase;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Entity
+@Table(name = "cars")
+/*
+ * This class is for testing multi-database (named datasources and persistence units) tests.
+ * For that, it is required that this entity is in separate package and is not linked to another entity in different PU.
+ */
+public class Car {
+    private static final int MAX_NAME_LENGTH = 30;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", unique = true, nullable = false)
+    private Integer id;
+
+    @NotNull
+    @Size(max = MAX_NAME_LENGTH)
+    private String name;
+
+    public Car() {
+    }
+
+    public Car(String name) {
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public @NotNull @Size(max = MAX_NAME_LENGTH) String getName() {
+        return name;
+    }
+
+    public void setName(@NotNull @Size(max = MAX_NAME_LENGTH) String name) {
+        this.name = name;
+    }
+}

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftMultiDatabaseHibernateReactiveIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftMultiDatabaseHibernateReactiveIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.ts.hibernate.reactive.openshift;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.ts.hibernate.reactive.MultiDatabaseHibernateReactiveIT;
+
+@OpenShiftScenario
+public class OpenShiftMultiDatabaseHibernateReactiveIT extends MultiDatabaseHibernateReactiveIT {
+
+}

--- a/hibernate/hibernate-reactive/src/test/resources/multidb.properties
+++ b/hibernate/hibernate-reactive/src/test/resources/multidb.properties
@@ -1,0 +1,44 @@
+# HttpClient config
+io.quarkus.ts.hibernate.reactive.http.SomeApi/mp-rest/url=http://localhost:${quarkus.http.port}
+
+# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
+quarkus.native.monitoring=none
+
+# for whatever reason quarkus requires to have "db-kind" defined for default datasource even though we are not using default datasource
+quarkus.datasource.db-kind=postgresql
+
+# define datasources
+quarkus.datasource."main".reactive.url=${main.url}
+quarkus.datasource."main".db-kind=postgresql
+quarkus.datasource."main".username=${db.username}
+quarkus.datasource."main".password=${db.password}
+
+quarkus.datasource."fruits".reactive=true
+quarkus.datasource."fruits".reactive.url=${fruits.url}
+quarkus.datasource."fruits".db-kind=postgresql
+quarkus.datasource."fruits".username=${db.username}
+quarkus.datasource."fruits".password=${db.password}
+
+quarkus.datasource."cars".reactive=true
+quarkus.datasource."cars".reactive.url=${cars.url}
+quarkus.datasource."cars".db-kind=mysql
+quarkus.datasource."cars".username=${db.username}
+quarkus.datasource."cars".password=${db.password}
+
+# define persistence units
+quarkus.hibernate-orm."cars".datasource=cars
+quarkus.hibernate-orm."cars".packages=io.quarkus.ts.hibernate.reactive.multidbSources.thirdDatabase
+quarkus.hibernate-orm."cars".schema-management.strategy=drop-and-create
+quarkus.hibernate-orm."cars".sql-load-script=multidb_mysql_car_import.sql
+
+quarkus.hibernate-orm."fruits".datasource=fruits
+quarkus.hibernate-orm."fruits".packages=io.quarkus.ts.hibernate.reactive.multidbSources.secondDatabase
+quarkus.hibernate-orm."fruits".schema-management.strategy=drop-and-create
+quarkus.hibernate-orm."fruits".sql-load-script=multidb_postgres_fruit_import.sql
+
+# define default persistence unit
+quarkus.hibernate-orm.datasource=main
+quarkus.hibernate-orm.packages=io.quarkus.ts.hibernate.reactive.database
+quarkus.hibernate-orm.sql-load-script=multidb_postgres_main_import.sql
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+quarkus.hibernate-orm.database.charset=utf-8

--- a/hibernate/hibernate-reactive/src/test/resources/multidb_mysql_car_import.sql
+++ b/hibernate/hibernate-reactive/src/test/resources/multidb_mysql_car_import.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS cars;
+CREATE TABLE cars (id INT NOT NULL AUTO_INCREMENT, name VARCHAR(31) NOT NULL, PRIMARY KEY(id));
+INSERT INTO cars(id,name) VALUES (1, 'BMW');
+INSERT INTO cars(id,name) VALUES (2, 'Audi');
+INSERT INTO cars(id,name) VALUES (3, 'Volkswagen');
+INSERT INTO cars(id,name) VALUES (4, 'Kia');

--- a/hibernate/hibernate-reactive/src/test/resources/multidb_postgres_fruit_import.sql
+++ b/hibernate/hibernate-reactive/src/test/resources/multidb_postgres_fruit_import.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS fruits;
+CREATE TABLE fruits(id SERIAL PRIMARY KEY, name TEXT NOT NULL);
+INSERT INTO fruits(id,name) VALUES (1, 'Apple');
+INSERT INTO fruits(id,name) VALUES (2, 'Banana');
+INSERT INTO fruits(id,name) VALUES (3, 'Orange');

--- a/hibernate/hibernate-reactive/src/test/resources/multidb_postgres_main_import.sql
+++ b/hibernate/hibernate-reactive/src/test/resources/multidb_postgres_main_import.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS authors CASCADE;
+CREATE TABLE authors(id SERIAL PRIMARY KEY, name TEXT NOT NULL);
+INSERT INTO authors(id,name) VALUES (1, 'Homer');
+INSERT INTO authors(id,name) VALUES (2, 'Vern');
+INSERT INTO authors(id,name) VALUES (3, 'Dlugi');
+INSERT INTO authors(id,name) VALUES (4, 'Kahneman');
+DROP TABLE IF EXISTS books CASCADE;
+CREATE TABLE books(id SERIAL PRIMARY KEY, author int references authors(id) , title TEXT NOT NULL, isbn TEXT NULL);
+INSERT INTO books(author, title) VALUES (3, 'Slovník');
+INSERT INTO books(author, title, isbn) VALUES (4, 'Thinking fast and slow', '978-0374275631');
+INSERT INTO books(author, title) VALUES (4, 'Attention and Effort');

--- a/hibernate/hibernate-reactive/src/test/resources/test.properties
+++ b/hibernate/hibernate-reactive/src/test/resources/test.properties
@@ -1,1 +1,5 @@
 ts.database.openshift.use-internal-service-as-url=true
+
+ts.postgresql1.openshift.use-internal-service-as-url=true
+ts.postgresql2.openshift.use-internal-service-as-url=true
+ts.mysql.openshift.use-internal-service-as-url=true

--- a/http/rest-client-reactive/pom.xml
+++ b/http/rest-client-reactive/pom.xml
@@ -28,6 +28,10 @@
             <artifactId>quarkus-jaxb</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/validation/UserProcessingService.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/validation/UserProcessingService.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.http.restclient.reactive.validation;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.groups.ConvertGroup;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+public interface UserProcessingService {
+
+    @POST
+    @Consumes(value = MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ValidatedUser process(
+            @Valid @ConvertGroup(to = ValidatedUser.ConvertedGroup.class) @NotNull ValidatedUser entity);
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/validation/UserProcessingServiceBean.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/validation/UserProcessingServiceBean.java
@@ -1,0 +1,12 @@
+package io.quarkus.ts.http.restclient.reactive.validation;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class UserProcessingServiceBean implements UserProcessingService {
+
+    @Override
+    public ValidatedUser process(ValidatedUser entity) {
+        return entity;
+    }
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/validation/UserValidationResource.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/validation/UserValidationResource.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.http.restclient.reactive.validation;
+
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/validator-check")
+public class UserValidationResource {
+
+    @Inject
+    UserProcessingServiceBean service;
+
+    @POST
+    @Consumes(value = MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public ValidatedUser check(@Valid ValidatedUser entity) {
+        return service.process(entity);
+    }
+}

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/validation/ValidatedUser.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/validation/ValidatedUser.java
@@ -1,0 +1,19 @@
+package io.quarkus.ts.http.restclient.reactive.validation;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import jakarta.validation.groups.Default;
+
+public class ValidatedUser {
+
+    @Size(min = 3, max = 20, groups = Default.class)
+    @NotNull(groups = ConvertedGroup.class)
+    public String username;
+
+    public ValidatedUser(String value) {
+        this.username = value;
+    }
+
+    public interface ConvertedGroup {
+    }
+}

--- a/http/rest-client-reactive/src/main/resources/application.properties
+++ b/http/rest-client-reactive/src/main/resources/application.properties
@@ -14,3 +14,5 @@ client.endpoint/mp-rest/url=http://unknown-domain:8080
 
 quarkus.otel.enabled=false
 quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true
+
+quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.validation.UserProcessingService".url=http://localhost:${quarkus.http.port}

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/UserProcessingValidationIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/UserProcessingValidationIT.java
@@ -1,0 +1,41 @@
+package io.quarkus.ts.http.restclient.reactive;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.http.restclient.reactive.validation.ValidatedUser;
+import io.restassured.http.ContentType;
+
+@QuarkusScenario
+@Tag("QUARKUS-6262")
+public class UserProcessingValidationIT {
+
+    @QuarkusApplication
+    static RestService app = new RestService();
+
+    @Test
+    public void shouldFailOnInvalidUser() {
+        app.given()
+                .contentType(ContentType.JSON)
+                .body(new ValidatedUser(null))
+                .when().post("/validator-check")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void shouldAcceptValidUser() {
+        app.given()
+                .contentType(ContentType.JSON)
+                .body(new ValidatedUser("alice"))
+                .when().post("/validator-check")
+                .then()
+                .statusCode(200)
+                .body("username", equalTo("alice"));
+    }
+}

--- a/monitoring/micrometer-opentelemetry/src/test/java/io/quarkus/ts/monitoring/micrometeropentelemetry/test/DevModeOtelCapabilitiesIT.java
+++ b/monitoring/micrometer-opentelemetry/src/test/java/io/quarkus/ts/monitoring/micrometeropentelemetry/test/DevModeOtelCapabilitiesIT.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.monitoring.micrometeropentelemetry.test;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.ts.monitoring.micrometeropentelemetry.rest.LoggingResource;
+
+@Tag("https://github.com/quarkusio/quarkus/pull/47458")
+@QuarkusScenario
+public class DevModeOtelCapabilitiesIT {
+    @DevModeQuarkusApplication(classes = LoggingResource.class)
+    static final RestService app = new RestService()
+            .withProperty("quarkus.otel.traces.enabled", "false")
+            .withProperty("quarkus.otel.metrics.enabled", "true")
+            .withProperty("quarkus.otel.logs.enabled", "true");
+
+    @Test
+    void testShouldNotContainFailedToExport() {
+        app.given().get("/logging").then().statusCode(200);
+        app.logs().assertDoesNotContain(" Failed to export LogsRequestMarshalers.");
+        app.logs().assertDoesNotContain(" Failed to export MetricsRequestMarshalers.");
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
                                 <amqbroker.1.0x.image>quay.io/artemiscloud/activemq-artemis-broker:1.0.32</amqbroker.1.0x.image>
                                 <redpanda.image>redpandadata/redpanda:v25.2.2</redpanda.image>
                                 <postgresql.latest.image>${postgresql.latest.image}</postgresql.latest.image>
-                                <elastic.9x.image>docker.io/library/elasticsearch:9.1.2</elastic.9x.image>
+                                <elastic.9x.image>docker.io/library/elasticsearch:9.1.4</elastic.9x.image>
                                 <mysql.upstream.80.image>docker.io/library/mysql:8.4</mysql.upstream.80.image>
                                 <mysql.80.image>${mysql.80.image}</mysql.80.image>
                                 <mariadb.11.image>docker.io/library/mariadb:11.8</mariadb.11.image>

--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
                                 <redis.image>docker.io/library/redis:8</redis.image>
                                 <wiremock.image>docker.io/wiremock/wiremock:3x</wiremock.image>
                                 <!-- TODO use official image when/if this fixed https://github.com/hashicorp/consul/issues/21762 -->
-                                <consul.image>docker.io/bitnami/consul:1</consul.image>
+                                <consul.image>docker.io/hashicorp/consul:1.21</consul.image>
                                 <infinispan.image>quay.io/infinispan/server:15.0</infinispan.image>
                                 <infinispan.expected-log>Infinispan Server.*started in</infinispan.expected-log>
                                 <spring.cloud.server.image>quay.io/quarkusqeteam/spring-cloud-config-server:4.1</spring.cloud.server.image>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.27.999-SNAPSHOT</quarkus.platform.version>
         <quarkus.ide.version>3.26.1</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.7.2</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.7.3</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.8.0</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.27.0</formatter-maven-plugin.version>

--- a/properties/src/test/java/io/quarkus/ts/properties/consul/OpenShiftConsulConfigSourceIT.java
+++ b/properties/src/test/java/io/quarkus/ts/properties/consul/OpenShiftConsulConfigSourceIT.java
@@ -1,10 +1,10 @@
 package io.quarkus.ts.properties.consul;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.Disabled;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "consul container not available on s390x & ppc64le.")
+@Disabled("https://github.com/hashicorp/consul/issues/21762")
 public class OpenShiftConsulConfigSourceIT extends ConsulConfigSourceIT {
 }

--- a/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/TokenRefreshInternalResource.java
+++ b/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/TokenRefreshInternalResource.java
@@ -1,0 +1,39 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh;
+
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.quarkus.oidc.client.NamedOidcClient;
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.security.Authenticated;
+
+@Path(TokenRefreshInternalResource.INTERNAL_URL)
+public class TokenRefreshInternalResource {
+    private static final String TOKEN_REFRESH_RESPONSE = "token refresh secret response";
+    public static final String INTERNAL_URL = "/token-refresh/internal";
+    public static final String NAMED_OIDC_CLIENT_NAME = "test-user";
+
+    @Inject
+    OidcClient defaultOidcClient;
+
+    @Inject
+    @NamedOidcClient(NAMED_OIDC_CLIENT_NAME)
+    OidcClient namedOidcClient;
+
+    @Authenticated
+    @POST
+    public String revokeAccessTokenAndRespond(@HeaderParam(AUTHORIZATION) String authorizationHeader, String named) {
+        String accessToken = authorizationHeader.substring("Bearer ".length());
+        OidcClient client = Boolean.parseBoolean(named) ? namedOidcClient : defaultOidcClient;
+        boolean tokenRevoked = client.revokeAccessToken(accessToken).await().indefinitely();
+        if (tokenRevoked) {
+            return TOKEN_REFRESH_RESPONSE;
+        }
+        // do not expect this to happen
+        throw new IllegalStateException("Token is not revoked");
+    }
+}

--- a/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/TokenRefreshResource.java
+++ b/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/TokenRefreshResource.java
@@ -1,0 +1,55 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.clients.TokenRefreshDisabledRestClient;
+import io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.clients.TokenRefreshEnabledRestClient;
+import io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.clients.TokenRefreshFilteredRestClient;
+import io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.clients.TokenRefreshNamedFilteredRestClient;
+
+@Path("/token-refresh-public/")
+public class TokenRefreshResource {
+    @Inject
+    @RestClient
+    TokenRefreshFilteredRestClient tokenRefreshFilterClient;
+
+    @Inject
+    @RestClient
+    TokenRefreshNamedFilteredRestClient tokenRefreshNamedFilterClient;
+
+    @Inject
+    @RestClient
+    TokenRefreshEnabledRestClient tokenRefreshEnabledRestClient;
+
+    @Inject
+    @RestClient
+    TokenRefreshDisabledRestClient tokenRefreshDisabledRestClient;
+
+    @GET
+    @Path("/filter")
+    public String filterRevokeAndRespond() {
+        return tokenRefreshFilterClient.revokeAccessTokenAndRespond("false");
+    }
+
+    @GET
+    @Path("/namedFilter")
+    public String namedFilterRevokeAndRespond() {
+        return tokenRefreshNamedFilterClient.revokeAccessTokenAndRespond("true");
+    }
+
+    @GET
+    @Path("/refreshDisabled")
+    public String refreshDisabledRevokeAndRespond() {
+        return tokenRefreshDisabledRestClient.revokeAccessTokenAndRespond("false");
+    }
+
+    @GET
+    @Path("/refreshEnabled")
+    public String refreshEnabledRevokeAndRespond() {
+        return tokenRefreshEnabledRestClient.revokeAccessTokenAndRespond("false");
+    }
+}

--- a/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/clients/RefreshDisabledRequestFilter.java
+++ b/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/clients/RefreshDisabledRequestFilter.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.clients;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+
+import io.quarkus.oidc.client.filter.runtime.AbstractOidcClientRequestFilter;
+
+@Priority(Priorities.AUTHENTICATION)
+public class RefreshDisabledRequestFilter extends AbstractOidcClientRequestFilter {
+    @Override
+    protected boolean refreshOnUnauthorized() {
+        return false;
+    }
+}

--- a/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/clients/RefreshEnabledRequestFilter.java
+++ b/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/clients/RefreshEnabledRequestFilter.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.clients;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+
+import io.quarkus.oidc.client.filter.runtime.AbstractOidcClientRequestFilter;
+
+@Priority(Priorities.AUTHENTICATION)
+public class RefreshEnabledRequestFilter extends AbstractOidcClientRequestFilter {
+    @Override
+    protected boolean refreshOnUnauthorized() {
+        return true;
+    }
+}

--- a/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/clients/TokenRefreshDisabledRestClient.java
+++ b/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/clients/TokenRefreshDisabledRestClient.java
@@ -1,0 +1,18 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.clients;
+
+import static io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.TokenRefreshInternalResource.INTERNAL_URL;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+@RegisterProvider(value = RefreshDisabledRequestFilter.class)
+@Path(INTERNAL_URL)
+public interface TokenRefreshDisabledRestClient {
+
+    @POST
+    String revokeAccessTokenAndRespond(String named);
+}

--- a/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/clients/TokenRefreshEnabledRestClient.java
+++ b/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/clients/TokenRefreshEnabledRestClient.java
@@ -1,0 +1,18 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.clients;
+
+import static io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.TokenRefreshInternalResource.INTERNAL_URL;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+@RegisterProvider(value = RefreshEnabledRequestFilter.class)
+@Path(INTERNAL_URL)
+public interface TokenRefreshEnabledRestClient {
+
+    @POST
+    String revokeAccessTokenAndRespond(String named);
+}

--- a/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/clients/TokenRefreshFilteredRestClient.java
+++ b/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/clients/TokenRefreshFilteredRestClient.java
@@ -1,0 +1,19 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.clients;
+
+import static io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.TokenRefreshInternalResource.INTERNAL_URL;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.oidc.client.filter.OidcClientFilter;
+
+@RegisterRestClient
+@OidcClientFilter
+@Path(INTERNAL_URL)
+public interface TokenRefreshFilteredRestClient {
+
+    @POST
+    String revokeAccessTokenAndRespond(String named);
+}

--- a/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/clients/TokenRefreshNamedFilteredRestClient.java
+++ b/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/tokens/refresh/clients/TokenRefreshNamedFilteredRestClient.java
@@ -1,0 +1,20 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.clients;
+
+import static io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.TokenRefreshInternalResource.INTERNAL_URL;
+import static io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.TokenRefreshInternalResource.NAMED_OIDC_CLIENT_NAME;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.oidc.client.filter.OidcClientFilter;
+
+@RegisterRestClient
+@OidcClientFilter(NAMED_OIDC_CLIENT_NAME)
+@Path(INTERNAL_URL)
+public interface TokenRefreshNamedFilteredRestClient {
+
+    @POST
+    String revokeAccessTokenAndRespond(String named);
+}

--- a/security/keycloak-oidc-client-extended/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client-extended/src/main/resources/application.properties
@@ -7,7 +7,7 @@ quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 
 quarkus.http.auth.basic=false
-quarkus.http.auth.permission.unsecured.paths=/generate-token/*,/q/*
+quarkus.http.auth.permission.unsecured.paths=/generate-token/*,/q/*,/token-refresh-public/*
 quarkus.http.auth.permission.unsecured.policy=permit
 
 quarkus.http.auth.permission.authenticated.paths=/*
@@ -50,6 +50,11 @@ io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.ping.clients.Toke
 
 io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.principal.clients.TokenPropagationFilteredClient/mp-rest/url=http://localhost:${quarkus.http.port}
 io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.principal.clients.JsonTokenClient/mp-rest/url=http://localhost:${quarkus.http.port}
+
+io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.clients.TokenRefreshFilteredRestClient/mp-rest/url=http://localhost:${quarkus.http.port}
+io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.clients.TokenRefreshNamedFilteredRestClient/mp-rest/url=http://localhost:${quarkus.http.port}
+io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.clients.TokenRefreshDisabledRestClient/mp-rest/url=http://localhost:${quarkus.http.port}
+io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.tokens.refresh.clients.TokenRefreshEnabledRestClient/mp-rest/url=http://localhost:${quarkus.http.port}
 
 #OpenAPI
 quarkus.smallrye-openapi.store-schema-directory=target/generated/jakarta-rest/

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractOidcRestClientIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractOidcRestClientIT.java
@@ -8,6 +8,7 @@ import static org.hamcrest.CoreMatchers.is;
 import java.util.UUID;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KeycloakService;
@@ -24,12 +25,17 @@ public abstract class AbstractOidcRestClientIT {
     static final String PONG_ENDPOINT = "/%s-pong";
     static final String WRONG_TOKEN = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
+    private static final String TOKEN_REFRESH_RESPONSE = "token refresh secret response";
+
     @LookupService
     static KeycloakService keycloak;
 
     @QuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            // token introspection is required for revoked access tokens to be actually checked against keycloak
+            .withProperty("quarkus.oidc.token.require-jwt-introspection-only", "true")
+            .withProperty("quarkus.resteasy-client-oidc-filter.refresh-on-unauthorized", "true")
             .withProperties(() -> keycloak.getTlsProperties());
 
     @Test
@@ -70,6 +76,19 @@ public abstract class AbstractOidcRestClientIT {
         assertPingPongCreate(pingEndpoint);
         assertPingPongUpdate(pingEndpoint);
         assertPingPongDelete(pingEndpoint);
+    }
+
+    @Test
+    @Tag("QUARKUS-6551")
+    public void testRefreshToken() {
+        // test default OIDC client with default filter (influenced by config property)
+        pingTokenRefreshEndpoints("filter", true);
+        // test named OIDC client with default filter (influenced by config property)
+        pingTokenRefreshEndpoints("namedFilter", true);
+        // test default OIDC client with refreshing enabled using request filter
+        pingTokenRefreshEndpoints("refreshEnabled", true);
+        // test default OIDC client with refreshing disabled using request filter
+        pingTokenRefreshEndpoints("refreshDisabled", false);
     }
 
     private void assertPongEndpoints(String endpointPrefix) {
@@ -169,4 +188,38 @@ public abstract class AbstractOidcRestClientIT {
                 .then().statusCode(HttpStatus.SC_OK).body(containsString("ping -> true"));
     }
 
+    private void pingTokenRefreshEndpoints(String endpoint, boolean shouldRefresh) {
+        // first request should always pass OK
+        tokenRefreshExpectSuccess(endpoint);
+        // after first request, the token is invalidated, but quarkus is not aware of it
+        // so second request should always fail on invalid token
+        // actual status code 500 because quarkus-side resource handling the RestClient response will take the authentication failure as server side error
+        tokenRefreshExportFailure(endpoint);
+
+        // If token is refreshed then third request should succeed again
+        // If not, token will still be invalid
+        if (shouldRefresh) {
+            tokenRefreshExpectSuccess(endpoint);
+        } else {
+            tokenRefreshExportFailure(endpoint);
+        }
+    }
+
+    private void tokenRefreshExpectSuccess(String endpoint) {
+        given()
+                .get("/token-refresh-public/" + endpoint)
+                .then()
+                .onFailMessage("Request should succeed for endpoint: " + endpoint)
+                .statusCode(200)
+                .body(containsString(TOKEN_REFRESH_RESPONSE));
+    }
+
+    private void tokenRefreshExportFailure(String endpoint) {
+        given()
+                .get("/token-refresh-public/" + endpoint)
+                .then()
+                .onFailMessage("Request should fail for endpoint: " + endpoint)
+                .statusCode(500)
+                .body(containsString("HTTP 401 Unauthorized"));
+    }
 }

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/exceptions/CustomError.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/exceptions/CustomError.java
@@ -58,4 +58,11 @@ public class CustomError {
         }
     }
 
+    @Override
+    public String toString() {
+        return "CustomError{" +
+                "code=" + code +
+                ", msg='" + msg + '\'' +
+                '}';
+    }
 }

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/TokenRefreshInternalResource.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/TokenRefreshInternalResource.java
@@ -1,0 +1,39 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh;
+
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.quarkus.oidc.client.NamedOidcClient;
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.security.Authenticated;
+
+@Path(TokenRefreshInternalResource.INTERNAL_URL)
+public class TokenRefreshInternalResource {
+    private static final String TOKEN_REFRESH_RESPONSE = "token refresh secret response";
+    public static final String INTERNAL_URL = "/token-refresh/internal";
+    public static final String NAMED_OIDC_CLIENT_NAME = "test-user";
+
+    @Inject
+    OidcClient defaultOidcClient;
+
+    @Inject
+    @NamedOidcClient(NAMED_OIDC_CLIENT_NAME)
+    OidcClient namedOidcClient;
+
+    @Authenticated
+    @POST
+    public String revokeAccessTokenAndRespond(@HeaderParam(AUTHORIZATION) String authorizationHeader, String named) {
+        String accessToken = authorizationHeader.substring("Bearer ".length());
+        OidcClient client = Boolean.parseBoolean(named) ? namedOidcClient : defaultOidcClient;
+        boolean tokenRevoked = client.revokeAccessToken(accessToken).await().indefinitely();
+        if (tokenRevoked) {
+            return TOKEN_REFRESH_RESPONSE;
+        }
+        // do not expect this to happen
+        throw new IllegalStateException("Token is not revoked");
+    }
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/TokenRefreshResource.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/TokenRefreshResource.java
@@ -1,0 +1,55 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.clients.TokenRefreshDisabledRestClient;
+import io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.clients.TokenRefreshEnabledRestClient;
+import io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.clients.TokenRefreshFilteredRestClient;
+import io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.clients.TokenRefreshNamedFilteredRestClient;
+
+@Path("/token-refresh-public/")
+public class TokenRefreshResource {
+    @Inject
+    @RestClient
+    TokenRefreshFilteredRestClient tokenRefreshFilterClient;
+
+    @Inject
+    @RestClient
+    TokenRefreshNamedFilteredRestClient tokenRefreshNamedFilterClient;
+
+    @Inject
+    @RestClient
+    TokenRefreshEnabledRestClient tokenRefreshEnabledRestClient;
+
+    @Inject
+    @RestClient
+    TokenRefreshDisabledRestClient tokenRefreshDisabledRestClient;
+
+    @GET
+    @Path("/filter")
+    public String filterRevokeAndRespond() {
+        return tokenRefreshFilterClient.revokeAccessTokenAndRespond("false");
+    }
+
+    @GET
+    @Path("/namedFilter")
+    public String namedFilterRevokeAndRespond() {
+        return tokenRefreshNamedFilterClient.revokeAccessTokenAndRespond("true");
+    }
+
+    @GET
+    @Path("/refreshDisabled")
+    public String refreshDisabledRevokeAndRespond() {
+        return tokenRefreshDisabledRestClient.revokeAccessTokenAndRespond("false");
+    }
+
+    @GET
+    @Path("/refreshEnabled")
+    public String refreshEnabledRevokeAndRespond() {
+        return tokenRefreshEnabledRestClient.revokeAccessTokenAndRespond("false");
+    }
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/clients/RefreshDisabledRequestFilter.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/clients/RefreshDisabledRequestFilter.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.clients;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+
+import io.quarkus.oidc.client.reactive.filter.runtime.AbstractOidcClientRequestReactiveFilter;
+
+@Priority(Priorities.AUTHENTICATION)
+public class RefreshDisabledRequestFilter extends AbstractOidcClientRequestReactiveFilter {
+    @Override
+    protected boolean refreshOnUnauthorized() {
+        return false;
+    }
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/clients/RefreshEnabledRequestFilter.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/clients/RefreshEnabledRequestFilter.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.clients;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+
+import io.quarkus.oidc.client.reactive.filter.runtime.AbstractOidcClientRequestReactiveFilter;
+
+@Priority(Priorities.AUTHENTICATION)
+public class RefreshEnabledRequestFilter extends AbstractOidcClientRequestReactiveFilter {
+    @Override
+    protected boolean refreshOnUnauthorized() {
+        return true;
+    }
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/clients/TokenRefreshDisabledRestClient.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/clients/TokenRefreshDisabledRestClient.java
@@ -1,0 +1,18 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.clients;
+
+import static io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.TokenRefreshInternalResource.INTERNAL_URL;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+@RegisterProvider(value = RefreshDisabledRequestFilter.class)
+@Path(INTERNAL_URL)
+public interface TokenRefreshDisabledRestClient {
+
+    @POST
+    String revokeAccessTokenAndRespond(String named);
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/clients/TokenRefreshEnabledRestClient.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/clients/TokenRefreshEnabledRestClient.java
@@ -1,0 +1,18 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.clients;
+
+import static io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.TokenRefreshInternalResource.INTERNAL_URL;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+@RegisterProvider(value = RefreshEnabledRequestFilter.class)
+@Path(INTERNAL_URL)
+public interface TokenRefreshEnabledRestClient {
+
+    @POST
+    String revokeAccessTokenAndRespond(String named);
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/clients/TokenRefreshFilteredRestClient.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/clients/TokenRefreshFilteredRestClient.java
@@ -1,0 +1,19 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.clients;
+
+import static io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.TokenRefreshInternalResource.INTERNAL_URL;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.oidc.client.filter.OidcClientFilter;
+
+@RegisterRestClient
+@OidcClientFilter
+@Path(INTERNAL_URL)
+public interface TokenRefreshFilteredRestClient {
+
+    @POST
+    String revokeAccessTokenAndRespond(String named);
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/clients/TokenRefreshNamedFilteredRestClient.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/tokens/refresh/clients/TokenRefreshNamedFilteredRestClient.java
@@ -1,0 +1,20 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.clients;
+
+import static io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.TokenRefreshInternalResource.INTERNAL_URL;
+import static io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.TokenRefreshInternalResource.NAMED_OIDC_CLIENT_NAME;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.oidc.client.filter.OidcClientFilter;
+
+@RegisterRestClient
+@OidcClientFilter(NAMED_OIDC_CLIENT_NAME)
+@Path(INTERNAL_URL)
+public interface TokenRefreshNamedFilteredRestClient {
+
+    @POST
+    String revokeAccessTokenAndRespond(String named);
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/resources/application.properties
@@ -4,7 +4,7 @@ quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 
 quarkus.http.auth.basic=false
-quarkus.http.auth.permission.unsecured.paths=/generate-token/*,/token/*,/filter-messages/*
+quarkus.http.auth.permission.unsecured.paths=/generate-token/*,/token/*,/filter-messages/*,/token-refresh-public/*
 quarkus.http.auth.permission.unsecured.policy=permit
 
 quarkus.http.auth.permission.authenticated.paths=/*
@@ -48,6 +48,12 @@ io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.ping.clients.AutoAc
 io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.ping.clients.TokenPropagationPongClient/mp-rest/url=http://localhost:${quarkus.http.port}
 
 io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.principal.clients.TokenPropagationFilteredClient/mp-rest/url=http://localhost:${quarkus.http.port}
+
+io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.clients.TokenRefreshFilteredRestClient/mp-rest/url=http://localhost:${quarkus.http.port}
+io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.clients.TokenRefreshNamedFilteredRestClient/mp-rest/url=http://localhost:${quarkus.http.port}
+io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.clients.TokenRefreshDisabledRestClient/mp-rest/url=http://localhost:${quarkus.http.port}
+io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.tokens.refresh.clients.TokenRefreshEnabledRestClient/mp-rest/url=http://localhost:${quarkus.http.port}
+
 
 # Logging
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=TRACE


### PR DESCRIPTION
### Summary

* Bump test framework to 1.7.3

Backports of:
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2616
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2627
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2638
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2639
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2650
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2655
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2659
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2660
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2665

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [x] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)