### PR TITLE
Update wiremock as the realocation wasn't picked up by dependabot

### DIFF
--- a/http/vertx-web-client/pom.xml
+++ b/http/vertx-web-client/pom.xml
@@ -24,8 +24,8 @@
             <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <mysql.upstream.image>docker.io/library/mysql:8.4</mysql.upstream.image>
         <mysql.84.image>${mysql.upstream.image}</mysql.84.image>
         <rhbk.image>registry.redhat.io/rhbk/keycloak-rhel9:26.4</rhbk.image>
-        <wiremock-jre8.version>2.35.2</wiremock-jre8.version>
+        <wiremock.version>3.13.2</wiremock.version>
         <build-reporter-maven-extension.version>3.13.1</build-reporter-maven-extension.version>
         <reruns>2</reruns>
         <oc.reruns>1</oc.reruns>
@@ -94,9 +94,9 @@
                 <version>${jsoup.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock-jre8</artifactId>
-                <version>${wiremock-jre8.version}</version>
+                <groupId>org.wiremock</groupId>
+                <artifactId>wiremock</artifactId>
+                <version>${wiremock.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
### Summary

The `com.github.tomakehurst:wiremock-jre8` was realocated to `org.wiremock:wiremock`. This probably wasn't caught by dependabot. Thus Pr realocating and bumping version. I spot the notification in https://mvnrepository.com/artifact/com.github.tomakehurst/wiremock-jre8 and this should be official issue for realocation https://github.com/wiremock/wiremock/issues/2237

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)