### PR TITLE
Expect 400 instead of 500 when exceeding multipart params max limit

### DIFF
--- a/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/BaseHttpAdvancedReactiveIT.java
+++ b/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/BaseHttpAdvancedReactiveIT.java
@@ -21,7 +21,7 @@ import static jakarta.ws.rs.core.MediaType.TEXT_XML;
 import static org.apache.http.HttpHeaders.ACCEPT_ENCODING;
 import static org.apache.http.HttpHeaders.ACCEPT_LANGUAGE;
 import static org.apache.http.HttpHeaders.CONTENT_TYPE;
-import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -262,7 +262,7 @@ public abstract class BaseHttpAdvancedReactiveIT {
         request
                 .post(ROOT_PATH + MULTIPART_FORM_PATH)
                 .then()
-                .statusCode(SC_INTERNAL_SERVER_ERROR);
+                .statusCode(SC_BAD_REQUEST);
     }
 
     @DisplayName("Jakarta REST RouterFilter and Vert.x Web Routes integration")


### PR DESCRIPTION
## Summary
- Update `exceedMultiPartParamsMaxLimit` test to expect HTTP 400 (Bad Request) instead of 500 (Internal Server Error)
- Quarkus now correctly returns 400 when the number of multipart parameters exceeds the configured maximum (1000), as this is a client error
- Caused by https://github.com/quarkusio/quarkus/pull/54698

Fixes failure in: https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/27219783386/job/80377828058

## Test plan
- [ ] Verify `HttpAdvancedReactiveIT.exceedMultiPartParamsMaxLimit` passes in CI