### PR TITLE
Disable check of version in update test for testcontainers

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli333UpdatesIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli333UpdatesIT.java
@@ -129,8 +129,9 @@ public class QuarkusCli333UpdatesIT extends AbstractQuarkusCliUpdateIT {
                 "Testcontainers dependency should keep its groupId");
         assertEquals("testcontainers-postgresql", postrgesSql.getArtifactId(),
                 "Testcontainers dependency should be renamed to testcontainers-postgresql");
-        assertTrue(postrgesSql.getVersion().matches("^2\\.\\d+\\.\\d+$"),
-                "Testcontainers dependency should be updated to version 2");
+        // TODO enable version check when https://redhat.atlassian.net/browse/QUARKUS-7802 if fixed
+        // assertTrue(postrgesSql.getVersion().matches("^2\\.\\d+\\.\\d+$"),
+        //        "Testcontainers dependency should be updated to version 2");
     }
 
     private static @NotNull List<String> getAllLinesWith(Path pom, String content) throws IOException {


### PR DESCRIPTION
### Summary

I disabling the version check in `QuarkusCli333UpdatesIT#testContainers` because of https://redhat.atlassian.net/browse/QUARKUS-7802. 

Personally I think maybe the version should not be there at all as the version is set to latest available, not the platform specific, which is managed by platform. I'm adding it first in main as it's possible that this won't be fixed fast.

For end user the impact is also minimal as the plaform bom manage the version, so it can be problematic only for users which manage theirs version for some specific reason.  

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)