### PR TITLE
Handle SP case for listExtensionsWithNoOffering CLI test

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingDefaultIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingDefaultIT.java
@@ -67,6 +67,11 @@ public class QuarkusCliOfferingDefaultIT {
         String quarkusVersionWithoutNumber = getQuarkusVersionWithoutNumberSuffix();
         assertThat(REST_EXTENSION_ARTIFACT + " should not have support scope as no offering was selected",
                 extensionLine, not(containsString(REST_SUPPORT_SCOPE)));
+        if (quarkusVersionWithoutNumber.contains("SP")) {
+            // quarkusVersionWithoutNumber is based on platform version, extensions are based on core version
+            // Example:     platform version: 3.27.4.SP1-redhat-00001     core version: 3.27.4.redhat-00005
+            quarkusVersionWithoutNumber = quarkusVersionWithoutNumber.replaceAll("SP.-", "");
+        }
         assertThat(REST_EXTENSION_ARTIFACT + " should contain Quarkus version " + quarkusVersionWithoutNumber,
                 extensionLine, containsString(quarkusVersionWithoutNumber));
     }


### PR DESCRIPTION
### Summary

Handle SP case for listExtensionsWithNoOffering CLI test

quarkusVersionWithoutNumber is based on platform version, extension versions are based on core version
Example:     platform version: 3.27.4.SP1-redhat-00001  vs.   core version: 3.27.4.redhat-00005

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)