### PR TITLE
Add 3.27-specific platform minimiser

### DIFF
--- a/.github/minimise_platform.xsl
+++ b/.github/minimise_platform.xsl
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns="http://maven.apache.org/POM/4.0.0"
+                xmlns:pom="http://maven.apache.org/POM/4.0.0"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="no"/>
+    <!-- Copy everything -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+    <!-- Remove explicit "enabled" tag from all platform members -->
+    <xsl:template match="/pom:project/pom:build/pom:pluginManagement/pom:plugins/pom:plugin[./pom:artifactId/text() = 'quarkus-platform-bom-maven-plugin']/pom:configuration/pom:platformConfig/pom:members/pom:member/pom:enabled"/>
+    <!-- Remove llama tests -->
+    <xsl:template match="/pom:project/pom:build/pom:pluginManagement/pom:plugins/pom:plugin[./pom:artifactId/text() = 'quarkus-platform-bom-maven-plugin']/pom:configuration/pom:platformConfig/pom:members/pom:member[pom:name/text()='LangChain4j']/pom:tests/pom:test[contains(pom:artifact,'integration-test-jlama') or contains(pom:artifact,'integration-test-llama3')]"/>
+    <!-- Disable all platform members, but langchain4j and MCP Server -->
+    <xsl:template match="/pom:project/pom:build/pom:pluginManagement/pom:plugins/pom:plugin[./pom:artifactId/text() = 'quarkus-platform-bom-maven-plugin']/pom:configuration/pom:platformConfig/pom:members/pom:member[pom:name/text()!='LangChain4j' and pom:name/text()!='MCPServer']">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()" />
+            <enabled>false</enabled>
+            <xsl:text>&#xA;</xsl:text>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
### Summary

Quarkus platform 3.27 and Langchain4j 1.2 include llama tests, which:
- require java 22 to be built
- not used by us
- are disabled in Quarkus platform 3.33 and newer

Thus I suggest to remove them before building the platform.

This particular XSL file was verified on Jenkins, in 3.27 platform build job

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)