### PR TITLE
Fix MariaDBHibernateOfflineStartupIT test failure in FIPS-enabled environment by correcting mounting paths specifically for each image

### DIFF
--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/MariaDBHibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/MariaDBHibernateOfflineStartupIT.java
@@ -16,6 +16,9 @@ import io.quarkus.test.services.QuarkusApplication;
 public class MariaDBHibernateOfflineStartupIT extends AbstractHibernateOfflineStartupIT {
 
     @Container(image = "${mariadb.11.image}", expectedLog = "socket: '.*/mysql.*sock'  port: 3306", mounts = {
+            // the MariaDB image has dynamically mounted files based on the actual resolved image
+            // for FIPS-enabled environment, see https://issues.redhat.com/browse/QUARKUS-5984
+            // if you change the image or mounting, please don't forget to change that code in FixedPortResourceBuilder
             @Mount(from = "mysql-init.sql", to = "/docker-entrypoint-initdb.d/init.sql")
     }, port = 3306, builder = FixedPortResourceBuilder.class)
     static final MariaDbService db = new MariaDbService().setAutoStart(false);


### PR DESCRIPTION
### Summary

There is known issue https://issues.redhat.com/browse/QUARKUS-5984 that MariaDB 11.x image fails in FIPS-enabled environment and we work around that by switching to a different image in FIPS-enabled environment https://github.com/quarkus-qe/quarkus-test-suite/blob/1bdb0715e06168a207d69ca1b74092f3fa4e0042/pom.xml#L1033. However this Red Hat image requires different mounting. This PR corrects mounting of the init SQL script and configuration when it detects Red Hat image, which only happens in FIPS.

This change is relevant only for bare-metal tests, as OpenShift uses different resource builder without fixed port paths.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)