### PR TITLE
Fix CI failures caused by Quarkus upstream changes

### DIFF
--- a/hibernate/hibernate-fulltext-search/pom.xml
+++ b/hibernate/hibernate-fulltext-search/pom.xml
@@ -57,6 +57,14 @@
                                     <groupId>org.hibernate.search</groupId>
                                     <artifactId>hibernate-search-processor</artifactId>
                                 </path>
+                                <dependency>
+                                    <groupId>org.hibernate.search</groupId>
+                                    <artifactId>hibernate-search-backend-elasticsearch</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.logging</groupId>
+                                    <artifactId>commons-logging-jboss-logging</artifactId>
+                                </dependency>
                             </annotationProcessorPaths>
                         </configuration>
                     </execution>

--- a/hibernate/hibernate-fulltext-search/pom.xml
+++ b/hibernate/hibernate-fulltext-search/pom.xml
@@ -57,10 +57,6 @@
                                     <groupId>org.hibernate.search</groupId>
                                     <artifactId>hibernate-search-processor</artifactId>
                                 </path>
-                                <dependency>
-                                    <groupId>org.hibernate.search</groupId>
-                                    <artifactId>hibernate-search-backend-elasticsearch</artifactId>
-                                </dependency>
                             </annotationProcessorPaths>
                         </configuration>
                     </execution>

--- a/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/validation/ValidatedUser.java
+++ b/http/rest-client-reactive/src/main/java/io/quarkus/ts/http/restclient/reactive/validation/ValidatedUser.java
@@ -10,6 +10,9 @@ public class ValidatedUser {
     @NotNull(groups = ConvertedGroup.class)
     public String username;
 
+    public ValidatedUser() {
+    }
+
     public ValidatedUser(String value) {
         this.username = value;
     }

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/DevModeIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/DevModeIT.java
@@ -58,7 +58,6 @@ public class DevModeIT {
         app.given()
                 .get("/meta/class/io.quarkus.ts.http.restclient.reactive.json.Author$quarkusjacksondeserializer")
                 .then()
-                .statusCode(200)
-                .body(is("io.quarkus.ts.http.restclient.reactive.json.Author$quarkusjacksondeserializer"));
+                .statusCode(204);
     }
 }

--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java
@@ -355,8 +355,7 @@ public class ReactiveRestClientIT {
         app.given()
                 .get("/meta/class/io.quarkus.ts.http.restclient.reactive.json.Book$quarkusjacksondeserializer")
                 .then()
-                .statusCode(200)
-                .body(is("io.quarkus.ts.http.restclient.reactive.json.Book$quarkusjacksondeserializer"));
+                .statusCode(204);
     }
 
     @Test

--- a/messaging/amqp-reactive/src/test/java/io/quarkus/ts/messaging/amqpreactive/DevModeAmqpDevServiceUserExperienceIT.java
+++ b/messaging/amqp-reactive/src/test/java/io/quarkus/ts/messaging/amqpreactive/DevModeAmqpDevServiceUserExperienceIT.java
@@ -31,7 +31,7 @@ public class DevModeAmqpDevServiceUserExperienceIT {
 
     @Test
     public void verifyIfUserIsInformedAboutAmqpDevServicePulling() {
-        app.logs().assertContains("Pulling docker image: quay.io/artemiscloud/activemq-artemis-broker");
+        app.logs().assertContains("Pulling docker image: quay.io/arkmq-org/arkmq-org-broker");
         app.logs().assertContains("Please be patient; this may take some time but only needs to be done once");
         app.logs().assertContains("Starting to pull image");
         app.logs().assertContains("Dev Services for AMQP started");

--- a/messaging/amqp-reactive/src/test/java/io/quarkus/ts/messaging/amqpreactive/DevModeAmqpReactiveIT.java
+++ b/messaging/amqp-reactive/src/test/java/io/quarkus/ts/messaging/amqpreactive/DevModeAmqpReactiveIT.java
@@ -19,6 +19,6 @@ public class DevModeAmqpReactiveIT extends BaseAmqpReactiveIT {
 
     @Test
     public void amqpContainerShouldBeStarted() {
-        app.logs().assertContains("Creating container for image: quay.io/artemiscloud/activemq-artemis-broker");
+        app.logs().assertContains("Creating container for image: quay.io/arkmq-org/arkmq-org-broker");
     }
 }

--- a/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/DataTypesResource.java
+++ b/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/DataTypesResource.java
@@ -2,11 +2,11 @@ package io.quarkus.ts.elasticsearch;
 
 import java.io.IOException;
 
-import org.apache.hc.core5.http.ParseException;
-
 import jakarta.inject.Inject;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+
+import org.apache.hc.core5.http.ParseException;
 
 @Path("/data-types")
 public class DataTypesResource {

--- a/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/DataTypesResource.java
+++ b/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/DataTypesResource.java
@@ -2,6 +2,8 @@ package io.quarkus.ts.elasticsearch;
 
 import java.io.IOException;
 
+import org.apache.hc.core5.http.ParseException;
+
 import jakarta.inject.Inject;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -13,7 +15,7 @@ public class DataTypesResource {
     DataTypesService dataTypesService;
 
     @POST
-    public DataTypes indexAndGet(DataTypes dataTypes) throws IOException {
+    public DataTypes indexAndGet(DataTypes dataTypes) throws IOException, ParseException {
         return dataTypesService.indexAndGet(dataTypes);
     }
 }

--- a/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/DataTypesService.java
+++ b/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/DataTypesService.java
@@ -5,19 +5,21 @@ import java.io.IOException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import org.apache.http.util.EntityUtils;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.Response;
-import org.elasticsearch.client.RestClient;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+
+import co.elastic.clients.transport.rest5_client.low_level.Request;
+import co.elastic.clients.transport.rest5_client.low_level.Response;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
 
 import io.vertx.core.json.JsonObject;
 
 @ApplicationScoped
 public class DataTypesService {
     @Inject
-    RestClient restClient;
+    Rest5Client restClient;
 
-    public DataTypes indexAndGet(DataTypes dataTypes) throws IOException {
+    public DataTypes indexAndGet(DataTypes dataTypes) throws IOException, ParseException {
         Request request = new Request(
                 "PUT",
                 "/foos/_doc/" + dataTypes.id);

--- a/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/DataTypesService.java
+++ b/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/DataTypesService.java
@@ -8,11 +8,11 @@ import jakarta.inject.Inject;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 
+import io.vertx.core.json.JsonObject;
+
 import co.elastic.clients.transport.rest5_client.low_level.Request;
 import co.elastic.clients.transport.rest5_client.low_level.Response;
 import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
-
-import io.vertx.core.json.JsonObject;
 
 @ApplicationScoped
 public class DataTypesService {

--- a/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/FruitResource.java
+++ b/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/FruitResource.java
@@ -5,6 +5,8 @@ import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.hc.core5.http.ParseException;
+
 import jakarta.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.DELETE;
@@ -32,7 +34,7 @@ public class FruitResource {
 
     @GET
     @Path("/{id}")
-    public Fruit get(String id) throws IOException {
+    public Fruit get(String id) throws IOException, ParseException {
         return fruitService.get(id);
     }
 
@@ -44,7 +46,7 @@ public class FruitResource {
 
     @GET
     @Path("/search")
-    public List<Fruit> search(@RestQuery String name, @RestQuery String color) throws IOException {
+    public List<Fruit> search(@RestQuery String name, @RestQuery String color) throws IOException, ParseException {
         if (name != null) {
             return fruitService.searchByName(name);
         } else if (color != null) {

--- a/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/FruitResource.java
+++ b/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/FruitResource.java
@@ -5,8 +5,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.hc.core5.http.ParseException;
-
 import jakarta.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.DELETE;
@@ -15,6 +13,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
 
+import org.apache.hc.core5.http.ParseException;
 import org.jboss.resteasy.reactive.RestQuery;
 
 @Path("/fruits")

--- a/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/FruitService.java
+++ b/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/FruitService.java
@@ -7,10 +7,12 @@ import java.util.List;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import org.apache.http.util.EntityUtils;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.Response;
-import org.elasticsearch.client.RestClient;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+
+import co.elastic.clients.transport.rest5_client.low_level.Request;
+import co.elastic.clients.transport.rest5_client.low_level.Response;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -18,7 +20,7 @@ import io.vertx.core.json.JsonObject;
 @ApplicationScoped
 public class FruitService {
     @Inject
-    RestClient restClient;
+    Rest5Client restClient;
 
     public void index(Fruit fruit) throws IOException {
         Request request = new Request(
@@ -28,7 +30,7 @@ public class FruitService {
         restClient.performRequest(request);
     }
 
-    public Fruit get(String id) throws IOException {
+    public Fruit get(String id) throws IOException, ParseException {
         Request request = new Request(
                 "GET",
                 "/fruits/_doc/" + id);
@@ -45,15 +47,15 @@ public class FruitService {
         restClient.performRequest(request);
     }
 
-    public List<Fruit> searchByColor(String color) throws IOException {
+    public List<Fruit> searchByColor(String color) throws IOException, ParseException {
         return search("color", color);
     }
 
-    public List<Fruit> searchByName(String name) throws IOException {
+    public List<Fruit> searchByName(String name) throws IOException, ParseException {
         return search("name", name);
     }
 
-    private List<Fruit> search(String term, String match) throws IOException {
+    private List<Fruit> search(String term, String match) throws IOException, ParseException {
         Request request = new Request(
                 "GET",
                 "/fruits/_search");

--- a/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/FruitService.java
+++ b/nosql-db/elasticsearch/src/main/java/io/quarkus/ts/elasticsearch/FruitService.java
@@ -10,12 +10,12 @@ import jakarta.inject.Inject;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
 import co.elastic.clients.transport.rest5_client.low_level.Request;
 import co.elastic.clients.transport.rest5_client.low_level.Response;
 import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
-
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 
 @ApplicationScoped
 public class FruitService {

--- a/nosql-db/elasticsearch/src/test/java/io/quarkus/ts/elasticsearch/DevModeElasticsearchIT.java
+++ b/nosql-db/elasticsearch/src/test/java/io/quarkus/ts/elasticsearch/DevModeElasticsearchIT.java
@@ -5,7 +5,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 
 import java.util.concurrent.TimeUnit;
 
-import org.apache.http.HttpStatus;
+import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;

--- a/nosql-db/elasticsearch/src/test/java/io/quarkus/ts/elasticsearch/ElasticsearchIT.java
+++ b/nosql-db/elasticsearch/src/test/java/io/quarkus/ts/elasticsearch/ElasticsearchIT.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.http.HttpStatus;
+import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.DefaultService;

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
                                 <!-- Services used in test suite -->
                                 <nginx.image>docker.io/library/nginx:1-alpine</nginx.image>
                                 <amqbroker.image>registry.access.redhat.com/amq-broker-7/amq-broker-72-openshift:latest</amqbroker.image>
-                                <amqbroker.1.0x.image>quay.io/artemiscloud/activemq-artemis-broker:1.0.32</amqbroker.1.0x.image>
+                                <amqbroker.1.0x.image>quay.io/arkmq-org/arkmq-org-broker:1.0.32</amqbroker.1.0x.image>
                                 <redpanda.image>redpandadata/redpanda:v25.3.9</redpanda.image>
                                 <postgresql.latest.image>${postgresql.latest.image}</postgresql.latest.image>
                                 <postgis.latest.image>${postgis.latest.image}</postgis.latest.image>

--- a/qute/reactive/src/test/java/io/quarkus/ts/qute/QuteReactiveIT.java
+++ b/qute/reactive/src/test/java/io/quarkus/ts/qute/QuteReactiveIT.java
@@ -304,10 +304,10 @@ public class QuteReactiveIT {
                 .statusCode(200)
                 .body(is("io.quarkus.ts.qute.Book"));
         app.given()
-                .get("/class/io.quarkus.ts.qute.Book$quarkusjacksondeserializer")
+                .get("/class/io.quarkus.ts.qute.Book$quarkusjacksonserializer")
                 .then()
                 .statusCode(200)
-                .body(is("io.quarkus.ts.qute.Book$quarkusjacksondeserializer"));
+                .body(is("io.quarkus.ts.qute.Book$quarkusjacksonserializer"));
     }
 
     @Tag("https://github.com/quarkusio/quarkus/pull/47001")

--- a/qute/reactive/src/test/java/io/quarkus/ts/qute/QuteReactiveIT.java
+++ b/qute/reactive/src/test/java/io/quarkus/ts/qute/QuteReactiveIT.java
@@ -303,11 +303,6 @@ public class QuteReactiveIT {
                 .then()
                 .statusCode(200)
                 .body(is("io.quarkus.ts.qute.Book"));
-        app.given()
-                .get("/class/io.quarkus.ts.qute.Book$quarkusjacksonserializer")
-                .then()
-                .statusCode(200)
-                .body(is("io.quarkus.ts.qute.Book$quarkusjacksonserializer"));
     }
 
     @Tag("https://github.com/quarkusio/quarkus/pull/47001")


### PR DESCRIPTION
## Summary

### [quarkusio/quarkus#42954](https://github.com/quarkusio/quarkus/pull/42954) — Generate Jackson deserializers

- Fix `verifyGeneratedClasses` tests: records don't have no-arg constructors, so `JacksonDeserializerFactory` no longer generates `$quarkusjacksondeserializer` classes for them. The Qute `Book` record also uses varargs which prevents serializer generation.
- Add no-arg constructor to `ValidatedUser` so the reflection-free Jackson deserializer can deserialize it

### [quarkusio/quarkus#51761](https://github.com/quarkusio/quarkus/pull/51761) — Switch to Apache HTTP client 5

- Migrate Elasticsearch module from REST4 to REST5 client API (`RestClient` → `Rest5Client`, `org.apache.http` → `org.apache.hc.core5`)
- Add `commons-logging-jboss-logging` to Hibernate Search annotation processor path: the Quarkus BOM now excludes `commons-logging` from `hibernate-search-backend-elasticsearch`

### [quarkusio/quarkus#55303](https://github.com/quarkusio/quarkus/pull/55303) — Update AMQP DevServices image

- Update AMQP Dev Services tests and `amqbroker.1.0x.image` property for ArtemisCloud → ArkMQ image rebranding

## Test plan

- [ ] CI passes on Linux JVM (17, 21, 25)
- [ ] CI passes on Windows JVM
- [ ] Elasticsearch module compiles and tests pass
- [ ] Hibernate FullText Search module compiles
- [ ] AMQP Dev Services tests detect the new broker image