### PR TITLE
Refactor Openshift Keycloak tests as they need to use rhbk image

### DIFF
--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/AuthorizationCodeFlowFiltersIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/AuthorizationCodeFlowFiltersIT.java
@@ -1,7 +1,17 @@
 package io.quarkus.ts.security.keycloak.multitenant;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
+import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KeycloakContainer;
 
 @QuarkusScenario
 public class AuthorizationCodeFlowFiltersIT extends BaseAuthorizationCodeFlowFiltersIT {
+
+    @KeycloakContainer(runKeycloakInProdMode = true)
+    static KeycloakService keycloak = new KeycloakService(
+            DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 }

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseAuthorizationCodeFlowFiltersIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseAuthorizationCodeFlowFiltersIT.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.security.keycloak.multitenant;
 
-import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
-import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
-import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -19,9 +16,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.LookupService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 public abstract class BaseAuthorizationCodeFlowFiltersIT {
@@ -29,9 +26,8 @@ public abstract class BaseAuthorizationCodeFlowFiltersIT {
     private static final String USER = "test-user";
     private WebClient webClient;
 
-    @KeycloakContainer(runKeycloakInProdMode = true)
-    static KeycloakService keycloak = new KeycloakService(
-            DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+    @LookupService
+    static KeycloakService keycloak;
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseBearerTokenAuthFilterIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseBearerTokenAuthFilterIT.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.security.keycloak.multitenant;
 
-import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
-import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
-import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -20,9 +17,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.LookupService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 public abstract class BaseBearerTokenAuthFilterIT {
@@ -30,9 +27,8 @@ public abstract class BaseBearerTokenAuthFilterIT {
     private static final String USER = "test-user";
     private WebClient webClient;
 
-    @KeycloakContainer(runKeycloakInProdMode = true)
-    static KeycloakService keycloak = new KeycloakService(
-            DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+    @LookupService
+    static KeycloakService keycloak;
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseOidcFilterIsolationIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BaseOidcFilterIsolationIT.java
@@ -1,8 +1,5 @@
 package io.quarkus.ts.security.keycloak.multitenant;
 
-import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
-import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
-import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -19,9 +16,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.LookupService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 public abstract class BaseOidcFilterIsolationIT {
@@ -29,9 +26,8 @@ public abstract class BaseOidcFilterIsolationIT {
     private static final String USER = "test-user";
     private WebClient webClient;
 
-    @KeycloakContainer(runKeycloakInProdMode = true)
-    static KeycloakService keycloak = new KeycloakService(
-            DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+    @LookupService
+    static KeycloakService keycloak;
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BearerTokenAuthFilterIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/BearerTokenAuthFilterIT.java
@@ -1,7 +1,17 @@
 package io.quarkus.ts.security.keycloak.multitenant;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
+import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KeycloakContainer;
 
 @QuarkusScenario
 public class BearerTokenAuthFilterIT extends BaseBearerTokenAuthFilterIT {
+
+    @KeycloakContainer(runKeycloakInProdMode = true)
+    static KeycloakService keycloak = new KeycloakService(
+            DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 }

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OidcFilterIsolationIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OidcFilterIsolationIT.java
@@ -1,7 +1,18 @@
 package io.quarkus.ts.security.keycloak.multitenant;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
+import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KeycloakContainer;
 
 @QuarkusScenario
 public class OidcFilterIsolationIT extends BaseOidcFilterIsolationIT {
+
+    @KeycloakContainer(runKeycloakInProdMode = true)
+    static KeycloakService keycloak = new KeycloakService(
+            DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+
 }

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftAuthorizationCodeFlowFiltersIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftAuthorizationCodeFlowFiltersIT.java
@@ -1,7 +1,17 @@
 package io.quarkus.ts.security.keycloak.multitenant;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
+import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.KeycloakContainer;
 
 @OpenShiftScenario
 public class OpenShiftAuthorizationCodeFlowFiltersIT extends BaseAuthorizationCodeFlowFiltersIT {
+
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService(
+            DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 }

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftBearerTokenAuthFilterIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftBearerTokenAuthFilterIT.java
@@ -1,7 +1,17 @@
 package io.quarkus.ts.security.keycloak.multitenant;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
+import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.KeycloakContainer;
 
 @OpenShiftScenario
-public class OpenShiftBearerTokenAuthFilterIT extends BearerTokenAuthFilterIT {
+public class OpenShiftBearerTokenAuthFilterIT extends BaseBearerTokenAuthFilterIT {
+
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService(
+            DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
 }

--- a/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftOidcFilterIsolationIT.java
+++ b/security/keycloak-multitenant/src/test/java/io/quarkus/ts/security/keycloak/multitenant/OpenShiftOidcFilterIsolationIT.java
@@ -1,7 +1,18 @@
 package io.quarkus.ts.security.keycloak.multitenant;
 
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
+import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.KeycloakContainer;
 
 @OpenShiftScenario
 public class OpenShiftOidcFilterIsolationIT extends BaseOidcFilterIsolationIT {
+
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}")
+    static KeycloakService keycloak = new KeycloakService(
+            DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+
 }


### PR DESCRIPTION
### Summary

This is need as the upstream Keycloak image don't have s390x architecture available. It's mainly to fix the problem of IBM Z/P team

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)