### PR TITLE
Add coverage for QUARKUS-7656 OpenShift Internal Registry Container Image Name

### DIFF
--- a/http/http-minimum/src/main/resources/application.properties
+++ b/http/http-minimum/src/main/resources/application.properties
@@ -4,6 +4,8 @@ quarkus.http.root-path=/api
 %OpenShiftServerlessUsingExtensionHttpMinimumIT.quarkus.container-image.registry=image-registry.openshift-image-registry.svc:5000
 %OpenShiftServerlessUsingExtensionDockerBuildStrategyHttpMinimumIT.quarkus.kubernetes.deployment-target=knative
 %OpenShiftServerlessUsingExtensionDockerBuildStrategyHttpMinimumIT.quarkus.container-image.registry=image-registry.openshift-image-registry.svc:5000
+%OpenShiftCustomImageNameIT.quarkus.container-image.name=custom-image-name
+%OpenShiftCustomImageNameIT.quarkus.container-image.registry=image-registry.openshift-image-registry.svc:5000
 # Only run tests annotated with @QuarkusTest
 %DevModeHttpMinimumIT.quarkus.test.type=quarkus-test
 # Test Framework expects the dev UI to be at /q/dev, not /api/q/dev

--- a/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftCustomImageNameIT.java
+++ b/http/http-minimum/src/test/java/io/quarkus/ts/http/minimum/OpenShiftCustomImageNameIT.java
@@ -1,0 +1,44 @@
+package io.quarkus.ts.http.minimum;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.inject.OpenShiftClient;
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@Tag("QUARKUS-7656")
+@Tag("use-quarkus-openshift-extension")
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
+public class OpenShiftCustomImageNameIT extends HttpMinimumIT {
+
+    private static final String CUSTOM_IMAGE_NAME = "custom-image-name";
+    private static final String APP_NAME = "app";
+
+    @Inject
+    static OpenShiftClient openshift;
+
+    @Test
+    public void verifyImageStreamUsesCustomImageName() {
+        var is = openshift.getFabric8Client().imageStreams()
+                .withName(CUSTOM_IMAGE_NAME).get();
+        assertNotNull(is, "ImageStream should exist with name " + CUSTOM_IMAGE_NAME);
+        assertEquals(CUSTOM_IMAGE_NAME, is.getMetadata().getName());
+    }
+
+    @Test
+    public void verifyBuildConfigOutputReferencesCustomImageName() {
+        var bc = openshift.getFabric8Client().buildConfigs()
+                .withName(APP_NAME).get();
+        assertNotNull(bc, "BuildConfig should exist with name " + APP_NAME);
+        assertTrue(bc.getSpec().getOutput().getTo().getName()
+                .startsWith(CUSTOM_IMAGE_NAME + ":"),
+                "BuildConfig output should reference " + CUSTOM_IMAGE_NAME);
+    }
+}


### PR DESCRIPTION
### Summary

Add coverage for QUARKUS-7656 OpenShift Internal Registry Container Image Name

Upstream PR: https://github.com/quarkusio/quarkus/pull/53191
Issue: https://github.com/quarkusio/quarkus/issues/53121
Jira: https://redhat.atlassian.net/browse/QUARKUS-7656

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)