### PR TITLE
Build Quarkus Platform in daily workflow to align platform BOM with core

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -26,6 +26,11 @@ jobs:
           mkdir maven-repository
           LOCAL_REPO="$(pwd)/maven-repository"
           git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations -Dmaven.repo.local=$LOCAL_REPO
+      - name: Build Quarkus Platform 999-SNAPSHOT
+        run: |
+          LOCAL_REPO="$(pwd)/maven-repository"
+          git clone https://github.com/quarkusio/quarkus-platform.git && cd quarkus-platform
+          ./mvnw install -Dquarkus.version=999-SNAPSHOT -DskipTests -DskipITs -Dmaven.repo.local=$LOCAL_REPO
       - name: Cache Build Outputs
         uses: actions/cache/save@v5
         with:


### PR DESCRIPTION
### Summary

All PR CI checks in quarkus-test-suite have been failing since the upstream PR  with `ReadOnlyZipFileSystem` class not found.

The PR [quarkusio/quarkus#54144](https://github.com/quarkusio/quarkus/pull/54144) bumped `quarkus-fs-util` from 1.3.0 to 1.4.0. The 999-SNAPSHOT jars were compiled against 1.4.0, but the platform BOM
  (io.quarkus.platform:quarkus-bom) still declares 1.3.0. 
Our ai/langchain4j and ai/mcp modules use the platform BOM because LangChain4j and MCP are not core extensions so Maven resolves the wrong version and fails.

FYI @aloubyansky 

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)