### PR TITLE
Skip DevModeWorkspaceIT.workspaceCanBeEdited on AArch64

### DIFF
--- a/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeWorkspaceIT.java
+++ b/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/DevModeWorkspaceIT.java
@@ -14,6 +14,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.ElementHandle;
@@ -82,6 +83,8 @@ public class DevModeWorkspaceIT {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true",
+            disabledReason = "Playwright times out waiting for code editor on AArch64")
     public void workspaceCanBeEdited() {
         app.given().when().get("/api/filter/any")
                 .then().statusCode(HttpStatus.SC_OK).body(containsString("ok"));


### PR DESCRIPTION
## Summary

- Skip `DevModeWorkspaceIT.workspaceCanBeEdited` on AArch64 runners using `@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes")`

The Playwright headless Chromium browser consistently times out (30s) waiting for the `#code` editor element on AArch64 runners. Verified this has been failing on every AArch64 run since at least Jul 10 while always passing on x86_64.

## Test plan

- [ ] `DevModeWorkspaceIT` passes on Linux x86_64 JVM
- [ ] `DevModeWorkspaceIT.workspaceCanBeEdited` is skipped on Linux AArch64 JVM