### PR TITLE
Enable consul on openshift, by using official openshift hashicorp/consul image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -822,6 +822,7 @@
                                         <!-- Kafka  (amq-streams) requires separate properties for image and version -->
                                         <amq-streams.image>registry.redhat.io/amq-streams/kafka-40-rhel9</amq-streams.image>
                                         <amq-streams.version>3.0.0</amq-streams.version>
+                                        <consul.image>registry.connect.redhat.com/hashicorp/consul:1.21</consul.image>
                                     </systemPropertyVariables>
                                     <rerunFailingTestsCount>${oc.reruns}</rerunFailingTestsCount>
                                 </configuration>

--- a/properties/src/test/java/io/quarkus/ts/properties/consul/OpenShiftConsulConfigSourceIT.java
+++ b/properties/src/test/java/io/quarkus/ts/properties/consul/OpenShiftConsulConfigSourceIT.java
@@ -1,10 +1,11 @@
 package io.quarkus.ts.properties.consul;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@Disabled("https://github.com/hashicorp/consul/issues/21762")
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "Consul for openshift don't have Arm64 image")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "Consul for openshift don't have s390x & ppc64le images")
 public class OpenShiftConsulConfigSourceIT extends ConsulConfigSourceIT {
 }


### PR DESCRIPTION
### Summary

The `registry.connect.redhat.com/hashicorp/consul:1.21` is official hashicorp image in RH registry. Tested it locally and on our runner and it was able to download it.

This is recommended image for openshift platform by https://developer.hashicorp.com/consul/docs/deploy/server/k8s/platform/openshift

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [x] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)