### PR TITLE
[3.27] Backports for 3.27.4 release

### DIFF
--- a/lifecycle-application/pom.xml
+++ b/lifecycle-application/pom.xml
@@ -22,6 +22,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-openshift</artifactId>
         </dependency>
         <dependency>

--- a/lifecycle-application/src/main/java/io/quarkus/ts/lifecycle/CdiContainerResource.java
+++ b/lifecycle-application/src/main/java/io/quarkus/ts/lifecycle/CdiContainerResource.java
@@ -1,0 +1,19 @@
+package io.quarkus.ts.lifecycle;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.quarkus.arc.Arc;
+
+@Path("/cdi")
+public class CdiContainerResource {
+
+    @GET
+    @Path("/container-status")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String containerStatus() {
+        return Arc.container() != null ? "active" : null;
+    }
+}

--- a/lifecycle-application/src/main/java/io/quarkus/ts/lifecycle/JacksonShutdownValidatorBean.java
+++ b/lifecycle-application/src/main/java/io/quarkus/ts/lifecycle/JacksonShutdownValidatorBean.java
@@ -1,0 +1,43 @@
+package io.quarkus.ts.lifecycle;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.StartupEvent;
+
+@ApplicationScoped
+public class JacksonShutdownValidatorBean {
+
+    private static final Logger LOG = Logger.getLogger(JacksonShutdownValidatorBean.class);
+    private static final long STARTUP_DELAY_MS = 3000;
+    public static final String SHUTDOWN_INITIATED = "JacksonShutdownValidator: shutdown initiated";
+
+    @ConfigProperty(name = "jackson.shutdown.test.enabled", defaultValue = "false")
+    boolean jacksonShutdownTestEnabled;
+
+    @Inject
+    ManagedExecutor managedExecutor;
+
+    void onStart(@Observes StartupEvent event) {
+        if (!jacksonShutdownTestEnabled) {
+            LOG.debug("JacksonShutdownValidatorBean disabled (jackson.shutdown.test.enabled=false)");
+            return;
+        }
+        managedExecutor.execute(() -> {
+            try {
+                Thread.sleep(STARTUP_DELAY_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            LOG.info(SHUTDOWN_INITIATED);
+            Quarkus.asyncExit();
+        });
+    }
+}

--- a/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/CdiContainerProfileTest.java
+++ b/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/CdiContainerProfileTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.ts.lifecycle;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+@Tag("QUARKUS-6793")
+@QuarkusTest
+@TestProfile(CdiContainerProfileTest.CdiDiagnosticProfile.class)
+public class CdiContainerProfileTest {
+
+    public static class CdiDiagnosticProfile implements QuarkusTestProfile {
+    }
+
+    @Test
+    public void verifyCdiContainerIsActiveWithProfile() {
+        given()
+                .when().get("/cdi/container-status")
+                .then()
+                .statusCode(200)
+                .body(is("active"));
+    }
+}

--- a/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/CdiContainerTest.java
+++ b/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/CdiContainerTest.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.lifecycle;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@Tag("QUARKUS-6793")
+@QuarkusTest
+public class CdiContainerTest {
+
+    @Test
+    public void verifyCdiContainerIsActive() {
+        given()
+                .when().get("/cdi/container-status")
+                .then()
+                .statusCode(200)
+                .body(is("active"));
+    }
+}

--- a/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/JacksonGracefulShutdownIT.java
+++ b/lifecycle-application/src/test/java/io/quarkus/ts/lifecycle/JacksonGracefulShutdownIT.java
@@ -1,0 +1,33 @@
+package io.quarkus.ts.lifecycle;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+@Tag("QUARKUS-7610")
+public class JacksonGracefulShutdownIT {
+
+    private static final String TIMED_OUT_MESSAGE = "Timed out waiting for graceful shutdown, shutting down anyway.";
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("jackson.shutdown.test.enabled", "true")
+            .withProperty("quarkus.shutdown.timeout", "5s");
+
+    @Test
+    public void shouldShutdownWithoutTimeout() {
+        await().atMost(10, SECONDS)
+                .pollInterval(1, SECONDS)
+                .until(() -> app.getLogs().stream().anyMatch(line -> line.contains("stopped in")));
+
+        app.logs().assertContains(JacksonShutdownValidatorBean.SHUTDOWN_INITIATED);
+        app.logs().assertDoesNotContain(TIMED_OUT_MESSAGE);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.27.999-SNAPSHOT</quarkus.platform.version>
-        <quarkus.ide.version>3.27.3</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.7.9</quarkus.qe.framework.version>
+        <quarkus.ide.version>3.27.4</quarkus.ide.version>
+        <quarkus.qe.framework.version>1.7.10</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.8.0</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.27.0</formatter-maven-plugin.version>

--- a/sql-db/sql-app/src/main/java/io/quarkus/ts/sqldb/sqlapp/OracleRollbackResource.java
+++ b/sql-db/sql-app/src/main/java/io/quarkus/ts/sqldb/sqlapp/OracleRollbackResource.java
@@ -1,0 +1,61 @@
+package io.quarkus.ts.sqldb.sqlapp;
+
+import java.sql.Connection;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.jboss.logging.Logger;
+
+import javax.sql.DataSource;
+
+@Path("/oracle-rollback")
+public class OracleRollbackResource {
+
+    private static final Logger LOG = Logger.getLogger(OracleRollbackResource.class);
+    private static final String CREATE_TABLE = "CREATE TABLE rollback_test ("
+            + "id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, "
+            + "value VARCHAR2(255) NOT NULL)";
+    private static final String DROP_TABLE = "DROP TABLE rollback_test";
+
+    @Inject
+    DataSource dataSource;
+
+    @Inject
+    ManagedExecutor managedExecutor;
+
+    @Inject
+    OracleRollbackService oracleRollbackService;
+
+    @POST
+    @Path("/init")
+    public Response init() throws Exception {
+        try (Connection conn = dataSource.getConnection()) {
+            try {
+                conn.createStatement().execute(DROP_TABLE);
+            } catch (Exception ignored) {
+                // table may not exist yet
+            }
+            conn.createStatement().execute(CREATE_TABLE);
+        }
+        return Response.ok("initialized").build();
+    }
+
+    @POST
+    @Path("/trigger")
+    public Response trigger() {
+        managedExecutor.execute(() -> {
+            try {
+                oracleRollbackService.insertAndBlock();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                LOG.warn("Transaction failed", e);
+            }
+        });
+        return Response.accepted().build();
+    }
+}

--- a/sql-db/sql-app/src/main/java/io/quarkus/ts/sqldb/sqlapp/OracleRollbackService.java
+++ b/sql-db/sql-app/src/main/java/io/quarkus/ts/sqldb/sqlapp/OracleRollbackService.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.sqldb.sqlapp;
+
+import java.sql.Connection;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.jboss.logging.Logger;
+
+import javax.sql.DataSource;
+
+@ApplicationScoped
+public class OracleRollbackService {
+
+    private static final Logger LOG = Logger.getLogger(OracleRollbackService.class);
+    public static final String INSERT_EXECUTED_LOG = "INSERT executed, blocking to simulate long-running operation";
+    private static final String INSERT = "INSERT INTO rollback_test (value) VALUES ('should-be-rolled-back')";
+
+    @Inject
+    DataSource dataSource;
+
+    @Transactional
+    public void insertAndBlock() throws Exception {
+        try (Connection conn = dataSource.getConnection()) {
+            conn.prepareStatement(INSERT).executeUpdate();
+            LOG.info(INSERT_EXECUTED_LOG);
+            Thread.sleep(30_000);
+        }
+    }
+}

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OracleConnectionRollbackIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OracleConnectionRollbackIT.java
@@ -1,0 +1,67 @@
+package io.quarkus.ts.sqldb.sqlapp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.HttpStatus;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+import io.quarkus.test.bootstrap.OracleService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+@Tag("QUARKUS-7644")
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "https://github.com/quarkus-qe/quarkus-test-suite/issues/2022")
+public class OracleConnectionRollbackIT {
+
+    private static final String INSERT_LOG = OracleRollbackService.INSERT_EXECUTED_LOG;
+
+    static final int ORACLE_PORT = 1521;
+
+    @Container(image = "${oracle.image}", port = ORACLE_PORT, expectedLog = "DATABASE IS READY TO USE!")
+    static OracleService database = new OracleService();
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperties("oracle.properties")
+            .withProperty("quarkus.datasource.username", database.getUser())
+            .withProperty("quarkus.datasource.password", database.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
+            .withProperty("quarkus.shutdown.timeout", "5s");
+
+    @Test
+    public void verifyInFlightTransactionRolledBackOnShutdown() throws Exception {
+        app.given().post("/oracle-rollback/init")
+                .then().statusCode(HttpStatus.SC_OK);
+
+        app.given().post("/oracle-rollback/trigger")
+                .then().statusCode(HttpStatus.SC_ACCEPTED);
+
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .until(() -> app.getLogs().stream().anyMatch(line -> line.contains(INSERT_LOG)));
+
+        app.stop();
+
+        try (Connection conn = DriverManager.getConnection(
+                database.getJdbcUrl(), database.getUser(), database.getPassword())) {
+            try (ResultSet rs = conn.prepareStatement("SELECT COUNT(*) FROM rollback_test").executeQuery()) {
+                rs.next();
+                assertEquals(0, rs.getInt(1),
+                        "In-flight transaction should be rolled back on shutdown, "
+                                + "but rows were committed (Oracle implicit commit on close)");
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Backports for 3.27.4 release

 * https://github.com/quarkus-qe/quarkus-test-suite/pull/3009
 * https://github.com/quarkus-qe/quarkus-test-suite/pull/2983
 * https://github.com/quarkus-qe/quarkus-test-suite/pull/3013

FW bump
 * FW 1.7.10 release - https://github.com/quarkus-qe/quarkus-test-framework/releases/tag/1.7.10

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)