### PR TITLE
Workaround DevModeOtelCapabilitiesIT startup failure

### DIFF
--- a/monitoring/micrometer-opentelemetry/src/test/java/io/quarkus/ts/monitoring/micrometeropentelemetry/test/DevModeOtelCapabilitiesIT.java
+++ b/monitoring/micrometer-opentelemetry/src/test/java/io/quarkus/ts/monitoring/micrometeropentelemetry/test/DevModeOtelCapabilitiesIT.java
@@ -15,7 +15,10 @@ public class DevModeOtelCapabilitiesIT {
     static final RestService app = new RestService()
             .withProperty("quarkus.otel.traces.enabled", "false")
             .withProperty("quarkus.otel.metrics.enabled", "true")
-            .withProperty("quarkus.otel.logs.enabled", "true");
+            .withProperty("quarkus.otel.logs.enabled", "true")
+            // workaround for https://github.com/quarkusio/quarkus/issues/54759
+            .withProperty("grafana.endpoint", "http://localhost:0")
+            .withProperty("otel-collector.url", "http://localhost:0");
 
     @Test
     void testShouldNotContainFailedToExport() {


### PR DESCRIPTION
## Summary
- Provide dummy `grafana.endpoint` and `otel-collector.url` config values in `DevModeOtelCapabilitiesIT` to work around a startup failure
- Quarkus [#54388](https://github.com/quarkusio/quarkus/pull/54388) introduced `ObservabilityJsonRPCService` with mandatory `@ConfigProperty` fields that are only populated when the LGTM container starts. When `quarkus.observability.lgtm.enabled=false`, the bean fails to initialize, preventing app startup.
- Upstream issue filed: https://github.com/quarkusio/quarkus/issues/54759

## Test plan
- [ ] Verify `DevModeOtelCapabilitiesIT` passes in daily CI