### PR TITLE
Bump org.htmlunit:htmlunit from 4.21.0 to 5.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <quarkiverse.config.version>2.5.0</quarkiverse.config.version>
         <quarkiverse.pact.version>1.6.0</quarkiverse.pact.version>
         <assertj.version>3.27.7</assertj.version>
-        <htmlunit.version>4.21.0</htmlunit.version>
+        <htmlunit.version>5.2.0</htmlunit.version>
         <java.websocket.version>1.6.0</java.websocket.version>
         <mcp-sdk.version>2.0.0</mcp-sdk.version>
         <!-- Faster build when using -DskipTests -->

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractLogoutSinglePageAppFlowIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractLogoutSinglePageAppFlowIT.java
@@ -22,7 +22,7 @@ import org.htmlunit.WebRequest;
 import org.htmlunit.WebResponse;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
-import org.htmlunit.util.Cookie;
+import org.htmlunit.http.Cookie;
 import org.htmlunit.util.NameValuePair;
 import org.junit.jupiter.api.Test;
 

--- a/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/AbstractLogoutSinglePageAppFlowIT.java
+++ b/security/keycloak-oidc-client-reactive-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/reactive/extended/AbstractLogoutSinglePageAppFlowIT.java
@@ -16,7 +16,7 @@ import org.htmlunit.WebClientOptions;
 import org.htmlunit.WebResponse;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
-import org.htmlunit.util.Cookie;
+import org.htmlunit.http.Cookie;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
## Summary

Bump org.htmlunit:htmlunit from 4.21.0 to 5.2.0

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

## Checklist:

- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow the best practices