### PR TITLE
Use Quarkus CLI 3.999-SNAPSHOT for daily jobs

### DIFF
--- a/.github/actions/prepare-quarkus-cli-win/action.yml
+++ b/.github/actions/prepare-quarkus-cli-win/action.yml
@@ -1,5 +1,5 @@
-name: 'Create Quarkus CLI 999-SNAPSHOT'
-description: 'Creates Quarkus CLI based on the current Quarkus main (999-SNAPSHOT version)'
+name: 'Create Quarkus CLI 3.999-SNAPSHOT'
+description: 'Creates Quarkus CLI based on the current Quarkus main (3.999-SNAPSHOT version)'
 runs:
   using: "composite"
   steps:
@@ -8,7 +8,7 @@ runs:
       run: |
         $quarkusCliFileContent = @"
         @ECHO OFF
-        java -jar %HOMEDRIVE%%HOMEPATH%\.m2\repository\io\quarkus\quarkus-cli\999-SNAPSHOT\quarkus-cli-999-SNAPSHOT-runner.jar %*
+        java -jar %HOMEDRIVE%%HOMEPATH%\.m2\repository\io\quarkus\quarkus-cli\3.999-SNAPSHOT\quarkus-cli-3.999-SNAPSHOT-runner.jar %*
         "@
         New-Item -Path "$(pwd)\quarkus-dev-cli.bat" -ItemType File
         Set-Content -Path "$(pwd)\quarkus-dev-cli.bat" -Value $quarkusCliFileContent

--- a/.github/actions/prepare-quarkus-cli/action.yml
+++ b/.github/actions/prepare-quarkus-cli/action.yml
@@ -1,5 +1,5 @@
-name: 'Create Quarkus CLI 999-SNAPSHOT'
-description: 'Creates Quarkus CLI based on the current Quarkus main (999-SNAPSHOT version)'
+name: 'Create Quarkus CLI 3.999-SNAPSHOT'
+description: 'Creates Quarkus CLI based on the current Quarkus main (3.999-SNAPSHOT version)'
 runs:
   using: "composite"
   steps:
@@ -8,7 +8,7 @@ runs:
       run: |
         cat <<EOF > ./quarkus-dev-cli
         #!/bin/bash
-        java -jar ~/.m2/repository/io/quarkus/quarkus-cli/999-SNAPSHOT/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+        java -jar ~/.m2/repository/io/quarkus/quarkus-cli/3.999-SNAPSHOT/quarkus-cli-3.999-SNAPSHOT-runner.jar "\$@"
         EOF
         chmod +x ./quarkus-dev-cli
         ./quarkus-dev-cli version


### PR DESCRIPTION
### Summary
Fixes our daily build, since we now build Quarkus 3.999-SNAPSHOT instead of 999-SNAPSHOT: https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/28424775706/job/84229958406

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)