### PR TITLE
Disable gradle-CLI test affected by QUARKUS-6691

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -118,6 +118,7 @@ public class QuarkusCliCreateJvmApplicationIT {
 
     @Tag("QUARKUS-1071")
     @TestQuarkusCli
+    @Disabled("https://issues.redhat.com/browse/QUARKUS-6691")
     public void shouldCreateApplicationWithGradleOnJvm(QuarkusVersionAwareCliClient cliClient) {
 
         // Create application


### PR DESCRIPTION
### Summary

Quarkus CLI test with gradle is affected by https://issues.redhat.com/browse/QUARKUS-6691 which is not expected to be fixed soon.

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)