### PR TITLE
Remove calls to QuarkusCliClient.useTemporaryDirectory()

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli320UpdatesIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli320UpdatesIT.java
@@ -59,9 +59,6 @@ public class QuarkusCli320UpdatesIT extends AbstractQuarkusCliUpdateIT {
         oldProperties.put("quarkus.log.console.json", "true");
         newProperties.put("quarkus.log.console.json.enabled", "true");
 
-        // TODO: drop using temp dir when https://github.com/quarkusio/quarkus-updates/issues/394 is fixed
-        try (var ignored = cliClient.useTemporaryDirectory()) {
-            QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
-        }
+        QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
     }
 }

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli327UpdatesIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli327UpdatesIT.java
@@ -114,12 +114,7 @@ public class QuarkusCli327UpdatesIT extends AbstractQuarkusCliUpdateIT {
         oldProperties.put("quarkus.hibernate-orm.\"fantastic\".database.generation.halt-on-error", "true");
         newProperties.put("quarkus.hibernate-orm.\"fantastic\".schema-management.halt-on-error", "true");
 
-        // here we create application in a temporary directory so that we also have a scenario
-        // where we test the CLI update command in a folder hierarchy without other maven projects
-        // it can make a difference, see for example https://github.com/quarkusio/quarkus-updates/issues/394
-        try (var ignored = cliClient.useTemporaryDirectory()) {
-            QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
-        }
+        QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
     }
 
     /**
@@ -226,10 +221,7 @@ public class QuarkusCli327UpdatesIT extends AbstractQuarkusCliUpdateIT {
         oldProperties.put("quarkus.log.handler.socket.\"whatever\".async.enable", "true");
         newProperties.put("quarkus.log.handler.socket.\"whatever\".async.enabled", "true");
 
-        // TODO: drop using temp dir when https://github.com/quarkusio/quarkus-updates/issues/394 is fixed
-        try (var ignored = cliClient.useTemporaryDirectory()) {
-            QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
-        }
+        QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
     }
 
     /**

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli333UpdatesIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli333UpdatesIT.java
@@ -89,10 +89,7 @@ public class QuarkusCli333UpdatesIT extends AbstractQuarkusCliUpdateIT {
         oldProperties.put("quarkus.datasource.jdbc.enable-metrics", "true");
         newProperties.put("quarkus.datasource.jdbc.metrics.enabled", "true");
 
-        // TODO: drop using temp dir when https://github.com/quarkusio/quarkus-updates/issues/394 is fixed
-        try (var ignored = cliClient.useTemporaryDirectory()) {
-            QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
-        }
+        QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Remove calls to `QuarkusCliClient.useTemporaryDirectory()` which was removed from the test framework in [quarkus-qe/quarkus-test-framework#1910](https://github.com/quarkus-qe/quarkus-test-framework/pull/1910)

Fixes https://redhat.atlassian.net/browse/QQE-2586

## Test plan
- [ ] Verify `quarkus-cli` module compiles successfully