### PR TITLE
[3.33] Workaround for failing platform build for 3.33

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
           git clone -b 3.33 https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
       - name: Build Quarkus Platform 3.33.999-SNAPSHOT
         run: |
-          git clone -b 3.33 https://github.com/quarkusio/quarkus-platform.git && cd quarkus-platform && ./mvnw versions:set -DnewVersion=3.33.999-SNAPSHOT -DgenerateBackupPoms=false && ./mvnw install -Dquarkus.version=3.33.999-SNAPSHOT -DskipTests -DskipITs
+          # TODO revert commit for excluding the camel-quarkus-integration-test-cxf-soap-grouped
+          git clone -b 3.33 https://github.com/quarkusio/quarkus-platform.git && cd quarkus-platform && ./mvnw versions:set -DnewVersion=3.33.999-SNAPSHOT -DgenerateBackupPoms=false && ./mvnw process-resources -Dquarkus.version=3.33.999-SNAPSHOT -Dquarkus.invoke-platform-project.skip=true && cd generated-platform-project && ../mvnw install -Dquarkus.version=3.33.999-SNAPSHOT -DskipTests -DskipITs -pl "-io.quarkus.platform:camel-quarkus-integration-test-cxf-soap-grouped"
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository


### PR DESCRIPTION
### Summary

Workaround for 3.33 platform build. As we need to build platform as well excluding the `camel-quarkus-integration-test-cxf-soap-grouped` for time being should be ok as it's not module which we are interested anyway.

Some info about it: https://github.com/quarkusio/quarkus-platform/pull/1981
 
Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)