### PR TITLE
Small fixes for 3.33

### DIFF
--- a/config/src/main/resources/application.properties
+++ b/config/src/main/resources/application.properties
@@ -29,3 +29,8 @@ quarkus.openshift.idempotent=true
 # see https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/deploying-to-kubernetes.adoc?plain=1#L212
 # or https://quarkus.io/guides/deploying-to-kubernetes#generating-idempotent-resources
 quarkus.kubernetes.output-directory=target/openshift
+
+# See https://issues.redhat.com/browse/MANDREL-245
+# the native executable is build before the tests and even when ConfigIT had DisableOnNativeAndFips annotation it first
+# tried to build native.
+quarkus.native.additional-build-args=--initialize-at-run-time=io.quarkus.ts.configmap.api.server.secrets.RsaSecretKeysHandler

--- a/config/src/test/java/io/quarkus/ts/configmap/api/server/ConfigIT.java
+++ b/config/src/test/java/io/quarkus/ts/configmap/api/server/ConfigIT.java
@@ -14,12 +14,10 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnFipsAndNative;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.configmap.api.server.config.PropertiesSource;
 import io.quarkus.ts.configmap.api.server.config.SecretKeysHandler;
 
-@DisabledOnFipsAndNative(reason = "https://issues.redhat.com/browse/MANDREL-245")
 @QuarkusScenario
 public class ConfigIT {
 

--- a/qute/reactive/src/test/java/io/quarkus/ts/qute/OpenShiftMessageBundlesReactiveIT.java
+++ b/qute/reactive/src/test/java/io/quarkus/ts/qute/OpenShiftMessageBundlesReactiveIT.java
@@ -3,6 +3,6 @@ package io.quarkus.ts.qute;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-public class OpenShiftMessageBundlesReactiveIT extends QuteReactiveIT {
+public class OpenShiftMessageBundlesReactiveIT extends MessageBundlesReactiveIT {
 
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMariadbIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMariadbIT.java
@@ -5,9 +5,11 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnFips;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @Tag("QUARKUS-959")
+@DisabledOnFips(reason = "https://redhat.atlassian.net/browse/QUARKUS-7816")
 @QuarkusScenario
 public class DevModeMariadbIT extends AbstractSqlDatabaseIT {
 


### PR DESCRIPTION
### Summary

This PR contains:
* Disable `DevModeMariadbIT` on FIPS as the current MariaDB is not compatible with FIPS (we had same problem with TS https://github.com/quarkus-qe/quarkus-test-suite/issues/2431)
* The `OpenShiftMessageBundlesReactiveIT` extended to wrong test class/parent, the `QuteReactiveIT` is also extend in https://github.com/quarkus-qe/quarkus-test-suite/blob/main/qute/reactive/src/test/java/io/quarkus/ts/qute/OpenShiftQuteReactiveIT.java#L6 so the openshift tests executed same set of tests
* Adding the `--initialize-at-run-time` for config module app. We build this app in FIPS native but it fail due to problem mentioned in https://issues.redhat.com/browse/MANDREL-245. In 3.27 testing this not happen, but when I try it now it's happening. I don't think it's a bug now as it was closed + explain by https://redhat.atlassian.net/browse/MANDREL-245?focusedCommentId=11832290 that it's need to initialized at runtime

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)