### PR TITLE
Fix graphql-client build failure due to provided-scope extension

### DIFF
--- a/http/graphql-client/pom.xml
+++ b/http/graphql-client/pom.xml
@@ -18,8 +18,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-graphql</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
## Summary
- Remove `provided` scope and `optional` flag from the `quarkus-smallrye-graphql` dependency in the `graphql-client` module
- Without the GraphQL deployment extension active, `ExecutionModelAnnotationsProcessor` rejects `@RunOnVirtualThread` on `@Query` methods because `GraphqlMethodsProcessor` never produces the required `ExecutionModelAnnotationsAllowedBuildItem`

## Test plan
- [x] `mvn clean integration-test` passes (2/2 tests: `GraphQLClientIT` and `SeparateDependenciesIT`)