### PR TITLE
[3.20] backport - Add test coverage for #47552 fix Restore loading of all JDBC drivers on datasource creation

### DIFF
--- a/sql-db/sql-app/src/main/java/io/quarkus/ts/sqldb/sqlapp/DriverRegistrationResource.java
+++ b/sql-db/sql-app/src/main/java/io/quarkus/ts/sqldb/sqlapp/DriverRegistrationResource.java
@@ -1,0 +1,32 @@
+package io.quarkus.ts.sqldb.sqlapp;
+
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/drivers")
+public class DriverRegistrationResource {
+
+    @GET
+    @Path("/list")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String listDrivers() {
+        String variableToChange = "initial value";
+        List<String> drivers = new ArrayList<>();
+        Enumeration<Driver> driverEnum = DriverManager.getDrivers();
+
+        while (driverEnum.hasMoreElements()) {
+            Driver driver = driverEnum.nextElement();
+            drivers.add(driver.getClass().getName());
+        }
+        return String.join("\n", drivers);
+    }
+
+}

--- a/sql-db/sql-app/src/main/java/io/quarkus/ts/sqldb/sqlapp/driver/TestJdbcDriver.java
+++ b/sql-db/sql-app/src/main/java/io/quarkus/ts/sqldb/sqlapp/driver/TestJdbcDriver.java
@@ -1,0 +1,57 @@
+package io.quarkus.ts.sqldb.sqlapp.driver;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public class TestJdbcDriver implements Driver {
+
+    static {
+        try {
+            DriverManager.registerDriver(new TestJdbcDriver());
+        } catch (SQLException e) {
+            throw new RuntimeException(
+                    "Failed to register io.quarkus.ts.qe.sqldb.sqlapp.driver.registration.driver.TestJdbcDriver", e);
+        }
+    }
+
+    @Override
+    public Connection connect(String url, Properties info) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean acceptsURL(String url) {
+        return false;
+    }
+
+    @Override
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) {
+        return new DriverPropertyInfo[0];
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 1;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public boolean jdbcCompliant() {
+        return false;
+    }
+
+    @Override
+    public Logger getParentLogger() {
+        return null;
+    }
+
+}

--- a/sql-db/sql-app/src/main/resources/META-INF/services/java.sql.Driver
+++ b/sql-db/sql-app/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+io.quarkus.ts.sqldb.sqlapp.driver.TestJdbcDriver

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/CustomDriverRegistrationIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/CustomDriverRegistrationIT.java
@@ -1,0 +1,76 @@
+package io.quarkus.ts.sqldb.sqlapp;
+
+import static org.hamcrest.Matchers.containsString;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.FileUtils;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.restassured.response.Response;
+
+@Tag("QUARKUS-6164")
+@QuarkusScenario
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class CustomDriverRegistrationIT {
+
+    @DevModeQuarkusApplication
+    static RestService app = new RestService();
+
+    @Test
+    @Order(1)
+    public void checkThatDriverIsRegisteredAfterStartUp() {
+        getDriverList();
+    }
+
+    @Test
+    @Order(2)
+    public void checkThatDriverIsRegisteredAfterReload() {
+        triggerDevModeReloadAndWait();
+        getDriverList();
+    }
+
+    private void getDriverList() {
+        app.given()
+                .when()
+                .get("/drivers/list")
+                .then()
+                .statusCode(200).body(containsString("io.quarkus.ts.sqldb.sqlapp.driver.TestJdbcDriver"));
+    }
+
+    private void triggerDevModeReloadAndWait() {
+        Path driverRegistrationResource = Path.of("src", "main", "java", "io", "quarkus", "ts", "sqldb", "sqlapp",
+                "DriverRegistrationResource.java");
+        Path file = app.getServiceFolder().resolve(driverRegistrationResource);
+        try {
+            String content = FileUtils.readFileToString(file.toFile(), StandardCharsets.UTF_8);
+            content = content.replace("initial value", "changedVariable");
+
+            FileUtils.writeStringToFile(file.toFile(), content, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            Assertions.fail("Could not load file " + file, e);
+        }
+
+        Awaitility.await()
+                .pollInterval(1, TimeUnit.SECONDS)
+                .atMost(10, TimeUnit.SECONDS).until(() -> {
+                    // Request trigger live reload, but need to wait for it,
+                    // otherwise the response returning the values before the reload
+                    Response response = app.given().when().get("/drivers/list");
+                    return response.statusCode() == 200
+                            && app.getLogs().stream().anyMatch(line -> line.contains("Live reload total time"));
+                });
+    }
+}


### PR DESCRIPTION
### Summary

Backport https://github.com/quarkus-qe/quarkus-test-suite/pull/2648 - Add test coverage for #47552 fix Restore loading of all JDBC drivers on datasource creation

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [X] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)