### PR TITLE
Switch AI tests from registry to build strategy

### DIFF
--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftChatbotIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftChatbotIT.java
@@ -11,10 +11,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-// Why this test uses container registry strategy?
-// It is the easiest one to debug and create a standalone reproducer, when there is no quarkus-openshift extension.
-// Feel free to replace it with another.
-@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.Build)
 public class OpenShiftChatbotIT extends AbstractChatbotIT {
     @Container(image = "${redis.image}", port = 6379, expectedLog = "Ready to accept connections")
     static DefaultService redis = new DefaultService().withProperty("ALLOW_EMPTY_PASSWORD", "YES");

--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftMoviesIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftMoviesIT.java
@@ -3,7 +3,7 @@ package io.quarkus.ts.langchain4j;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
-@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.Build)
 public class OpenShiftMoviesIT extends MoviesIT {
 
 }

--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftToolsIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftToolsIT.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.langchain4j.auxiliary.MCPFileServer;
 
-@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.Build)
 public class OpenShiftToolsIT extends AbstractToolsIT {
     @QuarkusApplication(boms = { @Dependency(artifactId = "quarkus-mcp-server-bom") }, dependencies = {
             @Dependency(artifactId = "quarkus-rest"),

--- a/ai/mcp/README.md
+++ b/ai/mcp/README.md
@@ -16,6 +16,7 @@ Thus, the architecture of this module is like this:
 - WebSocket classes run both basic tests and tests for server-only features. They use custom client (see Session class for details).
 
 Useful tips for making a standalone reproducer:
+- (if you're using OpenShift) change deployment strategy to registry (which we usually do not use due to issues with cross-compilation for ARM)
 - add property `quarkus.profile=debug`, you will see jsons, which are send between client and server and session info.
   - `-Dts.global.delete.folder.on.exit=false` option saves applications to `target/$TESTNAME/client/mvn-build` and to `target/$TESTNAME/server/mvn-build`  
 - For some server features the most convenient way is to run websocket tests, copy jsons and then use curl and http server to reproduce.


### PR DESCRIPTION
### Summary

Runners for ARM jobs are based on x86 and build x86-based images, which fail to run or ARM executors

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [x] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)