### PR TITLE
Drop ubi-quarkus-mandrel-builder-image:jdk-21 usage

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 21 ]
-        image: [ "ubi9-quarkus-mandrel-builder-image:jdk-25", "ubi-quarkus-mandrel-builder-image:jdk-21 -Dtest-ubi8-compatibility" ]
+        image: [ "ubi9-quarkus-mandrel-builder-image:jdk-25" ]
         profiles: [ "root-modules,websockets-modules,test-tooling-modules,nosql-db-modules,ai-modules",
                    "http-modules,cache-modules", "security-modules,spring-modules",
                     "hibernate-modules", "sql-db-modules", "messaging-modules,monitoring-modules"]
@@ -227,7 +227,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 21 ]
-        image: [ "ubi9-quarkus-mandrel-builder-image:jdk-21" ]
+        image: [ "ubi9-quarkus-mandrel-builder-image:jdk-25" ]
         profiles: [ "root-modules,websockets-modules,test-tooling-modules,nosql-db-modules,ai-modules",
                     "http-modules,cache-modules", "security-modules,spring-modules",
                     "hibernate-modules", "sql-db-modules", "messaging-modules,monitoring-modules"]


### PR DESCRIPTION
### Summary

Drop ubi-quarkus-mandrel-builder-image:jdk-21 usage

ubi-quarkus-mandrel-builder-image:jdk-25 is the way to go, one supported Mandrel version

ubi8-compatibility becomes irrelevant for native mode because Mandrel based on Java 25 needs UBI9 as a base
cc @jedla97 - sounds like a topic for RN if not covered already

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)