### PR TITLE
Fix DevModeInfinispanIT on Podman

### DIFF
--- a/nosql-db/infinispan/src/main/resources/application.properties
+++ b/nosql-db/infinispan/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+quarkus.infinispan-client.client-intelligence=BASIC
 quarkus.infinispan-client.cache."cache".configuration-uri=cache-configuration.xml
 
 quarkus.infinispan-client.cache.books.configuration-resource=books-cache-config.xml


### PR DESCRIPTION
**Summary**

DevModeInfinispanIT fails on CI (quarkus-main-rhel8-jdk17-baremetal-ts-jvm-podman-nightly) because the Infinispan client tries to connect to the container's internal IP instead of localhost, which doesn't work with rootless Podman. This causes the books cache to be created without transaction support, resulting in CacheNotTransactionalException (ISPN004084). Setting client-intelligence=BASIC keeps the client on localhost and fixes the issue.

The other tests in this module (`InfinispanIT`, `TransactionalInfinispanIT`) already set `client-intelligence=BASIC` via `infinispan-it.properties`, but `DevModeInfinispanIT` only uses `application.properties` which was missing this setting.

I reproduced the failure locally using Podman and confirmed the fix resolves the error.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

**Checklist:**

- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow the best practices