### PR TITLE
[3.33] Version bumps, workshop git ref change and disable `QuarkusCli327UpdatesIT` 

### DIFF
--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
@@ -45,7 +45,7 @@ public class OpenShiftWorkshopHeroesIT {
     static PostgresqlService database = new PostgresqlService()
             .withProperty("PGDATA", "/tmp/psql");
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-workshops.git", contextDir = "quarkus-workshop-super-heroes/super-heroes/rest-heroes", mavenArgs = "-Dquarkus.package.jar.type=uber-jar -DskipTests -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}", branch = "6bed33b640c8d5a2e271da5ef822474c74bacd0d")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-workshops.git", contextDir = "quarkus-workshop-super-heroes/super-heroes/rest-heroes", mavenArgs = "-Dquarkus.package.jar.type=uber-jar -DskipTests -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}", branch = "3fc9e634d4131786e190ce588fea3ce28d02d5cf")
     static final RestService app = new RestService()
             .withProperty("quarkus.http.port", "8080")
             .withProperty("quarkus.datasource.reactive.url", () -> database.getReactiveUrl())

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.33.999-SNAPSHOT</quarkus.platform.version>
-        <quarkus.ide.version>3.32.3</quarkus.ide.version>
+        <quarkus.ide.version>3.33.1</quarkus.ide.version>
         <quarkus.qe.framework.version>1.8.0</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.10.0</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.33.999-SNAPSHOT</quarkus.platform.version>
         <quarkus.ide.version>3.33.1</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.8.0</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.8.1</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.10.0</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.29.0</formatter-maven-plugin.version>

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli327UpdatesIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli327UpdatesIT.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.scenarios.annotations.EnabledOnQuarkusVersion;
 import io.quarkus.test.util.QuarkusCLIUtils;
 import io.quarkus.test.utils.FileUtils;
 
@@ -27,6 +28,7 @@ import io.quarkus.test.utils.FileUtils;
  * Tests Quarkus CLI update command recipes for changes between 3.20 and 3.27.
  */
 @Tag("quarkus-cli")
+@EnabledOnQuarkusVersion(version = "3.27.*redhat.*", reason = "https://github.com/quarkus-qe/quarkus-test-framework/issues/1766")
 public class QuarkusCli327UpdatesIT extends AbstractQuarkusCliUpdateIT {
 
     public QuarkusCli327UpdatesIT() {


### PR DESCRIPTION
### Summary

* Changing the workshop git ref as it was updated 
* Bump Quarkus IDE to 3.33.1
* Bump FW to 1.8.1
* Enable `QuarkusCli327UpdatesIT` on when using RHBQ 3.27 (after the release/in some spare time I will look at that as it's not seems that hard to fix)

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)