### PR TITLE
Add coverage for QUARKUS-7644 - Oracle rollback on connection close during shutdown

### DIFF
--- a/sql-db/sql-app/src/main/java/io/quarkus/ts/sqldb/sqlapp/OracleRollbackResource.java
+++ b/sql-db/sql-app/src/main/java/io/quarkus/ts/sqldb/sqlapp/OracleRollbackResource.java
@@ -1,0 +1,61 @@
+package io.quarkus.ts.sqldb.sqlapp;
+
+import java.sql.Connection;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.jboss.logging.Logger;
+
+import javax.sql.DataSource;
+
+@Path("/oracle-rollback")
+public class OracleRollbackResource {
+
+    private static final Logger LOG = Logger.getLogger(OracleRollbackResource.class);
+    private static final String CREATE_TABLE = "CREATE TABLE rollback_test ("
+            + "id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, "
+            + "value VARCHAR2(255) NOT NULL)";
+    private static final String DROP_TABLE = "DROP TABLE rollback_test";
+
+    @Inject
+    DataSource dataSource;
+
+    @Inject
+    ManagedExecutor managedExecutor;
+
+    @Inject
+    OracleRollbackService oracleRollbackService;
+
+    @POST
+    @Path("/init")
+    public Response init() throws Exception {
+        try (Connection conn = dataSource.getConnection()) {
+            try {
+                conn.createStatement().execute(DROP_TABLE);
+            } catch (Exception ignored) {
+                // table may not exist yet
+            }
+            conn.createStatement().execute(CREATE_TABLE);
+        }
+        return Response.ok("initialized").build();
+    }
+
+    @POST
+    @Path("/trigger")
+    public Response trigger() {
+        managedExecutor.execute(() -> {
+            try {
+                oracleRollbackService.insertAndBlock();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                LOG.warn("Transaction failed", e);
+            }
+        });
+        return Response.accepted().build();
+    }
+}

--- a/sql-db/sql-app/src/main/java/io/quarkus/ts/sqldb/sqlapp/OracleRollbackService.java
+++ b/sql-db/sql-app/src/main/java/io/quarkus/ts/sqldb/sqlapp/OracleRollbackService.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.sqldb.sqlapp;
+
+import java.sql.Connection;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.jboss.logging.Logger;
+
+import javax.sql.DataSource;
+
+@ApplicationScoped
+public class OracleRollbackService {
+
+    private static final Logger LOG = Logger.getLogger(OracleRollbackService.class);
+    public static final String INSERT_EXECUTED_LOG = "INSERT executed, blocking to simulate long-running operation";
+    private static final String INSERT = "INSERT INTO rollback_test (value) VALUES ('should-be-rolled-back')";
+
+    @Inject
+    DataSource dataSource;
+
+    @Transactional
+    public void insertAndBlock() throws Exception {
+        try (Connection conn = dataSource.getConnection()) {
+            conn.prepareStatement(INSERT).executeUpdate();
+            LOG.info(INSERT_EXECUTED_LOG);
+            Thread.sleep(30_000);
+        }
+    }
+}

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OracleConnectionRollbackIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OracleConnectionRollbackIT.java
@@ -1,0 +1,67 @@
+package io.quarkus.ts.sqldb.sqlapp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.HttpStatus;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+import io.quarkus.test.bootstrap.OracleService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+@Tag("QUARKUS-7644")
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2022")
+public class OracleConnectionRollbackIT {
+
+    private static final String INSERT_LOG = OracleRollbackService.INSERT_EXECUTED_LOG;
+
+    static final int ORACLE_PORT = 1521;
+
+    @Container(image = "${oracle.image}", port = ORACLE_PORT, expectedLog = "DATABASE IS READY TO USE!")
+    static OracleService database = new OracleService();
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperties("oracle.properties")
+            .withProperty("quarkus.datasource.username", database.getUser())
+            .withProperty("quarkus.datasource.password", database.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
+            .withProperty("quarkus.shutdown.timeout", "5s");
+
+    @Test
+    public void verifyInFlightTransactionRolledBackOnShutdown() throws Exception {
+        app.given().post("/oracle-rollback/init")
+                .then().statusCode(HttpStatus.SC_OK);
+
+        app.given().post("/oracle-rollback/trigger")
+                .then().statusCode(HttpStatus.SC_ACCEPTED);
+
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .until(() -> app.getLogs().stream().anyMatch(line -> line.contains(INSERT_LOG)));
+
+        app.stop();
+
+        try (Connection conn = DriverManager.getConnection(
+                database.getJdbcUrl(), database.getUser(), database.getPassword())) {
+            try (ResultSet rs = conn.prepareStatement("SELECT COUNT(*) FROM rollback_test").executeQuery()) {
+                rs.next();
+                assertEquals(0, rs.getInt(1),
+                        "In-flight transaction should be rolled back on shutdown, "
+                                + "but rows were committed (Oracle implicit commit on close)");
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary

- Upstream PR: https://github.com/quarkusio/quarkus/pull/53404
- Issue related: https://github.com/quarkusio/quarkus/issues/53382

Adds integration test coverage for the Oracle connection rollback interceptor fix. The test verifies that in-flight JTA transactions are rolled back (not implicitly committed by Oracle) when the application shuts down and the graceful shutdown timeout expires before the transaction completes.              

FAIL with 3.33.1:  `mvn clean verify -Psql-db-modules -pl sql-db/sql-app -Dquarkus.platform.version=3.33.1 -Dit.test=OracleConnectionRollbackIT`

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)