### PR TITLE
Tweak test for periodic token refresh

### DIFF
--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractOidcRestClientIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractOidcRestClientIT.java
@@ -4,6 +4,7 @@ import static io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.Tok
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -20,6 +21,7 @@ import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.model.Score;
 import io.restassured.http.ContentType;
+import io.restassured.response.Response;
 
 public abstract class AbstractOidcRestClientIT {
 
@@ -98,7 +100,10 @@ public abstract class AbstractOidcRestClientIT {
     public void testPeriodicTokenRefresh() throws InterruptedException {
         // get first token, this will start to make the app periodically check for token validity
         // accessing this endpoint will also reset counter of checks for token validity
-        String firstToken = app.given().get("/token-echo").getBody().asString();
+        Response firstTokenRequest = app.given().get("/token-echo");
+        // assert that token was successfully acquired and used
+        assertEquals(HttpStatus.SC_OK, firstTokenRequest.getStatusCode(), "App should acquire token and work with it.");
+        String firstToken = firstTokenRequest.getBody().asString();
 
         // give the app some time to check for token refresh several times and also actually refresh the token
         Thread.sleep(2000);
@@ -107,7 +112,10 @@ public abstract class AbstractOidcRestClientIT {
                 .parseInt(app.given().given().get("/token-echo/refresh-counts").getBody().asString());
 
         // after this time, original token should be expired and new token should be given
-        String secondToken = app.given().get("/token-echo").getBody().asString();
+        Response secondTokenRequest = app.given().get("/token-echo");
+        // assert that token was successfully acquired and used
+        assertEquals(HttpStatus.SC_OK, secondTokenRequest.getStatusCode(), "App should acquire token and work with it.");
+        String secondToken = secondTokenRequest.getBody().asString();
 
         // refresh-interval is configured to 0.5s so app should check every 0.5 if token is valid
         // if property "refresh-interval" is not configured, it will check only once - when the token is actually needed during HTTP request


### PR DESCRIPTION
### Summary

Follow up on https://github.com/quarkus-qe/quarkus-test-suite/pull/2697 In the original PR tests were not checking if token was successfully generated. While app will respond with error if not, tests will would originally not check for that and not fail.
Add validation, that tests will fail, if token generation fail.

Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)