### PR TITLE
Adapt step-up auth test to upstream code flow redirect change

### DIFF
--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractOidcStepUpAuthenticationIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractOidcStepUpAuthenticationIT.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -19,10 +20,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.http.HttpHeaders;
-import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.SilentCssErrorHandler;
 import org.htmlunit.WebClient;
 import org.htmlunit.WebClientOptions;
+import org.htmlunit.WebRequest;
 import org.htmlunit.WebResponse;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
@@ -135,10 +136,15 @@ public abstract class AbstractOidcStepUpAuthenticationIT {
                     .getWebResponse().getContentAsString();
             assertThat(content, containsString("Single ACR silver validated"));
 
-            // "gold" ACR needs step-up authentication, we expect 401
-            Assertions.assertThrows(FailingHttpStatusCodeException.class,
-                    () -> webClient.getPage(app.getURI(Protocol.HTTP).withPath("/step-up/single-acr-gold-web-app").toString())
-                            .getWebResponse().getContentAsString());
+            // "gold" ACR needs step-up authentication; Quarkus redirects to Keycloak with acr_values=gold
+            // per RFC 9470 (see https://github.com/quarkusio/quarkus/pull/54785)
+            webClient.getOptions().setRedirectEnabled(false);
+            WebResponse stepUpResponse = webClient.loadWebResponse(new WebRequest(
+                    URI.create(app.getURI(Protocol.HTTP).withPath("/step-up/single-acr-gold-web-app").toString()).toURL()));
+            Assertions.assertEquals(302, stepUpResponse.getStatusCode());
+            String location = stepUpResponse.getResponseHeaderValue("location");
+            assertThat(location, containsString("acr_values=gold"));
+            webClient.getOptions().setRedirectEnabled(true);
 
             // Clear the session cookie so that we can re-authenticate with the new ACR value
             webClient.getCookieManager().clearCookies();


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/QQE-2617

## Summary

- Adapt `testBrowserStepUpAuthenticationFlow` in `AbstractOidcStepUpAuthenticationIT` to match the new step-up authentication behavior introduced by [quarkusio/quarkus#54785](https://github.com/quarkusio/quarkus/pull/54785)

## What changed in Quarkus

Quarkus commit [`8a5058c6e8c`](https://github.com/quarkusio/quarkus/commit/8a5058c6e8c) ("Carry acr_values and max_age in the code flow authorization request") changed how step-up authentication works for web-app (authorization code flow) applications:

- **Before**: When a session did not have the required ACR level (e.g. user had "silver" but endpoint required "gold"), Quarkus returned **401 Unauthorized** with a `WWW-Authenticate` header containing `insufficient_user_authentication`
- **After**: Quarkus now **redirects the user (302)** to the OIDC provider's authorization endpoint with `acr_values` and `max_age` parameters in the request, allowing the provider to run a stronger authentication flow (step-up)

This aligns with [RFC 9470](https://www.rfc-editor.org/rfc/rfc9470) and enables seamless step-up authentication in the browser without requiring the user to manually re-authenticate.

## What changed in this PR

The test previously expected a `FailingHttpStatusCodeException` (triggered by a 401 response) when accessing a "gold" ACR endpoint with "silver" credentials:

```java
// Old: expected 401
Assertions.assertThrows(FailingHttpStatusCodeException.class,
    () -> webClient.getPage(...).getWebResponse().getContentAsString());
```

Now it verifies the redirect behavior instead:

```java
// New: expect 302 redirect to Keycloak with acr_values=gold
webClient.getOptions().setRedirectEnabled(false);
WebResponse stepUpResponse = webClient.loadWebResponse(new WebRequest(...));
Assertions.assertEquals(302, stepUpResponse.getStatusCode());
assertThat(location, containsString("acr_values=gold"));
webClient.getOptions().setRedirectEnabled(true);
```

This matches the pattern used in the upstream Quarkus test `CodeFlowStepUpAuthenticationTest.testStepUpFromExistingSession`.

## Test plan

- [x] Verify `OidcStepUpAuthenticationIT` passes locally in JVM mode
- [x] Verify `OpenShiftOidcStepUpAuthenticationIT` passes in OpenShift native mode