### PR TITLE
Decrease nuber of started Dev mode apps at same time

### DIFF
--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeComposeLocationsIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeComposeLocationsIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -20,29 +22,35 @@ public class DevModeComposeLocationsIT extends AbstractSqlDatabaseIT {
     @DevModeQuarkusApplication(properties = "postgresql.properties")
     static DevModeQuarkusService dockerComposeDevserviceApp = (DevModeQuarkusService) new DevModeQuarkusService()
             .withProperty("quarkus.compose.devservices.env-variables.IMAGE", "${postgresql.latest.image}")
+            .setAutoStart(false)
             .onPreStart(service -> ((DevModeQuarkusService) service)
                     .copyFile("src/test/resources/postgresql-compose-devservices.yml", "docker-compose-devservice.yml"));
 
     @DevModeQuarkusApplication(properties = "postgresql.properties")
     static DevModeQuarkusService composeDevserviceApp = (DevModeQuarkusService) new DevModeQuarkusService()
             .withProperty("quarkus.compose.devservices.env-variables.IMAGE", "${postgresql.latest.image}")
+            .setAutoStart(false)
             .onPreStart(service -> ((DevModeQuarkusService) service)
                     .copyFile("src/test/resources/postgresql-compose-devservices.yml", "compose-devservice.yml"));
 
     @DevModeQuarkusApplication(properties = "postgresql.properties")
     static DevModeQuarkusService dockerComposeDevserviceYamlApp = (DevModeQuarkusService) new DevModeQuarkusService()
             .withProperty("quarkus.compose.devservices.env-variables.IMAGE", "${postgresql.latest.image}")
+            .setAutoStart(false)
             .onPreStart(service -> ((DevModeQuarkusService) service)
                     .copyFile("src/test/resources/postgresql-compose-devservices.yml", "docker-compose-devservice.yaml"));
 
     @DevModeQuarkusApplication(properties = "postgresql.properties")
     static DevModeQuarkusService suffixedDockerComposeDevserviceApp = (DevModeQuarkusService) new DevModeQuarkusService()
             .withProperty("quarkus.compose.devservices.env-variables.IMAGE", "${postgresql.latest.image}")
+            .setAutoStart(false)
             .onPreStart(service -> ((DevModeQuarkusService) service)
                     .copyFile("src/test/resources/postgresql-compose-devservices.yml", "docker-compose-devservice-foo.yml"));
 
     @Test
-    public void composeDevServicesAreUsed() {
+    public void composeDevServicesAreReused() {
+        startStopDevserviceApps(List.of(dockerComposeDevserviceApp, composeDevserviceApp), true);
+
         // Compose dev service is triggered
         dockerComposeDevservicesApp.logs().assertContains("Compose is running command");
         dockerComposeDevservicesApp.logs().assertContains(System.getProperty("postgresql.latest.image"));
@@ -54,10 +62,27 @@ public class DevModeComposeLocationsIT extends AbstractSqlDatabaseIT {
         composeDevserviceApp.logs().assertContains("Compose Dev Service container found");
         composeDevserviceApp.logs().assertContains(System.getProperty("postgresql.latest.image"));
 
+        startStopDevserviceApps(List.of(dockerComposeDevserviceApp, composeDevserviceApp), false);
+    }
+
+    @Test
+    public void composeDevServicesAreUsed() {
+        startStopDevserviceApps(List.of(dockerComposeDevserviceYamlApp, suffixedDockerComposeDevserviceApp), true);
+
         dockerComposeDevserviceYamlApp.logs().assertContains("Compose Dev Service container found");
         dockerComposeDevserviceYamlApp.logs().assertContains(System.getProperty("postgresql.latest.image"));
 
         suffixedDockerComposeDevserviceApp.logs().assertContains("Compose Dev Service container found");
         suffixedDockerComposeDevserviceApp.logs().assertContains(System.getProperty("postgresql.latest.image"));
+
+        startStopDevserviceApps(List.of(dockerComposeDevserviceYamlApp, suffixedDockerComposeDevserviceApp), false);
+    }
+
+    private void startStopDevserviceApps(List<DevModeQuarkusService> services, boolean start) {
+        if (start) {
+            services.forEach(DevModeQuarkusService::start);
+        } else {
+            services.forEach(DevModeQuarkusService::stop);
+        }
     }
 }


### PR DESCRIPTION
### Summary

Running 5 devmode apps at the same time need lot of resources. Running this tests on 8GB system cause some unstability when the system needs some amount of ddle memory. For comparison our RHEL8 VM needs using around 300ory and RHEL 9 using 650MB.

The VMs running on the edge of out of memory when running this single test. When runnign the full module I belive there is some allocated memory which won't be freed and causing OOM for system.

For measuring I used the `watch -n 5 free -m`

These are the results of used memory:
```
| OS           | RHEL 8 | RHEL 9 |
| idle memory  | 274    | 646    |
| Before tests | 1200   | 1500   | 
| During tests | 6748   | 7398   |
```
These are the results of free and cached memory:
```
| OS            | RHEL 8 | RHEL 9 |
| free memory   | 149   | 140    |
| Cached memory | 683   | 436   | 
```

Note these are results with 3.33.1, It's possible that the 3.33 have also bigger memory footprint then 3.27. I'll check it and see, but I believe that this test was on edge of OOM even with 3.27.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)