### PR TITLE
Fix HQL Console test coverage on Windows

### DIFF
--- a/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/DevModeMySQLHQLConsoleIT.java
+++ b/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/DevModeMySQLHQLConsoleIT.java
@@ -1,11 +1,14 @@
 package io.quarkus.qe.hibernate;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Dependency;
 import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.smallrye.common.os.OS;
 
 @QuarkusScenario
 @Tag("QUARKUS-6243")
@@ -13,5 +16,15 @@ public class DevModeMySQLHQLConsoleIT extends AbstractHQLConsoleIT {
 
     @DevModeQuarkusApplication(dependencies = @Dependency(artifactId = "quarkus-jdbc-mysql"))
     static DevModeQuarkusService app = (DevModeQuarkusService) new DevModeQuarkusService()
-            .withProperties("mysql.properties");
+            .withProperties("mysql.properties")
+            .withProperties(() -> {
+                if (OS.WINDOWS.isCurrent() && DockerUtils.isNotPodman()) {
+                    String dockerIp = System.getenv(DockerUtils.DOCKER_IP);
+                    if (dockerIp != null && !dockerIp.isEmpty()) {
+                        // container IP in Minikube is not localhost
+                        return Map.of("quarkus.datasource.dev-ui.allowed-db-host", dockerIp);
+                    }
+                }
+                return Map.of();
+            });
 }

--- a/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/DevModePostgresqlHQLConsoleIT.java
+++ b/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/DevModePostgresqlHQLConsoleIT.java
@@ -1,15 +1,28 @@
 package io.quarkus.qe.hibernate;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.smallrye.common.os.OS;
 
 @QuarkusScenario
 @Tag("QUARKUS-6243")
 public class DevModePostgresqlHQLConsoleIT extends AbstractHQLConsoleIT {
 
     @DevModeQuarkusApplication
-    static DevModeQuarkusService app = new DevModeQuarkusService();
+    static DevModeQuarkusService app = (DevModeQuarkusService) new DevModeQuarkusService()
+            .withProperties(() -> {
+                if (OS.WINDOWS.isCurrent() && DockerUtils.isNotPodman()) {
+                    String dockerIp = System.getenv(DockerUtils.DOCKER_IP);
+                    if (dockerIp != null && !dockerIp.isEmpty()) {
+                        // container IP in Minikube is not localhost
+                        return Map.of("quarkus.datasource.dev-ui.allowed-db-host", dockerIp);
+                    }
+                }
+                return Map.of();
+            });
 }

--- a/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/DockerUtils.java
+++ b/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/DockerUtils.java
@@ -1,0 +1,13 @@
+package io.quarkus.qe.hibernate;
+
+public class DockerUtils {
+
+    static final String DOCKER_IP = "DOCKER_IP";
+
+    // TODO: move this to the framework
+    static boolean isNotPodman() {
+        final String dockerHostEnvVar = System.getenv("DOCKER_HOST");
+        return dockerHostEnvVar == null || !dockerHostEnvVar.contains("podman");
+    }
+
+}


### PR DESCRIPTION
### Summary

Containers in Minikube don't use localhost. Tested on Windows (both PG and MySQL).

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)