### PR TITLE
Accept MSSQL Server 2025 container license

### DIFF
--- a/sql-db/hibernate-orm-rest-data-panache/src/test/resources/container-license-acceptance.txt
+++ b/sql-db/hibernate-orm-rest-data-panache/src/test/resources/container-license-acceptance.txt
@@ -2,3 +2,4 @@ mcr.microsoft.com/mssql/server:2017-CU12
 mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-latest
+mcr.microsoft.com/mssql/server:2025-latest

--- a/sql-db/narayana-transactions/src/test/resources/container-license-acceptance.txt
+++ b/sql-db/narayana-transactions/src/test/resources/container-license-acceptance.txt
@@ -3,3 +3,4 @@ mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-latest
 mcr.microsoft.com/mssql/rhel/server:2022-latest
+mcr.microsoft.com/mssql/server:2025-latest

--- a/sql-db/reactive-vanilla/src/main/resources/container-license-acceptance.txt
+++ b/sql-db/reactive-vanilla/src/main/resources/container-license-acceptance.txt
@@ -2,4 +2,5 @@ mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-latest
 mcr.microsoft.com/mssql/rhel/server:2022-latest
-mcr.microsoft.com/mssql/server:2022-latestmcr.microsoft.com/mssql/server:2025-latest
+mcr.microsoft.com/mssql/server:2022-latest
+mcr.microsoft.com/mssql/server:2025-latest

--- a/sql-db/reactive-vanilla/src/main/resources/container-license-acceptance.txt
+++ b/sql-db/reactive-vanilla/src/main/resources/container-license-acceptance.txt
@@ -2,4 +2,4 @@ mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-latest
 mcr.microsoft.com/mssql/rhel/server:2022-latest
-mcr.microsoft.com/mssql/server:2022-latest
+mcr.microsoft.com/mssql/server:2022-latestmcr.microsoft.com/mssql/server:2025-latest

--- a/sql-db/sql-app-compatibility/src/test/resources/container-license-acceptance.txt
+++ b/sql-db/sql-app-compatibility/src/test/resources/container-license-acceptance.txt
@@ -3,3 +3,4 @@ mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-latest
 mcr.microsoft.com/mssql/rhel/server:2022-latest
+mcr.microsoft.com/mssql/server:2025-latest

--- a/sql-db/sql-app/src/test/resources/container-license-acceptance.txt
+++ b/sql-db/sql-app/src/test/resources/container-license-acceptance.txt
@@ -5,3 +5,4 @@ mcr.microsoft.com/mssql/server:2019-latest
 mcr.microsoft.com/mssql/rhel/server:2022-latest
 mcr.microsoft.com/mssql/server:2022-latest
 mcr.microsoft.com/azure-sql-edge:latest
+mcr.microsoft.com/mssql/server:2025-latest


### PR DESCRIPTION
## Summary

- Add `mcr.microsoft.com/mssql/server:2025-latest` to all `container-license-acceptance.txt` files

Quarkus upstream updated the default MSSQL Dev Services image from `2022-latest` to `2025-latest`, which requires explicit license acceptance via Testcontainers.

## Test plan

- [ ] `DevModeMssqlIT` passes
- [ ] `MssqlTransactionGeneralUsageIT` passes