### PR TITLE
Enable and rework the listExtensionsWithEmptyOffering test

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingDefaultIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingDefaultIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.ts.quarkus.cli.offering;
 
 import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.QUARKUS_CONFIG;
+import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.QUARKUS_REGISTRY_ID;
 import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.QUARKUS_TEST_CONFIG;
 import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.getExtensionLineFromListOutput;
 import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.getQuarkusVersionWithoutNumberSuffix;
@@ -8,8 +9,8 @@ import static io.quarkus.ts.quarkus.cli.offering.QuarkusCliOfferingUtils.updateR
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -18,12 +19,12 @@ import jakarta.inject.Inject;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.opentest4j.AssertionFailedError;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -99,13 +100,14 @@ public class QuarkusCliOfferingDefaultIT {
     }
 
     @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/50480")
     public void listExtensionsWithEmptyOffering() throws IOException {
-        // Testing output when the unknow offering is set
+        // Testing output when the empty/unknown offering is set
         updateRegistryConfigFileWithOffering("");
-        QuarkusCliClient.Result result = cliClient.listExtensions("--support-scope",
-                "--config=" + QUARKUS_TEST_CONFIG.getAbsolutePath());
-        assertFalse(result.isSuccessful());
-        // TODO the output in this case is not clear, needs to be updated when issue is fixed
+        // Checking for AssertionFailedError as FW QuarkusCliClient#listExtension throw the failure if the command is not successful
+        var exception = assertThrows(AssertionFailedError.class, () -> cliClient.listExtensions("--support-scope",
+                "--config=" + QUARKUS_TEST_CONFIG.getAbsolutePath()));
+        assertThat("Offering is set but it's empty, the error should be shown", exception.getMessage(),
+                containsString("Unable to list extensions: Registry '" + QUARKUS_REGISTRY_ID
+                        + "' config option 'offering' must not be empty"));
     }
 }

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingUtils.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/offering/QuarkusCliOfferingUtils.java
@@ -35,7 +35,7 @@ public class QuarkusCliOfferingUtils {
     public static final File QUARKUS_TEST_CONFIG = Paths.get("target", ".quarkus",
             "config.yaml").toFile();
 
-    private static final String QUARKUS_REGISTRY_ID = "testingregistry";
+    protected static final String QUARKUS_REGISTRY_ID = "testingregistry";
     private static final String LANGCHAIN4J_ARTIFACT_ID_NAME = "quarkus-langchain4j-bom";
 
     public static String getExtensionLineFromListOutput(QuarkusCliClient.Result result, String extensionArtifactName) {


### PR DESCRIPTION
### Summary

As https://github.com/quarkusio/quarkus/issues/50480 is fixed, I enable this test and finish it to work with the fixed version

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)