### PR TITLE
Remove quarkus.native.monitoring=none as this issue should not happening with Mandrel base on jdk 25

### DIFF
--- a/hibernate/hibernate-reactive/src/main/resources/application.properties
+++ b/hibernate/hibernate-reactive/src/main/resources/application.properties
@@ -4,6 +4,3 @@ quarkus.datasource.db-kind=postgresql
 
 # HttpClient config
 io.quarkus.ts.hibernate.reactive.http.SomeApi/mp-rest/url=http://localhost:${quarkus.http.port}
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/hibernate/hibernate-reactive/src/test/resources/entityless.properties
+++ b/hibernate/hibernate-reactive/src/test/resources/entityless.properties
@@ -1,5 +1,2 @@
 quarkus.hibernate-orm.database.charset=utf-8
 quarkus.datasource.db-kind=postgresql
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/hibernate/hibernate-reactive/src/test/resources/mixed.properties
+++ b/hibernate/hibernate-reactive/src/test/resources/mixed.properties
@@ -1,6 +1,3 @@
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none
-
 # define fruit datasource. It uses Postgres in reactive mode
 quarkus.datasource.jdbc=false
 quarkus.datasource.reactive=true

--- a/hibernate/hibernate-reactive/src/test/resources/multidb.properties
+++ b/hibernate/hibernate-reactive/src/test/resources/multidb.properties
@@ -1,9 +1,6 @@
 # HttpClient config
 io.quarkus.ts.hibernate.reactive.http.SomeApi/mp-rest/url=http://localhost:${quarkus.http.port}
 
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none
-
 # for whatever reason quarkus requires to have "db-kind" defined for default datasource even though we are not using default datasource
 quarkus.datasource.db-kind=postgresql
 

--- a/hibernate/jakarta-data/src/main/resources/application.properties
+++ b/hibernate/jakarta-data/src/main/resources/application.properties
@@ -80,6 +80,3 @@ quarkus.datasource.sql-server.active=false
 quarkus.datasource.sql-server.username=${db-username}
 quarkus.datasource.sql-server.password=${db-password}
 quarkus.datasource.sql-server.jdbc.url=${db-url}
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/hibernate/jakarta-data/src/test/resources/db2.properties
+++ b/hibernate/jakarta-data/src/test/resources/db2.properties
@@ -21,9 +21,6 @@ quarkus.http.auth.policy.role-policy1.permissions.reader-writer=read,write
 quarkus.http.auth.permission.roles1.paths=/book/*/type-permission,/book/*/method-permission,/book/*/method-multiple-permissions,/book/add/permission,/book/*/delete/permission
 quarkus.http.auth.permission.roles1.policy=role-policy1
 
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none
-
 quarkus.hibernate-orm.db2.packages=io.quarkus.ts.jakarta.data.db
 quarkus.hibernate-orm.db2.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.db2.datasource=db2

--- a/security/jpa/src/main/resources/application.properties
+++ b/security/jpa/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/narayana-transactions/src/main/resources/application.properties
+++ b/sql-db/narayana-transactions/src/main/resources/application.properties
@@ -34,9 +34,6 @@ quarkus.transaction-manager.enable-recovery=true
 quarkus.transaction-manager.object-store.create-table=true
 quarkus.transaction-manager.object-store.table-prefix=quarkus_qe_
 
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none
-
 # allows us to assert logging messages related to the transaction recovery
 quarkus.log.category."com.arjuna".level=TRACE
 quarkus.log.category."com.arjuna".min-level=TRACE

--- a/sql-db/reactive-rest-data-panache/src/main/resources/application.properties
+++ b/sql-db/reactive-rest-data-panache/src/main/resources/application.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/main/resources/application.properties
+++ b/sql-db/sql-app-compatibility/src/main/resources/application.properties
@@ -2,6 +2,3 @@ quarkus.datasource.db-kind=h2
 quarkus.hibernate-orm.database.charset=utf-8
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/test/resources/db2_app.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/db2_app.properties
@@ -4,6 +4,3 @@ quarkus.hibernate-orm.sql-load-script=db2_import.sql
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-orm.database.orm-compatibility.version=5.6
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/test/resources/h2.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/h2.properties
@@ -7,6 +7,3 @@ quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
 
 quarkus.hibernate-orm.database.orm-compatibility.version=5.6
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/test/resources/mariadb_app.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/mariadb_app.properties
@@ -5,6 +5,3 @@ quarkus.hibernate-orm.sql-load-script=mariadb_import.sql
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-orm.database.orm-compatibility.version=5.6
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/test/resources/mssql.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/mssql.properties
@@ -5,6 +5,3 @@ quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.datasource.jdbc.additional-jdbc-properties.trustservercertificate=true
 
 quarkus.hibernate-orm.database.orm-compatibility.version=5.6
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/test/resources/mysql.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/mysql.properties
@@ -5,6 +5,3 @@ quarkus.hibernate-orm.sql-load-script=mariadb_import.sql
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-orm.database.orm-compatibility.version=5.6
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/test/resources/oracle.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/oracle.properties
@@ -3,6 +3,3 @@ quarkus.hibernate-orm.sql-load-script=oracle_import.sql
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-orm.database.orm-compatibility.version=5.6
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/sql-app-compatibility/src/test/resources/postgresql.properties
+++ b/sql-db/sql-app-compatibility/src/test/resources/postgresql.properties
@@ -3,6 +3,3 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-orm.database.orm-compatibility.version=5.6
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/sql-app/src/main/resources/application.properties
+++ b/sql-db/sql-app/src/main/resources/application.properties
@@ -2,6 +2,3 @@ quarkus.datasource.db-kind=h2
 quarkus.hibernate-orm.database.charset=utf-8
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/sql-app/src/test/resources/db2_app.properties
+++ b/sql-db/sql-app/src/test/resources/db2_app.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=db2
 #quarkus.hibernate-orm.dialect=org.hibernate.dialect.DB2Dialect
 quarkus.hibernate-orm.sql-load-script=db2_import.sql
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/sql-app/src/test/resources/h2.properties
+++ b/sql-db/sql-app/src/test/resources/h2.properties
@@ -5,6 +5,3 @@ quarkus.datasource.password=sa
 quarkus.hibernate-orm.database.charset=utf-8
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/sql-app/src/test/resources/mariadb_app.properties
+++ b/sql-db/sql-app/src/test/resources/mariadb_app.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=mariadb
 quarkus.hibernate-orm.sql-load-script=mariadb_import.sql
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/sql-app/src/test/resources/mssql.properties
+++ b/sql-db/sql-app/src/test/resources/mssql.properties
@@ -2,6 +2,3 @@ quarkus.datasource.db-kind=mssql
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServerDialect
 quarkus.hibernate-orm.sql-load-script=mssql_import.sql
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/sql-app/src/test/resources/mysql.properties
+++ b/sql-db/sql-app/src/test/resources/mysql.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=mysql
 quarkus.hibernate-orm.sql-load-script=mysql_import.sql
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/sql-app/src/test/resources/oracle.properties
+++ b/sql-db/sql-app/src/test/resources/oracle.properties
@@ -2,8 +2,5 @@ quarkus.datasource.db-kind=oracle
 quarkus.hibernate-orm.sql-load-script=oracle_import.sql
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none
-
 # Oracle database startup can take longer than current global start-up timeout 1 minute
 quarkus.devservices.timeout=240s

--- a/sql-db/sql-app/src/test/resources/postgresql.properties
+++ b/sql-db/sql-app/src/test/resources/postgresql.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.sql-load-script=import.sql
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none

--- a/sql-db/vertx-sql/src/main/resources/application.properties
+++ b/sql-db/vertx-sql/src/main/resources/application.properties
@@ -62,6 +62,3 @@ quarkus.datasource.oracle.reactive.url=oracle:thin:@localhost:1521:amadeus
 ## Flyway
 quarkus.datasource.oracle.jdbc.url=jdbc:oracle:thin:@localhost:1521:amadeus
 quarkus.flyway.oracle.locations=db/migration/oracle,db/migration/common
-
-# TODO: drop when https://github.com/quarkusio/quarkus/issues/46890 gets fixed
-quarkus.native.monitoring=none


### PR DESCRIPTION
### Summary

Removing this workaround as it should be fixed/work with mandrel  base on jdk 25. Let's run it for few week and monitor if we spot it.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)