### PR TITLE
[3.20] Add classes needed to execute DevModeOtelCapabilitiesIT inside monitoring/micrometer-opentelemetry

### DIFF
--- a/monitoring/micrometer-opentelemetry/pom.xml
+++ b/monitoring/micrometer-opentelemetry/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>monitoring-micrometer-opentelemetry</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: Monitoring: Micrometer to OpenTelemetry Bridge</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-opentelemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-observability-devservices-lgtm</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-grafana</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/monitoring/micrometer-opentelemetry/src/main/java/io/quarkus/ts/monitoring/micrometeropentelemetry/rest/LoggingResource.java
+++ b/monitoring/micrometer-opentelemetry/src/main/java/io/quarkus/ts/monitoring/micrometeropentelemetry/rest/LoggingResource.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.monitoring.micrometeropentelemetry.rest;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+@Path("/logging")
+public class LoggingResource {
+
+    private static final Logger LOG = Logger.getLogger(LoggingResource.class);
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        LOG.info("This is info message 1");
+        LOG.info("This is info message 2");
+        LOG.debug("This is a debug message 1");
+        LOG.debug("This is a debug message 2");
+        LOG.warn("This is a warning 1");
+        LOG.warn("This is a warning 2");
+        LOG.error("This is an error 1");
+        LOG.error("This is an error 2");
+        LOG.trace("Tris is a trace 1");
+        LOG.trace("Tris is a trace 2");
+        return "This is logging resource";
+    }
+
+}

--- a/monitoring/micrometer-opentelemetry/src/main/resources/application.properties
+++ b/monitoring/micrometer-opentelemetry/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+quarkus.log.category."io.quarkus.ts.monitoring.micrometeropentelemetry.rest.LoggingResource".level=DEBUG
+quarkus.application.name=app
+quarkus.otel.logs.enabled=true
+quarkus.otel.blrp.schedule.delay=5s
+quarkus.otel.blrp.max.export.batch.size=10
+quarkus.otel.metrics.enabled=true
+quarkus.otel.metric.export.interval=1s
+quarkus.otel.bsp.export.timeout=10s
+quarkus.otel.bsp.schedule.delay=2s
+quarkus.micrometer.binder.netty.enabled=false
+quarkus.observability.lgtm.enabled=false

--- a/monitoring/micrometer-opentelemetry/src/test/java/io/quarkus/ts/monitoring/micrometeropentelemetry/test/DevModeOtelCapabilitiesIT.java
+++ b/monitoring/micrometer-opentelemetry/src/test/java/io/quarkus/ts/monitoring/micrometeropentelemetry/test/DevModeOtelCapabilitiesIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.ts.monitoring.micrometeropentelemetry.test;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -8,6 +9,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.ts.monitoring.micrometeropentelemetry.rest.LoggingResource;
 
+@Disabled("Because of https://issues.redhat.com/browse/QUARKUS-6463")
 @Tag("https://github.com/quarkusio/quarkus/pull/47458")
 @QuarkusScenario
 public class DevModeOtelCapabilitiesIT {

--- a/pom.xml
+++ b/pom.xml
@@ -611,6 +611,7 @@
                 <module>monitoring/micrometer-prometheus-kafka</module>
                 <module>monitoring/micrometer-prometheus-kafka-reactive</module>
                 <module>monitoring/micrometer-prometheus-oidc</module>
+                <module>monitoring/micrometer-opentelemetry</module>
                 <module>monitoring/opentelemetry</module>
                 <module>monitoring/opentelemetry-reactive</module>
             </modules>


### PR DESCRIPTION
### Summary

Add classes needed to execute the test DevModeOtelCapabilitiesIT because [QUARKUS-6612](https://issues.redhat.com/browse/QUARKUS-6612)

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)