### PR TITLE
Add distribution to setup-graalvm in Windows Native job

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -160,6 +160,7 @@ jobs:
         with:
           version: ${{ matrix.graalvm-version }}
           java-version: ${{ matrix.graalvm-java-version }}
+          distribution: 'mandrel'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure Pagefile
         # Increased the page-file size due to memory-consumption of native-image command


### PR DESCRIPTION
## Summary

- Add `distribution: 'mandrel'` to the `graalvm/setup-graalvm` step in the Windows Native job in `daily.yaml`

## Why

The `windows-latest` GitHub Actions runner [now resolves to `windows-2025-vs2026`](https://github.com/actions/runner-images/issues/14017) (rolled out June 8–15, 2026), which ships with **Visual Studio 2026**. The `graalvm/setup-graalvm@v1` action only knows about VS 2017, 2019, and 2022 installation paths when searching for `vcvarsall.bat`, so it fails immediately with:

```
##[error]Failed to find vcvarsall.bat
```

This has been breaking the Windows Native daily build (see [run #27516266920](https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/27516266920)).

Reported upstream as [graalvm/setup-graalvm#218](https://github.com/graalvm/setup-graalvm/issues/218), fix submitted in [graalvm/setup-graalvm#219](https://github.com/graalvm/setup-graalvm/pull/219).

## Fix

Adding `distribution: 'mandrel'` makes the action recognize this as a JDK 17+ setup and skip the `vcvarsall.bat` lookup entirely (it's unnecessary for modern GraalVM/Mandrel). This matches what [quarkusio/quarkus does in its CI](https://github.com/quarkusio/quarkus/blob/main/.github/workflows/ci-actions-incremental.yml).

## Test plan

- [ ] Verify the Windows Native daily build passes on `windows-latest`