### PR TITLE
[3.27] Disable DevModeMySQLHQLConsoleIT in FIPS-enabled environment

### DIFF
--- a/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/DevModeMySQLHQLConsoleIT.java
+++ b/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/DevModeMySQLHQLConsoleIT.java
@@ -10,6 +10,7 @@ import io.quarkus.test.services.Dependency;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.smallrye.common.os.OS;
 
+@Tag("fips-incompatible") // TODO: enable when https://github.com/quarkusio/quarkus/issues/40526 gets fixed
 @QuarkusScenario
 @Tag("QUARKUS-6243")
 public class DevModeMySQLHQLConsoleIT extends AbstractHQLConsoleIT {


### PR DESCRIPTION
### Summary

Backports:
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2710
(cherry picked from commit dacb1cf846806c00aa52eb2ccf37f4dedd11e7d3)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)