### PR TITLE
[3.33] Build and deploy Quarkus platform during daily CI, use platform by default

### DIFF
--- a/ai/langchain4j/pom.xml
+++ b/ai/langchain4j/pom.xml
@@ -15,7 +15,6 @@
         <quarkus.build.skip>true</quarkus.build.skip>
         <skipTests>true</skipTests>
         <skipITs>true</skipITs>
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -75,9 +74,6 @@
                                     <quarkus.s2i.base-native-image>${quarkus.s2i.base-native-image}</quarkus.s2i.base-native-image>
                                     <!-- Services used in test suite -->
                                     <pgvector.image>docker.io/pgvector/pgvector:pg18</pgvector.image>
-                                    <!-- Passing values to cloned applications -->
-                                    <!-- Langchain4j extensions are not in core, so use platform prefix by default -->
-                                    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
                                 </systemPropertyVariables>
                             </configuration>
                         </execution>

--- a/ai/mcp/pom.xml
+++ b/ai/mcp/pom.xml
@@ -13,7 +13,6 @@
     <properties>
         <!-- The line below is required because we have empty src/main: https://github.com/quarkusio/quarkus/issues/33061 -->
         <quarkus.build.skip>true</quarkus.build.skip>
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -82,9 +81,6 @@
                                     <!-- S2i configuration for OpenShift -->
                                     <quarkus.s2i.base-jvm-image>${quarkus.s2i.base-jvm-image}</quarkus.s2i.base-jvm-image>
                                     <quarkus.s2i.base-native-image>${quarkus.s2i.base-native-image}</quarkus.s2i.base-native-image>
-                                    <!-- Passing values to cloned applications -->
-                                    <!-- Langchain4j extensions are not in core, so use platform prefix by default -->
-                                    <quarkus.platform.group-id>${quarkus.platform.group-id}</quarkus.platform.group-id>
                                 </systemPropertyVariables>
                             </configuration>
                         </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <surefire-plugin.version>3.5.5</surefire-plugin.version>
         <failsafe-plugin.version>3.5.5</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.33.999-SNAPSHOT</quarkus.platform.version>
         <quarkus.ide.version>3.33.1</quarkus.ide.version>
         <quarkus.qe.framework.version>1.8.3</quarkus.qe.framework.version>
@@ -179,12 +179,12 @@
         <pluginRepository>
             <id>quarkus-snapshots-plugin-repository</id>
             <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </pluginRepository>
     </pluginRepositories>
     <build>
@@ -323,6 +323,8 @@
                                 <keycloak.image>quay.io/keycloak/keycloak:26.5</keycloak.image>
                                 <bouncycastle.bctls-fips.version>1.0.12.2</bouncycastle.bctls-fips.version>
                                 <rhbk.image>${rhbk.image}</rhbk.image>
+                                <quarkus.platform.group-id>${quarkus.platform.group-id}</quarkus.platform.group-id>
+                                <quarkus.platform.version>${quarkus.platform.version}</quarkus.platform.version>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>
@@ -448,6 +450,9 @@
                     <name>all-modules</name>
                 </property>
             </activation>
+            <properties>
+                <quarkus.platform.version>3.33.999-core-3.33-SNAPSHOT</quarkus.platform.version>
+            </properties>
             <modules>
                 <module>env-info</module>
                 <module>ai/langchain4j</module>


### PR DESCRIPTION
### Summary

Changes:
- Switch default quarkus group-id from io.quarkus to io.quarkus.platform (just like prod builds and generated quarkus applications)
- Build Quarkus core and platform. Upstream 999-SNAPSHOT platform build is based on stable core, ours is based on 999-SNAPSHOT core, so it has different version
- Remove kludges for ai tests
- Pass platform version and group-id to tests as system variables

(cherry picked from commit 447e6293e7d874b26edbbf5b84254b35cb2ff6ce)


Backport of https://github.com/quarkus-qe/quarkus-test-suite/pull/2978

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)