### PR TITLE
Allow devui DB from any host

### DIFF
--- a/hibernate/hibernate-orm/src/main/resources/application.properties
+++ b/hibernate/hibernate-orm/src/main/resources/application.properties
@@ -17,3 +17,6 @@ quarkus.hibernate-orm.test-hql-pu.datasource=<default>
 quarkus.hibernate-orm.test-hql-pu.packages=io.quarkus.qe.hibernate.hql
 quarkus.hibernate-orm.test-hql-pu.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.test-hql-pu.sql-load-script=test-hql-pu-import-script.sql
+
+quarkus.datasource.dev-ui.allowed-db-host=*
+


### PR DESCRIPTION
### Summary

Some of the DevMode*HQLConsoleIT are failing on windows with:
```
 The persistence unit's datasource points to a non-allowed datasource. By default only local databases are enabled; you can use the 'quarkus.datasource.dev-ui.allowed-db-host' configuration property to configure allowed hosts ('*' to allow all).
```

I don't know how devUI services or working on windows, but possibly they are running on different machine (maybe quarkus on windows is treating docker containers like another machine?).

I haven't tested this PR yet, it's just an idea.


Please select the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)