### PR TITLE
Disable OpenshiftMoviesIT for IBM z and P as pgvector container is not available for s390x & ppc64le

### DIFF
--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftMoviesIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftMoviesIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.ts.langchain4j;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "pgvector container not available on s390x & ppc64le.")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.Build)
 public class OpenShiftMoviesIT extends MoviesIT {
 


### PR DESCRIPTION
### Summary

Disable the OpenShiftMoviesIT for IBM Z and P as `docker.io/pgvector/pgvector:pg18` is not available for theirs architectures see https://hub.docker.com/layers/pgvector/pgvector/pg18/images

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)