### PR TITLE
[3.33] Fix BeanParamPermissionIT Use USER instead of ADMIN in testRecordBeanParamDenialInvalidDocumentId

### DIFF
--- a/security/permissions/src/test/java/io/quarkus/ts/security/permissions/beanparam/BeanParamPermissionIT.java
+++ b/security/permissions/src/test/java/io/quarkus/ts/security/permissions/beanparam/BeanParamPermissionIT.java
@@ -156,7 +156,7 @@ public class BeanParamPermissionIT extends BaseBeanParamPermissionsIT {
 
     @Test
     public void testRecordBeanParamDenialInvalidDocumentId() {
-        givenAuthenticatedUser(ADMIN)
+        givenAuthenticatedUser(USER)
                 .header("CustomAuthorization", "valid-token")
                 .queryParam("docId", "invalid-id")
                 .queryParam("version", "1")


### PR DESCRIPTION
### Summary

Fix BeanParamPermissionIT Use USER instead of ADMIN in testRecordBeanParamDenialInvalidDocumentId

Custom backport of https://github.com/quarkus-qe/quarkus-test-suite/commit/027e318c1727c833893a9eedea60484f02aca1d8

Note: This needs 3.33 branch build or Quarkus 3.33.2 (which is to be released)

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)