### PR TITLE
Test coverage for QUARKUS-6550 - Support for customizing request and response body in OIDC filters

### DIFF
--- a/security/keycloak-oidc-client-reactive-extended/pom.xml
+++ b/security/keycloak-oidc-client-reactive-extended/pom.xml
@@ -55,5 +55,15 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>3.13.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc-client-registration</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/ChainedParameterRequestFilter.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/ChainedParameterRequestFilter.java
@@ -1,0 +1,38 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.ping.filters;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcRequestContextProperties;
+import io.quarkus.oidc.common.OidcRequestFilter;
+import io.vertx.mutiny.core.buffer.Buffer;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = OidcEndpoint.Type.TOKEN)
+public class ChainedParameterRequestFilter implements OidcRequestFilter {
+
+    public static final List<String> interceptedMessageLogs = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void filter(OidcRequestContext requestContext) {
+
+        // Check if a previous filter in the chain already modified the request body
+        // If so, we need to work with that modified version, not the original
+        Buffer modifiedBody = requestContext.contextProperties().get(OidcRequestContextProperties.REQUEST_BODY);
+
+        String currentBody = (modifiedBody != null)
+                ? modifiedBody.toString()
+                : requestContext.requestBody().toString();
+
+        if (currentBody.contains("custom_param=custom_value")) {
+            String newBody = currentBody + "&chained_param=added_by_second_filter";
+            requestContext.requestBody(Buffer.buffer(newBody));
+            interceptedMessageLogs.add("Second filter acted and added chained_param");
+        }
+    }
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/ClientRegistrationRequest.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/ClientRegistrationRequest.java
@@ -1,0 +1,5 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.ping.filters;
+
+public class ClientRegistrationRequest {
+    public String clientName;
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/ClientRegistrationRequestFilter.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/ClientRegistrationRequestFilter.java
@@ -1,0 +1,45 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.ping.filters;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcRequestFilter;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.buffer.Buffer;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = OidcEndpoint.Type.CLIENT_REGISTRATION)
+public class ClientRegistrationRequestFilter implements OidcRequestFilter {
+
+    public static final List<String> interceptedMessageLogs = new CopyOnWriteArrayList<>();
+    private static final Logger LOG = Logger.getLogger(ClientRegistrationRequestFilter.class);
+
+    @Override
+    public void filter(OidcRequestContext requestContext) {
+        LOG.info("ClientRegistrationRequestFilter invoked");
+        interceptedMessageLogs.add("ClientRegistrationRequestFilter invoked");
+        try {
+            JsonObject body = requestContext.requestBody().toJsonObject();
+
+            // Modify client_name if present
+            if (body.containsKey("client_name")) {
+                String originalName = body.getString("client_name");
+                LOG.infof("Client name is %s", originalName);
+                String modifiedName = "Modified_" + originalName;
+                body.put("client_name", modifiedName);
+                requestContext.requestBody(Buffer.buffer(body.toString()));
+                LOG.info(String.format("ClientRegistrationRequestFilter received request %s", modifiedName));
+                interceptedMessageLogs.add("Modified client_name from '" + originalName + "' to '" + modifiedName + "'");
+            }
+        } catch (Exception e) {
+            interceptedMessageLogs.add("Error processing request: " + e.getMessage());
+        }
+    }
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/ClientRegistrationResource.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/ClientRegistrationResource.java
@@ -1,0 +1,55 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.ping.filters;
+
+import java.util.Set;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.oidc.client.registration.ClientMetadata;
+import io.quarkus.oidc.client.registration.OidcClientRegistration;
+import io.quarkus.oidc.client.registration.RegisteredClient;
+
+@Path("/client-registration")
+public class ClientRegistrationResource {
+
+    private static final Logger LOG = Logger.getLogger(ClientRegistrationResource.class);
+
+    @Inject
+    OidcClientRegistration clientRegistration;
+
+    @POST
+    @Path("/register")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String registerClient(ClientRegistrationRequest request) {
+        try {
+            // Use the Builder pattern - cleaner and type-safe
+            ClientMetadata clientMetadata = ClientMetadata.builder()
+                    .clientName(request.clientName)
+                    .redirectUri("http://localhost:8080/callback")
+                    .grantTypes(Set.of("authorization_code", "refresh_token"))
+                    .build();
+
+            LOG.infof("Registering client with name: %s", request.clientName);
+
+            // Register the client - triggers ClientRegistrationRequestFilter
+            RegisteredClient registered = clientRegistration.registerClient(clientMetadata)
+                    .await()
+                    .indefinitely();
+
+            LOG.infof("Client registered successfully with ID: %s",
+                    registered.metadata().getClientId());
+
+            // Return the metadata as JSON string
+            return registered.metadata().getMetadataString();
+
+        } catch (Exception e) {
+            LOG.errorf(e, "Failed to register client: %s", e.getMessage());
+            throw new RuntimeException("Client registration failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/ClientRegistrationResponseFilter.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/ClientRegistrationResponseFilter.java
@@ -1,0 +1,47 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.ping.filters;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcResponseFilter;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.buffer.Buffer;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = OidcEndpoint.Type.CLIENT_REGISTRATION)
+public class ClientRegistrationResponseFilter implements OidcResponseFilter {
+
+    private static final Logger LOG = Logger.getLogger(ClientRegistrationResponseFilter.class);
+    public static final List<String> interceptedMessageLogs = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void filter(OidcResponseContext responseContext) {
+        LOG.info("ClientRegistrationResponseFilter invoked");
+        interceptedMessageLogs.add("ClientRegistrationResponseFilter invoked");
+
+        if (responseContext.statusCode() == 201 || responseContext.statusCode() == 200) {
+            try {
+                JsonObject body = responseContext.responseBody().toJsonObject();
+
+                // Add custom metadata to response
+                if (body.containsKey("client_id")) {
+                    body.put("custom_metadata", "Added by filter");
+                    responseContext.responseBody(Buffer.buffer(body.toString()));
+
+                    LOG.info("Added custom_metadata to client registration response");
+                    interceptedMessageLogs.add("Added custom_metadata to response");
+                }
+            } catch (Exception e) {
+                LOG.errorf("Error processing client registration response: %s", e.getMessage());
+                interceptedMessageLogs.add("Error processing response: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/CustomTokenRequestBodyFilter.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/CustomTokenRequestBodyFilter.java
@@ -1,0 +1,42 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.ping.filters;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcRequestContextProperties;
+import io.quarkus.oidc.common.OidcRequestFilter;
+import io.vertx.mutiny.core.buffer.Buffer;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = OidcEndpoint.Type.TOKEN)
+@Priority(1)
+public class CustomTokenRequestBodyFilter implements OidcRequestFilter {
+    private static final Logger LOG = Logger.getLogger(CustomTokenRequestBodyFilter.class);
+    public static final List<String> interceptedMessageLogs = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void filter(OidcRequestContext requestContext) {
+        Buffer existingModification = requestContext.contextProperties()
+                .get(OidcRequestContextProperties.REQUEST_BODY);
+
+        String originalBody = (existingModification != null)
+                ? existingModification.toString()
+                : requestContext.requestBody().toString();
+        LOG.infof("Original request body: %s", originalBody);
+        interceptedMessageLogs.add("Original body captured");
+
+        String modifiedBody = originalBody + "&custom_param=custom_value";
+        LOG.infof("Modified body request : %s", modifiedBody);
+        requestContext.requestBody(Buffer.buffer(modifiedBody));
+        interceptedMessageLogs.add("Custom param added to request");
+    }
+
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/CustomTokenResponseBodyFilter.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/CustomTokenResponseBodyFilter.java
@@ -1,0 +1,40 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.ping.filters;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcResponseFilter;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.buffer.Buffer;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = OidcEndpoint.Type.TOKEN)
+public class CustomTokenResponseBodyFilter implements OidcResponseFilter {
+
+    public static final List<String> interceptedMessageLogs = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void filter(OidcResponseContext responseContext) {
+        if (responseContext.responseBody() == null) {
+            return;
+        }
+        interceptedMessageLogs.add("Response body intercepted");
+        JsonObject body = responseContext.responseBody().toJsonObject();
+
+        // Modify scope format from comma-separated to space-separated
+        if (body.containsKey("scope")) {
+            String scope = body.getString("scope");
+            if (scope != null && scope.contains(",")) {
+                String modifiedScope = scope.replace(",", " ");
+                body.put("scope", modifiedScope);
+                responseContext.responseBody(Buffer.buffer(body.toString()));
+                interceptedMessageLogs.add("Scope corrected from '" + scope + "' to '" + modifiedScope + "'");
+            }
+        }
+    }
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/FilterCustomizationMessagesResource.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/FilterCustomizationMessagesResource.java
@@ -1,0 +1,67 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.ping.filters;
+
+import java.util.List;
+
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/filter-customization-messages")
+public class FilterCustomizationMessagesResource {
+
+    @Path("/request")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getRequestFilterMessages() {
+
+        return CustomTokenRequestBodyFilter.interceptedMessageLogs;
+    }
+
+    @Path("/response")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getResponseFilterMessages() {
+        return CustomTokenResponseBodyFilter.interceptedMessageLogs;
+    }
+
+    @Path("/chained-request")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getChainedRequestFilterMessages() {
+        return ChainedParameterRequestFilter.interceptedMessageLogs;
+    }
+
+    @Path("/keycloak-userinfo")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getKeycloakUserInfoFilterMessages() {
+        return KeycloakUserInfoFilter.interceptedMessageLogs;
+    }
+
+    @Path("/client-registration-request")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getClientRegistrationRequestMessages() {
+        return ClientRegistrationRequestFilter.interceptedMessageLogs;
+    }
+
+    @Path("/client-registration-response")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getClientRegistrationResponseMessages() {
+        return ClientRegistrationResponseFilter.interceptedMessageLogs;
+    }
+
+    @Path("/clear")
+    @DELETE
+    public void clearLogs() {
+        CustomTokenRequestBodyFilter.interceptedMessageLogs.clear();
+        CustomTokenResponseBodyFilter.interceptedMessageLogs.clear();
+        ChainedParameterRequestFilter.interceptedMessageLogs.clear();
+        ClientRegistrationRequestFilter.interceptedMessageLogs.clear();
+        ClientRegistrationResponseFilter.interceptedMessageLogs.clear();
+    }
+
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/KeycloakUserInfoFilter.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/ping/filters/KeycloakUserInfoFilter.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.ping.filters;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcResponseFilter;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = OidcEndpoint.Type.USERINFO)
+public class KeycloakUserInfoFilter implements OidcResponseFilter {
+
+    public static final List<String> interceptedMessageLogs = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void filter(OidcResponseContext responseContext) {
+        interceptedMessageLogs.add("UserInfo response intercepted by Keycloak-specific filter");
+    }
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client-reactive-extended/src/main/resources/application.properties
@@ -4,7 +4,7 @@ quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 
 quarkus.http.auth.basic=false
-quarkus.http.auth.permission.unsecured.paths=/generate-token/*,/token/*,/filter-messages/*,/token-refresh-public/*
+quarkus.http.auth.permission.unsecured.paths=/generate-token/*,/token/*,/filter-messages/*,/token-refresh-public/*,/filter-customization-messages/*,/client-registration/*
 quarkus.http.auth.permission.unsecured.policy=permit
 
 quarkus.http.auth.permission.authenticated.paths=/*
@@ -65,7 +65,6 @@ quarkus.log.file.format=%C - %s%n
 #OpenAPI
 quarkus.smallrye-openapi.store-schema-directory=target/generated/jakarta-rest/
 
-# Quarkus need set tls registry for oidc-client in addition of oidc for self-sign certs
 quarkus.oidc-client.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}
 quarkus.oidc-client.test-user.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}
 quarkus.oidc-client.exchange-token.tls.tls-configuration-name=${quarkus.oidc.tls.tls-configuration-name}

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/AbstractOidcCustomizationFiltersKeycloakIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/AbstractOidcCustomizationFiltersKeycloakIT.java
@@ -1,0 +1,114 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended;
+
+import static io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.OidcItUtils.CLIENT_ID_DEFAULT;
+import static io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.OidcItUtils.CLIENT_SECRET_DEFAULT;
+import static io.quarkus.ts.security.keycloak.oidcclient.reactive.extended.OidcItUtils.USER;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.AccessTokenResponse;
+
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.LookupService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.services.QuarkusApplication;
+
+public abstract class AbstractOidcCustomizationFiltersKeycloakIT {
+    static AccessTokenResponse tokenResponse;
+
+    @LookupService
+    static KeycloakService keycloak;
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperties(() -> keycloak.getTlsProperties());
+
+    @BeforeEach
+    public void setUp() {
+        tokenResponse = keycloak
+                .createAuthzClient(CLIENT_ID_DEFAULT, CLIENT_SECRET_DEFAULT)
+                .obtainAccessToken(USER, USER);
+    }
+
+    @Test
+    public void testRequestFilterIsInvokedOnTokenRequest() {
+        app.given()
+                .get("/generate-token/client-credentials")
+                .then().statusCode(200);
+
+        app.given()
+                .get("/filter-customization-messages/request")
+                .then()
+                .statusCode(200)
+                .body("$", hasItem("Custom param added to request"));
+    }
+
+    @Test
+    public void testRequestFilterIsInvokedOnTokenRefresh() {
+        app.given()
+                .queryParam("refreshToken", tokenResponse.getRefreshToken())
+                .when()
+                .get("/token/refresh")
+                .then()
+                .statusCode(200);
+
+        app.given()
+                .get("/filter-customization-messages/request")
+                .then()
+                .statusCode(200)
+                .body("$", hasItem("Custom param added to request"));
+    }
+
+    @Test
+    public void testJwksResponseFilterIsInvoked() {
+        String accessToken = OidcItUtils.createToken(keycloak);
+
+        app.given()
+                .auth().oauth2(accessToken)
+                .when()
+                .get("/secured/getClaimsFromBeans")
+                .then()
+                .statusCode(200);
+
+        app.given()
+                .get("/filter-messages/jwks")
+                .then()
+                .statusCode(200)
+                .body("$", hasItem(containsString("JWKS response intercepted")))
+                .body("$", hasItem(containsString("keys")));
+
+    }
+
+    @Test
+    public void testResponseFiltersAreInvoked() {
+        app.given()
+                .get("/generate-token/client-credentials")
+                .then()
+                .statusCode(200);
+
+        app.given()
+                .get("/filter-customization-messages/response")
+                .then()
+                .statusCode(200)
+                .body("$", hasItem("Response body intercepted"));
+    }
+
+    @Test
+    public void testUserInfoFilterIsInvoked() {
+        app.given()
+                .auth().oauth2(tokenResponse.getToken())
+                .when()
+                .get("/userinfo-check/me")
+                .then()
+                .statusCode(200);
+
+        app.given()
+                .get("/filter-customization-messages/keycloak-userinfo")
+                .then()
+                .statusCode(200)
+                .body("$", hasItem("UserInfo response intercepted by Keycloak-specific filter"));
+    }
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OidcFiltersCustomizationKeycloakIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OidcFiltersCustomizationKeycloakIT.java
@@ -1,0 +1,17 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended;
+
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KeycloakContainer;
+
+@QuarkusScenario
+public class OidcFiltersCustomizationKeycloakIT extends AbstractOidcCustomizationFiltersKeycloakIT {
+
+    @KeycloakContainer(runKeycloakInProdMode = true)
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OidcRequestResponseCustomizationIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OidcRequestResponseCustomizationIT.java
@@ -1,0 +1,298 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.notMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+
+@QuarkusScenario
+public class OidcRequestResponseCustomizationIT {
+
+    private static WireMockServer wiremock;
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url",
+                    () -> getWiremock().baseUrl() + "/auth/realms/test-realm")
+            .withProperty("quarkus.oidc.client-id", "test-client")
+            .withProperty("quarkus.oidc.credentials.secret", "test-secret")
+            .withProperty("quarkus.oidc-client-registration.discovery-enabled", "false")
+            .withProperty("quarkus.oidc-client-registration.registration-path", "/clients-registrations/default")
+            .withProperty("quarkus.oidc-client-registration.auth-server-url",
+                    () -> getWiremock().baseUrl() + "/auth/realms/test-realm")
+            .withProperty("quarkus.http.auth.permission.all.policy", "permit");
+
+    private static WireMockServer getWiremock() {
+        if (wiremock == null) {
+            wiremock = new WireMockServer(options().dynamicPort());
+            wiremock.start();
+            OidcWiremockTestUtils.setupOidc(wiremock);
+        }
+        return wiremock;
+    }
+
+    @BeforeEach
+    public void setupTest() {
+        wiremock.resetRequests();
+        clearFilterLogs();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        wiremock.stop();
+    }
+
+    private static void clearFilterLogs() {
+        app.given().delete("/filter-customization-messages/clear");
+    }
+
+    private static String createTokenResponse(String scope) {
+        return String.format("""
+                {
+                    "access_token": "mock-access-token-%s",
+                    "token_type": "Bearer",
+                    "expires_in": 300,
+                    "scope": "%s"
+                }
+                """, System.currentTimeMillis(), scope);
+    }
+
+    private static String createTokenResponseWithRefresh(String scope) {
+        return String.format("""
+                {
+                    "access_token": "mock-access-token-%s",
+                    "token_type": "Bearer",
+                    "expires_in": 300,
+                    "refresh_token": "mock-refresh-token",
+                    "scope": "%s"
+                }
+                """, System.currentTimeMillis(), scope);
+    }
+
+    @Test
+    public void testProviderReceivesModifiedRequestBody() {
+        mockTokenEndpoint("client_credentials", "openid profile", false);
+
+        Response response = requestToken();
+        Assertions.assertNotNull(response.asString());
+        Assertions.assertFalse(response.asString().isEmpty());
+
+        verifyFilterInvoked("request", "Custom param added", "token request");
+        verifyWireMockRequest("client_credentials");
+    }
+
+    @Test
+    public void testClientReceivesModifiedResponseBody() {
+        mockTokenEndpoint("client_credentials", "openid,profile,email", false);
+        requestToken();
+
+        verifyFilterInvoked("response",
+                "Scope corrected from 'openid,profile,email' to 'openid profile email'",
+                "response transformation");
+    }
+
+    @Test
+    public void testProviderReceivesChainedRequestBody() {
+        wiremock.stubFor(
+                post(urlEqualTo("/auth/realms/test-realm/protocol/openid-connect/token"))
+                        .withRequestBody(containing("custom_param=custom_value"))
+                        .withRequestBody(containing("chained_param=added_by_second_filter"))
+                        .willReturn(aResponse()
+                                .withStatus(200)
+                                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                                .withBody(createTokenResponse("openid profile"))));
+
+        Response response = requestToken();
+        Assertions.assertNotNull(response.asString());
+
+        verifyFilterInvoked("request", "Custom param added", "first filter");
+        verifyFilterInvoked("chained-request", "Second filter acted and added chained_param", "second filter");
+    }
+
+    @Test
+    public void testTokenRefreshTriggersFilters() {
+        mockTokenEndpoint("client_credentials", "openid profile", true);
+        requestToken();
+        verifyFilterInvoked("request", "Custom param added", "initial token request");
+
+        clearFilterLogs();
+
+        mockTokenEndpoint("refresh_token", "openid,profile", true);
+        Response refreshResponse = refreshToken();
+        Assertions.assertNotNull(refreshResponse.asString());
+
+        verifyFilterInvoked("request", "Custom param added", "token refresh");
+        verifyFilterInvoked("response", "Response body intercepted", "token refresh");
+        verifyFilterInvoked("response", "Scope corrected", "scope transformation");
+        verifyWireMockRequest("refresh_token");
+    }
+
+    @Test
+    public void testFilterHandlesMalformedProviderResponse() {
+        wiremock.stubFor(
+                post(urlEqualTo("/auth/realms/test-realm/protocol/openid-connect/token"))
+                        .willReturn(aResponse()
+                                .withStatus(200)
+                                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                                .withBody("{ invalid json ]")));
+
+        app.given()
+                .get("/generate-token/client-credentials")
+                .then()
+                .statusCode(500);
+    }
+
+    @Test
+    public void testProviderRequiresCustomParameter() {
+
+        wiremock.stubFor(
+                post(urlEqualTo("/auth/realms/test-realm/protocol/openid-connect/token"))
+                        .withRequestBody(notMatching(".*custom_param=custom_value.*"))
+                        .willReturn(aResponse()
+                                .withStatus(400)
+                                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                                .withBody("{\"error\":\"invalid_request\",\"error_description\":\"Missing custom_param\"}")));
+
+        mockTokenEndpoint("client_credentials", "openid profile", false);
+
+        Response response = requestToken();
+        Assertions.assertNotNull(response.asString());
+
+        verifyFilterInvoked("request", "Custom param added", "provider validation");
+    }
+
+    @Test
+    public void testClientRegistrationRequestFilterModifiesBody() {
+        wiremock.stubFor(
+                post(urlEqualTo("/auth/realms/test-realm/clients-registrations/default"))
+                        .withRequestBody(containing("\"client_name\":\"Modified_TestClient\""))
+                        .willReturn(aResponse()
+                                .withStatus(201)
+                                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                                .withBody(
+                                        "{\"client_id\":\"test-client-123\",\"client_secret\":\"secret-123\",\"client_name\":\"Modified_TestClient\",\"redirect_uris\":[\"http://localhost:8080/callback\"]}")));
+
+        String requestBody = "{\"clientName\": \"TestClient\"}";
+
+        app.given()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .when()
+                .post("/client-registration/register")
+                .then()
+                .statusCode(200);
+
+        app.given()
+                .get("/filter-customization-messages/client-registration-request")
+                .then()
+                .statusCode(200)
+                .body("$", hasItem(containsString("Modified client_name from 'TestClient' to 'Modified_TestClient'")));
+
+        wiremock.verify(1,
+                WireMock.postRequestedFor(
+                        urlEqualTo("/auth/realms/test-realm/clients-registrations/default"))
+                        .withRequestBody(containing("Modified_TestClient")));
+    }
+
+    @Test
+    public void testClientRegistrationResponseFilterAddsMetadata() {
+        wiremock.stubFor(
+                post(urlEqualTo("/auth/realms/test-realm/clients-registrations/default"))
+                        .willReturn(aResponse()
+                                .withStatus(201)
+                                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                                .withBody(
+                                        "{\"client_id\":\"test-client-456\",\"client_secret\":\"secret-456\",\"client_name\":\"TestClient\",\"redirect_uris\":[\"http://localhost:8080/callback\"]}")));
+
+        String requestBody = "{\"clientName\": \"TestClient\"}";
+
+        app.given()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .when()
+                .post("/client-registration/register")
+                .then()
+                .statusCode(200)
+                .body("client_id", equalTo("test-client-456"))
+                .body("custom_metadata", equalTo("Added by filter"));
+
+        app.given()
+                .get("/filter-customization-messages/client-registration-response")
+                .then()
+                .statusCode(200)
+                .body("$", hasItem(containsString("Added custom_metadata to response")));
+    }
+
+    private void mockTokenEndpoint(String grantType, String scope, boolean withRefreshToken) {
+        String body = withRefreshToken
+                ? createTokenResponseWithRefresh(scope)
+                : createTokenResponse(scope);
+
+        wiremock.stubFor(
+                post(urlEqualTo("/auth/realms/test-realm/protocol/openid-connect/token"))
+                        .withRequestBody(containing("grant_type=" + grantType))
+                        .withRequestBody(containing("custom_param=custom_value"))
+                        .willReturn(aResponse()
+                                .withStatus(200)
+                                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                                .withBody(body)));
+    }
+
+    private Response requestToken() {
+        return app.given()
+                .get("/generate-token/client-credentials")
+                .then()
+                .statusCode(200)
+                .extract().response();
+    }
+
+    private Response refreshToken() {
+        return app.given()
+                .queryParam("refreshToken", "mock-refresh-token")
+                .get("/token/refresh")
+                .then()
+                .statusCode(200)
+                .extract().response();
+    }
+
+    private void verifyFilterInvoked(String filterType, String expectedContent, String context) {
+        Response logs = app.given()
+                .get("/filter-customization-messages/" + filterType)
+                .then()
+                .statusCode(200)
+                .extract().response();
+
+        Assertions.assertTrue(logs.asString().contains(expectedContent),
+                String.format("%s filter should contain '%s' during %s",
+                        filterType, expectedContent, context));
+    }
+
+    private void verifyWireMockRequest(String grantType) {
+        wiremock.verify(1,
+                WireMock.postRequestedFor(
+                        urlEqualTo("/auth/realms/test-realm/protocol/openid-connect/token"))
+                        .withRequestBody(containing("grant_type=" + grantType))
+                        .withRequestBody(containing("custom_param=custom_value")));
+    }
+
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OidcWiremockTestUtils.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OidcWiremockTestUtils.java
@@ -1,0 +1,46 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+public class OidcWiremockTestUtils {
+    public static void setupOidc(WireMockServer wiremock) {
+        setupDiscoveryEndpoint(wiremock);
+        setupJwksEndpoint(wiremock);
+    }
+
+    private static void setupDiscoveryEndpoint(WireMockServer wiremock) {
+        String discoveryJson = String.format("""
+                {
+                    "issuer": "%s/auth/realms/test-realm",
+                    "token_endpoint": "%s/auth/realms/test-realm/protocol/openid-connect/token",
+                    "jwks_uri": "%s/auth/realms/test-realm/protocol/openid-connect/certs"
+                }
+                """, wiremock.baseUrl(), wiremock.baseUrl(), wiremock.baseUrl());
+
+        wiremock.stubFor(
+                WireMock.get(urlEqualTo("/auth/realms/test-realm/.well-known/openid-configuration"))
+                        .willReturn(aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(discoveryJson)));
+    }
+
+    private static void setupJwksEndpoint(WireMockServer wiremock) {
+        String jwksJson = """
+                {
+                    "keys": [{"kid": "test-key", "kty": "RSA", "alg": "RS256", "use": "sig", "n": "test-n-value", "e": "AQAB"}]
+                }
+                """;
+
+        wiremock.stubFor(
+                WireMock.get(urlEqualTo("/auth/realms/test-realm/protocol/openid-connect/certs"))
+                        .willReturn(aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(jwksJson)));
+    }
+}

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenShiftOidcCustomizationFiltersIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/OpenShiftOidcCustomizationFiltersIT.java
@@ -1,0 +1,15 @@
+package io.quarkus.ts.security.keycloak.oidcclient.reactive.extended;
+
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.KeycloakContainer;
+
+@OpenShiftScenario
+public class OpenShiftOidcCustomizationFiltersIT extends AbstractOidcCustomizationFiltersKeycloakIT {
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+}


### PR DESCRIPTION
### Summary
Test coverage for QUARKUS-6550 according to the [test plan](https://github.com/quarkus-qe/quarkus-test-plans/pull/268)


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)