### PR TITLE
Add update policy for repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <reruns>2</reruns>
         <oc.reruns>1</oc.reruns>
         <flaky-run-reporter.version>0.1.7</flaky-run-reporter.version>
+        <repository.update.policy>daily</repository.update.policy>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -170,6 +171,7 @@
             <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
+                <updatePolicy>${repository.update.policy}</updatePolicy>
             </snapshots>
             <releases>
                 <enabled>false</enabled>
@@ -182,6 +184,7 @@
             <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
+                <updatePolicy>${repository.update.policy}</updatePolicy>
             </snapshots>
             <releases>
                 <enabled>false</enabled>
@@ -439,6 +442,7 @@
             <properties>
                 <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
                 <quarkus.platform.version>3.999-SNAPSHOT</quarkus.platform.version>
+                <repository.update.policy>never</repository.update.policy>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
### Summary

This is useful especially for local developments currently it trying to download metadata for platform version which is not available. When running without core-only profile it still stay same value as default one. When running the core-only the value for update is never.

Currently every time when I run some tests it's try to download `maven-metadat.xml`. I don't see much point to even try to download the the as they are not existing. Possibly when you run much tests daily it could even cause rate limit (never happen to me yet, but I not running that much tests currently). Also downloading it every run create log noise.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)