### PR TITLE
Fix tests using reactive Vert.x MySQL client running in FIPS-enabled environment

### DIFF
--- a/security/webauthn/src/test/java/io/quarkus/ts/security/webauthn/MySqlWebAuthnIT.java
+++ b/security/webauthn/src/test/java/io/quarkus/ts/security/webauthn/MySqlWebAuthnIT.java
@@ -1,6 +1,6 @@
 package io.quarkus.ts.security.webauthn;
 
-import org.junit.jupiter.api.Tag;
+import java.util.Map;
 
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
@@ -8,7 +8,6 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
-@Tag("fips-incompatible") // TODO: enable when the https://github.com/eclipse-vertx/vertx-sql-client/issues/1436 is fixed
 @QuarkusScenario
 public class MySqlWebAuthnIT extends AbstractWebAuthnTest {
 
@@ -21,7 +20,18 @@ public class MySqlWebAuthnIT extends AbstractWebAuthnTest {
     static RestService app = new RestService().withProperties("mysql.properties")
             .withProperty("quarkus.datasource.username", database::getUser)
             .withProperty("quarkus.datasource.password", database::getPassword)
-            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl);
+            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl)
+            .withProperties(() -> {
+                boolean fipsEnabledEnv = System.getProperty("excludedGroups", "").contains("fips-incompatible");
+                if (fipsEnabledEnv) {
+                    // TODO: drop when Quarkus migrates to Vert.x with https://github.com/eclipse-vertx/vertx-sql-client/issues/1539
+                    // see https://github.com/eclipse-vertx/vertx-sql-client/issues/1436#issuecomment-3109720406
+                    return Map.of(
+                            "quarkus.datasource.reactive.mysql.ssl-mode", "preferred",
+                            "quarkus.datasource.reactive.trust-all", "true");
+                }
+                return Map.of();
+            });
 
     @Override
     protected RestService getApp() {


### PR DESCRIPTION
### Summary

Newly added `MultiDatabaseHibernateReactiveIT` test is failing and previously disabled tests were not running even though we know a workaround for https://github.com/eclipse-vertx/vertx-sql-client/issues/1539. This PR fixes it, I tested it in FIPS-enabled environment.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)