### PR TITLE
Fix flaky OpenShiftToolsIT.askAI test

### DIFF
--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/AbstractToolsIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/AbstractToolsIT.java
@@ -64,7 +64,7 @@ public abstract class AbstractToolsIT {
         waitForAnswers(answers);
         Assertions.assertEquals("Hello, I am a filesystem robot, how can I help?", answers.get(0));
         answers.clear();
-        String prompt = "Read the contents of the file longword.txt";
+        String prompt = "Use readFileContent to read playground/longword.txt and return its contents";
         webSocket.sendText(prompt, true);
         waitForAnswers(answers);
         Assertions.assertTrue(answers.get(0).contains(LONG_WORD),
@@ -75,13 +75,13 @@ public abstract class AbstractToolsIT {
         int repeats = -1;
         int lastSize = 0;
         while (answers.isEmpty() || answers.size() != lastSize) {
-            if (++repeats > 10) {
-                LOG.warn("We have waited for: " + repeats / 2 + " seconds and it is too much!");
+            if (++repeats > 20) {
+                LOG.warn("We have waited for: " + repeats + " seconds and it is too much!");
                 break;
             }
             lastSize = answers.size();
             try {
-                Thread.sleep(500);
+                Thread.sleep(1000);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return;

--- a/ai/mcp/src/main/resources/application.properties
+++ b/ai/mcp/src/main/resources/application.properties
@@ -2,4 +2,5 @@
 %debug.quarkus.mcp.server.traffic-logging.text-limit=1000
 quarkus.mcp.server.tools.page-size=2
 working.folder=target/classes/
-quarkus.console.color=false #otherwise we run into problems while parsing CLI logs on Windows
+# otherwise we run into problems while parsing CLI logs on Windows
+quarkus.console.color=false


### PR DESCRIPTION
## Summary
- Use an explicit prompt that names the `readFileContent` tool and provides the full `playground/longword.txt` path, reducing ambiguity for the LLM
- Increase the `waitForAnswers` timeout from ~5s to ~20s to accommodate tool invocation round-trips on OpenShift
- Needed for QQE-2544: the LLM sometimes responds with conversational filler instead of invoking the MCP tool
- Companion PR: https://github.com/quarkiverse/quarkus-langchain4j/pull/2469 (strengthens the upstream system prompt)
- Also get rid of the warning message:
```
15:02:31 18:02:31,648 INFO  mvn: [WARNING] [io.smallrye.config] SRCFG01008: The value false #otherwise we run into problems while parsing CLI logs on Windows has been converted by a Boolean Converter to "false"
```

## Test plan
- [x] Run `OpenShiftToolsIT` on OpenShift to verify the test passes consistently
- [x] Verify `ToolsIT` still passes locally