### PR TITLE
Build and deploy Quarkus platform during daily CI

### DIFF
--- a/.github/build_platform.sh
+++ b/.github/build_platform.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -xeuo pipefail
+
+#QUARKUS_BUILD=999-SNAPSHOT
+#LANGCHAIN4J_BUILD=999-SNAPSHOT
+#MCP_BUILD=999-SNAPSHOT
+#PLATFORM_BUILD=999-core-main-SNAPSHOT
+
+# This output also allows us to fail early if any variable is unset
+echo "Building platform ${PLATFORM_BUILD} using Quarkus Core ${QUARKUS_BUILD}, Langchain4j ${LANGCHAIN4J_BUILD} and MCP server ${MCP_BUILD}"
+
+./mvnw versions:set -DnewVersion=${PLATFORM_BUILD}
+./mvnw versions:set-property -Dproperty=quarkus.version -DnewVersion=${QUARKUS_BUILD} -DgenerateBackupPoms=false
+./mvnw versions:set-property -Dproperty=quarkus-langchain4j.version -DnewVersion=${LANGCHAIN4J_BUILD} -DgenerateBackupPoms=false
+./mvnw versions:set-property -Dproperty=quarkus-mcp-server.version -DnewVersion=${MCP_BUILD} -DgenerateBackupPoms=false
+
+# mark everything as disabled
+xsltproc -o pom.xml minimise_platform.xsl pom.xml
+./mvnw -Dsync
+#same script but with standard bash
+#grep -A1 '<member>' pom.xml | grep name | grep -iv -e 'langchain4j' -e 'mcpserver' | xargs -I '{}' sed -i '\|{}|a <enabled>false<\/enabled>' pom.xml
+./mvnw clean -V install -DskipTests -DskipITs -Prelease -Dgpg.skip=true

--- a/.github/minimise_platform.xsl
+++ b/.github/minimise_platform.xsl
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns="http://maven.apache.org/POM/4.0.0"
+                xmlns:pom="http://maven.apache.org/POM/4.0.0"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="no"/>
+    <!-- Copy everything -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+    <!-- Remove explicit "enabled" tag from all platform members -->
+    <xsl:template match="/pom:project/pom:build/pom:pluginManagement/pom:plugins/pom:plugin[./pom:artifactId/text() = 'quarkus-platform-bom-maven-plugin']/pom:configuration/pom:platformConfig/pom:members/pom:member/pom:enabled"/>
+    <!-- Disable all platform members, but langchain4j and MCP Server -->
+    <xsl:template match="/pom:project/pom:build/pom:pluginManagement/pom:plugins/pom:plugin[./pom:artifactId/text() = 'quarkus-platform-bom-maven-plugin']/pom:configuration/pom:platformConfig/pom:members/pom:member[pom:name/text()!='LangChain4j' and pom:name/text()!='MCPServer']">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()" />
+            <enabled>false</enabled>
+            <xsl:text>&#xA;</xsl:text>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -21,11 +21,41 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           check-latest: true
+      - name: Initialize Repository Path
+        run: |
+          # Save local repo to GH ENV to ensure that it's the same in all steps
+          mkdir -p maven-repository
+          echo "LOCAL_REPO=$(pwd)/maven-repository" >> $GITHUB_ENV
       - name: Build Quarkus 999-SNAPSHOT
         run: |
-          mkdir maven-repository
-          LOCAL_REPO="$(pwd)/maven-repository"
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations -Dmaven.repo.local=$LOCAL_REPO
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus
+          ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations -Dmaven.repo.local=${{ env.LOCAL_REPO }}
+      - name: Build Quarkus Langchain4j 999-SNAPSHOT
+        run: |
+          git clone https://github.com/quarkiverse/quarkus-langchain4j.git && cd quarkus-langchain4j
+          
+          # integration tests depend on platform by default (see https://github.com/quarkiverse/quarkus-langchain4j/issues/2633)
+          ./mvnw versions:set-property -Dproperty=quarkus.platform.version -DnewVersion=${QUARKUS_BUILD} -DgenerateBackupPoms=false
+          ./mvnw versions:set-property -Dproperty=quarkus.platform.group-id -DnewVersion=io.quarkus -DgenerateBackupPoms=false
+
+          ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -DskipTests -Dquarkus.version=999-SNAPSHOT -Dmaven.repo.local=${{ env.LOCAL_REPO }}
+      - name: Build Quarkus MCP Server 999-SNAPSHOT
+        run: |
+          git clone https://github.com/quarkiverse/quarkus-mcp-server.git && cd quarkus-mcp-server
+          ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -DskipTests -Dquarkus.version=999-SNAPSHOT -Dmaven.repo.local=${{ env.LOCAL_REPO }}
+      - name: Build Quarkus Platform main with Quarkus core 999-SNAPSHOT (version 999-core-main-SNAPSHOT)
+        run: |
+          git clone https://github.com/quarkusio/quarkus-platform.git && cd quarkus-platform
+
+          # add some common options
+          cat <<EOF >> .mvn/maven.config
+            --no-transfer-progress
+            -Dmaven.repo.local=${{ env.LOCAL_REPO }}
+            -s.github/mvn-settings.xml
+          EOF
+          cp .github/minimise_platform.xsl .
+          chmod u+x ./github/build_platform.sh
+          PLATFORM_BUILD=999-core-main-SNAPSHOT MCP_BUILD=999-SNAPSHOT LANGCHAIN4J_BUILD=999-SNAPSHOT QUARKUS_BUILD=999-SNAPSHOT ./github/build_platform.sh
       - name: Cache Build Outputs
         uses: actions/cache/save@v6
         with:

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 23 * * *'
+env:
+  QUARKUS_BUILD: 3.999-SNAPSHOT
 jobs:
   build-quarkus:
     name: Build Quarkus
@@ -26,9 +28,9 @@ jobs:
           # Save local repo to GH ENV to ensure that it's the same in all steps
           mkdir -p maven-repository
           echo "LOCAL_REPO=$(pwd)/maven-repository" >> $GITHUB_ENV
-      - name: Build Quarkus 999-SNAPSHOT
+      - name: Build Quarkus ${QUARKUS_BUILD}
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus
+          git clone -b 3.x https://github.com/quarkusio/quarkus.git && cd quarkus
           ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations -Dmaven.repo.local=${{ env.LOCAL_REPO }}
       - name: Build Quarkus Langchain4j 999-SNAPSHOT
         run: |
@@ -38,12 +40,12 @@ jobs:
           ./mvnw versions:set-property -Dproperty=quarkus.platform.version -DnewVersion=${QUARKUS_BUILD} -DgenerateBackupPoms=false
           ./mvnw versions:set-property -Dproperty=quarkus.platform.group-id -DnewVersion=io.quarkus -DgenerateBackupPoms=false
 
-          ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -DskipTests -Dquarkus.version=999-SNAPSHOT -Dmaven.repo.local=${{ env.LOCAL_REPO }}
+          ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -DskipTests -Dquarkus.version=${QUARKUS_BUILD} -Dmaven.repo.local=${{ env.LOCAL_REPO }}
       - name: Build Quarkus MCP Server 999-SNAPSHOT
         run: |
           git clone https://github.com/quarkiverse/quarkus-mcp-server.git && cd quarkus-mcp-server
-          ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -DskipTests -Dquarkus.version=999-SNAPSHOT -Dmaven.repo.local=${{ env.LOCAL_REPO }}
-      - name: Build Quarkus Platform main with Quarkus core 999-SNAPSHOT (version 999-core-main-SNAPSHOT)
+          ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -DskipTests -Dquarkus.version=${QUARKUS_BUILD} -Dmaven.repo.local=${{ env.LOCAL_REPO }}
+      - name: Build Quarkus Platform main with Quarkus core ${QUARKUS_BUILD} (version 999-core-main-SNAPSHOT)
         run: |
           git clone https://github.com/quarkusio/quarkus-platform.git && cd quarkus-platform
 
@@ -55,7 +57,7 @@ jobs:
           EOF
           cp .github/minimise_platform.xsl .
           chmod u+x ./github/build_platform.sh
-          PLATFORM_BUILD=999-core-main-SNAPSHOT MCP_BUILD=999-SNAPSHOT LANGCHAIN4J_BUILD=999-SNAPSHOT QUARKUS_BUILD=999-SNAPSHOT ./github/build_platform.sh
+          PLATFORM_BUILD=999-core-main-SNAPSHOT MCP_BUILD=999-SNAPSHOT LANGCHAIN4J_BUILD=999-SNAPSHOT QUARKUS_BUILD=${QUARKUS_BUILD} ./github/build_platform.sh
       - name: Cache Build Outputs
         uses: actions/cache/save@v6
         with:


### PR DESCRIPTION
### Summary

Changes:
- Build Quarkus core and platform. Upstream 999-SNAPSHOT platform build is based on stable core, ours is based on 999-SNAPSHOT core, so it has different version

Split from the https://github.com/quarkus-qe/quarkus-test-suite/pull/2978

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)