### PR TITLE
[3.33] Disable AOT cache test on Semeru + Backport 15.05.2026

### DIFF
--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/AoTQuickstartIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/AoTQuickstartIT.java
@@ -14,10 +14,12 @@ import org.junit.jupiter.api.condition.JRE;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.DisabledOnSemeruJdk;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
 @DisabledOnNative(reason = "AoT is for JVM only")
 @DisabledForJreRange(max = JRE.JAVA_24, disabledReason = "The generation of AoT file from ITs is available for Java 25+")
+@DisabledOnSemeruJdk(reason = "The Semeru don't implement project Leyden. The Quarkus 3.35 add support for SCC (which is similar to Leyden)")
 @QuarkusScenario
 public class AoTQuickstartIT {
     public static final String QUICKSTART_DIRECTORY = "getting-started-reactive";

--- a/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpenTelemetryMetricsIT.java
+++ b/monitoring/opentelemetry-reactive/src/test/java/io/quarkus/ts/opentelemetry/reactive/OpenTelemetryMetricsIT.java
@@ -20,9 +20,9 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.scenarios.annotations.DisabledOnSemeruJdk;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.utils.AwaitilityUtils;
+import io.quarkus.test.utils.JavaUtils;
 import io.quarkus.ts.opentelemetry.reactive.metrics.gc.RunGarbageCollectorTrigger;
 
 /**
@@ -31,7 +31,6 @@ import io.quarkus.ts.opentelemetry.reactive.metrics.gc.RunGarbageCollectorTrigge
  */
 @QuarkusScenario
 @DisabledOnNative(reason = "To save time and resources needed for building the apps")
-@DisabledOnSemeruJdk(reason = "Flight Recorder is not supported on IBM Semeru Runtime")
 public class OpenTelemetryMetricsIT {
     private static final Duration TIME_TO_LOGS_READY = Duration.ofSeconds(15); // metric.export.interval is 10s
     /**
@@ -70,12 +69,18 @@ public class OpenTelemetryMetricsIT {
         verifyNoDuplicateMetrics("jvm.cpu.time");
         metricAvailable(app, "jvm.cpu.recent_utilization");
         verifyNoDuplicateMetrics("jvm.cpu.recent_utilization");
-        metricAvailable(app, "jvm.cpu.limit");
-        verifyNoDuplicateMetrics("jvm.cpu.limit");
-        metricAvailable(app, "jvm.cpu.longlock");
-        verifyNoDuplicateMetrics("jvm.cpu.longlock");
-        metricAvailable(app, "jvm.cpu.context_switch");
-        verifyNoDuplicateMetrics("jvm.cpu.context_switch");
+        if (!JavaUtils.isRunningSemeruJdk()) {
+            // These metrics are not available on Semeru yet
+            // There was effort from OpenJ9 team, but it was not implemented
+            // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10443
+            // TODO remove Semeru check when Semeru JFR is enhanced/ support all features implemented in other Java distribution
+            metricAvailable(app, "jvm.cpu.limit");
+            verifyNoDuplicateMetrics("jvm.cpu.limit");
+            metricAvailable(app, "jvm.cpu.longlock");
+            verifyNoDuplicateMetrics("jvm.cpu.longlock");
+            metricAvailable(app, "jvm.cpu.context_switch");
+            verifyNoDuplicateMetrics("jvm.cpu.context_switch");
+        }
     }
 
     @Tag("https://github.com/quarkusio/quarkus/issues/46535")

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/DevModeOpenTelemetryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/DevModeOpenTelemetryIT.java
@@ -21,14 +21,12 @@ import org.junit.jupiter.api.TestMethodOrder;
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
 import io.quarkus.test.bootstrap.JaegerService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnSemeruJdk;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.services.JaegerContainer;
 import io.restassured.response.Response;
 
 @QuarkusScenario
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@DisabledOnSemeruJdk(reason = "Flight Recorder is not supported on IBM Semeru Runtime")
 public class DevModeOpenTelemetryIT {
 
     private static final Logger LOG = Logger.getLogger(DevModeOpenTelemetryIT.class);

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryGrpcIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryGrpcIT.java
@@ -14,12 +14,10 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.JaegerService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnSemeruJdk;
 import io.quarkus.test.services.JaegerContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-@DisabledOnSemeruJdk(reason = "Flight Recorder is not supported on IBM Semeru Runtime")
 public class OpenTelemetryGrpcIT {
 
     @JaegerContainer(useOtlpCollector = true)

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryIT.java
@@ -29,14 +29,12 @@ import org.junit.jupiter.api.TestMethodOrder;
 import io.quarkus.test.bootstrap.JaegerService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnSemeruJdk;
 import io.quarkus.test.services.JaegerContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.response.Response;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class) // order methods as SDK autoconfigure test expects previous traces
 @QuarkusScenario
-@DisabledOnSemeruJdk(reason = "Flight Recorder is not supported on IBM Semeru Runtime")
 public class OpenTelemetryIT {
 
     private Response resp;

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryLoggingIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryLoggingIT.java
@@ -22,14 +22,12 @@ import org.junit.jupiter.api.condition.OS;
 import io.quarkus.test.bootstrap.GrafanaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnSemeruJdk;
 import io.quarkus.test.services.GrafanaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.response.Response;
 
 @Tag("QUARKUS-5623")
 @QuarkusScenario
-@DisabledOnSemeruJdk(reason = "Flight Recorder is not supported on IBM Semeru Runtime")
 public class OpenTelemetryLoggingIT {
     private static final String SERVICE_NAME = "logging-app";
 

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryManagementIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryManagementIT.java
@@ -18,7 +18,6 @@ import io.quarkus.test.bootstrap.JaegerService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnSemeruJdk;
 import io.quarkus.test.security.certificate.Certificate;
 import io.quarkus.test.security.certificate.PemClientCertificate;
 import io.quarkus.test.services.JaegerContainer;
@@ -27,7 +26,6 @@ import io.quarkus.ts.opentelemetry.jaeger.builder.JaegerLocalhostDockerManagerRe
 
 @Tag("QUARKUS-4592")
 @QuarkusScenario
-@DisabledOnSemeruJdk(reason = "Flight Recorder is not supported on IBM Semeru Runtime")
 public class OpenTelemetryManagementIT {
     @JaegerContainer(tls = true, builder = JaegerLocalhostDockerManagerResource.class)
     static final JaegerService jaeger = new JaegerService();

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryMetricsGrpcExportRecoveryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryMetricsGrpcExportRecoveryIT.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.logging.Log;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnSemeruJdk;
 import io.quarkus.test.services.QuarkusApplication;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -30,7 +29,6 @@ import io.vertx.junit5.VertxExtension;
 @Tag("https://github.com/quarkusio/quarkus/pull/47245")
 @QuarkusScenario
 @ExtendWith(VertxExtension.class)
-@DisabledOnSemeruJdk(reason = "Flight Recorder is not supported on IBM Semeru Runtime")
 public class OpenTelemetryMetricsGrpcExportRecoveryIT {
 
     private static final int METRICS_COLLECTOR_PORT = 9998;

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryProxyIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryProxyIT.java
@@ -19,7 +19,6 @@ import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.logging.Log;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnSemeruJdk;
 import io.quarkus.test.services.JaegerContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.URILike;
@@ -40,7 +39,6 @@ import io.vertx.junit5.VertxExtension;
 @Tag("QUARKUS-4550")
 @ExtendWith(VertxExtension.class)
 @QuarkusScenario
-@DisabledOnSemeruJdk(reason = "Flight Recorder is not supported on IBM Semeru Runtime")
 public class OpenTelemetryProxyIT {
 
     private static final int PAGE_LIMIT = 10;

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli333UpdatesIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli333UpdatesIT.java
@@ -129,8 +129,9 @@ public class QuarkusCli333UpdatesIT extends AbstractQuarkusCliUpdateIT {
                 "Testcontainers dependency should keep its groupId");
         assertEquals("testcontainers-postgresql", postrgesSql.getArtifactId(),
                 "Testcontainers dependency should be renamed to testcontainers-postgresql");
-        assertTrue(postrgesSql.getVersion().matches("^2\\.\\d+\\.\\d+$"),
-                "Testcontainers dependency should be updated to version 2");
+        // TODO enable version check when https://redhat.atlassian.net/browse/QUARKUS-7802 if fixed
+        // assertTrue(postrgesSql.getVersion().matches("^2\\.\\d+\\.\\d+$"),
+        //        "Testcontainers dependency should be updated to version 2");
     }
 
     private static @NotNull List<String> getAllLinesWith(Path pom, String content) throws IOException {


### PR DESCRIPTION
### Summary

Disabling the AOT cache test on Semeru as the Semeru not implementing the project Leyden. They have something similar called SCC. Support to SCC was added in Quarkus 3.35, You can see blogpost https://quarkus.io/blog/semeru-scc/

Backport of:
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2988
* https://github.com/quarkus-qe/quarkus-test-suite/pull/2993

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)