### PR TITLE
Fix Windows native build, bump Mandrel from JDK 21 to JDK 25

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -145,7 +145,7 @@ jobs:
       matrix:
         java: [ 21 ]
         graalvm-version: [ "mandrel-latest" ]
-        graalvm-java-version: [ "21" ]
+        graalvm-java-version: [ "25" ]
     steps:
       - uses: actions/checkout@v6
       - name: Install JDK ${{ matrix.java }}


### PR DESCRIPTION
### Summary

Bump Mandrel from JDK 21 to JDK 25
The Linux native job already uses JDK 25, but the Windows native job was still using graalvm-java 21

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)