### PR TITLE
Add coverage for QUARKUS-7806

### DIFF
--- a/security/basic/src/main/java/io/quarkus/ts/openshift/security/basic/RequestContextLost.java
+++ b/security/basic/src/main/java/io/quarkus/ts/openshift/security/basic/RequestContextLost.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.openshift.security.basic;
+
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+
+import io.quarkus.security.Authenticated;
+
+@Path("/lost-context")
+@Authenticated
+public class RequestContextLost {
+
+    @Context
+    HttpHeaders requestHeaders;
+
+    @POST
+    @Path("delay")
+    public Response delay(@QueryParam("wait_time") @DefaultValue("-1") final long waitTime) throws Exception {
+        Thread.sleep(waitTime);
+        requestHeaders.getDate();
+        return Response.ok().build();
+    }
+}

--- a/security/basic/src/test/java/io/quarkus/ts/openshift/security/basic/RequestContextLostIT.java
+++ b/security/basic/src/test/java/io/quarkus/ts/openshift/security/basic/RequestContextLostIT.java
@@ -1,0 +1,50 @@
+package io.quarkus.ts.openshift.security.basic;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.SocketTimeoutException;
+
+import org.apache.http.params.CoreConnectionPNames;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.RestAssured;
+import io.restassured.config.HttpClientConfig;
+
+@Tag("QUARKUS-7806")
+@QuarkusScenario
+public class RequestContextLostIT {
+
+    private static final int SOCKET_TIMEOUT = 500;
+    private static final int WAIT_TIME = 1000;
+    private static final int DELAY = 2000;
+
+    @QuarkusApplication
+    static RestService app = new RestService();
+
+    @Test
+    void testThatRequestContextIsNotLostWhenConnectionTimeoutBeforeEndOfOperation() throws InterruptedException {
+
+        // Setting the socket timeout to be lower, then wait_time
+        var config = RestAssured.config()
+                .httpClient(HttpClientConfig.httpClientConfig().setParam(CoreConnectionPNames.SO_TIMEOUT, SOCKET_TIMEOUT));
+
+        assertThrows(SocketTimeoutException.class, () -> {
+            RestAssured
+                    .given()
+                    .config(config)
+                    .auth().basic("albert", "E!nst3iN")
+                    .queryParam("wait_time", WAIT_TIME).when().post("/lost-context/delay");
+        });
+
+        // There is need to wait for RequestContextLost#delay to finish before checking the log.
+        // It's because we access HttpHeaders after the timeout passed by `timeout` query parameter
+        Thread.sleep(DELAY);
+
+        app.logs().assertDoesNotContain(
+                "jakarta.enterprise.context.ContextNotActiveException: RequestScoped context was not active");
+    }
+}


### PR DESCRIPTION
### Summary

Add coverage for QUARKUS-7806 (ContextNotActiveException due to race condition when Quarkus REST and Reactive routes are used during the same request)

Jira: https://redhat.atlassian.net/browse/QUARKUS-7806

This passing on 3.x and 3.33 Quarkus branches. Only affected branch is 3.27 (in scope of our testing)

To reproduce issue you can run `mvn -fae -V -B clean verify -Doc.reruns=0 -Dreruns=0 -Phttp-modules -f security/basic -Dit.test=RequestContextLostIT -Dquarkus.platform.version=3.27.4`

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)