### PR TITLE
Add CLI coverage for multiple offering and support-scope command

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -32,6 +32,7 @@ public class QuarkusCliExtensionsIT {
     static final String REST_EXTENSION_ARTIFACT = "quarkus-rest";
     static final String QUARKUS_BOM = "quarkus-bom";
     static final String REST_EXTENSION_GUIDE = "https://quarkus.io/guides/rest";
+    static final String SUPPORT_SCOPE = "Support scope";
     static final List<String> EXPECTED_PLATFORM_VERSIONS = Arrays.asList("2.0.0.Final", "2.1.0.Final");
     static final ListExtensionRequest NO_STREAM = new ListExtensionRequest(null); // --stream and --platform-bom are not compatible
 
@@ -68,6 +69,12 @@ public class QuarkusCliExtensionsIT {
     public void shouldListExtensionsUsingFull() {
         result = cliClient.listExtensions("--full");
         assertListFullOptionOutput();
+    }
+
+    @Test
+    public void shouldListExtensionsUsingSupportScope() {
+        result = cliClient.listExtensions("--support-scope");
+        assertListSupportScopeOptionOutput();
     }
 
     @Test
@@ -140,6 +147,13 @@ public class QuarkusCliExtensionsIT {
                 && result.getOutput().contains(REST_EXTENSION_ARTIFACT)
                 && result.getOutput().contains(REST_EXTENSION_GUIDE),
                 "--full option output is unexpected. Output: " + result.getOutput());
+    }
+
+    private void assertListSupportScopeOptionOutput() {
+        // Only checking if Support scope column is present
+        // as to see the support scope value the registry needs to be setup
+        assertTrue(result.getOutput().contains(SUPPORT_SCOPE),
+                "--support-scope option output is unexpected. Output: " + result.getOutput());
     }
 
 }

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingBase.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingBase.java
@@ -1,0 +1,81 @@
+package io.quarkus.ts.quarkus.cli.offering;
+
+import static io.quarkus.test.bootstrap.QuarkusCliClient.CreateApplicationRequest.defaults;
+import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.QUARKUS_CONFIG;
+import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.QUARKUS_TEST_CONFIG;
+import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.assertCorrectLangChain4jBom;
+import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.assertCorrectPlatformBom;
+import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.getExtensionLineFromListOutput;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import jakarta.inject.Inject;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.bootstrap.QuarkusCliRestService;
+
+public abstract class QuarkusCliOfferingBase {
+
+    public static final String REST_EXTENSION_NAME = "REST Jackson";
+    public static final String REST_EXTENSION_ARTIFACT = "quarkus-rest-jackson";
+    public static final String REST_SUPPORT_SCOPE = "supported";
+    public static final String LANGCHAIN4J_OPENAI_EXTENSION_NAME = "LangChain4j OpenAI ";
+    public static final String LANGCHAIN4J_OPENAI_EXTENSION_ARTIFACT = "quarkus-langchain4j-openai";
+    public static final String LANGCHAIN4J_OPENAI_SUPPORT_SCOPE = "tech-preview";
+
+    @Inject
+    static QuarkusCliClient cliClient;
+
+    @BeforeAll
+    public static void prepareConfigBackup() throws IOException {
+        FileUtils.copyFile(QUARKUS_CONFIG, QUARKUS_TEST_CONFIG);
+    }
+
+    @Test
+    public void listedExtensionShouldContainSupportScope() {
+        QuarkusCliClient.Result result = cliClient.listExtensions("--support-scope");
+        assertTrue(result.getOutput().contains(REST_EXTENSION_NAME)
+                && result.getOutput().contains(REST_EXTENSION_ARTIFACT),
+                "--support-scope option output should contain" + REST_EXTENSION_ARTIFACT + ". Output: " + result.getOutput());
+
+        String extensionLine = getExtensionLineFromListOutput(result, REST_EXTENSION_ARTIFACT);
+
+        assertNotNull(extensionLine);
+        assertThat(REST_EXTENSION_ARTIFACT + " should have support scope equal to " + REST_SUPPORT_SCOPE,
+                extensionLine, containsString(REST_SUPPORT_SCOPE));
+    }
+
+    @Test
+    public void createAndBuildAppWhenOfferingIsSet() throws IOException {
+        // Check if it's possible to create and build app when the offering is set in registry
+        Path pathToTmpDirectory = Files.createTempDirectory("cli");
+        File pathToConfigInTmpDirectory = Paths.get(pathToTmpDirectory.toAbsolutePath().toString(), ".quarkus",
+                "config.yaml").toFile();
+        FileUtils.copyFile(QUARKUS_TEST_CONFIG, pathToConfigInTmpDirectory);
+
+        QuarkusCliRestService app = cliClient.createApplication("app",
+                defaults().withExtensions(REST_EXTENSION_ARTIFACT, LANGCHAIN4J_OPENAI_EXTENSION_ARTIFACT),
+                pathToTmpDirectory.toAbsolutePath().toString());
+        File pom = app.getFileFromApplication("pom.xml");
+        assertCorrectPlatformBom(pom, getQuarkusPlatformGroupId());
+        assertCorrectLangChain4jBom(pom, langchain4JBomVersion());
+        QuarkusCliClient.Result result = app.buildOnJvm();
+        assertTrue(result.isSuccessful(), "The application didn't build on JVM. Output: " + result.getOutput());
+    }
+
+    public abstract String getQuarkusPlatformGroupId();
+
+    public abstract String langchain4JBomVersion();
+}

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingDefaultIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingDefaultIT.java
@@ -1,0 +1,98 @@
+package io.quarkus.ts.quarkus.cli.offering;
+
+import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.QUARKUS_CONFIG;
+import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.QUARKUS_TEST_CONFIG;
+import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.getExtensionLineFromListOutput;
+import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.getQuarkusVersionWithoutNumberSuffix;
+import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.updateRegistryConfigFileWithOffering;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import jakarta.inject.Inject;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.EnabledOnQuarkusVersion;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+
+@Tag("quarkus-cli")
+@Tag("QUARKUS-6397")
+@QuarkusScenario
+@DisabledOnNative(reason = "Only for JVM verification")
+@EnabledOnQuarkusVersion(version = ".*redhat.*", reason = "Need set up registry config for prod testing")
+public class QuarkusCliOfferingDefaultIT {
+
+    public static final String REST_EXTENSION_NAME = "REST Jackson";
+    public static final String REST_EXTENSION_ARTIFACT = "quarkus-rest-jackson";
+    public static final String REST_SUPPORT_SCOPE = "supported";
+
+    @Inject
+    static QuarkusCliClient cliClient;
+
+    @BeforeEach
+    public void prepareConfigBackup() throws IOException {
+        FileUtils.copyFile(QUARKUS_CONFIG, QUARKUS_TEST_CONFIG);
+    }
+
+    @Test
+    @Order(Integer.MAX_VALUE)
+    public void listExtensionsWithNoOffering() {
+        QuarkusCliClient.Result result = cliClient.listExtensions("--support-scope");
+        assertTrue(result.getOutput().contains(REST_EXTENSION_NAME)
+                && result.getOutput().contains(REST_EXTENSION_ARTIFACT),
+                "--support-scope option output should contain" + REST_EXTENSION_ARTIFACT + ". Output: " + result.getOutput());
+
+        String extensionLine = getExtensionLineFromListOutput(result, REST_EXTENSION_ARTIFACT);
+
+        assertNotNull(extensionLine);
+        String quarkusVersionWithoutNumber = getQuarkusVersionWithoutNumberSuffix();
+        assertThat(REST_EXTENSION_ARTIFACT + " should not have support scope as no offering was selected",
+                extensionLine, not(containsString(REST_SUPPORT_SCOPE)));
+        assertThat(REST_EXTENSION_ARTIFACT + " should contain Quarkus version " + quarkusVersionWithoutNumber,
+                extensionLine, containsString(quarkusVersionWithoutNumber));
+    }
+
+    @Test
+    public void listExtensionsWithWrongOffering() throws IOException {
+        // Testing output when the unknow offering is set
+        updateRegistryConfigFileWithOffering("unknown-offering");
+        QuarkusCliClient.Result result = cliClient.listExtensions("--support-scope");
+        assertTrue(result.getOutput().contains(REST_EXTENSION_NAME)
+                && result.getOutput().contains(REST_EXTENSION_ARTIFACT),
+                "--support-scope option output should contain" + REST_EXTENSION_ARTIFACT + ". Output: " + result.getOutput());
+
+        String extensionLine = getExtensionLineFromListOutput(result, REST_EXTENSION_ARTIFACT);
+
+        assertNotNull(extensionLine);
+        assertThat(REST_EXTENSION_ARTIFACT + " should not have support scope equal to " + REST_SUPPORT_SCOPE,
+                extensionLine, not(containsString(REST_SUPPORT_SCOPE)));
+        assertThat(
+                REST_EXTENSION_ARTIFACT + " should have already released version from public registry and not testing version"
+                        + QuarkusProperties.getVersion(),
+                extensionLine, not(containsString(getQuarkusVersionWithoutNumberSuffix())));
+    }
+
+    @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/50480")
+    public void listExtensionsWithEmptyOffering() throws IOException {
+        // Testing output when the unknow offering is set
+        updateRegistryConfigFileWithOffering("");
+        QuarkusCliClient.Result result = cliClient.listExtensions("--support-scope");
+        assertFalse(result.isSuccessful());
+        // TODO the output in this case is not clear, needs to be updated when issue is fixed
+    }
+}

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingIbmIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingIbmIT.java
@@ -1,0 +1,58 @@
+package io.quarkus.ts.quarkus.cli.offering;
+
+import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.getExtensionLineFromListOutput;
+import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.updateRegistryConfigFileWithOffering;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.EnabledOnQuarkusVersion;
+
+@Tag("quarkus-cli")
+@Tag("QUARKUS-6397")
+@QuarkusScenario
+@DisabledOnNative(reason = "Only for JVM verification")
+@EnabledOnQuarkusVersion(version = ".*redhat.*", reason = "Need set up registry config for prod testing")
+public class QuarkusCliOfferingIbmIT extends QuarkusCliOfferingBase {
+
+    @BeforeAll
+    public static void setOfferingInConfigFile() throws IOException {
+        updateRegistryConfigFileWithOffering("ibm");
+    }
+
+    @Test
+    public void listedExtensionShouldContainSupportScopeForLangchain4jOpenAi() throws IOException {
+        QuarkusCliClient.Result result = cliClient.listExtensions("--support-scope");
+        assertTrue(result.getOutput().contains(LANGCHAIN4J_OPENAI_EXTENSION_NAME)
+                && result.getOutput().contains(LANGCHAIN4J_OPENAI_EXTENSION_ARTIFACT),
+                "--support-scope option output is unexpected. Output: " + result.getOutput());
+
+        String extensionLine = getExtensionLineFromListOutput(result, LANGCHAIN4J_OPENAI_EXTENSION_ARTIFACT);
+
+        assertNotNull(extensionLine);
+        assertThat(
+                LANGCHAIN4J_OPENAI_EXTENSION_ARTIFACT + " should have support scope equal to "
+                        + LANGCHAIN4J_OPENAI_SUPPORT_SCOPE,
+                extensionLine, containsString(LANGCHAIN4J_OPENAI_SUPPORT_SCOPE));
+    }
+
+    @Override
+    public String getQuarkusPlatformGroupId() {
+        return "com.redhat.quarkus.platform";
+    }
+
+    @Override
+    public String langchain4JBomVersion() {
+        return "${quarkus.platform.version}";
+    }
+}

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingRedHatIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingRedHatIT.java
@@ -1,0 +1,59 @@
+package io.quarkus.ts.quarkus.cli.offering;
+
+import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.getExtensionLineFromListOutput;
+import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.updateRegistryConfigFileWithOffering;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.EnabledOnQuarkusVersion;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+
+@Tag("quarkus-cli")
+@Tag("QUARKUS-6397")
+@QuarkusScenario
+@DisabledOnNative(reason = "Only for JVM verification")
+@EnabledOnQuarkusVersion(version = ".*redhat.*", reason = "Need set up registry config for prod testing")
+public class QuarkusCliOfferingRedHatIT extends QuarkusCliOfferingBase {
+
+    @BeforeAll
+    public static void setOfferingInConfigFile() throws IOException {
+        updateRegistryConfigFileWithOffering("redhat");
+    }
+
+    @Test
+    public void listedExtensionShouldNotContainSupportScopeForLangchain4jOpenAi() throws IOException {
+        QuarkusCliClient.Result result = cliClient.listExtensions("--support-scope");
+        assertTrue(result.getOutput().contains(LANGCHAIN4J_OPENAI_EXTENSION_NAME)
+                && result.getOutput().contains(LANGCHAIN4J_OPENAI_EXTENSION_ARTIFACT),
+                "--support-scope option output is unexpected. Output: " + result.getOutput());
+
+        String extensionLine = getExtensionLineFromListOutput(result, LANGCHAIN4J_OPENAI_EXTENSION_ARTIFACT);
+
+        assertNotNull(extensionLine);
+        assertThat(LANGCHAIN4J_OPENAI_EXTENSION_ARTIFACT + " should not have support scope",
+                extensionLine, not(containsString(LANGCHAIN4J_OPENAI_SUPPORT_SCOPE)));
+    }
+
+    @Override
+    public String getQuarkusPlatformGroupId() {
+        return "com.redhat.quarkus.platform";
+    }
+
+    @Override
+    public String langchain4JBomVersion() {
+        // The version of platform should be unproductized version e.g. 3.27.0
+        return QuarkusProperties.getVersion().replaceAll("^(\\d+\\.\\d+\\.\\d+).*", "$1");
+    }
+}

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingUtils.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingUtils.java
@@ -1,0 +1,129 @@
+package io.quarkus.ts.quarkus.cli.offering;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Writer;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Assertions;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+
+public class QuarkusCliOfferingUtils {
+
+    private static final Logger log = Logger.getLogger(QuarkusCliOfferingUtils.class);
+
+    public static final File QUARKUS_CONFIG = Paths.get(System.getProperty("user.home"), ".quarkus", "config.yaml").toFile();
+    public static final File QUARKUS_TEST_CONFIG = Paths.get("target", ".quarkus",
+            "config.yaml").toFile();
+
+    private static final String QUARKUS_REGISTRY_ID = "testingregistry";
+    private static final String LANGCHAIN4J_ARTIFACT_ID_NAME = "quarkus-langchain4j-bom";
+
+    public static String getExtensionLineFromListOutput(QuarkusCliClient.Result result, String extensionArtifactName) {
+        return result.getOutput()
+                .lines()
+                .filter(line -> line.contains(extensionArtifactName))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public static void assertCorrectPlatformBom(File pomFile, String quarkusPlatformGroupId) {
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        try (FileReader fileReader = new FileReader(pomFile)) {
+            Model model = reader.read(fileReader);
+            Assertions.assertEquals(model.getProperties().get("quarkus.platform.group-id"), quarkusPlatformGroupId,
+                    "Unexpected Quarkus platform bom (`quarkus.platform.group-id`) defined in pom.xml of created app.");
+        } catch (IOException | XmlPullParserException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    public static void assertCorrectLangChain4jBom(File pomFile, String expectedLangchain4jVersion) {
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        try (FileReader fileReader = new FileReader(pomFile)) {
+            Model model = reader.read(fileReader);
+            List<Dependency> dependencies = model.getDependencyManagement()
+                    .getDependencies()
+                    .stream()
+                    .filter(dependency -> dependency.getArtifactId().equals(LANGCHAIN4J_ARTIFACT_ID_NAME))
+                    .toList();
+            assertEquals(1, dependencies.size(), "Langchain4j bom should be present only once");
+            assertEquals(expectedLangchain4jVersion, dependencies.get(0).getVersion(),
+                    "Langchain4j bom should have " + expectedLangchain4jVersion
+                            + " set instead of " + dependencies.get(0).getVersion());
+        } catch (IOException | XmlPullParserException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    /**
+     * Load data from ~/.quarkus/config.yaml and update them
+     *
+     * @param offering offering value e.g. ibm, redhat
+     * @throws IOException
+     */
+    public static void updateRegistryConfigFileWithOffering(String offering) throws IOException {
+        DumperOptions options = new DumperOptions();
+        options.setIndent(2);
+        options.setPrettyFlow(true);
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+
+        Yaml yaml = new Yaml(options);
+
+        Map<String, Object> data;
+        try (InputStream inputStream = new FileInputStream(QUARKUS_TEST_CONFIG)) {
+            data = yaml.load(inputStream);
+        }
+
+        updateRegistryConfig((List<Object>) data.get("registries"), offering);
+
+        try (Writer writer = new FileWriter(QUARKUS_TEST_CONFIG)) {
+            log.info("Quarkus config in use is: located at " + QUARKUS_TEST_CONFIG.getAbsolutePath()
+                    + " and content of config is:\n" + data);
+            yaml.dump(data, writer);
+        }
+    }
+
+    /**
+     * Iterate over registries and add offering value to registry with name of {@link #QUARKUS_REGISTRY_ID}
+     *
+     * @param registries list of all set registries
+     * @param offering offering value e.g. ibm, redhat
+     */
+    private static void updateRegistryConfig(List<Object> registries, String offering) {
+        for (Object item : registries) {
+            if (item instanceof Map) {
+                Map<String, Object> registryMap = (Map<String, Object>) item;
+                if (registryMap.containsKey(QUARKUS_REGISTRY_ID)) {
+                    // Get the testing registry and set the offering
+                    Map<String, Object> details = (Map<String, Object>) registryMap.get(QUARKUS_REGISTRY_ID);
+                    details.put("offering", offering);
+                    return;
+                }
+            }
+        }
+        Assertions.fail(QUARKUS_REGISTRY_ID + " registry is not present in quarkus config");
+    }
+
+    public static String getQuarkusVersionWithoutNumberSuffix() {
+        return QuarkusProperties.getVersion().replaceAll("-\\d{5}$", "");
+    }
+}


### PR DESCRIPTION
### Summary

Created coverage base on https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-6397.md test plan

All test except `QuarkusCliExtensionsIT#shouldListExtensionsUsingSupportScope` will be run only when product testing. Atm they will run at the same time as for testing only one registry is used, but for future if this requirement change adding the profile base of test name should be problem.

Note I executed this on prod test job and the test passed

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)