### PR TITLE
Try to fix DevModeWorkspaceIT flakiness by waiting for changes in the file system submitted by DEV UI

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeWorkspaceIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeWorkspaceIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.http.advanced;
 
+import static io.quarkus.test.utils.AwaitilityUtils.AwaitilitySettings.usingTimeout;
+import static java.time.Duration.ofSeconds;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 
@@ -21,6 +23,7 @@ import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.test.utils.AwaitilityUtils;
 import io.quarkus.test.utils.FileUtils;
 import io.restassured.response.Response;
 
@@ -77,11 +80,14 @@ public class DevModeWorkspaceIT {
                 ElementHandle save = page.waitForSelector(".mainMenuBarButtons > vaadin-button:nth-child(1)");
                 save.click();
 
-                Path file = app.getServiceFolder()
-                        .resolve(Path.of("src", "main", "java", "io", "quarkus", "ts", "http", "advanced",
-                                "PathSpecificHeadersResource.java"));
-                String content = FileUtils.loadFile(file.toFile());
-                Assertions.assertTrue(content.contains("@Path(\"/this\")"), file + " wasn't edited: " + code);
+                AwaitilityUtils.untilAsserted(() -> {
+                    Path file = app.getServiceFolder()
+                            .resolve(Path.of("src", "main", "java", "io", "quarkus", "ts", "http", "advanced",
+                                    "PathSpecificHeadersResource.java"));
+                    String content = FileUtils.loadFile(file.toFile());
+                    Assertions.assertTrue(content.contains("@Path(\"/this\")"),
+                            file + " wasn't edited:" + System.lineSeparator() + content);
+                }, usingTimeout(ofSeconds(5)));
 
                 // Sometimes the app returns the old results, so let's refresh the page
                 page.reload();


### PR DESCRIPTION
### Summary

Seems like the `DevModeWorkspaceIT` is bit flaky. This test was introduced recently in https://github.com/quarkus-qe/quarkus-test-suite/pull/2597. 

**Example failure**: https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/18150424641/job/51660265400
**Example success (same code, same Quarkus HEAD commit)**: https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/18150424641/job/51698498598

I think waiting for a file changes could help because how do we know that right after the click on DEV UI button `save.click();`, the file is already changed? It must take couple of milliseconds, right?

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)