### PR TITLE
Disable DevModeHibernateIT and DevModePostgresqlHQLConsoleIT on aarch64

### DIFF
--- a/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/DevModeHibernateIT.java
+++ b/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/DevModeHibernateIT.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.qe.hibernate.data.TestDataEntity;
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
@@ -16,6 +17,7 @@ import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.AwaitilityUtils;
 
 @QuarkusScenario
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "postgis/postgis image used by Hibernate Spatial dev service is not available for aarch64")
 public class DevModeHibernateIT extends BaseHibernateIT {
 
     private static final String TEST_DATA_ENTITY_PATH = "src/main/java/io/quarkus/qe/hibernate/data/TestDataEntity.java";

--- a/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/DevModePostgresqlHQLConsoleIT.java
+++ b/hibernate/hibernate-orm/src/test/java/io/quarkus/qe/hibernate/DevModePostgresqlHQLConsoleIT.java
@@ -3,6 +3,7 @@ package io.quarkus.qe.hibernate;
 import java.util.Map;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -11,6 +12,7 @@ import io.smallrye.common.os.OS;
 
 @QuarkusScenario
 @Tag("QUARKUS-6243")
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "postgis/postgis image used by Hibernate Spatial dev service is not available for aarch64")
 public class DevModePostgresqlHQLConsoleIT extends AbstractHQLConsoleIT {
 
     @DevModeQuarkusApplication


### PR DESCRIPTION
## Summary
- Disable `DevModeHibernateIT` and `DevModePostgresqlHQLConsoleIT` on aarch64 runners via `@DisabledIfSystemProperty`
- The `hibernate-orm` module includes `hibernate-spatial`, which causes Quarkus dev services to default to the `postgis/postgis:18-3.6` container image. This image does not publish an aarch64 variant, resulting in `exec format error` on ARM64 runners.
- Follows the same pattern used by other tests disabled on ARM (MSSQL, Oracle, DB2)
- Introduced in https://github.com/quarkus-qe/quarkus-test-suite/pull/2923 (tests) and https://github.com/quarkusio/quarkus/pull/54429 (image selection)

Fixes failure in: https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/27199293077/job/80302983071

## Test plan
- [ ] Verify Linux AArch64 JVM (hibernate-modules) CI job passes with these tests skipped