### PR TITLE
Pass GH_TOKEN to quarkus-snapshot workflow

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -54,3 +54,4 @@ jobs:
         env:
           ECOSYSTEM_CI_TOKEN: ${{ secrets.ECOSYSTEM_CI_TOKEN }}
           MAVEN_PROFILES: ${{ matrix.profiles }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The ecosystem CI job needs a GitHub token to use GitHub CLI when fetching the latest Quarkus binaries