### PR TITLE
Use Quarkus 3.999-SNAPSHOT

### DIFF
--- a/.github/actions/prepare-quarkus-cli-win/action.yml
+++ b/.github/actions/prepare-quarkus-cli-win/action.yml
@@ -1,5 +1,5 @@
-name: 'Create Quarkus CLI 999-SNAPSHOT'
-description: 'Creates Quarkus CLI based on the current Quarkus main (999-SNAPSHOT version)'
+name: 'Create Quarkus CLI 3.999-SNAPSHOT'
+description: 'Creates Quarkus CLI based on the current Quarkus main (3.999-SNAPSHOT version)'
 runs:
   using: "composite"
   steps:
@@ -8,7 +8,7 @@ runs:
       run: |
         $quarkusCliFileContent = @"
         @ECHO OFF
-        java -jar %HOMEDRIVE%%HOMEPATH%\.m2\repository\io\quarkus\quarkus-cli\999-SNAPSHOT\quarkus-cli-999-SNAPSHOT-runner.jar %*
+        java -jar %HOMEDRIVE%%HOMEPATH%\.m2\repository\io\quarkus\quarkus-cli\3.999-SNAPSHOT\quarkus-cli-3.999-SNAPSHOT-runner.jar %*
         "@
         New-Item -Path "$(pwd)\quarkus-dev-cli.bat" -ItemType File
         Set-Content -Path "$(pwd)\quarkus-dev-cli.bat" -Value $quarkusCliFileContent

--- a/.github/actions/prepare-quarkus-cli/action.yml
+++ b/.github/actions/prepare-quarkus-cli/action.yml
@@ -1,5 +1,5 @@
-name: 'Create Quarkus CLI 999-SNAPSHOT'
-description: 'Creates Quarkus CLI based on the current Quarkus main (999-SNAPSHOT version)'
+name: 'Create Quarkus CLI 3.999-SNAPSHOT'
+description: 'Creates Quarkus CLI based on the current Quarkus main (3.999-SNAPSHOT version)'
 runs:
   using: "composite"
   steps:
@@ -8,7 +8,7 @@ runs:
       run: |
         cat <<EOF > ./quarkus-dev-cli
         #!/bin/bash
-        java -jar ~/.m2/repository/io/quarkus/quarkus-cli/999-SNAPSHOT/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+        java -jar ~/.m2/repository/io/quarkus/quarkus-cli/3.999-SNAPSHOT/quarkus-cli-3.999-SNAPSHOT-runner.jar "\$@"
         EOF
         chmod +x ./quarkus-dev-cli
         ./quarkus-dev-cli version

--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/utils/AnalyticsUtils.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/utils/AnalyticsUtils.java
@@ -6,10 +6,10 @@ import java.util.regex.Pattern;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 public class AnalyticsUtils {
-    private static final String QUARKUS_SNAPSHOT_VERSION = "999-SNAPSHOT";
+    private static final String QUARKUS_SNAPSHOT_VERSION = "3.999-SNAPSHOT";
     // Quarkus reports extensions' versions in the analytics payload as full artifact version.
     // So for 999-SNAPSHOT, it can look like e.g. 999-20230718.203351-1091
-    private static final String QUARKUS_EXTENSION_SNAPSHOT_VERSION_REGEX = "999-.*";
+    private static final String QUARKUS_EXTENSION_SNAPSHOT_VERSION_REGEX = "3\\.999-.*";
     // RHBQ artifacts may differ in the number suffix from a platform version.
     // E.g.: 3.8.0.redhat-00002 vs. 3.8.5.redhat-00003
     private static final String RHBQ_VERSION_REGEX_FORMAT = "%s\\.redhat-\\d{5}";

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <failsafe-plugin.version>3.5.6</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>3.999-SNAPSHOT</quarkus.platform.version>
         <quarkus.ide.version>3.30.0</quarkus.ide.version>
         <quarkus.qe.framework.version>999-SNAPSHOT</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.12.0</quarkus-qpid-jms.version>

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -155,11 +155,11 @@ public class QuarkusCliCreateJvmApplicationIT {
 
     private static void useQuarkusSnapshotFromSonatypeIfNeeded(QuarkusCliRestService app, String quarkusVersion) {
         // must match only the 'main' branch snapshot, not 999-SNAPSHOT in other branches as they are not published
-        boolean is999Snapshot = "999-SNAPSHOT".equals(quarkusVersion);
+        boolean is999Snapshot = "3.999-SNAPSHOT".equals(quarkusVersion);
         var localRepository = System.getProperty("localRepository");
         if (is999Snapshot && localRepository != null) {
             if (!doesQuarkusSnapshotExistInLocalRepo(localRepository)) { // not adding external repository when not needed
-                Log.info("Configuring Sonatype Maven Snapshots repository to make Quarkus 999-SNAPSHOT available");
+                Log.info("Configuring Sonatype Maven Snapshots repository to make Quarkus 3.999-SNAPSHOT available");
                 configureGradleSnapshotRepository(app, "build.gradle"); // Maven repository
                 configureGradleSnapshotRepository(app, "settings.gradle"); // plugin Maven repository
             }
@@ -173,8 +173,8 @@ public class QuarkusCliCreateJvmApplicationIT {
                 .resolve("io")
                 .resolve("quarkus")
                 .resolve("io.quarkus.gradle.plugin")
-                .resolve("999-SNAPSHOT")
-                .resolve("io.quarkus.gradle.plugin-999-SNAPSHOT.jar"));
+                .resolve("3.999-SNAPSHOT")
+                .resolve("io.quarkus.gradle.plugin-3.999-SNAPSHOT.jar"));
     }
 
     private void runGradleDaemon(QuarkusCliRestService app) {
@@ -258,7 +258,7 @@ public class QuarkusCliCreateJvmApplicationIT {
         // The snapshot not providing platform-bom so it use the latest stream in registry
         // otherwise when the quarkus version is defined (3.27.0) or if it's snapshot of some quarkus stream (3.27.999-SNAPSHOT)
         // it will set the correct stream to use
-        String quarkusStream = QuarkusProperties.getVersion().equals("999-SNAPSHOT") ? null
+        String quarkusStream = QuarkusProperties.getVersion().equals("3.999-SNAPSHOT") ? null
                 : QuarkusProperties.getVersion().replaceAll("^(\\d+\\.\\d+).*", "$1");
         // This can't use `--platform-bom` as it contain quarkiverse extension
         QuarkusCliRestService app = cliClient.createApplication("app",

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -93,7 +93,7 @@ public class QuarkusCliExtensionsIT {
         assertListDefaultOptionOutput();
     }
 
-    @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not pushed into the platform site")
+    @DisabledOnQuarkusSnapshot(reason = "3.999-SNAPSHOT is not pushed into the platform site")
     @Test
     public void shouldListExtensionsUsingStream() {
         var req = ListExtensionRequest.withSetStream();


### PR DESCRIPTION
### Summary

Start using 3.999-SNAPSHOT across the testsuite. The 3.999-SNAPSHOT is base for Quarkus 3.x (we need it to continuously testing for Quarkus 3.40). The main is currently for Quarkus 4

The comments which contains 999-SNAPSHOT was not changed as they can stay as they are. All code was moved to use 3.999-SNAPSHOT


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)