### PR TITLE
Update MySQL and MariaDB for preparation to 3.40

### DIFF
--- a/hibernate/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/MysqlMultitenantHibernateSearchIT.java
+++ b/hibernate/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/MysqlMultitenantHibernateSearchIT.java
@@ -12,13 +12,13 @@ public class MysqlMultitenantHibernateSearchIT extends AbstractMultitenantHibern
     static final int ELASTIC_PORT = 9200;
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
     static MySqlService base = new MySqlService().withDatabase("base");
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
     static MySqlService company1 = new MySqlService().withDatabase("company1");
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
     static MySqlService company2 = new MySqlService().withDatabase("company2");
 
     @Container(image = "${elastic.9x.image}", port = ELASTIC_PORT, expectedLog = "started")

--- a/hibernate/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftMysqlMultitenantHibernateSearchIT.java
+++ b/hibernate/hibernate-fulltext-search/src/test/java/io/quarkus/ts/hibernate/search/OpenShiftMysqlMultitenantHibernateSearchIT.java
@@ -20,17 +20,17 @@ public class OpenShiftMysqlMultitenantHibernateSearchIT extends AbstractMultiten
     private static final String MAX_ALLOWED_PACKET_KEY = "MYSQL_MAX_ALLOWED_PACKET";
     private static final String EXPECTED_LOG = "Only MySQL server logs after this point";
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = EXPECTED_LOG)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = EXPECTED_LOG)
     static MySqlService base = new MySqlService()
             .withDatabase("base")
             .withProperty(MAX_ALLOWED_PACKET_KEY, MAX_ALLOWED_PACKET_VALUE);
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = EXPECTED_LOG)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = EXPECTED_LOG)
     static MySqlService company1 = new MySqlService()
             .withDatabase("company1")
             .withProperty(MAX_ALLOWED_PACKET_KEY, MAX_ALLOWED_PACKET_VALUE);
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = EXPECTED_LOG)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = EXPECTED_LOG)
     static MySqlService company2 = new MySqlService()
             .withDatabase("company2")
             .withProperty(MAX_ALLOWED_PACKET_KEY, MAX_ALLOWED_PACKET_VALUE);

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/FixedPortResourceBuilder.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/FixedPortResourceBuilder.java
@@ -52,7 +52,7 @@ public final class FixedPortResourceBuilder extends ContainerManagedResourceBuil
     private static final class FixedPortManagedResource extends GenericDockerContainerManagedResource {
 
         private static final PropertyLookup DB2_IMAGE_PROPERTY = new PropertyLookup("db2.image");
-        private static final PropertyLookup MARIADB_IMAGE_PROPERTY = new PropertyLookup("mariadb.11.image");
+        private static final PropertyLookup MARIADB_IMAGE_PROPERTY = new PropertyLookup("mariadb.12.image");
         private final FixedPortResourceBuilder model;
         private final Supplier<Mount[]> mounts;
 

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/MariaDBHibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/MariaDBHibernateOfflineStartupIT.java
@@ -15,7 +15,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class MariaDBHibernateOfflineStartupIT extends AbstractHibernateOfflineStartupIT {
 
-    @Container(image = "${mariadb.11.image}", expectedLog = "socket: '.*sock'  port: 3306", mounts = {
+    @Container(image = "${mariadb.12.image}", expectedLog = "socket: '.*sock'  port: 3306", mounts = {
             // the MariaDB image has dynamically mounted files based on the actual resolved image
             // for FIPS-enabled environment, see https://issues.redhat.com/browse/QUARKUS-5984
             // if you change the image or mounting, please don't forget to change that code in FixedPortResourceBuilder

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/MariaDBStorageEngineOnlineIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/MariaDBStorageEngineOnlineIT.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class MariaDBStorageEngineOnlineIT extends AbstractStorageEngineOnlineIT {
 
-    @Container(image = "${mariadb.11.image}", expectedLog = "socket: '.*sock'  port: 3306", mounts = {
+    @Container(image = "${mariadb.12.image}", expectedLog = "socket: '.*sock'  port: 3306", mounts = {
             @Mount(from = "mysql-init.sql", to = "/docker-entrypoint-initdb.d/init.sql")
     }, port = 3306, builder = FixedPortResourceBuilder.class)
     static final MariaDbService db = new MariaDbService();

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/MySqlDBHibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/MySqlDBHibernateOfflineStartupIT.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class MySqlDBHibernateOfflineStartupIT extends AbstractHibernateOfflineStartupIT {
 
-    @Container(image = "${mysql.84.image}", expectedLog = "ready for connections.* port: 3306", mounts = {
+    @Container(image = "${mysql.image}", expectedLog = "ready for connections.* port: 3306", mounts = {
             // Upstream MySQL is using `docker-entrypoint-initdb.d` to init DB
             // RH image repository MySQL image using `my.cnf` script
             // To ensure it will work for both images we need to mount it to both location

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/MySqlStorageEngineOnlineIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/MySqlStorageEngineOnlineIT.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class MySqlStorageEngineOnlineIT extends AbstractStorageEngineOnlineIT {
 
-    @Container(image = "${mysql.84.image}", expectedLog = "ready for connections.* port: 3306", mounts = {
+    @Container(image = "${mysql.image}", expectedLog = "ready for connections.* port: 3306", mounts = {
             // Upstream MySQL is using `docker-entrypoint-initdb.d` to init DB
             // RH image repository MySQL image using `my.cnf` script
             // To ensure it will work for both images we need to mount it to both location

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/OpenShiftMariaDBHibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/OpenShiftMariaDBHibernateOfflineStartupIT.java
@@ -14,7 +14,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @OpenShiftScenario
 public class OpenShiftMariaDBHibernateOfflineStartupIT extends AbstractHibernateOfflineStartupIT {
 
-    @Container(image = "${mariadb.1011.image}", expectedLog = "socket: '.*sock'  port: 3306", mounts = {
+    @Container(image = "${mariadb.118.image}", expectedLog = "socket: '.*sock'  port: 3306", mounts = {
             @Mount(from = "mysql-init.sql", to = "/tmp/init.sql"),
             @Mount(from = "mysql-my-conf.config", to = "/etc/my.cnf.d/custom.cnf")
     }, port = 3306)

--- a/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/OpenShiftMySqlDBHibernateOfflineStartupIT.java
+++ b/hibernate/hibernate-offline-startup/src/test/java/io/quarkus/ts/hibernate/startup/offline/test/OpenShiftMySqlDBHibernateOfflineStartupIT.java
@@ -14,7 +14,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @OpenShiftScenario
 public class OpenShiftMySqlDBHibernateOfflineStartupIT extends AbstractHibernateOfflineStartupIT {
 
-    @Container(image = "${mysql.84.image}", expectedLog = "Only MySQL server logs after this point", mounts = {
+    @Container(image = "${mysql.image}", expectedLog = "Only MySQL server logs after this point", mounts = {
             @Mount(from = "mysql-init.sql", to = "/tmp/init.sql"),
             @Mount(from = "mysql-my-conf.config", to = "/etc/my.cnf.d/custom.cnf")
     }, port = 3306)

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MariaDbDatabaseHibernateReactiveIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MariaDbDatabaseHibernateReactiveIT.java
@@ -19,7 +19,7 @@ public class MariaDbDatabaseHibernateReactiveIT extends AbstractDatabaseHibernat
 
     // TODO At the time of writing, there is no specific connector for mariadb, so we are using MY SQL driver.
     // we need to change this, if this connector will be ever provided. Additionally, we need to add an OpenShift test
-    @Container(image = "${mariadb.1011.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.118.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
     static MariaDbService database = new MariaDbService()
             .withUser(MYSQL_USER)
             .withPassword(MYSQL_PASSWORD)

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MariaDbHibernateValidatorCallbackIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MariaDbHibernateValidatorCallbackIT.java
@@ -21,7 +21,7 @@ public class MariaDbHibernateValidatorCallbackIT extends AbstractHibernateValida
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.1011.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.118.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MixedSourcesIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MixedSourcesIT.java
@@ -40,7 +40,7 @@ public class MixedSourcesIT {
             .withDatabase(SQL_DATABASE)
             .withProperty("PGDATA", "/tmp/psql");
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
     static MySqlService mysql = new MySqlService()
             .withUser(SQL_USER)
             .withPassword(SQL_PASSWORD)

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MultiDatabaseHibernateReactiveIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MultiDatabaseHibernateReactiveIT.java
@@ -62,7 +62,7 @@ public class MultiDatabaseHibernateReactiveIT extends AbstractDatabaseHibernateR
             .withDatabase(SQL_DATABASE)
             .withProperty("PGDATA", "/tmp/psql");
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
     static MySqlService mysql = new MySqlService()
             .withUser(SQL_USER)
             .withPassword(SQL_PASSWORD)

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MySQLDatabaseHibernateReactiveIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MySQLDatabaseHibernateReactiveIT.java
@@ -16,7 +16,7 @@ public class MySQLDatabaseHibernateReactiveIT extends AbstractDatabaseHibernateR
     private static final String MYSQL_DATABASE = "quarkus_test";
     private static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService()
             .withUser(MYSQL_USER)
             .withPassword(MYSQL_PASSWORD)

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MySQLHibernateValidatorDisabledIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MySQLHibernateValidatorDisabledIT.java
@@ -24,7 +24,7 @@ public class MySQLHibernateValidatorDisabledIT {
     private static final String MYSQL_DATABASE = "quarkus_test";
     private static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService()
             .withUser(MYSQL_USER)
             .withPassword(MYSQL_PASSWORD)

--- a/hibernate/hibernate-spatial/src/test/java/io/quarkus/qe/hibernate/spatial/MySqlHibernateSpatialIT.java
+++ b/hibernate/hibernate-spatial/src/test/java/io/quarkus/qe/hibernate/spatial/MySqlHibernateSpatialIT.java
@@ -12,7 +12,7 @@ public class MySqlHibernateSpatialIT extends AbstractHibernateSpatialIT {
 
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication(dependencies = @Dependency(artifactId = "quarkus-jdbc-mysql"))

--- a/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/MariaDbJakartaDataIT.java
+++ b/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/MariaDbJakartaDataIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class MariaDbJakartaDataIT extends AbstractJakartaDataIT {
 
-    @Container(image = "${mariadb.11.image}", port = 3306, expectedLog = "socket: '.*sock'  port: 3306")
+    @Container(image = "${mariadb.12.image}", port = 3306, expectedLog = "socket: '.*sock'  port: 3306")
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/MySqlJakartaDataIT.java
+++ b/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/MySqlJakartaDataIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class MySqlJakartaDataIT extends AbstractJakartaDataIT {
 
-    @Container(image = "${mysql.84.image}", port = 3306, expectedLog = "ready for connections.* port: 3306")
+    @Container(image = "${mysql.image}", port = 3306, expectedLog = "ready for connections.* port: 3306")
     public static final MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/security/MariaDbJakartaDataSecurityIT.java
+++ b/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/security/MariaDbJakartaDataSecurityIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class MariaDbJakartaDataSecurityIT extends AbstractJakartaDataSecurityIT {
 
-    @Container(image = "${mariadb.11.image}", port = 3306, expectedLog = "socket: '.*sock'  port: 3306")
+    @Container(image = "${mariadb.12.image}", port = 3306, expectedLog = "socket: '.*sock'  port: 3306")
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/security/MySqlJakartaDataSecurityIT.java
+++ b/hibernate/jakarta-data/src/test/java/io/quarkus/ts/jakarta/data/security/MySqlJakartaDataSecurityIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class MySqlJakartaDataSecurityIT extends AbstractJakartaDataSecurityIT {
 
-    @Container(image = "${mysql.84.image}", port = 3306, expectedLog = "ready for connections.* port: 3306")
+    @Container(image = "${mysql.image}", port = 3306, expectedLog = "ready for connections.* port: 3306")
     public static final MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
                                 <elastic.9x.image>docker.io/library/elasticsearch:9.4.1</elastic.9x.image>
                                 <mysql.upstream.image>${mysql.upstream.image}</mysql.upstream.image>
                                 <mysql.image>${mysql.image}</mysql.image>
-                                <mariadb.11.image>docker.io/library/mariadb:11.8-ubi9</mariadb.11.image>
+                                <mariadb.12.image>docker.io/library/mariadb:12.3-ubi10</mariadb.12.image>
                                 <mssql.image>mcr.microsoft.com/mssql/rhel/server:2025-latest</mssql.image>
                                 <!-- Oracle image - we aim to use same version as Dev Services for Oracle so that we only download one image -->
                                 <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,8 @@
         <postgresql.latest.image>docker.io/library/postgres:18</postgresql.latest.image>
         <postgis.latest.image>docker.io/postgis/postgis:18-3.6</postgis.latest.image>
         <!-- The upstream MySQL version is needed for DevMode as the RH image is not starting with Quarkus-->
-        <mysql.upstream.image>docker.io/library/mysql:8.4</mysql.upstream.image>
-        <mysql.84.image>${mysql.upstream.image}</mysql.84.image>
+        <mysql.upstream.image>docker.io/library/mysql:9.7</mysql.upstream.image>
+        <mysql.image>${mysql.upstream.image}</mysql.image>
         <rhbk.image>registry.redhat.io/rhbk/keycloak-rhel9:26.6</rhbk.image>
         <wiremock.version>3.13.2</wiremock.version>
         <build-reporter-maven-extension.version>3.13.1</build-reporter-maven-extension.version>
@@ -273,7 +273,7 @@
                         <postgresql.latest.image>${postgresql.latest.image}</postgresql.latest.image>
                         <postgis.latest.image>${postgis.latest.image}</postgis.latest.image>
                         <mysql.upstream.image>${mysql.upstream.image}</mysql.upstream.image>
-                        <mysql.84.image>${mysql.84.image}</mysql.84.image>
+                        <mysql.image>${mysql.image}</mysql.image>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -312,7 +312,7 @@
                                 <postgis.latest.image>${postgis.latest.image}</postgis.latest.image>
                                 <elastic.9x.image>docker.io/library/elasticsearch:9.4.1</elastic.9x.image>
                                 <mysql.upstream.image>${mysql.upstream.image}</mysql.upstream.image>
-                                <mysql.84.image>${mysql.84.image}</mysql.84.image>
+                                <mysql.image>${mysql.image}</mysql.image>
                                 <mariadb.11.image>docker.io/library/mariadb:11.8-ubi9</mariadb.11.image>
                                 <mssql.image>mcr.microsoft.com/mssql/rhel/server:2025-latest</mssql.image>
                                 <!-- Oracle image - we aim to use same version as Dev Services for Oracle so that we only download one image -->
@@ -853,7 +853,7 @@
                                         <postgresql.15.image>registry.redhat.io/rhel9/postgresql-15:latest</postgresql.15.image>
                                         <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-18:latest</postgresql.latest.image>
                                         <mariadb.1011.image>registry.redhat.io/rhel9/mariadb-1011:latest</mariadb.1011.image>
-                                        <mysql.84.image>registry.redhat.io/rhel9/mysql-84:latest</mysql.84.image>
+                                        <mysql.image>registry.redhat.io/rhel9/mysql-84:latest</mysql.image>
                                         <!-- Kafka  (amq-streams) requires separate properties for image and version -->
                                         <amq-streams.image>registry.redhat.io/amq-streams/kafka-42-rhel9</amq-streams.image>
                                         <amq-streams.version>3.2.0</amq-streams.version>
@@ -882,7 +882,7 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-18:latest</postgresql.latest.image>
-                                <mysql.84.image>registry.redhat.io/rhel9/mysql-84:latest</mysql.84.image>
+                                <mysql.image>registry.redhat.io/rhel9/mysql-84:latest</mysql.image>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -905,7 +905,7 @@
                                         <postgresql.15.image>registry.redhat.io/rhel9/postgresql-15:latest</postgresql.15.image>
                                         <postgresql.dev.svc.latest.image>${postgresql.latest.image}</postgresql.dev.svc.latest.image>
                                         <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-18:latest</postgresql.latest.image>
-                                        <mysql.84.image>registry.redhat.io/rhel9/mysql-84:latest</mysql.84.image>
+                                        <mysql.image>registry.redhat.io/rhel9/mysql-84:latest</mysql.image>
                                         <mariadb.1011.image>registry.redhat.io/rhel9/mariadb-1011:latest</mariadb.1011.image>
                                         <amqbroker.image>registry.redhat.io/amq7/amq-broker-rhel9:7.14</amqbroker.image>
                                         <!-- Kafka  (amq-streams) requires separate properties for image and version -->
@@ -972,7 +972,7 @@
                                         <rhbk.image>${rhbk.image}</rhbk.image>
                                         <postgresql.15.image>registry.redhat.io/rhel9/postgresql-15:latest</postgresql.15.image>
                                         <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-18:latest</postgresql.latest.image>
-                                        <mysql.84.image>registry.redhat.io/rhel9/mysql-84:latest</mysql.84.image>
+                                        <mysql.image>registry.redhat.io/rhel9/mysql-84:latest</mysql.image>
                                         <mariadb.1011.image>registry.redhat.io/rhel9/mariadb-1011:latest</mariadb.1011.image>
                                         <!-- Kafka  (amq-streams) requires separate properties for image and version -->
                                         <amq-streams.image>registry.redhat.io/amq-streams/kafka-40-rhel9</amq-streams.image>

--- a/pom.xml
+++ b/pom.xml
@@ -852,7 +852,7 @@
                                         <rhbk.image>${rhbk.image}</rhbk.image>
                                         <postgresql.15.image>registry.redhat.io/rhel9/postgresql-15:latest</postgresql.15.image>
                                         <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-18:latest</postgresql.latest.image>
-                                        <mariadb.1011.image>registry.redhat.io/rhel9/mariadb-1011:latest</mariadb.1011.image>
+                                        <mariadb.118.image>registry.redhat.io/rhel9/mariadb-118:latest</mariadb.118.image>
                                         <mysql.image>registry.redhat.io/rhel9/mysql-84:latest</mysql.image>
                                         <!-- Kafka  (amq-streams) requires separate properties for image and version -->
                                         <amq-streams.image>registry.redhat.io/amq-streams/kafka-42-rhel9</amq-streams.image>
@@ -906,7 +906,7 @@
                                         <postgresql.dev.svc.latest.image>${postgresql.latest.image}</postgresql.dev.svc.latest.image>
                                         <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-18:latest</postgresql.latest.image>
                                         <mysql.image>registry.redhat.io/rhel9/mysql-84:latest</mysql.image>
-                                        <mariadb.1011.image>registry.redhat.io/rhel9/mariadb-1011:latest</mariadb.1011.image>
+                                        <mariadb.118.image>registry.redhat.io/rhel9/mariadb-118:latest</mariadb.118.image>
                                         <amqbroker.image>registry.redhat.io/amq7/amq-broker-rhel9:7.14</amqbroker.image>
                                         <!-- Kafka  (amq-streams) requires separate properties for image and version -->
                                         <amq-streams.image>registry.redhat.io/amq-streams/kafka-42-rhel9</amq-streams.image>
@@ -973,7 +973,7 @@
                                         <postgresql.15.image>registry.redhat.io/rhel9/postgresql-15:latest</postgresql.15.image>
                                         <postgresql.latest.image>registry.redhat.io/rhel9/postgresql-18:latest</postgresql.latest.image>
                                         <mysql.image>registry.redhat.io/rhel9/mysql-84:latest</mysql.image>
-                                        <mariadb.1011.image>registry.redhat.io/rhel9/mariadb-1011:latest</mariadb.1011.image>
+                                        <mariadb.118.image>registry.redhat.io/rhel9/mariadb-118:latest</mariadb.118.image>
                                         <!-- Kafka  (amq-streams) requires separate properties for image and version -->
                                         <amq-streams.image>registry.redhat.io/amq-streams/kafka-40-rhel9</amq-streams.image>
                                         <amq-streams.version>3.0.0</amq-streams.version>

--- a/scheduling/quartz/src/test/java/io/quarkus/ts/scheduling/quartz/BaseMySqlQuartzIT.java
+++ b/scheduling/quartz/src/test/java/io/quarkus/ts/scheduling/quartz/BaseMySqlQuartzIT.java
@@ -7,6 +7,6 @@ public abstract class BaseMySqlQuartzIT {
     static final String MYSQL_PROPERTIES = "mysql.properties";
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService();
 }

--- a/security/jpa/src/test/java/io/quarkus/ts/security/jpa/MariaDbMd5JpaIT.java
+++ b/security/jpa/src/test/java/io/quarkus/ts/security/jpa/MariaDbMd5JpaIT.java
@@ -17,7 +17,7 @@ public class MariaDbMd5JpaIT extends BaseJpaSecurityRealmIT {
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '.*sock'  port: " + MARIADB_PORT)
+    @Container(image = "${mariadb.12.image}", port = MARIADB_PORT, expectedLog = "socket: '.*sock'  port: " + MARIADB_PORT)
     static MariaDbService database = new MariaDbService();
 
     @QuarkusApplication(classes = { AdminResource.class, PublicResource.class, UserResource.class,

--- a/security/jpa/src/test/java/io/quarkus/ts/security/jpa/MySqlSha256JpaIT.java
+++ b/security/jpa/src/test/java/io/quarkus/ts/security/jpa/MySqlSha256JpaIT.java
@@ -17,7 +17,7 @@ public class MySqlSha256JpaIT extends BaseJpaSecurityRealmIT {
 
     private static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication(classes = { AdminResource.class, PublicResource.class, UserResource.class,

--- a/security/webauthn/src/test/java/io/quarkus/ts/security/webauthn/BasicHigherThanWebAuthnPriorityIT.java
+++ b/security/webauthn/src/test/java/io/quarkus/ts/security/webauthn/BasicHigherThanWebAuthnPriorityIT.java
@@ -17,7 +17,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class BasicHigherThanWebAuthnPriorityIT {
     private static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/security/webauthn/src/test/java/io/quarkus/ts/security/webauthn/MySqlWebAuthnIT.java
+++ b/security/webauthn/src/test/java/io/quarkus/ts/security/webauthn/MySqlWebAuthnIT.java
@@ -13,7 +13,7 @@ public class MySqlWebAuthnIT extends AbstractWebAuthnTest {
 
     private static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/security/webauthn/src/test/java/io/quarkus/ts/security/webauthn/WebAuthnHigherThanBasicPriorityIT.java
+++ b/security/webauthn/src/test/java/io/quarkus/ts/security/webauthn/WebAuthnHigherThanBasicPriorityIT.java
@@ -17,7 +17,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class WebAuthnHigherThanBasicPriorityIT {
     private static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/OpenShiftSpringWebQuteReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/OpenShiftSpringWebQuteReactiveIT.java
@@ -13,7 +13,7 @@ import io.quarkus.ts.spring.web.reactive.db.MariaDBConstants;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftSpringWebQuteReactiveIT extends AbstractSpringWebQuteReactiveIT {
 
-    @Container(image = MariaDBConstants.IMAGE_1011, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG)
+    @Container(image = MariaDBConstants.IMAGE_118, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/OpenShiftSpringWebRestReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/OpenShiftSpringWebRestReactiveIT.java
@@ -13,7 +13,7 @@ import io.quarkus.ts.spring.web.reactive.db.MariaDBConstants;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftSpringWebRestReactiveIT extends AbstractSpringWebRestReactiveIT {
 
-    @Container(image = MariaDBConstants.IMAGE_1011, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG)
+    @Container(image = MariaDBConstants.IMAGE_118, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/SpringWebQuteReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/SpringWebQuteReactiveIT.java
@@ -10,7 +10,7 @@ import io.quarkus.ts.spring.web.reactive.db.MariaDBConstants;
 @QuarkusScenario
 public class SpringWebQuteReactiveIT extends AbstractSpringWebQuteReactiveIT {
 
-    @Container(image = MariaDBConstants.IMAGE_11, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG_11)
+    @Container(image = MariaDBConstants.IMAGE_12, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG_11)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/SpringWebRestReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/bootstrap/SpringWebRestReactiveIT.java
@@ -10,7 +10,7 @@ import io.quarkus.ts.spring.web.reactive.db.MariaDBConstants;
 @QuarkusScenario
 public class SpringWebRestReactiveIT extends AbstractSpringWebRestReactiveIT {
 
-    @Container(image = MariaDBConstants.IMAGE_11, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG_11)
+    @Container(image = MariaDBConstants.IMAGE_12, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG_11)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/db/MariaDBConstants.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/db/MariaDBConstants.java
@@ -3,7 +3,7 @@ package io.quarkus.ts.spring.web.reactive.db;
 public class MariaDBConstants {
     public static final int PORT = 3306;
     public static final String START_LOG = "Only MySQL server logs after this point";
-    public static final String IMAGE_1011 = "${mariadb.1011.image}";
+    public static final String IMAGE_118 = "${mariadb.118.image}";
     public static final String START_LOG_11 = "socket: '.*sock'  port: " + PORT;
     public static final String IMAGE_11 = "${mariadb.11.image}";
 }

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/db/MariaDBConstants.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/db/MariaDBConstants.java
@@ -5,5 +5,5 @@ public class MariaDBConstants {
     public static final String START_LOG = "Only MySQL server logs after this point";
     public static final String IMAGE_118 = "${mariadb.118.image}";
     public static final String START_LOG_11 = "socket: '.*sock'  port: " + PORT;
-    public static final String IMAGE_11 = "${mariadb.11.image}";
+    public static final String IMAGE_12 = "${mariadb.12.image}";
 }

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/OpenShiftSpringWebOpenApiReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/OpenShiftSpringWebOpenApiReactiveIT.java
@@ -16,7 +16,7 @@ import io.quarkus.ts.spring.web.reactive.db.MariaDBConstants;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftSpringWebOpenApiReactiveIT extends AbstractSpringWebOpenApiReactiveIT {
 
-    @Container(image = MariaDBConstants.IMAGE_1011, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG)
+    @Container(image = MariaDBConstants.IMAGE_118, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/SpringWebOpenApiReactiveIT.java
+++ b/spring/spring-web-reactive/src/test/java/io/quarkus/ts/spring/web/reactive/openapi/SpringWebOpenApiReactiveIT.java
@@ -14,7 +14,7 @@ import io.quarkus.ts.spring.web.reactive.db.MariaDBConstants;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class SpringWebOpenApiReactiveIT extends AbstractSpringWebOpenApiReactiveIT {
 
-    @Container(image = MariaDBConstants.IMAGE_11, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG_11)
+    @Container(image = MariaDBConstants.IMAGE_12, port = MariaDBConstants.PORT, expectedLog = MariaDBConstants.START_LOG_11)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/OpenShiftSpringWebQuteIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/OpenShiftSpringWebQuteIT.java
@@ -1,6 +1,6 @@
 package io.quarkus.ts.spring.web.bootstrap;
 
-import static io.quarkus.ts.spring.web.db.MariaDBConstants.IMAGE_1011;
+import static io.quarkus.ts.spring.web.db.MariaDBConstants.IMAGE_118;
 import static io.quarkus.ts.spring.web.db.MariaDBConstants.PORT;
 import static io.quarkus.ts.spring.web.db.MariaDBConstants.START_LOG_1011;
 
@@ -13,7 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @OpenShiftScenario
 public class OpenShiftSpringWebQuteIT extends AbstractSpringWebQuteIT {
 
-    @Container(image = IMAGE_1011, port = PORT, expectedLog = START_LOG_1011)
+    @Container(image = IMAGE_118, port = PORT, expectedLog = START_LOG_1011)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/OpenShiftSpringWebRestIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/OpenShiftSpringWebRestIT.java
@@ -1,6 +1,6 @@
 package io.quarkus.ts.spring.web.bootstrap;
 
-import static io.quarkus.ts.spring.web.db.MariaDBConstants.IMAGE_1011;
+import static io.quarkus.ts.spring.web.db.MariaDBConstants.IMAGE_118;
 import static io.quarkus.ts.spring.web.db.MariaDBConstants.PORT;
 import static io.quarkus.ts.spring.web.db.MariaDBConstants.START_LOG_1011;
 
@@ -16,7 +16,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftSpringWebRestIT extends AbstractSpringWebRestIT {
 
-    @Container(image = IMAGE_1011, port = PORT, expectedLog = START_LOG_1011)
+    @Container(image = IMAGE_118, port = PORT, expectedLog = START_LOG_1011)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/SpringWebQuteIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/SpringWebQuteIT.java
@@ -1,6 +1,6 @@
 package io.quarkus.ts.spring.web.bootstrap;
 
-import static io.quarkus.ts.spring.web.db.MariaDBConstants.IMAGE_11;
+import static io.quarkus.ts.spring.web.db.MariaDBConstants.IMAGE_12;
 import static io.quarkus.ts.spring.web.db.MariaDBConstants.PORT;
 import static io.quarkus.ts.spring.web.db.MariaDBConstants.START_LOG_11;
 
@@ -13,7 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class SpringWebQuteIT extends AbstractSpringWebQuteIT {
 
-    @Container(image = IMAGE_11, port = PORT, expectedLog = START_LOG_11)
+    @Container(image = IMAGE_12, port = PORT, expectedLog = START_LOG_11)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/SpringWebRestIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/bootstrap/SpringWebRestIT.java
@@ -1,6 +1,6 @@
 package io.quarkus.ts.spring.web.bootstrap;
 
-import static io.quarkus.ts.spring.web.db.MariaDBConstants.IMAGE_11;
+import static io.quarkus.ts.spring.web.db.MariaDBConstants.IMAGE_12;
 import static io.quarkus.ts.spring.web.db.MariaDBConstants.PORT;
 import static io.quarkus.ts.spring.web.db.MariaDBConstants.START_LOG_11;
 
@@ -13,7 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class SpringWebRestIT extends AbstractSpringWebRestIT {
 
-    @Container(image = IMAGE_11, port = PORT, expectedLog = START_LOG_11)
+    @Container(image = IMAGE_12, port = PORT, expectedLog = START_LOG_11)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/db/MariaDBConstants.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/db/MariaDBConstants.java
@@ -5,5 +5,5 @@ public class MariaDBConstants {
     public static final String START_LOG_11 = "socket: '.*sock'  port: " + PORT;
     public static final String START_LOG_1011 = "Only MySQL server logs after this point";
     public static final String IMAGE_11 = "${mariadb.11.image}";
-    public static final String IMAGE_1011 = "${mariadb.1011.image}";
+    public static final String IMAGE_118 = "${mariadb.118.image}";
 }

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/db/MariaDBConstants.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/db/MariaDBConstants.java
@@ -4,6 +4,6 @@ public class MariaDBConstants {
     public static final int PORT = 3306;
     public static final String START_LOG_11 = "socket: '.*sock'  port: " + PORT;
     public static final String START_LOG_1011 = "Only MySQL server logs after this point";
-    public static final String IMAGE_11 = "${mariadb.11.image}";
+    public static final String IMAGE_12 = "${mariadb.12.image}";
     public static final String IMAGE_118 = "${mariadb.118.image}";
 }

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/openapi/OpenShiftSpringWebOpenApiIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/openapi/OpenShiftSpringWebOpenApiIT.java
@@ -1,6 +1,6 @@
 package io.quarkus.ts.spring.web.openapi;
 
-import static io.quarkus.ts.spring.web.db.MariaDBConstants.IMAGE_1011;
+import static io.quarkus.ts.spring.web.db.MariaDBConstants.IMAGE_118;
 import static io.quarkus.ts.spring.web.db.MariaDBConstants.PORT;
 import static io.quarkus.ts.spring.web.db.MariaDBConstants.START_LOG_1011;
 
@@ -19,7 +19,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
 public class OpenShiftSpringWebOpenApiIT extends AbstractSpringWebOpenApiIT {
 
-    @Container(image = IMAGE_1011, port = PORT, expectedLog = START_LOG_1011)
+    @Container(image = IMAGE_118, port = PORT, expectedLog = START_LOG_1011)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/openapi/SpringWebOpenApiIT.java
+++ b/spring/spring-web/src/test/java/io/quarkus/ts/spring/web/openapi/SpringWebOpenApiIT.java
@@ -1,6 +1,6 @@
 package io.quarkus.ts.spring.web.openapi;
 
-import static io.quarkus.ts.spring.web.db.MariaDBConstants.IMAGE_11;
+import static io.quarkus.ts.spring.web.db.MariaDBConstants.IMAGE_12;
 import static io.quarkus.ts.spring.web.db.MariaDBConstants.PORT;
 import static io.quarkus.ts.spring.web.db.MariaDBConstants.START_LOG_11;
 
@@ -17,7 +17,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class SpringWebOpenApiIT extends AbstractSpringWebOpenApiIT {
 
-    @Container(image = IMAGE_11, port = PORT, expectedLog = START_LOG_11)
+    @Container(image = IMAGE_12, port = PORT, expectedLog = START_LOG_11)
     static final MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/sql-db/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MariaDBPanacheResourceIT.java
+++ b/sql-db/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MariaDBPanacheResourceIT.java
@@ -11,7 +11,7 @@ public class MariaDBPanacheResourceIT extends AbstractPanacheResourceIT {
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '.*sock'  port: " + MARIADB_PORT)
+    @Container(image = "${mariadb.12.image}", port = MARIADB_PORT, expectedLog = "socket: '.*sock'  port: " + MARIADB_PORT)
     static MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/sql-db/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MySqlPanacheResourceIT.java
+++ b/sql-db/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/MySqlPanacheResourceIT.java
@@ -13,7 +13,7 @@ public class MySqlPanacheResourceIT extends AbstractPanacheResourceIT {
 
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/sql-db/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/OpenShiftMariaDBPanacheResourceIT.java
+++ b/sql-db/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/OpenShiftMariaDBPanacheResourceIT.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class OpenShiftMariaDBPanacheResourceIT extends AbstractPanacheResourceIT {
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.1011.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.118.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/sql-db/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/OpenShiftMySqlPanacheResourceIT.java
+++ b/sql-db/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/ts/reactive/rest/data/panache/OpenShiftMySqlPanacheResourceIT.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class OpenShiftMySqlPanacheResourceIT extends AbstractPanacheResourceIT {
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/CustomDatasourceProducerIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/CustomDatasourceProducerIT.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class CustomDatasourceProducerIT extends AbstractCustomDatasourceProducerIT {
 
-    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '.*sock'  port: " + MARIADB_PORT)
+    @Container(image = "${mariadb.12.image}", port = MARIADB_PORT, expectedLog = "socket: '.*sock'  port: " + MARIADB_PORT)
     static MariaDbService mariadb = new MariaDbService();
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiDatabaseActiveInactiveIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiDatabaseActiveInactiveIT.java
@@ -18,7 +18,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class MultiDatabaseActiveInactiveIT extends AbstractMultiDatabaseActiveInactiveIT {
 
-    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '.*sock'  port: " + MARIADB_PORT)
+    @Container(image = "${mariadb.12.image}", port = MARIADB_PORT, expectedLog = "socket: '.*sock'  port: " + MARIADB_PORT)
     static MariaDbService mariadb = new MariaDbService();
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/MultiplePersistenceIT.java
@@ -14,7 +14,7 @@ public class MultiplePersistenceIT extends AbstractMultiplePersistenceIT {
     static final int POSTGRESQL_PORT = 5432;
     private static final String MARIADB_START_LOG = "socket: '.*sock'  port: " + MARIADB_PORT;
 
-    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = MARIADB_START_LOG)
+    @Container(image = "${mariadb.12.image}", port = MARIADB_PORT, expectedLog = MARIADB_START_LOG)
     static MariaDbService mariadb = new MariaDbService();
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftCustomDatasourceProducerIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftCustomDatasourceProducerIT.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @OpenShiftScenario
 public class OpenShiftCustomDatasourceProducerIT extends AbstractCustomDatasourceProducerIT {
 
-    @Container(image = "${mariadb.1011.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.118.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static MariaDbService mariadb = new MariaDbService();
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiDatabaseActiveInactiveIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiDatabaseActiveInactiveIT.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @OpenShiftScenario
 public class OpenShiftMultiDatabaseActiveInactiveIT extends AbstractMultiDatabaseActiveInactiveIT {
 
-    @Container(image = "${mariadb.1011.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.118.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static MariaDbService mariadb = new MariaDbService();
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")

--- a/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
+++ b/sql-db/multiple-pus/src/test/java/io/quarkus/ts/sqldb/multiplepus/OpenShiftMultiplePersistenceIT.java
@@ -17,7 +17,7 @@ public class OpenShiftMultiplePersistenceIT extends AbstractMultiplePersistenceI
 
     static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "${mariadb.1011.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.118.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
     static MariaDbService mariadb = new MariaDbService();
 
     @Container(image = "${postgresql.latest.image}", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address")

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MariaDbTransactionGeneralUsageIT.java
@@ -15,7 +15,7 @@ public class MariaDbTransactionGeneralUsageIT extends TransactionCommons {
     private static final String DATASOURCE_JDBC_ENABLE_RECOVERY = "quarkus.datasource.%s.jdbc.enable-recovery";
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '.*sock'  port: " + MARIADB_PORT)
+    @Container(image = "${mariadb.12.image}", port = MARIADB_PORT, expectedLog = "socket: '.*sock'  port: " + MARIADB_PORT)
     static MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MysqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/MysqlTransactionGeneralUsageIT.java
@@ -17,12 +17,12 @@ import io.quarkus.ts.transactions.recovery.TransactionExecutor;
 public class MysqlTransactionGeneralUsageIT extends TransactionCommons {
 
     static final int MYSQL_PORT = 3306;
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
     static final MySqlService database = new MySqlService().onPostStart(service -> {
         // enable transactions recovery for user
         var self = (MySqlService) service;
         // RH MySQL image allow login root user locally without using password and ignoring set root password
-        String passwordString = System.getProperty("mysql.84.image").contains("redhat") ? "" : "-p" + self.getPassword();
+        String passwordString = System.getProperty("mysql.image").contains("redhat") ? "" : "-p" + self.getPassword();
         try {
             self
                     .<GenericContainer<?>> getPropertyFromContext(DOCKER_INNER_CONTAINER)

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMariaDbTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMariaDbTransactionGeneralUsageIT.java
@@ -15,7 +15,7 @@ public class OpenShiftMariaDbTransactionGeneralUsageIT extends TransactionCommon
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.1011.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.118.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMysqlTransactionGeneralUsageIT.java
+++ b/sql-db/narayana-transactions/src/test/java/io/quarkus/ts/transactions/OpenShiftMysqlTransactionGeneralUsageIT.java
@@ -16,7 +16,7 @@ public class OpenShiftMysqlTransactionGeneralUsageIT extends TransactionCommons 
     private static final Logger LOG = Logger.getLogger(OpenShiftMysqlTransactionGeneralUsageIT.class);
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/PanacheWithFlywayBaseIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/PanacheWithFlywayBaseIT.java
@@ -8,7 +8,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public abstract class PanacheWithFlywayBaseIT {
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "ready for connections.* port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/MySqlDatabaseTestResource.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/dbpool/MySqlDatabaseTestResource.java
@@ -31,7 +31,7 @@ public class MySqlDatabaseTestResource implements QuarkusTestResourceLifecycleMa
 
     @Override
     public Map<String, String> start() {
-        String image = System.getProperty("mysql.84.image");
+        String image = System.getProperty("mysql.image");
 
         // we used managed version of 'org.testcontainers:mysql' and version '1.19.7' failed in FIPS-enabled environment
         // over 'SA/ECB/OAEPWithSHA-1AndMGF1Padding' cipher as SunJCE provider was not available in FIPS

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/init/OpenShiftDefaultInitContainerIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/init/OpenShiftDefaultInitContainerIT.java
@@ -28,7 +28,7 @@ public class OpenShiftDefaultInitContainerIT {
             "app/target/kubernetes/openshift.yml");
     private static final String CUSTOM_IMAGE = "quay.io/quarkusqeteam/wait:0.0.4";
 
-    @Container(image = "${mysql.84.image}", port = 3306, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mysql.image}", port = 3306, expectedLog = "Only MySQL server logs after this point")
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/init/OpenShiftFlywayInitContainerIT.java
+++ b/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/init/OpenShiftFlywayInitContainerIT.java
@@ -28,7 +28,7 @@ public class OpenShiftFlywayInitContainerIT {
             "app/target/kubernetes/openshift.yml");
     private static final String CUSTOM_IMAGE = "quay.io/quarkusqeteam/wait";
 
-    @Container(image = "${mysql.84.image}", port = 3306, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mysql.image}", port = 3306, expectedLog = "Only MySQL server logs after this point")
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MariaDBDatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MariaDBDatabaseIT.java
@@ -11,7 +11,7 @@ public class MariaDBDatabaseIT extends AbstractSqlDatabaseIT {
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '.*sock'  port: " + MARIADB_PORT)
+    @Container(image = "${mariadb.12.image}", port = MARIADB_PORT, expectedLog = "socket: '.*sock'  port: " + MARIADB_PORT)
     static MariaDbService database = new MariaDbService();
 
     @QuarkusApplication(properties = "mariadb_app.properties")

--- a/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MySqlDatabaseIT.java
+++ b/sql-db/sql-app-compatibility/src/test/java/io/quarkus/ts/sqldb/compatibility/MySqlDatabaseIT.java
@@ -13,7 +13,7 @@ public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {
 
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication(properties = "mysql.properties")

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMariadbComposeIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMariadbComposeIT.java
@@ -14,11 +14,11 @@ public class DevModeMariadbComposeIT extends AbstractSqlDatabaseIT {
     @DevModeQuarkusApplication(properties = "mariadb_app.properties")
     static RestService app = new RestService()
             .withProperty("quarkus.compose.devservices.files", "src/main/resources/mysql-compose-devservices.yml")
-            .withProperty("quarkus.compose.devservices.env-variables.IMAGE", "${mariadb.11.image}");
+            .withProperty("quarkus.compose.devservices.env-variables.IMAGE", "${mariadb.12.image}");
 
     @Test
     public void composeDevServicesAreUsed() {
         app.logs().assertContains("Compose is running command");
-        app.logs().assertContains(System.getProperty("mariadb.11.image"));
+        app.logs().assertContains(System.getProperty("mariadb.12.image"));
     }
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMariadbDevServicesUserExperienceIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMariadbDevServicesUserExperienceIT.java
@@ -20,14 +20,14 @@ import io.quarkus.test.utils.SocketUtils;
 @QuarkusScenario
 public class DevModeMariadbDevServicesUserExperienceIT {
 
-    private static final String MARIA_DB_NAME = getImageName("mariadb.11.image");
-    private static final String MARIA_DB_VERSION = getImageVersion("mariadb.11.image");
+    private static final String MARIA_DB_NAME = getImageName("mariadb.12.image");
+    private static final String MARIA_DB_VERSION = getImageVersion("mariadb.12.image");
 
     @DevModeQuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.datasource.db-kind", "mariadb")
             .withProperty("quarkus.datasource.devservices.port", Integer.toString(SocketUtils.findAvailablePort()))
-            .withProperty("quarkus.datasource.devservices.image-name", "${mariadb.11.image}")
+            .withProperty("quarkus.datasource.devservices.image-name", "${mariadb.12.image}")
             .withProperty("quarkus.hibernate-orm.schema-management.strategy", "none")
             .onPreStart(s -> DockerUtils.removeImage(MARIA_DB_NAME, MARIA_DB_VERSION));
 

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMysqlComposeIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMysqlComposeIT.java
@@ -14,11 +14,11 @@ public class DevModeMysqlComposeIT extends AbstractSqlDatabaseIT {
     @DevModeQuarkusApplication(properties = "mysql.properties")
     static RestService app = new RestService()
             .withProperty("quarkus.compose.devservices.files", "src/main/resources/mysql-compose-devservices.yml")
-            .withProperty("quarkus.compose.devservices.env-variables.IMAGE", "${mysql.84.image}");
+            .withProperty("quarkus.compose.devservices.env-variables.IMAGE", "${mysql.image}");
 
     @Test
     public void composeDevServicesAreUsed() {
         app.logs().assertContains("Compose is running command");
-        app.logs().assertContains(System.getProperty("mysql.84.image"));
+        app.logs().assertContains(System.getProperty("mysql.image"));
     }
 }

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMysqlDevServiceUserExperienceIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMysqlDevServiceUserExperienceIT.java
@@ -21,14 +21,14 @@ import io.quarkus.test.utils.SocketUtils;
 @QuarkusScenario
 public class DevModeMysqlDevServiceUserExperienceIT {
 
-    private static final String MYSQL_NAME = getImageName("mysql.84.image");
-    private static final String MYSQL_VERSION = getImageVersion("mysql.84.image");
+    private static final String MYSQL_NAME = getImageName("mysql.image");
+    private static final String MYSQL_VERSION = getImageVersion("mysql.image");
 
     @DevModeQuarkusApplication
     static RestService app = new RestService()
             .withProperty("quarkus.datasource.db-kind", "mysql")
             .withProperty("quarkus.datasource.devservices.port", Integer.toString(SocketUtils.findAvailablePort()))
-            .withProperty("quarkus.datasource.devservices.image-name", "${mysql.84.image}")
+            .withProperty("quarkus.datasource.devservices.image-name", "${mysql.image}")
             .withProperty("quarkus.hibernate-orm.schema-management.strategy", "none")
             .onPreStart(s -> DockerUtils.removeImage(MYSQL_NAME, MYSQL_VERSION));
 

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MariaDBDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MariaDBDatabaseIT.java
@@ -11,7 +11,7 @@ public class MariaDBDatabaseIT extends AbstractSqlDatabaseIT {
 
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.11.image}", port = MARIADB_PORT, expectedLog = "socket: '.*sock'  port: " + MARIADB_PORT)
+    @Container(image = "${mariadb.12.image}", port = MARIADB_PORT, expectedLog = "socket: '.*sock'  port: " + MARIADB_PORT)
     static MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MySqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/MySqlDatabaseIT.java
@@ -11,7 +11,7 @@ public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {
 
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "port: " + MYSQL_PORT)
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMariaDBDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMariaDBDatabaseIT.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class OpenShiftMariaDBDatabaseIT extends AbstractSqlDatabaseIT {
     static final int MARIADB_PORT = 3306;
 
-    @Container(image = "${mariadb.1011.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mariadb.118.image}", port = MARIADB_PORT, expectedLog = "Only MySQL server logs after this point")
     static MariaDbService database = new MariaDbService();
 
     @QuarkusApplication

--- a/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMySqlDatabaseIT.java
+++ b/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/OpenShiftMySqlDatabaseIT.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class OpenShiftMySqlDatabaseIT extends AbstractSqlDatabaseIT {
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "${mysql.84.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "Only MySQL server logs after this point")
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MysqlHandlerIT.java
+++ b/sql-db/vertx-sql/src/test/java/io/quarkus/ts/vertx/sql/handlers/MysqlHandlerIT.java
@@ -10,7 +10,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class MysqlHandlerIT extends CommonTestCases {
     private static final String DATABASE = "amadeus";
 
-    @Container(image = "${mysql.84.image}", port = 3306, expectedLog = "ready for connections.* port: 3306")
+    @Container(image = "${mysql.image}", port = 3306, expectedLog = "ready for connections.* port: 3306")
     static MySqlService mysql = new MySqlService()
             .with("test", "test", DATABASE);
 


### PR DESCRIPTION
### Summary

* Updating the MySQL to 9.7, which is latest LTS + making the image property more general
* Updating RH MariaDB image to 11.8 (Latest available in RH image registry) + updating the property name
* Updating MariaDB to 12.3, which is latest LTS + updating the property name

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [x] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)