### PR TITLE
Disable DevModeMySQLHQLConsoleIT in FIPS-enabled environment

### DIFF
--- a/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/DevModeMySQLHQLConsoleIT.java
+++ b/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/DevModeMySQLHQLConsoleIT.java
@@ -10,6 +10,7 @@ import io.quarkus.test.services.Dependency;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.smallrye.common.os.OS;
 
+@Tag("fips-incompatible") // TODO: enable when https://github.com/quarkusio/quarkus/issues/40526 gets fixed
 @QuarkusScenario
 @Tag("QUARKUS-6243")
 public class DevModeMySQLHQLConsoleIT extends AbstractHQLConsoleIT {


### PR DESCRIPTION
### Summary

It is known issue that MySQL dev services doesn't work in FIPS-enabled environment.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)