### PR TITLE
[3.33] Enable AI tests

### DIFF
--- a/ai/mcp/src/test/java/io/quarkus/ts/mcp/BasicMCPIT.java
+++ b/ai/mcp/src/test/java/io/quarkus/ts/mcp/BasicMCPIT.java
@@ -83,12 +83,12 @@ public abstract class BasicMCPIT {
     public void toolChanges() {
         Response before = client().given().get("/mcp/tools");
         Assertions.assertEquals(200, before.statusCode());
-        String initialTools = "[filereader, rootchecker, wait, meta]";
+        String initialTools = "[rootchecker, wait, filereader, meta]";
         Assertions.assertEquals(initialTools, before.body().asString());
 
         Response create = client().given().post("/mcp/meta/greeter");
         Assertions.assertEquals(200, create.statusCode());
-        String changedTools = "[filereader, rootchecker, wait, meta, greeter]";
+        String changedTools = "[rootchecker, wait, filereader, meta, greeter]";
 
         Response after = client().given().get("/mcp/tools");
         Assertions.assertEquals(200, after.statusCode());

--- a/ai/mcp/src/test/java/io/quarkus/ts/mcp/BasicMCPIT.java
+++ b/ai/mcp/src/test/java/io/quarkus/ts/mcp/BasicMCPIT.java
@@ -5,11 +5,9 @@ import java.util.List;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.restassured.response.Response;
 
 public abstract class BasicMCPIT {
@@ -23,7 +21,6 @@ public abstract class BasicMCPIT {
     }
 
     @Test
-    @Disabled("https://github.com/quarkiverse/quarkus-langchain4j/issues/2223")
     public void tools() {
         Response response = client().given().get("/mcp/tools");
         Assertions.assertEquals(200, response.statusCode());
@@ -31,7 +28,6 @@ public abstract class BasicMCPIT {
     }
 
     @Test
-    @Disabled("https://github.com/quarkiverse/quarkus-langchain4j/issues/2223")
     public void args() {
         Response response = client().given().get("/mcp/tools/filereader/arguments");
         Assertions.assertEquals(200, response.statusCode());
@@ -84,16 +80,15 @@ public abstract class BasicMCPIT {
     }
 
     @Test
-    @Disabled("https://github.com/quarkiverse/quarkus-langchain4j/issues/2223")
     public void toolChanges() {
         Response before = client().given().get("/mcp/tools");
         Assertions.assertEquals(200, before.statusCode());
-        String initialTools = "[rootchecker, wait, filereader, meta]";
+        String initialTools = "[filereader, rootchecker, wait, meta]";
         Assertions.assertEquals(initialTools, before.body().asString());
 
         Response create = client().given().post("/mcp/meta/greeter");
         Assertions.assertEquals(200, create.statusCode());
-        String changedTools = "[rootchecker, wait, filereader, meta, greeter]";
+        String changedTools = "[filereader, rootchecker, wait, meta, greeter]";
 
         Response after = client().given().get("/mcp/tools");
         Assertions.assertEquals(200, after.statusCode());
@@ -119,7 +114,6 @@ public abstract class BasicMCPIT {
     }
 
     @Test
-    @DisabledOnNative(reason = "https://github.com/quarkiverse/quarkus-langchain4j/issues/2287")
     public void roots() {
         Response before = client().given().get("/mcp/roots");
         Assertions.assertEquals(200, before.statusCode());

--- a/ai/mcp/src/test/java/io/quarkus/ts/mcp/OpenShiftHttpIT.java
+++ b/ai/mcp/src/test/java/io/quarkus/ts/mcp/OpenShiftHttpIT.java
@@ -25,6 +25,8 @@ public class OpenShiftHttpIT extends LocalStreamingHTTPIT {
             }, classes = { MCPClient.class })
     static final RestService client = new RestService()
             .withProperty("quarkus.langchain4j.mcp.filesystem.transport-type", "streamable-http")
+            // todo remove the line below when https://github.com/quarkiverse/quarkus-langchain4j/issues/2159 is fixed
+            .withProperty("quarkus.langchain4j.mcp.filesystem.cache-tool-list", "false")
             .withProperty("quarkus.langchain4j.mcp.filesystem.url",
                     () -> server.getURI(Protocol.HTTP).withPath("/mcp").toString());
 

--- a/ai/mcp/src/test/java/io/quarkus/ts/mcp/WebSocketIT.java
+++ b/ai/mcp/src/test/java/io/quarkus/ts/mcp/WebSocketIT.java
@@ -203,7 +203,6 @@ public class WebSocketIT extends BasicMCPIT {
     }
 
     @Test
-    @DisabledOnNative(reason = "https://github.com/quarkiverse/quarkus-mcp-server/issues/679")
     void sampling() {
         Session session = new Session(getUrl(server));
         session.sendRequest("initialize", Session.initParamas());
@@ -258,7 +257,6 @@ public class WebSocketIT extends BasicMCPIT {
     }
 
     @Test
-    @DisabledOnNative(reason = "https://github.com/quarkiverse/quarkus-mcp-server/issues/679")
     void elicitation() {
         Session session = new Session(getUrl(server));
         session.sendRequest("initialize", Session.initParamas());

--- a/ai/mcp/src/test/java/io/quarkus/ts/mcp/WebSocketIT.java
+++ b/ai/mcp/src/test/java/io/quarkus/ts/mcp/WebSocketIT.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -12,7 +11,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.Dependency;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.mcp.app.AdvancedServer;
@@ -50,7 +48,6 @@ public class WebSocketIT extends BasicMCPIT {
     }
 
     @Test
-    @Disabled("https://github.com/quarkiverse/quarkus-langchain4j/issues/2223")
     @Override // This test has access to more tools due to AdvancedServer class. They also may be in a different order
     public void toolChanges() {
         Response before = client().given().get("/mcp/tools");
@@ -79,7 +76,6 @@ public class WebSocketIT extends BasicMCPIT {
     }
 
     @Test
-    @DisabledOnNative(reason = "https://github.com/quarkiverse/quarkus-mcp-server/issues/706")
     void iconCheck() {
         Session session = new Session(getUrl(server));
         session.sendRequest("initialize", Session.initParamas());


### PR DESCRIPTION
### Summary

Backports the following:
- https://github.com/quarkus-qe/quarkus-test-suite/pull/2982
- https://github.com/quarkus-qe/quarkus-test-suite/pull/2951

And adds a fix to adapt to differences between 3.33 and main

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)