### PR TITLE
Add audience mapper to fix token introspection with Keycloak 26.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
                                 <infinispan.image>quay.io/infinispan/server:16.0</infinispan.image>
                                 <infinispan.expected-log>Infinispan Server.*started in</infinispan.expected-log>
                                 <spring.cloud.server.image>quay.io/quarkusqeteam/spring-cloud-config-server:4.1</spring.cloud.server.image>
-                                <keycloak.image>quay.io/keycloak/keycloak:26.5</keycloak.image>
+                                <keycloak.image>quay.io/keycloak/keycloak:26.6</keycloak.image>
                                 <bouncycastle.bctls-fips.version>1.0.12.2</bouncycastle.bctls-fips.version>
                                 <rhbk.image>${rhbk.image}</rhbk.image>
                             </systemPropertyVariables>

--- a/security/keycloak-multitenant/src/test/resources/test-realm-realm.json
+++ b/security/keycloak-multitenant/src/test/resources/test-realm-realm.json
@@ -78,7 +78,22 @@
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": true,
       "clientAuthenticatorType": "client-secret",
-      "secret": "test-service-client-secret"
+      "secret": "test-service-client-secret",
+      "protocolMappers": [
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "test-service-client",
+            "id.token.claim": "false",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
     },
     {
       "clientId": "test-jwt-client",

--- a/security/keycloak-oauth2/src/test/resources/test-realm-realm.json
+++ b/security/keycloak-oauth2/src/test/resources/test-realm-realm.json
@@ -88,6 +88,19 @@
           }
         },
         {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "test-application-client",
+            "id.token.claim": "false",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        },
+        {
           "id": "12c7ffdd-f1bc-4e98-a625-20002527e1f4",
           "name": "add-roles-to-claim",
           "protocol": "openid-connect",

--- a/security/keycloak-oidc-client-extended/src/test/resources/test-realm-realm.json
+++ b/security/keycloak-oidc-client-extended/src/test/resources/test-realm-realm.json
@@ -67,6 +67,19 @@
             "claim.name": "preferred_username",
             "jsonType.label": "String"
           }
+        },
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "test-application-client",
+            "id.token.claim": "false",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
         }
       ],
       "redirectUris": [
@@ -117,6 +130,19 @@
             "access.token.claim": "true",
             "claim.name": "preferred_username",
             "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "token-application-client",
+            "id.token.claim": "false",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
           }
         }
       ],

--- a/security/keycloak-oidc-client-reactive-extended/src/test/resources/test-realm-realm.json
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/resources/test-realm-realm.json
@@ -96,6 +96,19 @@
             "claim.name": "preferred_username",
             "jsonType.label": "String"
           }
+        },
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "test-application-client",
+            "id.token.claim": "false",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
         }
       ],
       "redirectUris": [

--- a/security/keycloak/src/test/resources/test-realm-realm.json
+++ b/security/keycloak/src/test/resources/test-realm-realm.json
@@ -117,6 +117,19 @@
             "claim.name": "preferred_username",
             "jsonType.label": "String"
           }
+        },
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "test-application-client",
+            "id.token.claim": "false",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
         }
       ],
       "defaultClientScopes": [


### PR DESCRIPTION
Keycloak 26.6 (quarkusio/quarkus@adafc2544e6) enforces that the client calling the introspection endpoint must be listed in the token's audience claim. Without the mapper, introspection returns active=false causing test failures in modules that rely on token introspection.

- Fixes https://redhat.atlassian.net/browse/QQE-2565

Affected modules:
- security/keycloak
- security/keycloak-oauth2
- security/keycloak-multitenant
- security/keycloak-oidc-client-extended
- security/keycloak-oidc-client-reactive-extended

