### PR TITLE
Increase memory for native build for vertx-web-client

### DIFF
--- a/http/vertx-web-client/pom.xml
+++ b/http/vertx-web-client/pom.xml
@@ -10,6 +10,9 @@
     <artifactId>vertx-web-client</artifactId>
     <packaging>jar</packaging>
     <name>Quarkus QE TS: HTTP: vertx-web-client</name>
+    <properties>
+        <quarkus.native.native-image-xmx>7g</quarkus.native.native-image-xmx>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
### Summary

Increasing memory for native build for vertx-web-client. Default for testsuite is 6g and this increase it to 7g only for this module.

Even when the test not failing in GH CI, it's failing all the time when testing the 3.33, also tried on my machine with main + 999-SNAPSHOT and it also failing constantly. 

I try to measured it and see it around 6GB usage when the 7g is set. When the 6g is set before crash I see 5.7GB. In log I see  `5.73GB of memory (17.3% of system memory, set via '-Xmx6g')` so maybe the GI runners using memory efficiently or just RHEL and Fedora + docker is bad with memory cleanup during the process. When checked I don't see this error at nightly podman, but I see it on RHEL 9 with 3.33.

I personally think it's OK to increase it as it's not a bug from my POV.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)