### PR TITLE
Fix Narayana recovery module failure on OpenShift native builds

### DIFF
--- a/sql-db/panache-flyway/src/main/resources/application.properties
+++ b/sql-db/panache-flyway/src/main/resources/application.properties
@@ -13,6 +13,10 @@ quarkus.datasource.with-xa.password=${quarkus.datasource.password}
 quarkus.datasource.with-xa.jdbc.url=${quarkus.datasource.jdbc.url}
 quarkus.datasource.with-xa.jdbc.transactions=xa
 
+# Use /tmp for the transaction object store so Narayana recovery modules
+# can initialize on OpenShift where the working directory may be read-only
+quarkus.transaction-manager.object-store.directory=/tmp/ObjectStore
+
 # Flyway
 quarkus.flyway.migrate-at-start=true
 quarkus.flyway.schemas=test


### PR DESCRIPTION
The panache-flyway OpenShift native tests (OpenShiftDefaultInitContainerIT, OpenShiftFlywayInitContainerIT, OpenShiftSecuredPanacheEntityResourceIT, OpenShiftSecuredPanacheRepositoryResourceIT) have been failing for 23 consecutive weekly builds with:

  ARJUNA048006: cannot create new instance of AtomicActionRecoveryModule
  ARJUNA048006: cannot create new instance of XARecoveryModule
  ARJUNA048006: cannot create new instance of ExpiredTransactionStatusManagerScanner
  ARJUNA032011: No suitable recovery module in which to register
                XAResourceRecovery instance

The XA datasource configuration (quarkus.datasource.with-xa.jdbc.transactions=xa) enables Narayana transaction recovery, which requires an object store directory.
The default directory ("ObjectStore") is relative to the working directory, which may be read-only on OpenShift containers. When the recovery modules cannot create this directory, their constructors fail, no XARecoveryModule is available, and Agroal's datasource creation crashes the application.

Set the object store directory to /tmp/ObjectStore, which is always writable in OpenShift containers.
