### PR TITLE
Add -nsu to CI and daily workflows to skip remote snapshot resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
           wait-before-restore: false
       - name: Build with Maven
         run: |
-          mvn -V -B --no-transfer-progress -s .github/mvn-settings.xml verify -Dall-modules -Dvalidate-format -DskipTests -DskipITs -Dquarkus.container-image.build=false -Dquarkus.container-image.push=false
+          mvn -V -B -nsu --no-transfer-progress -s .github/mvn-settings.xml verify -Dall-modules -Dvalidate-format -DskipTests -DskipITs -Dquarkus.container-image.build=false -Dquarkus.container-image.push=false
   linux-build-jvm-latest:
     name: Linux JVM
     runs-on: ubuntu-latest
@@ -162,7 +162,7 @@ jobs:
       - uses: ./.github/actions/use-docker-mirror
       - name: Build with Maven
         run: |
-          mvn -fae -V -B --no-transfer-progress clean verify -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" ${{ matrix.module-mvn-args }} -am
+          mvn -fae -V -B -nsu --no-transfer-progress clean verify -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" ${{ matrix.module-mvn-args }} -am
       - name: Detect flaky tests
         id: flaky-test-detector
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
@@ -218,7 +218,7 @@ jobs:
       - uses: ./.github/actions/use-docker-mirror
       - name: Build with Maven
         run: |
-          mvn -fae -V -B --no-transfer-progress \
+          mvn -fae -V -B -nsu --no-transfer-progress \
                       -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" \
                       ${{ matrix.module-mvn-args }} clean verify -Dnative -am
       - name: Detect flaky tests
@@ -273,7 +273,7 @@ jobs:
       - name: Build in JVM mode
         shell: bash
         run: |
-          mvn -B --no-transfer-progress -fae clean verify ${{ matrix.module-mvn-args }} -am -D"include.quarkus-cli-tests" -D"ts.quarkus.cli.cmd=$(pwd)\quarkus-dev-cli.bat" -D"gh-action-disable-on-win"
+          mvn -B -nsu --no-transfer-progress -fae clean verify ${{ matrix.module-mvn-args }} -am -D"include.quarkus-cli-tests" -D"ts.quarkus.cli.cmd=$(pwd)\quarkus-dev-cli.bat" -D"gh-action-disable-on-win"
       - name: Detect flaky tests
         id: flaky-test-detector
         if: ${{ hashFiles('**/flaky-run-report.json') != '' }}

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -59,7 +59,7 @@ jobs:
       - uses: ./.github/actions/use-docker-mirror
       - name: Test in JVM mode
         run: |
-          mvn -fae -V -B --no-transfer-progress clean verify -P ${{ matrix.profiles }} -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
+          mvn -fae -V -B -nsu --no-transfer-progress clean verify -P ${{ matrix.profiles }} -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - uses: ./.github/actions/zip-and-archive
         name: Zip and archive artifacts
         if: failure()
@@ -95,7 +95,7 @@ jobs:
       - uses: ./.github/actions/use-docker-mirror
       - name: Test in Native mode
         run: |
-          mvn -fae -V -B --no-transfer-progress -P ${{ matrix.profiles }} clean verify -Dnative \
+          mvn -fae -V -B -nsu --no-transfer-progress -P ${{ matrix.profiles }} clean verify -Dnative \
             -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }} \
             -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - uses: ./.github/actions/zip-and-archive
@@ -128,7 +128,7 @@ jobs:
       - name: Build in JVM mode
         shell: bash
         run: |
-          mvn -B --no-transfer-progress -fae clean verify -D"all-modules" -D"include.quarkus-cli-tests" -D"ts.quarkus.cli.cmd=$(pwd)\quarkus-dev-cli.bat" -D"gh-action-disable-on-win"
+          mvn -B -nsu --no-transfer-progress -fae clean verify -D"all-modules" -D"include.quarkus-cli-tests" -D"ts.quarkus.cli.cmd=$(pwd)\quarkus-dev-cli.bat" -D"gh-action-disable-on-win"
       - uses: ./.github/actions/zip-and-archive
         name: Zip and archive artifacts
         if: failure()
@@ -170,7 +170,7 @@ jobs:
         shell: bash
         run: |
           # Running only http/http-minimum as after some time, it gives disk full in Windows when running on Native.
-          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean verify -Dall-modules -Dnative -Dquarkus.native.container-build=false -pl http/http-minimum
+          mvn -B -nsu --no-transfer-progress -fae -s .github/mvn-settings.xml clean verify -Dall-modules -Dnative -Dquarkus.native.container-build=false -pl http/http-minimum
       - uses: ./.github/actions/zip-and-archive
         name: Zip and archive artifacts
         if: failure()
@@ -210,7 +210,7 @@ jobs:
           password: ${{ secrets.RED_HAT_REGISTRY_PASSWORD }}
       - name: Test in JVM mode
         run: |
-          mvn -fae -V -B --no-transfer-progress clean verify -Daarch64 -P ${{ matrix.profiles }} -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
+          mvn -fae -V -B -nsu --no-transfer-progress clean verify -Daarch64 -P ${{ matrix.profiles }} -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - uses: ./.github/actions/zip-and-archive
         name: Zip and archive artifacts
         if: failure()
@@ -252,7 +252,7 @@ jobs:
           password: ${{ secrets.RED_HAT_REGISTRY_PASSWORD }}
       - name: Test in Native mode
         run: |
-          mvn -fae -V -B --no-transfer-progress -P ${{ matrix.profiles }} clean verify -Daarch64 -Dnative \
+          mvn -fae -V -B -nsu --no-transfer-progress -P ${{ matrix.profiles }} clean verify -Daarch64 -Dnative \
             -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }} \
             -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
       - uses: ./.github/actions/zip-and-archive


### PR DESCRIPTION
## Summary
- Add `-nsu` (`--no-snapshot-updates`) to all `mvn` test commands in both `daily.yaml` and `ci.yml` workflows
- Both workflows restore a pre-built Quarkus `999-SNAPSHOT` from cache into the local Maven repository. Without `-nsu`, Maven still checks the Sonatype Central SNAPSHOT repository for updates, which is unnecessary and can pull unwanted artifacts.

## Test plan
- [ ] Verify CI and daily builds still resolve all Quarkus artifacts from the local repository
- [ ] Confirm no remote snapshot resolution attempts in Maven logs