### PR TITLE
Add coverage for QUARKUS-7308 (Kafka OAuthBearer authentication fails in native mode)

### DIFF
--- a/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/OauthKafkaNativeFailIT.java
+++ b/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/OauthKafkaNativeFailIT.java
@@ -1,0 +1,34 @@
+package io.quarkus.ts.messaging.kafka.producer;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.EnabledOnNative;
+import io.quarkus.test.services.QuarkusApplication;
+
+@Tag("QUARKUS-7308")
+@EnabledOnNative
+@QuarkusScenario
+public class OauthKafkaNativeFailIT {
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperties("oauthbearer.properties")
+            .setAutoStart(false);
+
+    @Test
+    public void checkThatQuarkusStartNotFailWithMissingConstructor() {
+        assertThrows(AssertionError.class, () -> app.start(),
+                "Expecting to fail to start as it's need to set complicated setup for Kafka");
+        app.logs().assertDoesNotContain(
+                "Could not find a public no-argument constructor for org.apache.kafka.common.security.oauthbearer.DefaultJwtRetriever");
+        app.logs().assertDoesNotContain(
+                "Could not find a public no-argument constructor for org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator");
+        // Need to check if it failed with expected error
+        app.logs().assertContains("configuration encountered an error on configure(): Invalid value");
+    }
+}

--- a/messaging/kafka-producer/src/test/resources/oauthbearer.properties
+++ b/messaging/kafka-producer/src/test/resources/oauthbearer.properties
@@ -1,0 +1,10 @@
+kafka.sasl.login.callback.handler.class:org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler
+# This is just mocking url
+kafka.sasl.oauthbearer.token.endpoint.url=https://localhost:8080/protocol/openid-connect/token
+
+mp.messaging.connector.smallrye-kafka.security.protocol=SASL_PLAINTEXT
+mp.messaging.connector.smallrye-kafka.sasl.mechanism=OAUTHBEARER
+mp.messaging.connector.smallrye-kafka.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
+  clientId="team-a-client" \
+  clientSecret="team-a-client-secret" ;
+quarkus.ssl.native=true


### PR DESCRIPTION
### Summary

Coverage for [QUARKUS-7308](https://redhat.atlassian.net/browse/QUARKUS-7308)

Test fail with `mvn -fae -V -B clean verify -Doc.reruns=0 -Dreruns=0 -Pmessaging-modules -f messaging/kafka-producer -Dit.test=OauthKafkaNativeFailIT -Dnative -Dquarkus.platform.version=3.31.2`

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)