### PR TITLE
Bump RHBK image version from 26.4 to 26.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <!-- The upstream MySQL version is needed for DevMode as the RH image is not starting with Quarkus-->
         <mysql.upstream.image>docker.io/library/mysql:8.4</mysql.upstream.image>
         <mysql.84.image>${mysql.upstream.image}</mysql.84.image>
-        <rhbk.image>registry.redhat.io/rhbk/keycloak-rhel9:26.4</rhbk.image>
+        <rhbk.image>registry.redhat.io/rhbk/keycloak-rhel9:26.6</rhbk.image>
         <wiremock.version>3.13.2</wiremock.version>
         <build-reporter-maven-extension.version>3.13.1</build-reporter-maven-extension.version>
         <reruns>2</reruns>


### PR DESCRIPTION
### Summary

Bump RHBK image version from 26.4 to 26.6

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [x] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)