### PR TITLE
[3.33] Backport 7.5.2026 + Bump of FW + revert of one commit

### DIFF
--- a/ai/mcp/src/test/java/io/quarkus/ts/mcp/WebSocketIT.java
+++ b/ai/mcp/src/test/java/io/quarkus/ts/mcp/WebSocketIT.java
@@ -207,6 +207,7 @@ public class WebSocketIT extends BasicMCPIT {
     }
 
     @Test
+    @DisabledOnNative(reason = "https://github.com/quarkiverse/quarkus-mcp-server/issues/679")
     void sampling() {
         Session session = new Session(getUrl(server));
         session.sendRequest("initialize", Session.initParamas());
@@ -261,6 +262,7 @@ public class WebSocketIT extends BasicMCPIT {
     }
 
     @Test
+    @DisabledOnNative(reason = "https://github.com/quarkiverse/quarkus-mcp-server/issues/679")
     void elicitation() {
         Session session = new Session(getUrl(server));
         session.sendRequest("initialize", Session.initParamas());

--- a/http/vertx-web-client/pom.xml
+++ b/http/vertx-web-client/pom.xml
@@ -10,6 +10,9 @@
     <artifactId>vertx-web-client</artifactId>
     <packaging>jar</packaging>
     <name>Quarkus QE TS: HTTP: vertx-web-client</name>
+    <properties>
+        <quarkus.native.native-image-xmx>7g</quarkus.native.native-image-xmx>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/infinispan-client/src/main/java/io/quarkus/ts/infinispan/client/InfinispanClientApp.java
+++ b/infinispan-client/src/main/java/io/quarkus/ts/infinispan/client/InfinispanClientApp.java
@@ -31,17 +31,6 @@ public class InfinispanClientApp {
             "<distributed-cache name=\"%s\"></distributed-cache>" +
             "</cache-container></infinispan>";
 
-    private static final String MYSHOP_CACHE_CONFIG = """
-            <infinispan><cache-container>\
-            <distributed-cache name="%s">\
-            <encoding>
-            <key media-type="application/x-protostream"/>
-            <value media-type="application/x-protostream"/>
-            </encoding>\
-            <memory max-count="5" when-full="REMOVE"/>\
-            </distributed-cache>\
-            </cache-container></infinispan>""";
-
     void onStart(@Observes StartupEvent ev) {
         LOGGER.info("Create or get cache named mycache with the default configuration");
         RemoteCache<Object, Object> cache = cacheManager.administration().getOrCreateCache("mycache",
@@ -51,9 +40,6 @@ public class InfinispanClientApp {
             cache.put("counter", 0);
         }
 
-        LOGGER.info("Create or get cache named myshop with the x-protostream configuration");
-        RemoteCache<Object, Object> myshop = cacheManager.administration().getOrCreateCache("myshop",
-                new StringConfiguration(String.format(MYSHOP_CACHE_CONFIG, "myshop")));
         cache.addClientListener(new EventPrintListener());
     }
 

--- a/infinispan-client/src/main/resources/application.properties
+++ b/infinispan-client/src/main/resources/application.properties
@@ -20,3 +20,5 @@ quarkus.infinispan-client.trust-store-type=JKS
 
 # configmap settings
 quarkus.openshift.app-config-map=infinispan-config
+
+quarkus.infinispan-client.cache.myshop.configuration-resource=myshop-cache-config.xml

--- a/infinispan-client/src/main/resources/myshop-cache-config.xml
+++ b/infinispan-client/src/main/resources/myshop-cache-config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan>
+    <cache-container>
+        <distributed-cache name="myshop">
+            <encoding>
+                <key media-type="application/x-protostream"/>
+                <value media-type="application/x-protostream"/>
+            </encoding>
+            <memory max-count="5" when-full="REMOVE"/>
+        </distributed-cache>
+    </cache-container>
+</infinispan>

--- a/nosql-db/infinispan/src/main/resources/application.properties
+++ b/nosql-db/infinispan/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+quarkus.infinispan-client.client-intelligence=BASIC
 quarkus.infinispan-client.cache."cache".configuration-uri=cache-configuration.xml
 
 quarkus.infinispan-client.cache.books.configuration-resource=books-cache-config.xml

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.33.999-SNAPSHOT</quarkus.platform.version>
         <quarkus.ide.version>3.33.1</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.8.1</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.8.2</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.10.0</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.29.0</formatter-maven-plugin.version>

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli333UpdatesIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli333UpdatesIT.java
@@ -2,14 +2,12 @@ package io.quarkus.ts.quarkus.cli.update;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Stream;
 
@@ -18,7 +16,6 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -85,18 +82,17 @@ public class QuarkusCli333UpdatesIT extends AbstractQuarkusCliUpdateIT {
      * See https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.30#breaking-changes
      */
     @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/53384")
     void testJDBCMetrics() throws IOException {
-        QuarkusCliRestService app = quarkusCLIAppManager.createApplicationWithExtensions("quarkus-jdbc-postgresql");
         Properties oldProperties = new Properties();
+        Properties newProperties = new Properties();
+
         oldProperties.put("quarkus.datasource.jdbc.enable-metrics", "true");
-        QuarkusCLIUtils.writePropertiesToPropertiesFile(app, oldProperties);
+        newProperties.put("quarkus.datasource.jdbc.metrics.enabled", "true");
 
-        quarkusCLIAppManager.updateApp(app);
-
-        Map<String, String> newProperties = app.getProperties();
-        assertNull(newProperties.get("quarkus.datasource.jdbc.enable-metrics"));
-        assertEquals("true", newProperties.get("quarkus.datasource.jdbc.metrics.enabled"));
+        // TODO: drop using temp dir when https://github.com/quarkusio/quarkus-updates/issues/394 is fixed
+        try (var ignored = cliClient.useTemporaryDirectory()) {
+            QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
+        }
     }
 
     /**

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeComposeLocationsIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeComposeLocationsIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.ts.sqldb.sqlapp;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -20,29 +22,35 @@ public class DevModeComposeLocationsIT extends AbstractSqlDatabaseIT {
     @DevModeQuarkusApplication(properties = "postgresql.properties")
     static DevModeQuarkusService dockerComposeDevserviceApp = (DevModeQuarkusService) new DevModeQuarkusService()
             .withProperty("quarkus.compose.devservices.env-variables.IMAGE", "${postgresql.latest.image}")
+            .setAutoStart(false)
             .onPreStart(service -> ((DevModeQuarkusService) service)
                     .copyFile("src/test/resources/postgresql-compose-devservices.yml", "docker-compose-devservice.yml"));
 
     @DevModeQuarkusApplication(properties = "postgresql.properties")
     static DevModeQuarkusService composeDevserviceApp = (DevModeQuarkusService) new DevModeQuarkusService()
             .withProperty("quarkus.compose.devservices.env-variables.IMAGE", "${postgresql.latest.image}")
+            .setAutoStart(false)
             .onPreStart(service -> ((DevModeQuarkusService) service)
                     .copyFile("src/test/resources/postgresql-compose-devservices.yml", "compose-devservice.yml"));
 
     @DevModeQuarkusApplication(properties = "postgresql.properties")
     static DevModeQuarkusService dockerComposeDevserviceYamlApp = (DevModeQuarkusService) new DevModeQuarkusService()
             .withProperty("quarkus.compose.devservices.env-variables.IMAGE", "${postgresql.latest.image}")
+            .setAutoStart(false)
             .onPreStart(service -> ((DevModeQuarkusService) service)
                     .copyFile("src/test/resources/postgresql-compose-devservices.yml", "docker-compose-devservice.yaml"));
 
     @DevModeQuarkusApplication(properties = "postgresql.properties")
     static DevModeQuarkusService suffixedDockerComposeDevserviceApp = (DevModeQuarkusService) new DevModeQuarkusService()
             .withProperty("quarkus.compose.devservices.env-variables.IMAGE", "${postgresql.latest.image}")
+            .setAutoStart(false)
             .onPreStart(service -> ((DevModeQuarkusService) service)
                     .copyFile("src/test/resources/postgresql-compose-devservices.yml", "docker-compose-devservice-foo.yml"));
 
     @Test
-    public void composeDevServicesAreUsed() {
+    public void composeDevServicesAreReused() {
+        startStopDevserviceApps(List.of(dockerComposeDevserviceApp, composeDevserviceApp), true);
+
         // Compose dev service is triggered
         dockerComposeDevservicesApp.logs().assertContains("Compose is running command");
         dockerComposeDevservicesApp.logs().assertContains(System.getProperty("postgresql.latest.image"));
@@ -54,10 +62,27 @@ public class DevModeComposeLocationsIT extends AbstractSqlDatabaseIT {
         composeDevserviceApp.logs().assertContains("Compose Dev Service container found");
         composeDevserviceApp.logs().assertContains(System.getProperty("postgresql.latest.image"));
 
+        startStopDevserviceApps(List.of(dockerComposeDevserviceApp, composeDevserviceApp), false);
+    }
+
+    @Test
+    public void composeDevServicesAreUsed() {
+        startStopDevserviceApps(List.of(dockerComposeDevserviceYamlApp, suffixedDockerComposeDevserviceApp), true);
+
         dockerComposeDevserviceYamlApp.logs().assertContains("Compose Dev Service container found");
         dockerComposeDevserviceYamlApp.logs().assertContains(System.getProperty("postgresql.latest.image"));
 
         suffixedDockerComposeDevserviceApp.logs().assertContains("Compose Dev Service container found");
         suffixedDockerComposeDevserviceApp.logs().assertContains(System.getProperty("postgresql.latest.image"));
+
+        startStopDevserviceApps(List.of(dockerComposeDevserviceYamlApp, suffixedDockerComposeDevserviceApp), false);
+    }
+
+    private void startStopDevserviceApps(List<DevModeQuarkusService> services, boolean start) {
+        if (start) {
+            services.forEach(DevModeQuarkusService::start);
+        } else {
+            services.forEach(DevModeQuarkusService::stop);
+        }
     }
 }


### PR DESCRIPTION
### Summary

This PR backports:
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2985
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2977
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2976
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2973
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2966

Reverts:
* https://github.com/quarkus-qe/quarkus-test-suite/commit/2d8ee898cfed16496ade61d7082eca199b3e3cea as this didn't make it to 3.33.1 platform and needs to be backported for 3.33.2

Updates:
* Bump of FW to 1.8.2

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)