### PR TITLE
Make OpenShiftMetaEndpointIT use RHBK on OCP

### DIFF
--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/AbstractMetaEndpointIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/AbstractMetaEndpointIT.java
@@ -1,0 +1,125 @@
+package io.quarkus.ts.security.keycloak;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.LookupService;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.URILike;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public abstract class AbstractMetaEndpointIT {
+
+    @LookupService
+    static KeycloakService keycloak;
+    static final String CUSTOM_ENDPOINT = "/custom-endpoint";
+    private static final String DEFAULT_META_ENDPOINT = ".well-known/oauth-protected-resource";
+    static final String OVERLOADED_META_ENDPOINT = "/" + DEFAULT_META_ENDPOINT + CUSTOM_ENDPOINT;
+
+    @QuarkusApplication
+    static RestService http = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperty("quarkus.oidc.resource-metadata.enabled", "true")
+            .withProperty("quarkus.oidc.client-id", BaseOidcSecurityIT.CLIENT_ID_DEFAULT)
+            .withProperty("quarkus.oidc.credentials.secret", BaseOidcSecurityIT.CLIENT_SECRET_DEFAULT)
+            .withProperties(() -> keycloak.getTlsProperties());
+
+    @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureTruststore = true, configureHttpServer = true))
+    static RestService https = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperty("quarkus.oidc.resource-metadata.enabled", "true")
+            .withProperty("quarkus.http.ssl.client-auth", "request")
+            .withProperty("quarkus.http.auth.permission.auth.policy", "authenticated")
+            .withProperty("quarkus.http.auth.permission.auth.paths", "/user")
+            .withProperty("quarkus.oidc.resource-metadata.resource", CUSTOM_ENDPOINT)
+            .withProperty("quarkus.oidc.client-id", BaseOidcSecurityIT.CLIENT_ID_DEFAULT)
+            .withProperty("quarkus.oidc.credentials.secret", BaseOidcSecurityIT.CLIENT_SECRET_DEFAULT)
+            .withProperties(() -> keycloak.getTlsProperties());
+
+    @Test
+    @Order(1)
+    public void httpHasHTTPSMetadata() {
+        Response response = http.given()
+                .when()
+                .get(DEFAULT_META_ENDPOINT);
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+        JsonPath jsonPath = response.body().jsonPath();
+        assertEquals(getAppURL(http, Protocol.HTTP).withScheme("https").toString(),
+                jsonPath.getString("resource"),
+                "No app URL in the body: " + response.body().asString());
+        assertEquals(keycloak.getRealmUrl(),
+                jsonPath.getString("authorization_servers[0]"),
+                "No authorization server URL in the body: " + response.body().asString());
+    }
+
+    @Test
+    @Order(2)
+    public void noForcedHttps() {
+        http.stop();
+        http.withProperty("quarkus.oidc.resource-metadata.force-https-scheme", "false");
+        http.start();
+        Response response = http.given()
+                .when()
+                .get(DEFAULT_META_ENDPOINT);
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+        JsonPath jsonPath = response.body().jsonPath();
+        assertEquals(getAppURL(http, Protocol.HTTP).toString(),
+                jsonPath.getString("resource"),
+                "No app URL in the body: " + response.body().asString());
+        assertEquals(keycloak.getRealmUrl(),
+                jsonPath.getString("authorization_servers[0]"),
+                "No authorization server URL in the body: " + response.body().asString());
+    }
+
+    @Test
+    public void endpointInfoInHeader() {
+        Response response = https
+                .relaxedHttps()
+                .given()
+                .when()
+                .get("/user");
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, response.statusCode());
+        String header = response.header("www-authenticate");
+        Assertions.assertNotNull(header, "There is no authentication header in the answer!");
+        String metadataURL = getAppURL(https, Protocol.HTTPS)
+                .withPath(OVERLOADED_META_ENDPOINT)
+                .toString();
+        // What value of the 'www-authenticate' header looks like:
+        // Bearer resource_metadata="https://localhost:1103/.well-known/oauth-protected-resource/custom-endpoint"
+        assertEquals(metadataURL,
+                header.split("=")[1].replaceAll("\"", ""),
+                "Authentication header doesn't contain metadata endpoint");
+    }
+
+    URILike getAppURL(RestService app, Protocol protocol) {
+        return app.getURI(protocol);
+    }
+
+    @Test
+    public void httpsHasMetadata() {
+        Response response = https
+                .relaxedHttps()
+                .given()
+                .when()
+                .get(OVERLOADED_META_ENDPOINT);
+        JsonPath jsonPath = response.body().jsonPath();
+        assertEquals(getAppURL(https, Protocol.HTTPS).withPath(CUSTOM_ENDPOINT).toString(),
+                jsonPath.getString("resource"),
+                "No app URL in the body: " + response.body().asString());
+        assertEquals(keycloak.getRealmUrl(),
+                jsonPath.getString("authorization_servers[0]"),
+                "No authorization server URL in the body: " + response.body().asString());
+    }
+}

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/MetaEndpointIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/MetaEndpointIT.java
@@ -3,128 +3,15 @@ package io.quarkus.ts.security.keycloak;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
 import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 
 import io.quarkus.test.bootstrap.KeycloakService;
-import io.quarkus.test.bootstrap.Protocol;
-import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Certificate;
 import io.quarkus.test.services.KeycloakContainer;
-import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.test.services.URILike;
-import io.restassured.path.json.JsonPath;
-import io.restassured.response.Response;
 
 @QuarkusScenario
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class MetaEndpointIT {
+public class MetaEndpointIT extends AbstractMetaEndpointIT {
 
     @KeycloakContainer(runKeycloakInProdMode = true)
     static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
-    static final String CUSTOM_ENDPOINT = "/custom-endpoint";
-    private static final String DEFAULT_META_ENDPOINT = ".well-known/oauth-protected-resource";
-    static final String OVERLOADED_META_ENDPOINT = "/" + DEFAULT_META_ENDPOINT + CUSTOM_ENDPOINT;
 
-    @QuarkusApplication
-    static RestService http = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
-            .withProperty("quarkus.oidc.resource-metadata.enabled", "true")
-            .withProperty("quarkus.oidc.client-id", BaseOidcSecurityIT.CLIENT_ID_DEFAULT)
-            .withProperty("quarkus.oidc.credentials.secret", BaseOidcSecurityIT.CLIENT_SECRET_DEFAULT)
-            .withProperties(keycloak::getTlsProperties);
-
-    @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureTruststore = true, configureHttpServer = true))
-    static RestService https = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
-            .withProperty("quarkus.oidc.resource-metadata.enabled", "true")
-            .withProperty("quarkus.http.ssl.client-auth", "request")
-            .withProperty("quarkus.http.auth.permission.auth.policy", "authenticated")
-            .withProperty("quarkus.http.auth.permission.auth.paths", "/user")
-            .withProperty("quarkus.oidc.resource-metadata.resource", CUSTOM_ENDPOINT)
-            .withProperty("quarkus.oidc.client-id", BaseOidcSecurityIT.CLIENT_ID_DEFAULT)
-            .withProperty("quarkus.oidc.credentials.secret", BaseOidcSecurityIT.CLIENT_SECRET_DEFAULT)
-            .withProperties(keycloak::getTlsProperties);
-
-    @Test
-    @Order(1)
-    public void httpHasHTTPSMetadata() {
-        Response response = http.given()
-                .when()
-                .get(DEFAULT_META_ENDPOINT);
-        assertEquals(HttpStatus.SC_OK, response.statusCode());
-        JsonPath jsonPath = response.body().jsonPath();
-        assertEquals(getAppURL(http, Protocol.HTTP).withScheme("https").toString(),
-                jsonPath.getString("resource"),
-                "No app URL in the body: " + response.body().asString());
-        assertEquals(keycloak.getRealmUrl(),
-                jsonPath.getString("authorization_servers[0]"),
-                "No authorization server URL in the body: " + response.body().asString());
-    }
-
-    @Test
-    @Order(2)
-    public void noForcedHttps() {
-        http.stop();
-        http.withProperty("quarkus.oidc.resource-metadata.force-https-scheme", "false");
-        http.start();
-        Response response = http.given()
-                .when()
-                .get(DEFAULT_META_ENDPOINT);
-        assertEquals(HttpStatus.SC_OK, response.statusCode());
-        JsonPath jsonPath = response.body().jsonPath();
-        assertEquals(getAppURL(http, Protocol.HTTP).toString(),
-                jsonPath.getString("resource"),
-                "No app URL in the body: " + response.body().asString());
-        assertEquals(keycloak.getRealmUrl(),
-                jsonPath.getString("authorization_servers[0]"),
-                "No authorization server URL in the body: " + response.body().asString());
-    }
-
-    @Test
-    public void endpointInfoInHeader() {
-        Response response = https
-                .relaxedHttps()
-                .given()
-                .when()
-                .get("/user");
-        assertEquals(HttpStatus.SC_UNAUTHORIZED, response.statusCode());
-        String header = response.header("www-authenticate");
-        Assertions.assertNotNull(header, "There is no authentication header in the answer!");
-        String metadataURL = getAppURL(https, Protocol.HTTPS)
-                .withPath(OVERLOADED_META_ENDPOINT)
-                .toString();
-        // What value of the 'www-authenticate' header looks like:
-        // Bearer resource_metadata="https://localhost:1103/.well-known/oauth-protected-resource/custom-endpoint"
-        assertEquals(metadataURL,
-                header.split("=")[1].replaceAll("\"", ""),
-                "Authentication header doesn't contain metadata endpoint");
-    }
-
-    URILike getAppURL(RestService app, Protocol protocol) {
-        return app.getURI(protocol);
-    }
-
-    @Test
-    public void httpsHasMetadata() {
-        Response response = https
-                .relaxedHttps()
-                .given()
-                .when()
-                .get(OVERLOADED_META_ENDPOINT);
-        JsonPath jsonPath = response.body().jsonPath();
-        assertEquals(getAppURL(https, Protocol.HTTPS).withPath(CUSTOM_ENDPOINT).toString(),
-                jsonPath.getString("resource"),
-                "No app URL in the body: " + response.body().asString());
-        assertEquals(keycloak.getRealmUrl(),
-                jsonPath.getString("authorization_servers[0]"),
-                "No authorization server URL in the body: " + response.body().asString());
-    }
 }

--- a/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftMetaEndpointIT.java
+++ b/security/keycloak/src/test/java/io/quarkus/ts/security/keycloak/OpenShiftMetaEndpointIT.java
@@ -1,12 +1,22 @@
 package io.quarkus.ts.security.keycloak;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
+import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.URILike;
 
 @OpenShiftScenario
-public class OpenShiftMetaEndpointIT extends MetaEndpointIT {
+public class OpenShiftMetaEndpointIT extends AbstractMetaEndpointIT {
+
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+
     @Override
     URILike getAppURL(RestService app, Protocol protocol) {
         // For some reason, when running on OpenStack, the URI contains port number,


### PR DESCRIPTION
### Summary

* Just like all the other OCP tests using KC. For this, we need to
  extract the test logic into abstract parent also

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)