### PR TITLE
[3.33] Bump Quarkus QE Framework to 1.8.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.33.999-SNAPSHOT</quarkus.platform.version>
         <quarkus.ide.version>3.33.1</quarkus.ide.version>
-        <quarkus.qe.framework.version>1.8.3</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.8.4</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.10.0</quarkus-qpid-jms.version>
         <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
         <formatter-maven-plugin.version>2.29.0</formatter-maven-plugin.version>

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli320UpdatesIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli320UpdatesIT.java
@@ -59,9 +59,6 @@ public class QuarkusCli320UpdatesIT extends AbstractQuarkusCliUpdateIT {
         oldProperties.put("quarkus.log.console.json", "true");
         newProperties.put("quarkus.log.console.json.enabled", "true");
 
-        // TODO: drop using temp dir when https://github.com/quarkusio/quarkus-updates/issues/394 is fixed
-        try (var ignored = cliClient.useTemporaryDirectory()) {
-            QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
-        }
+        QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
     }
 }

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli327UpdatesIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli327UpdatesIT.java
@@ -116,12 +116,7 @@ public class QuarkusCli327UpdatesIT extends AbstractQuarkusCliUpdateIT {
         oldProperties.put("quarkus.hibernate-orm.\"fantastic\".database.generation.halt-on-error", "true");
         newProperties.put("quarkus.hibernate-orm.\"fantastic\".schema-management.halt-on-error", "true");
 
-        // here we create application in a temporary directory so that we also have a scenario
-        // where we test the CLI update command in a folder hierarchy without other maven projects
-        // it can make a difference, see for example https://github.com/quarkusio/quarkus-updates/issues/394
-        try (var ignored = cliClient.useTemporaryDirectory()) {
-            QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
-        }
+        QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
     }
 
     /**
@@ -228,10 +223,7 @@ public class QuarkusCli327UpdatesIT extends AbstractQuarkusCliUpdateIT {
         oldProperties.put("quarkus.log.handler.socket.\"whatever\".async.enable", "true");
         newProperties.put("quarkus.log.handler.socket.\"whatever\".async.enabled", "true");
 
-        // TODO: drop using temp dir when https://github.com/quarkusio/quarkus-updates/issues/394 is fixed
-        try (var ignored = cliClient.useTemporaryDirectory()) {
-            QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
-        }
+        QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
     }
 
     /**

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli333UpdatesIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/update/QuarkusCli333UpdatesIT.java
@@ -89,10 +89,7 @@ public class QuarkusCli333UpdatesIT extends AbstractQuarkusCliUpdateIT {
         oldProperties.put("quarkus.datasource.jdbc.enable-metrics", "true");
         newProperties.put("quarkus.datasource.jdbc.metrics.enabled", "true");
 
-        // TODO: drop using temp dir when https://github.com/quarkusio/quarkus-updates/issues/394 is fixed
-        try (var ignored = cliClient.useTemporaryDirectory()) {
-            QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
-        }
+        QuarkusCLIUtils.checkPropertiesUpdate(quarkusCLIAppManager, oldProperties, newProperties);
     }
 
     /**


### PR DESCRIPTION
### Summary

Bumping the FW to 1.8.4 as it was released

Backport of:
* https://github.com/quarkus-qe/quarkus-test-suite/pull/3022
  * The `useTemporaryDirectory` was removed in 1.8.4 FW so this one needs to be bacported

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)