### PR TITLE
Add GiB incremental profile for Quarkus CI integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <properties>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.release>17</maven.compiler.release>
+        <gitflow-incremental-builder.version>4.6.0</gitflow-incremental-builder.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -1078,6 +1079,29 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>incremental</id>
+            <activation>
+                <property>
+                    <name>incremental</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.github.gitflow-incremental-builder</groupId>
+                        <artifactId>gitflow-incremental-builder</artifactId>
+                        <version>${gitflow-incremental-builder.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <referenceBranch>HEAD</referenceBranch>
+                            <uncommitted>false</uncommitted>
+                            <untracked>false</untracked>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Summary

- Add a `gitflow-incremental-builder` profile activated by `-Dincremental` to enable selective module testing when integrated into the Quarkus CI pipeline
- This allows the Quarkus CI to pass Scalpel-detected impacted GAVs via `-Dgib.loadImpactedDependenciesFrom=gib-dependencies.log` so only test modules affected by Quarkus changes are built and tested
- Follows the same pattern used in [quarkusio/quarkus-quickstarts](https://github.com/quarkusio/quarkus-quickstarts/blob/development/pom.xml#L133-L157)

## Context

We are adding a `qe-test-suite-tests` job to the [Quarkus CI workflow](https://github.com/quarkusio/quarkus/blob/main/.github/workflows/ci-actions-incremental.yml) that will clone this repository and run its tests against the current Quarkus build. To avoid running all tests on every PR, we use the same GiB incremental approach that quarkus-quickstarts already uses.

## Test plan

- [x] `./mvnw validate -Dincremental -N` succeeds (profile activates without errors)