### PR TITLE
JWT bearer is used instead of just Bearer after #53773 changes

### DIFF
--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BearerFilesystemIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/BearerFilesystemIT.java
@@ -86,7 +86,8 @@ public class BearerFilesystemIT {
                 .then().statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
 
         app.logs()
-                .assertContains("Bearer token file at path " + getTokenFilePath() + " is empty or contains only whitespace");
+                .assertContains(
+                        "JWT bearer token file at path " + getTokenFilePath() + " is empty or contains only whitespace");
     }
 
     @Test
@@ -97,7 +98,7 @@ public class BearerFilesystemIT {
                 .get("/secured/getClaimsFromToken")
                 .then().statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
 
-        app.logs().assertContains("Bearer token or its expiry claim is invalid");
+        app.logs().assertContains("JWT bearer token or its expiry claim is invalid");
     }
 
     @Test


### PR DESCRIPTION
### Summary

JWT bearer is used instead of just Bearer after #53773 changes

https://github.com/quarkusio/quarkus/pull/53773

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)