### PR TITLE
Trigger daily build on push to main

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -1,5 +1,8 @@
 name: "Daily Build"
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
     - cron: '0 23 * * *'


### PR DESCRIPTION
## Summary

- Add `push` trigger on `main` branch to the daily build workflow so it runs on every merge, not just on the nightly schedule

## Test plan

- [ ] Verify the workflow triggers on the next push to main