### PR TITLE
Drop -Dplatform-deps from langchain4j sample builds to fix Agroal BOM conflict

### DIFF
--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/ChatbotIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/ChatbotIT.java
@@ -16,8 +16,7 @@ public class ChatbotIT extends AbstractChatbotIT {
     @Container(image = "${redis.image}", port = 6379, expectedLog = "Ready to accept connections")
     static DefaultService redis = new DefaultService().withProperty("ALLOW_EMPTY_PASSWORD", "YES");
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkiverse/quarkus-langchain4j.git", branch = SAMPLE_BRANCH, contextDir = "samples/chatbot", mavenArgs = DEFAULT_ARGS
-            + " -Dsamples -Dplatform-deps")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkiverse/quarkus-langchain4j.git", branch = SAMPLE_BRANCH, contextDir = "samples/chatbot", mavenArgs = DEFAULT_ARGS)
     static final RestService app = new RestService()
             .withProperty("quarkus.redis.hosts",
                     () -> {

--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/MoviesIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/MoviesIT.java
@@ -28,8 +28,7 @@ public class MoviesIT {
             // store data in /tmp/psql as in OpenShift we don't have permissions to /var/lib/postgresql/data
             .withProperty("PGDATA", "/tmp/psql");
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkiverse/quarkus-langchain4j.git", branch = SAMPLE_BRANCH, contextDir = "samples/movie-similarity-search", mavenArgs = DEFAULT_ARGS
-            + " -Dsamples -Dplatform-deps")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkiverse/quarkus-langchain4j.git", branch = SAMPLE_BRANCH, contextDir = "samples/movie-similarity-search", mavenArgs = DEFAULT_ARGS)
     static final RestService app = new RestService()
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
             .withProperty("quarkus.datasource.username", database.getUser())

--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftChatbotIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftChatbotIT.java
@@ -19,8 +19,7 @@ public class OpenShiftChatbotIT extends AbstractChatbotIT {
     // TODO when any of these issues is solved, change the properties code below:
     //  - https://github.com/quarkus-qe/quarkus-test-framework/issues/1737
     //  - https://github.com/quarkus-qe/quarkus-test-framework/issues/1582
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkiverse/quarkus-langchain4j.git", branch = SAMPLE_BRANCH, contextDir = "samples/chatbot", mavenArgs = DEFAULT_ARGS
-            + " -Dsamples -Dplatform-deps")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkiverse/quarkus-langchain4j.git", branch = SAMPLE_BRANCH, contextDir = "samples/chatbot", mavenArgs = DEFAULT_ARGS)
     static final RestService app = new RestService()
             .withProperty("quarkus.redis.hosts",
                     () -> {

--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftToolsIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftToolsIT.java
@@ -24,7 +24,7 @@ public class OpenShiftToolsIT extends AbstractToolsIT {
             .withProperty("working.folder", "/tmp/playground/");
 
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkiverse/quarkus-langchain4j.git", branch = SAMPLE_BRANCH, contextDir = "samples/mcp-tools", mavenArgs = DEFAULT_ARGS
-            + " -Dsamples -Dplatform-deps -Dquarkus.langchain4j.mcp.filesystem.transport-type=streamable-http")
+            + " -Dquarkus.langchain4j.mcp.filesystem.transport-type=streamable-http")
     static final RestService client = new RestService()
             .withProperty("quarkus.langchain4j.mcp.filesystem.transport-type", "streamable-http")
             .withProperty("quarkus.langchain4j.mcp.filesystem.url",

--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/ToolsIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/ToolsIT.java
@@ -24,7 +24,7 @@ public class ToolsIT extends AbstractToolsIT {
             .withProperty("working.folder", () -> getFileFolder(ToolsIT.class));
 
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkiverse/quarkus-langchain4j.git", branch = SAMPLE_BRANCH, contextDir = "samples/mcp-tools", mavenArgs = DEFAULT_ARGS
-            + " -Dsamples -Dplatform-deps -Dquarkus.langchain4j.mcp.filesystem.transport-type=streamable-http")
+            + " -Dquarkus.langchain4j.mcp.filesystem.transport-type=streamable-http")
     static final RestService client = new RestService()
             .withProperty("quarkus.langchain4j.mcp.filesystem.transport-type", "streamable-http")
             .withProperty("quarkus.langchain4j.mcp.filesystem.url",

--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/auxiliary/CommonTools.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/auxiliary/CommonTools.java
@@ -3,7 +3,7 @@ package io.quarkus.ts.langchain4j.auxiliary;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 public final class CommonTools {
-    public static final String DEFAULT_ARGS = "--no-transfer-progress -DskipTests=true -DskipITs=true -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID}";
+    public static final String DEFAULT_ARGS = "--no-transfer-progress -DskipTests=true -DskipITs=true -Dsamples -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID}";
     public static final String SAMPLE_BRANCH = "1.7";
 
     public static String getKey() {


### PR DESCRIPTION
## Summary

- Fixes `OpenShiftMoviesIT` native build failure (failing since build #118, 5 consecutive failures)
- The `quarkus-langchain4j-bom` from the Quarkus Platform is aligned to Quarkus 3.27.2, which manages `agroal-api:2.8`. When testing against Quarkus `999-SNAPSHOT` (which uses `agroal-api:3.1.2`), the platform BOM causes the older Agroal version to end up on the classpath. This breaks native image compilation because `DataSources.networkTimeout(Duration)` only exists in `agroal-api:3.1.2`
- By dropping `-Dplatform-deps`, the sample apps use the `default-project-deps` profile which imports **only** `quarkus-bom` (no conflicting langchain4j platform BOM) and declares langchain4j extension versions explicitly

## Test plan

- [ ] Verify `OpenShiftMoviesIT` passes on OpenShift native build with Quarkus `999-SNAPSHOT`
- [ ] Verify `OpenShiftChatbotIT` and `OpenShiftToolsIT` still pass
- [ ] Verify local `MoviesIT`, `ChatbotIT`, `ToolsIT` still pass