### PR TITLE
Disable LGTM devservice in DevModeOpenTelemetryIT tests

### DIFF
--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/DevModeOpenTelemetryIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/DevModeOpenTelemetryIT.java
@@ -44,7 +44,9 @@ public class DevModeOpenTelemetryIT {
     @DevModeQuarkusApplication(classes = { PingPongService.class, PingResource.class,
             PongResource.class })
     static DevModeQuarkusService otel = (DevModeQuarkusService) new DevModeQuarkusService()
-            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl);
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
+            // TODO: remove once https://github.com/quarkusio/quarkus/issues/54953 is fixed
+            .withProperty("quarkus.observability.lgtm.enabled", "false");
 
     @Test
     @Order(2)

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/DevModeOpenTelemetryIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/DevModeOpenTelemetryIT.java
@@ -41,7 +41,9 @@ public class DevModeOpenTelemetryIT {
     static DevModeQuarkusService app = (DevModeQuarkusService) new DevModeQuarkusService()
             .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
             .withProperty("quarkus.datasource.jdbc.telemetry", "true")
-            .withProperty("quarkus.otel.enabled", "true");
+            .withProperty("quarkus.otel.enabled", "true")
+            // TODO: remove once https://github.com/quarkusio/quarkus/issues/54953 is fixed
+            .withProperty("quarkus.observability.lgtm.enabled", "false");
 
     @Test
     void testJdbcTraces() {


### PR DESCRIPTION
## Summary

- Disable LGTM devservice (`quarkus.observability.lgtm.enabled=false`) in both `DevModeOpenTelemetryIT` test classes
- Fixes daily build failures caused by Quarkus PR [quarkusio/quarkus#54276](https://github.com/quarkusio/quarkus/pull/54276), which added `quarkus-observability-devservices-lgtm` as a `conditionalDevDependency` of the `opentelemetry` extension
- The LGTM devservice auto-starts in dev mode and overrides `quarkus.otel.exporter.otlp.endpoint`, sending traces to the LGTM collector instead of the test's Jaeger instance

Upstream issue: https://github.com/quarkusio/quarkus/issues/54953

## Test plan

- [ ] Next daily build passes `DevModeOpenTelemetryIT` in `monitoring/opentelemetry`
- [ ] Next daily build passes `DevModeOpenTelemetryIT` in `sql-db/narayana-transactions`