### PR TITLE
[3.33] Add a workaround for https://github.com/quarkus-qe/quarkus-test-framework/issues/1884

### DIFF
--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftToolsIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftToolsIT.java
@@ -22,8 +22,8 @@ public class OpenShiftToolsIT extends AbstractToolsIT {
     static final RestService server = new RestService()
             .withProperty("_ignored", "resource_with_destination::/tmp/playground/|playground/longword.txt")
             .withProperty("working.folder", "/tmp/playground/");
-
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkiverse/quarkus-langchain4j.git", branch = SAMPLE_BRANCH, contextDir = "samples/mcp-tools", mavenArgs = DEFAULT_ARGS
+    // TODO switch back to quarkus-qe/quarkus-langchain4j repo, when https://github.com/quarkus-qe/quarkus-test-framework/issues/1884 is fixed
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkus-qe/quarkus-langchain4j.git", branch = SAMPLE_BRANCH, contextDir = "samples/mcp-tools", mavenArgs = DEFAULT_ARGS
             + " -Dsamples -Dplatform-deps -Dquarkus.langchain4j.mcp.filesystem.transport-type=streamable-http")
     static final RestService client = new RestService()
             .withProperty("quarkus.langchain4j.mcp.filesystem.transport-type", "streamable-http")

--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/ToolsIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/ToolsIT.java
@@ -22,8 +22,8 @@ public class ToolsIT extends AbstractToolsIT {
     }, classes = { MCPFileServer.class })
     static final RestService server = new RestService()
             .withProperty("working.folder", () -> getFileFolder(ToolsIT.class));
-
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkiverse/quarkus-langchain4j.git", branch = SAMPLE_BRANCH, contextDir = "samples/mcp-tools", mavenArgs = DEFAULT_ARGS
+    // TODO switch back to quarkus-qe/quarkus-langchain4j repo, when https://github.com/quarkus-qe/quarkus-test-framework/issues/1884 is fixed
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkus-qe/quarkus-langchain4j.git", branch = SAMPLE_BRANCH, contextDir = "samples/mcp-tools", mavenArgs = DEFAULT_ARGS
             + " -Dsamples -Dplatform-deps -Dquarkus.langchain4j.mcp.filesystem.transport-type=streamable-http")
     static final RestService client = new RestService()
             .withProperty("quarkus.langchain4j.mcp.filesystem.transport-type", "streamable-http")


### PR DESCRIPTION
### Summary

Changed branch, which is used in tests to this one: https://github.com/quarkus-qe/quarkus-langchain4j/tree/1.7, which contains `streamable-http` in application.properties and will use it during build time.

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [x] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)