### PR TITLE
Revert aarch disabled snapshot tests

### DIFF
--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftChatbotIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftChatbotIT.java
@@ -4,8 +4,6 @@ import static io.quarkus.ts.langchain4j.auxiliary.CommonTools.DEFAULT_ARGS;
 import static io.quarkus.ts.langchain4j.auxiliary.CommonTools.SAMPLE_BRANCH;
 import static io.quarkus.ts.langchain4j.auxiliary.CommonTools.getKey;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
@@ -13,7 +11,6 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "The newest/3.x SNAPSHOT is not available in public repository.")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.Build)
 public class OpenShiftChatbotIT extends AbstractChatbotIT {
     @Container(image = "${redis.image}", port = 6379, expectedLog = "Ready to accept connections")

--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftMoviesIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftMoviesIT.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "The newest/3.x SNAPSHOT is not available in public repository.")
 @DisabledIfSystemProperty(named = "ts.ibm-z-p.missing.services.excludes", matches = "true", disabledReason = "pgvector container not available on s390x & ppc64le.")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.Build)
 public class OpenShiftMoviesIT extends MoviesIT {

--- a/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftToolsIT.java
+++ b/ai/langchain4j/src/test/java/io/quarkus/ts/langchain4j/OpenShiftToolsIT.java
@@ -4,8 +4,6 @@ import static io.quarkus.ts.langchain4j.auxiliary.CommonTools.DEFAULT_ARGS;
 import static io.quarkus.ts.langchain4j.auxiliary.CommonTools.SAMPLE_BRANCH;
 import static io.quarkus.ts.langchain4j.auxiliary.CommonTools.getKey;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
@@ -15,7 +13,6 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.ts.langchain4j.auxiliary.MCPFileServer;
 
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "The newest/3.x SNAPSHOT is not available in public repository.")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.Build)
 public class OpenShiftToolsIT extends AbstractToolsIT {
     @QuarkusApplication(boms = { @Dependency(artifactId = "quarkus-mcp-server-bom") }, dependencies = {

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftQuickstartIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftQuickstartIT.java
@@ -1,12 +1,9 @@
 package io.quarkus.ts.external.applications;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 
 @DisabledOnNative(reason = "Native + s2i not supported")
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "The newest/3.x SNAPSHOT is not available in public repository.")
 @OpenShiftScenario
 public class OpenShiftQuickstartIT extends QuickstartIT {
 }

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftTodoDemoIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftTodoDemoIT.java
@@ -1,12 +1,9 @@
 package io.quarkus.ts.external.applications;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 
 @DisabledOnNative(reason = "Native + s2i not supported")
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "The newest/3.x SNAPSHOT is not available in public repository.")
 @OpenShiftScenario
 public class OpenShiftTodoDemoIT extends TodoDemoIT {
 }

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/OpenShiftWorkshopHeroesIT.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.PostgresqlService;
@@ -26,7 +25,6 @@ import io.restassured.http.ContentType;
 @OpenShiftScenario
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @EnabledIfSystemProperty(named = "ts.redhat.registry.enabled", matches = "true")
-@DisabledIfSystemProperty(named = "ts.arm.missing.services.excludes", matches = "true", disabledReason = "The newest/3.x SNAPSHOT is not available in public repository.")
 public class OpenShiftWorkshopHeroesIT {
     private static String heroId;
 


### PR DESCRIPTION
### Summary

Aarch test pipelines now can use snapshot repo from an artifactory

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [x] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)