### PR TITLE
Upgrade PostgreSQL 13 to 15 in OpenShift tests

### DIFF
--- a/hibernate/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
+++ b/hibernate/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftPostgresqlMultitenantHibernateSearchIT.java
@@ -27,7 +27,7 @@ public class OpenShiftPostgresqlMultitenantHibernateSearchIT extends AbstractMul
             .withProperty("cluster.routing.allocation.disk.threshold_enabled", "false")
             .withProperty("xpack.security.enabled", "false");
 
-    @Container(image = "${postgresql.13.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static PostgresqlService database = new PostgresqlService();
 
     @QuarkusApplication

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftPostgresql15HibernateReactiveIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/openshift/OpenShiftPostgresql15HibernateReactiveIT.java
@@ -11,14 +11,14 @@ import io.quarkus.ts.hibernate.reactive.AbstractDatabaseHibernateReactiveIT;
 
 @OpenShiftScenario
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
-public class OpenShiftPostgresql13HibernateReactiveIT extends AbstractDatabaseHibernateReactiveIT {
+public class OpenShiftPostgresql15HibernateReactiveIT extends AbstractDatabaseHibernateReactiveIT {
 
     private static final String POSTGRES_USER = "quarkus_test";
     private static final String POSTGRES_PASSWORD = "quarkus_test";
     private static final String POSTGRES_DATABASE = "quarkus_test";
     private static final int POSTGRES_PORT = 5432;
 
-    @Container(image = "${postgresql.13.image}", port = POSTGRES_PORT, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.15.image}", port = POSTGRES_PORT, expectedLog = "listening on IPv4 address")
     static PostgresqlService database = new PostgresqlService()
             .withUser(POSTGRES_USER)
             .withPassword(POSTGRES_PASSWORD)

--- a/pom.xml
+++ b/pom.xml
@@ -835,7 +835,7 @@
                                         <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                         <!-- Product Services -->
                                         <rhbk.image>${rhbk.image}</rhbk.image>
-                                        <postgresql.13.image>registry.redhat.io/rhel9/postgresql-13:latest</postgresql.13.image>
+                                        <postgresql.15.image>registry.redhat.io/rhel9/postgresql-15:latest</postgresql.15.image>
                                         <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16:latest</postgresql.latest.image>
                                         <mariadb.1011.image>registry.redhat.io/rhel9/mariadb-1011:latest</mariadb.1011.image>
                                         <mysql.84.image>registry.redhat.io/rhel9/mysql-84:latest</mysql.84.image>
@@ -887,7 +887,7 @@
                                         <ts.redhat.registry.enabled>true</ts.redhat.registry.enabled>
                                         <!-- Product Services -->
                                         <rhbk.image>${rhbk.image}</rhbk.image>
-                                        <postgresql.13.image>registry.redhat.io/rhel9/postgresql-13:latest</postgresql.13.image>
+                                        <postgresql.15.image>registry.redhat.io/rhel9/postgresql-15:latest</postgresql.15.image>
                                         <postgresql.dev.svc.latest.image>${postgresql.latest.image}</postgresql.dev.svc.latest.image>
                                         <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16:latest</postgresql.latest.image>
                                         <mysql.84.image>registry.redhat.io/rhel9/mysql-84:latest</mysql.84.image>
@@ -955,7 +955,7 @@
                                         <!-- Product Services -->
                                         <amqbroker.image>registry.redhat.io/amq7/amq-broker-rhel8:7.12</amqbroker.image>
                                         <rhbk.image>${rhbk.image}</rhbk.image>
-                                        <postgresql.13.image>registry.redhat.io/rhel9/postgresql-13:latest</postgresql.13.image>
+                                        <postgresql.15.image>registry.redhat.io/rhel9/postgresql-15:latest</postgresql.15.image>
                                         <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-16:latest</postgresql.latest.image>
                                         <mysql.84.image>registry.redhat.io/rhel9/mysql-84:latest</mysql.84.image>
                                         <mariadb.1011.image>registry.redhat.io/rhel9/mariadb-1011:latest</mariadb.1011.image>

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresql15DatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftPostgresql15DatabaseIT.java
@@ -10,10 +10,10 @@ import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
-public class OpenShiftPostgresql13DatabaseIT extends AbstractSqlDatabaseIT {
+public class OpenShiftPostgresql15DatabaseIT extends AbstractSqlDatabaseIT {
     static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "${postgresql.13.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.15.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")
     static PostgresqlService database = new PostgresqlService();
 
     @QuarkusApplication


### PR DESCRIPTION
## Summary

Fixes OpenShift test failures in the `hibernate-modules` scenario caused by Quarkus now requiring PostgreSQL 14+ by default. Tests using PostgreSQL 13 crash-loop at startup with:

```
Persistence unit '<default>' was configured to run with a database version of at least '14.0.0',
but the actual version is '13.23.0'.
```

Observed in [build #164 (hibernate-modules)](https://jenkins-csb-quarkusqe-main.dno.corp.redhat.com/view/periodic-builds/job/quarkus-main-rhel8-jdk17-openshift-ts-jvm-ocp-4-stable-weekly/SCENARIO=hibernate-modules,jdk=openjdk-17,label=RHEL8%20&&%20large/).

### Changes

PostgreSQL 14 is not available on the Red Hat registry, so we upgrade to PostgreSQL 15 as the oldest supported version:

- **`postgresql.13.image`** property replaced with **`postgresql.15.image`** (`registry.redhat.io/rhel9/postgresql-15:latest`) in all 3 Maven profiles in `pom.xml`
- **`OpenShiftPostgresql13HibernateReactiveIT`** renamed to **`OpenShiftPostgresql15HibernateReactiveIT`**
- **`OpenShiftPostgresql13DatabaseIT`** renamed to **`OpenShiftPostgresql15DatabaseIT`**
- **`OpenShiftPostgresqlMultitenantHibernateSearchIT`** switched from `${postgresql.13.image}` to `${postgresql.latest.image}` (PostgreSQL 16), matching its non-OpenShift sibling `PostgresqlMultitenantHibernateSearchIT`

## Test plan

- [ ] Verify `OpenShiftPostgresql15HibernateReactiveIT` passes on OpenShift with PostgreSQL 15
- [ ] Verify `OpenShiftPostgresqlMultitenantHibernateSearchIT` passes on OpenShift with PostgreSQL 16
- [ ] Verify `OpenShiftPostgresql15DatabaseIT` passes on OpenShift with PostgreSQL 15