### PR TITLE
Set explicit provider definition for redpanda

### DIFF
--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeKafkaStreamIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeKafkaStreamIT.java
@@ -28,6 +28,6 @@ public class DevModeKafkaStreamIT extends BaseKafkaStreamTest {
 
     @Test
     public void kafkaContainerShouldBeStarted() {
-        app.logs().assertContains("Creating container for image: docker.io/redpandadata/redpanda");
+        app.logs().assertContains("Creating container for image: docker.io/apache/kafka-native");
     }
 }

--- a/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeRedPandaDevServiceUserExperienceIT.java
+++ b/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DevModeRedPandaDevServiceUserExperienceIT.java
@@ -26,6 +26,7 @@ public class DevModeRedPandaDevServiceUserExperienceIT {
     @DevModeQuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.kafka.devservices.enabled", Boolean.TRUE.toString())
+            .withProperty("quarkus.kafka.devservices.provider", "redpanda")
             .withProperty("quarkus.kafka.devservices.image-name", "${redpanda.image}")
             .onPreStart(s -> DockerUtils.removeImage(RED_PANDA_IMAGE, RED_PANDA_VERSION));
 


### PR DESCRIPTION
### Summary

Set explicit provider definition for redpanda

Redpanda is not the default for Kafka Dev Service, see https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.35#kafka-dev-service


Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)