### PR TITLE
Disable AI OpenShift tests using the Sonatype snapshot repository

### DIFF
--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftChatbotIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftChatbotIT.java
@@ -4,6 +4,8 @@ import static io.quarkus.ts.langchain4j.auxiliary.CommonTools.DEFAULT_ARGS;
 import static io.quarkus.ts.langchain4j.auxiliary.CommonTools.SAMPLE_BRANCH;
 import static io.quarkus.ts.langchain4j.auxiliary.CommonTools.getKey;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
@@ -11,6 +13,7 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "The newest/3.x SNAPSHOT is not available in public repository.")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.Build)
 public class OpenShiftChatbotIT extends AbstractChatbotIT {
     @Container(image = "${redis.image}", port = 6379, expectedLog = "Ready to accept connections")

--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftMoviesIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftMoviesIT.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "The newest/3.x SNAPSHOT is not available in public repository.")
 @DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "pgvector container not available on s390x & ppc64le.")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.Build)
 public class OpenShiftMoviesIT extends MoviesIT {

--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftToolsIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftToolsIT.java
@@ -4,6 +4,8 @@ import static io.quarkus.ts.langchain4j.auxiliary.CommonTools.DEFAULT_ARGS;
 import static io.quarkus.ts.langchain4j.auxiliary.CommonTools.SAMPLE_BRANCH;
 import static io.quarkus.ts.langchain4j.auxiliary.CommonTools.getKey;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
@@ -13,6 +15,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.langchain4j.auxiliary.MCPFileServer;
 
+@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "The newest/3.x SNAPSHOT is not available in public repository.")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.Build)
 public class OpenShiftToolsIT extends AbstractToolsIT {
     @QuarkusApplication(boms = { @Dependency(artifactId = "quarkus-mcp-server-bom") }, dependencies = {


### PR DESCRIPTION

### Summary
Similar to this PR: https://github.com/quarkus-qe/quarkus-test-suite/pull/3066

This PR disables the AI OpenShift tests on ARM where the latest 3.x SNAPSHOT is not available from the public Sonatype repository causing Jenkins pipeline to fail.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)