### PR TITLE
Coverage for quarkus compilation failure with vertx-hazelcast

### DIFF
--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/HazelcastIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/HazelcastIT.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.vertx;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Dependency;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+@Tag("QUARKUS-8412") // beware, that this issues is about compilation failure
+@DisabledOnNative(reason = "Support for Hazelcast in native mode is not implemented: https://github.com/quarkusio/quarkus/issues/9877")
+public class HazelcastIT {
+
+    @QuarkusApplication(dependencies = @Dependency(groupId = "io.vertx", artifactId = "vertx-hazelcast"))
+    static RestService app = new RestService();
+
+    @Test
+    public void smoke() {
+        app.given().get("/hello?name=you").then().statusCode(HttpStatus.SC_OK).body("content", is("Hello, you!"));
+    }
+}


### PR DESCRIPTION
### Summary

Some version of Quarkus fails to compile, if there is vertx-hazelcast in the classpath:

https://redhat.atlassian.net/browse/QUARKUS-8412
https://github.com/quarkusio/quarkus/issues/53613


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)