### PR TITLE
Update AMQP custom image to multi-arch arkmq-org tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
                                 <!-- Services used in test suite -->
                                 <nginx.image>docker.io/library/nginx:1-alpine</nginx.image>
                                 <amqbroker.image>registry.access.redhat.com/amq-broker-7/amq-broker-72-openshift:latest</amqbroker.image>
-                                <amqbroker.1.0x.image>quay.io/arkmq-org/arkmq-org-broker:1.0.32</amqbroker.1.0x.image>
+                                <amqbroker.1.0x.image>quay.io/arkmq-org/arkmq-org-broker:artemis.2.55.0</amqbroker.1.0x.image>
                                 <redpanda.image>redpandadata/redpanda:v25.3.9</redpanda.image>
                                 <postgresql.latest.image>${postgresql.latest.image}</postgresql.latest.image>
                                 <postgis.latest.image>${postgis.latest.image}</postgis.latest.image>


### PR DESCRIPTION
## Summary

- Update `amqbroker.1.0x.image` property from `quay.io/arkmq-org/arkmq-org-broker:1.0.32` to `quay.io/arkmq-org/arkmq-org-broker:artemis.2.55.0`

The `1.0.x` tags on `arkmq-org/arkmq-org-broker` are amd64-only, causing `DevModeAmqpDevServiceUserExperienceIT` to fail on AArch64 runners with "Resource failed to start". The `artemis.X.Y.Z` tags provide multi-arch manifests (amd64 + arm64).

Upstream: https://github.com/quarkusio/quarkus/pull/55303

## Test plan

- [x] `DevModeAmqpDevServiceUserExperienceIT` passes on Linux AArch64 JVM