### PR TITLE
[3.27] Disabled DevModeWorkspaceIT

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeWorkspaceIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeWorkspaceIT.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.http.HttpStatus;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +30,7 @@ import io.quarkus.test.utils.AwaitilityUtils;
 import io.quarkus.test.utils.FileUtils;
 import io.restassured.response.Response;
 
+@Disabled("Flaky test for 3.27 some tests failing com.microsoft.playwright.TimeoutError - Timeout 30000ms exceeded")
 @Tag("QUARKUS-6247")
 @QuarkusScenario
 public class DevModeWorkspaceIT {


### PR DESCRIPTION
### Summary

Some tests (such as `workspaceCanBeEdited`, `workspaceContainsText` are failing in our jenkins jobs with:
```
com.microsoft.playwright.TimeoutError: Error {
  message='Timeout 30000ms exceeded.
  name='TimeoutError
  stack='TimeoutError: Timeout 30000ms exceeded.
    at ProgressController.run (/tmp/playwright-java-832403974107047270/package/lib/server/progress.js:68:28)
    at FrameDispatcher._runCommand (/tmp/playwright-java-832403974107047270/package/lib/server/dispatchers/dispatcher.js:95:31)
    at DispatcherConnection.dispatch (/tmp/playwright-java-832403974107047270/package/lib/server/dispatchers/dispatcher.js:329:39)
}
```


Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)