### PR TITLE
Enable some disabled tests

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
@@ -2,8 +2,6 @@ package io.quarkus.ts.quarkus.cli;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliDefaultService;
 import io.quarkus.test.bootstrap.QuarkusVersionAwareCliClient;
@@ -16,8 +14,6 @@ import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 public class QuarkusCliCreateExtensionIT {
 
     @TestQuarkusCli
-    // TODO enable when Quarkus 3.35 is out
-    @Disabled("https://github.com/quarkusio/quarkus/pull/53251 introduces breaking change in main tests compared to Quarkus release in registry")
     public void shouldCreateAndBuildExtension(QuarkusVersionAwareCliClient cliClient) {
         // Create extension
         QuarkusCliDefaultService app = cliClient.createExtension("extension-abc");

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractDpopNonceProviderIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractDpopNonceProviderIT.java
@@ -81,8 +81,8 @@ abstract public class AbstractDpopNonceProviderIT {
                 .header("WWW-Authenticate", containsString("dpop error=\"use_dpop_nonce\""));
     }
 
-    @Disabled("https://github.com/quarkusio/quarkus/pull/54855 is merged in main branch (for Quarkus 4.0), enable after it is backported to 3.x branch.")
     @Test
+    @Disabled("https://github.com/quarkusio/quarkus/pull/54855 is merged in main branch (for Quarkus 4.0), enable after it is backported to 3.x branch.")
     public void invalidNonceShouldReturnUseDpopNonceChallenge() throws Exception {
         KeyPair keyPair = generateKeyPair();
         String accessToken = getAccessToken(keyPair);

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractDpopNonceProviderIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractDpopNonceProviderIT.java
@@ -10,7 +10,6 @@ import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -82,7 +81,6 @@ abstract public class AbstractDpopNonceProviderIT {
     }
 
     @Test
-    @Disabled("https://github.com/quarkusio/quarkus/pull/54855 is merged in main branch (for Quarkus 4.0), enable after it is backported to 3.x branch.")
     public void invalidNonceShouldReturnUseDpopNonceChallenge() throws Exception {
         KeyPair keyPair = generateKeyPair();
         String accessToken = getAccessToken(keyPair);

--- a/security/keycloak-webapp/src/main/java/io/quarkus/ts/security/keycloak/webapp/AuthenticationCompletionSecondary.java
+++ b/security/keycloak-webapp/src/main/java/io/quarkus/ts/security/keycloak/webapp/AuthenticationCompletionSecondary.java
@@ -5,13 +5,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import io.quarkus.arc.Unremovable;
-import io.quarkus.arc.profile.IfBuildProfile;
 import io.quarkus.oidc.AuthenticationCompletionAction;
 import io.smallrye.mutiny.Uni;
 
 @ApplicationScoped
 @Unremovable
-@IfBuildProfile("multi-action")
 public class AuthenticationCompletionSecondary implements AuthenticationCompletionAction {
 
     private final AtomicInteger callCount = new AtomicInteger();

--- a/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/BaseAuthenticationCompletionActionIT.java
+++ b/security/keycloak-webapp/src/test/java/io/quarkus/ts/security/keycloak/webapp/BaseAuthenticationCompletionActionIT.java
@@ -21,7 +21,6 @@ import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -108,7 +107,6 @@ public abstract class BaseAuthenticationCompletionActionIT {
     }
 
     @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/55158 - fix not yet backported to 3.x")
     public void verifyMultipleActionsExecuted() throws Exception {
         resetState();
         loginAs("test-user");


### PR DESCRIPTION
### Summary

Enabling some disabled test which are fixed/backported to 3.x

Note: the `@IfBuildProfile("multi-action")` is removed as it was only to disable that `AuthenticationCompletionSecondary` per https://github.com/quarkus-qe/quarkus-test-suite/pull/3059#issuecomment-4873429583. In original PR it was asked to be removed https://github.com/quarkus-qe/quarkus-test-suite/pull/3059#discussion_r3504877285 but it was not possible because the reason mentioned earlier 


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)