### PR TITLE
Add coverage for QUARKUS-7728 - Fix @ServerExceptionMapper handling for generic types

### DIFF
--- a/http/jakarta-rest-reactive/src/main/java/io/quarkus/ts/http/jakartarest/reactive/exceptions/AbstractGenericExceptionMapper.java
+++ b/http/jakarta-rest-reactive/src/main/java/io/quarkus/ts/http/jakartarest/reactive/exceptions/AbstractGenericExceptionMapper.java
@@ -1,0 +1,8 @@
+package io.quarkus.ts.http.jakartarest.reactive.exceptions;
+
+import org.jboss.resteasy.reactive.RestResponse;
+
+public abstract class AbstractGenericExceptionMapper<E extends Exception> {
+
+    public abstract RestResponse<?> toResponse(E e);
+}

--- a/http/jakarta-rest-reactive/src/main/java/io/quarkus/ts/http/jakartarest/reactive/exceptions/GenericExceptionMapperBean.java
+++ b/http/jakarta-rest-reactive/src/main/java/io/quarkus/ts/http/jakartarest/reactive/exceptions/GenericExceptionMapperBean.java
@@ -1,0 +1,15 @@
+package io.quarkus.ts.http.jakartarest.reactive.exceptions;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+
+@ApplicationScoped
+public class GenericExceptionMapperBean extends AbstractGenericExceptionMapper<GenericMapperException> {
+
+    @ServerExceptionMapper(GenericMapperException.class)
+    public RestResponse<?> toResponse(GenericMapperException e) {
+        return RestResponse.status(499);
+    }
+}

--- a/http/jakarta-rest-reactive/src/main/java/io/quarkus/ts/http/jakartarest/reactive/exceptions/GenericMapperException.java
+++ b/http/jakarta-rest-reactive/src/main/java/io/quarkus/ts/http/jakartarest/reactive/exceptions/GenericMapperException.java
@@ -1,0 +1,8 @@
+package io.quarkus.ts.http.jakartarest.reactive.exceptions;
+
+public class GenericMapperException extends RuntimeException {
+
+    public GenericMapperException(String message) {
+        super(message);
+    }
+}

--- a/http/jakarta-rest-reactive/src/main/java/io/quarkus/ts/http/jakartarest/reactive/exceptions/ServerExceptionMapperResource.java
+++ b/http/jakarta-rest-reactive/src/main/java/io/quarkus/ts/http/jakartarest/reactive/exceptions/ServerExceptionMapperResource.java
@@ -1,0 +1,22 @@
+package io.quarkus.ts.http.jakartarest.reactive.exceptions;
+
+import static io.quarkus.ts.http.jakartarest.reactive.exceptions.ServerExceptionMapperResource.EXCEPTION_MAPPER_PATH;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path(EXCEPTION_MAPPER_PATH)
+public class ServerExceptionMapperResource {
+
+    public static final String EXCEPTION_MAPPER_PATH = "/server-exception-mapper";
+
+    @GET
+    @Path("/generic")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String throwGeneric() {
+        throw new GenericMapperException("generic mapper test");
+    }
+
+}

--- a/http/jakarta-rest-reactive/src/test/java/io/quarkus/ts/http/jakartarest/reactive/ServerExceptionMapperIT.java
+++ b/http/jakarta-rest-reactive/src/test/java/io/quarkus/ts/http/jakartarest/reactive/ServerExceptionMapperIT.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.http.jakartarest.reactive;
+
+import static io.quarkus.ts.http.jakartarest.reactive.exceptions.ServerExceptionMapperResource.EXCEPTION_MAPPER_PATH;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.restassured.RestAssured;
+
+@Tag("QUARKUS-7728")
+@QuarkusScenario
+public class ServerExceptionMapperIT {
+
+    @Test
+    public void verifyGenericExceptionMapperWorks() {
+        RestAssured.get(EXCEPTION_MAPPER_PATH + "/generic")
+                .then().statusCode(499);
+    }
+
+}


### PR DESCRIPTION
### Summary

Add coverage for QUARKUS-7728 - Fix @ServerExceptionMapper handling for generic types

Upstream issue: github.com/quarkusio/quarkus/issues/53418
Upstream fix: https://github.com/quarkusio/quarkus/pull/53420
Jira --> https://redhat.atlassian.net/browse/QUARKUS-7728

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)