### PR TITLE
Add link to hibernate bug tracing.

### DIFF
--- a/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/entityless/EntitylessEndpoint.java
+++ b/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/entityless/EntitylessEndpoint.java
@@ -22,6 +22,7 @@ public class EntitylessEndpoint {
     @Startup
     @Transactional
     public void init() {
+        // TODO: remove once https://hibernate.atlassian.net/browse/HHH-20321 is fixed and fix is available in quarkus
         // Initiate the DB, since hibernate will not import SQL script if no entity is defined
         statelessSession.createNativeQuery("DROP TABLE IF EXISTS person;").executeUpdate();
         statelessSession.createNativeQuery("""


### PR DESCRIPTION
### Summary

Add link to import.sql bug in hibernate, which we are working-around by initializing it manually. 
It was mentioned in https://github.com/quarkus-qe/quarkus-test-suite/pull/2828#discussion_r3086385626
We should remove this workaround once the bug is fixed. 

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)