### PR TITLE
Fix security/permissions/BeanParamPermissionIT after upstream @Context injection fix in records

### DIFF
--- a/security/permissions/src/test/java/io/quarkus/ts/security/permissions/beanparam/BeanParamPermissionIT.java
+++ b/security/permissions/src/test/java/io/quarkus/ts/security/permissions/beanparam/BeanParamPermissionIT.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.containsString;
 import jakarta.ws.rs.core.MediaType;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -156,9 +155,8 @@ public class BeanParamPermissionIT extends BaseBeanParamPermissionsIT {
     }
 
     @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/53477")
     public void testRecordBeanParamDenialInvalidDocumentId() {
-        givenAuthenticatedUser(ADMIN)
+        givenAuthenticatedUser(USER)
                 .header("CustomAuthorization", "valid-token")
                 .queryParam("docId", "invalid-id")
                 .queryParam("version", "1")


### PR DESCRIPTION
### Summary

Upstream [quarkusio/quarkus#53345 (ASM to Gizmo rewrite)](https://github.com/quarkusio/quarkus/pull/53484) fixed a bug where `@Context` parameters                                              
  were never injected in record @BeanParam classes. Our test was relying on that broken behavior.
Now that `@Context `works correctly, the fix is to use USER instead of ADMIN for the denial scenario.


Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)