### PR TITLE
[3.20] backport Enable consul on openshift

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -820,6 +820,7 @@
                                         <!-- Kafka  (amq-streams) requires separate properties for image and version -->
                                         <amq-streams.image>registry.redhat.io/amq-streams/kafka-35-rhel8</amq-streams.image>
                                         <amq-streams.version>2.6.0</amq-streams.version>
+                                        <consul.image>registry.connect.redhat.com/hashicorp/consul:1.21</consul.image>
                                     </systemPropertyVariables>
                                     <rerunFailingTestsCount>${oc.reruns}</rerunFailingTestsCount>
                                 </configuration>

--- a/properties/src/test/java/io/quarkus/ts/properties/consul/OpenShiftConsulConfigSourceIT.java
+++ b/properties/src/test/java/io/quarkus/ts/properties/consul/OpenShiftConsulConfigSourceIT.java
@@ -1,10 +1,11 @@
 package io.quarkus.ts.properties.consul;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@Disabled("https://github.com/hashicorp/consul/issues/21762")
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "Consul for openshift don't have Arm64 image")
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "Consul for openshift don't have s390x & ppc64le images")
 public class OpenShiftConsulConfigSourceIT extends ConsulConfigSourceIT {
 }


### PR DESCRIPTION
### Summary

Backport:
- https://github.com/quarkus-qe/quarkus-test-suite/pull/2671 - Enable consul on openshift, by using official openshift hashicorp/consul image

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [X] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)