### PR TITLE
Test Coverage for QUARKUS-7866 - Add JsonProvider SPI for per-record dynamic JSON field additions

### DIFF
--- a/logging/jboss/src/main/java/io/quarkus/ts/logging/jboss/CdiJsonProvider.java
+++ b/logging/jboss/src/main/java/io/quarkus/ts/logging/jboss/CdiJsonProvider.java
@@ -1,0 +1,36 @@
+package io.quarkus.ts.logging.jboss;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.Level;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.logging.json.runtime.JsonFormatter.JsonLogGenerator;
+import io.quarkus.logging.json.runtime.JsonProvider;
+
+@ApplicationScoped
+@LookupIfProperty(name = "json-provider-test.enabled", stringValue = "true")
+public class CdiJsonProvider implements JsonProvider {
+    @Override
+    public void writeTo(JsonLogGenerator generator, ExtLogRecord record) throws Exception {
+        generator.add("customField", "customValue");
+        generator.add("loggerNameFromRecord", record.getLoggerName());
+
+        String requestId = record.getMdcCopy().get("requestId");
+        if (requestId != null) {
+            generator.add("requestIdFromMdc", requestId);
+        }
+
+        if (record.getLevel().intValue() >= Level.ERROR.intValue()) {
+            generator.add("isErrorRecord", "true");
+        }
+
+        generator.startObject("nestedObject")
+                .add("nestedField1", "nestedValue1")
+                .add("nestedField2", "nestedValue2")
+                .endObject();
+
+        generator.add("excludedField", "excludedValue");
+    }
+}

--- a/logging/jboss/src/main/java/io/quarkus/ts/logging/jboss/JsonProviderResource.java
+++ b/logging/jboss/src/main/java/io/quarkus/ts/logging/jboss/JsonProviderResource.java
@@ -1,0 +1,25 @@
+package io.quarkus.ts.logging.jboss;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.logging.Logger;
+import org.jboss.logging.MDC;
+
+@Path("/json-provider")
+public class JsonProviderResource {
+    private static final Logger LOG = Logger.getLogger("json-provider-category");
+
+    @GET
+    @Path("/info")
+    public void info() {
+        MDC.put("requestId", "request-123");
+        LOG.info("JSON Provider Info");
+    }
+
+    @GET
+    @Path("/error")
+    public void error() {
+        LOG.error("JSON Provider Error");
+    }
+}

--- a/logging/jboss/src/main/java/io/quarkus/ts/logging/jboss/ServiceLoaderJsonProvider.java
+++ b/logging/jboss/src/main/java/io/quarkus/ts/logging/jboss/ServiceLoaderJsonProvider.java
@@ -1,0 +1,13 @@
+package io.quarkus.ts.logging.jboss;
+
+import org.jboss.logmanager.ExtLogRecord;
+
+import io.quarkus.logging.json.runtime.JsonFormatter.JsonLogGenerator;
+import io.quarkus.logging.json.runtime.JsonProvider;
+
+public class ServiceLoaderJsonProvider implements JsonProvider {
+    @Override
+    public void writeTo(JsonLogGenerator generator, ExtLogRecord record) throws Exception {
+        generator.add("serviceLoaderField", "serviceLoaderValue");
+    }
+}

--- a/logging/jboss/src/main/resources/META-INF/services/io.quarkus.logging.json.runtime.JsonProvider
+++ b/logging/jboss/src/main/resources/META-INF/services/io.quarkus.logging.json.runtime.JsonProvider
@@ -1,0 +1,1 @@
+io.quarkus.ts.logging.jboss.ServiceLoaderJsonProvider

--- a/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/JsonProviderConsoleIT.java
+++ b/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/JsonProviderConsoleIT.java
@@ -1,0 +1,47 @@
+package io.quarkus.ts.logging.jboss;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@Tag("QUARKUS-7866")
+@QuarkusScenario
+public class JsonProviderConsoleIT {
+    @QuarkusApplication
+    static final RestService app = new RestService()
+            .withProperty("quarkus.log.console.json.excluded-keys", "excludedField")
+            .withProperty("json-provider-test.enabled", "true");
+
+    @AfterEach
+    void restartApp() {
+        app.stop();
+        app.start();
+    }
+
+    @Test
+    void shouldWriteFieldsToConsoleLog() {
+        app.given().get("/json-provider/info");
+
+        app.logs().assertContains("\"message\":\"JSON Provider Info\"");
+        app.logs().assertContains("\"customField\":\"customValue\"");
+        app.logs().assertContains("\"loggerNameFromRecord\":\"json-provider-category\"");
+        app.logs().assertContains("\"requestIdFromMdc\":\"request-123\"");
+        app.logs().assertContains("\"nestedObject\":{\"nestedField1\":\"nestedValue1\",\"nestedField2\":\"nestedValue2\"}");
+        app.logs().assertContains("\"serviceLoaderField\":\"serviceLoaderValue\"");
+        app.logs().assertDoesNotContain("\"excludedField\"");
+        app.logs().assertDoesNotContain(("\"isErrorRecord\""));
+    }
+
+    @Test
+    void shouldWriteErrorFieldsToConsole() {
+        app.given().get("/json-provider/error");
+
+        app.logs().assertContains("\"message\":\"JSON Provider Error\"");
+        app.logs().assertContains("\"isErrorRecord\":\"true\"");
+        app.logs().assertDoesNotContain("\"requestIdFromMdc\"");
+    }
+}

--- a/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/JsonProviderFileIT.java
+++ b/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/JsonProviderFileIT.java
@@ -1,0 +1,73 @@
+package io.quarkus.ts.logging.jboss;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@Tag("QUARKUS-7866")
+@QuarkusScenario
+public class JsonProviderFileIT {
+    private static final String LOG_FILE_NAME = "json-provider.log";
+    private static final Path LOG_FILE_DIR = Path.of("target/JsonProviderFileIT/app");
+
+    @QuarkusApplication
+    static final RestService app = new RestService()
+            .withProperty("quarkus.log.file.enabled", "true")
+            .withProperty("quarkus.log.file.path", LOG_FILE_NAME)
+            .withProperty("quarkus.log.file.json.excluded-keys", "excludedField")
+            .withProperty("json-provider-test.enabled", "true");
+
+    @AfterAll
+    static void cleanup() throws IOException {
+        app.stop();
+        Files.deleteIfExists(LOG_FILE_DIR.resolve(LOG_FILE_NAME));
+    }
+
+    @AfterEach
+    void restartApp() {
+        app.stop();
+        app.start();
+    }
+
+    @Test
+    void shouldWriteFieldsToFile() throws IOException {
+        app.given().get("/json-provider/info");
+
+        Path logFile = LOG_FILE_DIR.resolve(LOG_FILE_NAME);
+        assertTrue(Files.exists(logFile));
+        String log = Files.readString(logFile);
+
+        assertTrue(log.contains("\"message\":\"JSON Provider Info\""));
+        assertTrue(log.contains("\"customField\":\"customValue\""));
+        assertTrue(log.contains("\"loggerNameFromRecord\":\"json-provider-category\""));
+        assertTrue(log.contains("\"requestIdFromMdc\":\"request-123\""));
+        assertTrue(log.contains("\"nestedObject\":{\"nestedField1\":\"nestedValue1\",\"nestedField2\":\"nestedValue2\"}"));
+        assertFalse(log.contains("\"excludedField\""));
+        assertFalse(log.contains("\"isErrorRecord\""));
+    }
+
+    @Test
+    void shouldWriteErrorFieldsToFile() throws IOException {
+        app.given().get("/json-provider/error");
+
+        Path logFile = LOG_FILE_DIR.resolve(LOG_FILE_NAME);
+        assertTrue(Files.exists(logFile));
+        String log = Files.readString(logFile);
+
+        assertTrue(log.contains("\"message\":\"JSON Provider Error\""));
+        assertTrue(log.contains("\"isErrorRecord\":\"true\""));
+        assertFalse(log.contains("\"requestIdFromMdc\""));
+    }
+}

--- a/logging/thirdparty/src/main/java/io/quarkus/ts/logging/jboss/CdiJsonProvider.java
+++ b/logging/thirdparty/src/main/java/io/quarkus/ts/logging/jboss/CdiJsonProvider.java
@@ -1,0 +1,36 @@
+package io.quarkus.ts.logging.jboss;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.Level;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.logging.json.runtime.JsonFormatter.JsonLogGenerator;
+import io.quarkus.logging.json.runtime.JsonProvider;
+
+@ApplicationScoped
+@LookupIfProperty(name = "json-provider-test.enabled", stringValue = "true")
+public class CdiJsonProvider implements JsonProvider {
+    @Override
+    public void writeTo(JsonLogGenerator generator, ExtLogRecord record) throws Exception {
+        generator.add("customField", "customValue");
+        generator.add("loggerNameFromRecord", record.getLoggerName());
+
+        String requestId = record.getMdcCopy().get("requestId");
+        if (requestId != null) {
+            generator.add("requestIdFromMdc", requestId);
+        }
+
+        if (record.getLevel().intValue() >= Level.ERROR.intValue()) {
+            generator.add("isErrorRecord", "true");
+        }
+
+        generator.startObject("nestedObject")
+                .add("nestedField1", "nestedValue1")
+                .add("nestedField2", "nestedValue2")
+                .endObject();
+
+        generator.add("excludedField", "excludedValue");
+    }
+}

--- a/logging/thirdparty/src/main/java/io/quarkus/ts/logging/jboss/JsonProviderResource.java
+++ b/logging/thirdparty/src/main/java/io/quarkus/ts/logging/jboss/JsonProviderResource.java
@@ -1,0 +1,25 @@
+package io.quarkus.ts.logging.jboss;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.logging.Logger;
+import org.jboss.logging.MDC;
+
+@Path("/json-provider")
+public class JsonProviderResource {
+    private static final Logger LOG = Logger.getLogger("json-provider-category");
+
+    @GET
+    @Path("/info")
+    public void info() {
+        MDC.put("requestId", "request-123");
+        LOG.info("JSON Provider Info");
+    }
+
+    @GET
+    @Path("/error")
+    public void error() {
+        LOG.error("JSON Provider Error");
+    }
+}

--- a/logging/thirdparty/src/test/java/io/quarkus/ts/logging/jboss/JsonProviderSocketIT.java
+++ b/logging/thirdparty/src/test/java/io/quarkus/ts/logging/jboss/JsonProviderSocketIT.java
@@ -1,0 +1,59 @@
+package io.quarkus.ts.logging.jboss;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@Tag("QUARKUS-7866")
+@QuarkusScenario
+public class JsonProviderSocketIT {
+    @Container(image = "linuxserver/syslog-ng", port = 8514, expectedLog = ".*syslog-ng starting up")
+    static RestService receiver = new RestService()
+            .withProperty("LOG_TO_STDOUT", "true")
+            .withProperty("_ignored", "resource_with_destination::/config/|syslog-ng.conf");
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.log.socket.enabled", "true")
+            .withProperty("quarkus.log.socket.json.enabled", "true")
+            .withProperty("quarkus.log.socket.endpoint", () -> receiver.getURI().toString())
+            .withProperty("quarkus.log.socket.protocol", "tcp")
+            .withProperty("quarkus.log.socket.json.excluded-keys", "excludedField")
+            .withProperty("json-provider-test.enabled", "true");
+
+    @AfterEach
+    void restartServices() {
+        receiver.stop();
+        receiver.start();
+        app.stop();
+        app.start();
+    }
+
+    @Test
+    void shouldWriteFieldsToSocket() {
+        app.given().get("/json-provider/info");
+
+        receiver.logs().assertContains("\"message\":\"JSON Provider Info\"");
+        receiver.logs().assertContains("\"customField\":\"customValue\"");
+        receiver.logs().assertContains("\"loggerNameFromRecord\":\"json-provider-category\"");
+        receiver.logs().assertContains("\"requestIdFromMdc\":\"request-123\"");
+        receiver.logs()
+                .assertContains("\"nestedObject\":{\"nestedField1\":\"nestedValue1\",\"nestedField2\":\"nestedValue2\"}");
+        receiver.logs().assertDoesNotContain("\"excludedField\"");
+        receiver.logs().assertDoesNotContain("\"isErrorRecord\"");
+    }
+
+    @Test
+    void shouldWriteErrorFieldsToSocket() {
+        app.given().get("/json-provider/error");
+
+        receiver.logs().assertContains("\"message\":\"JSON Provider Error\"");
+        receiver.logs().assertContains("\"isErrorRecord\":\"true\"");
+        receiver.logs().assertDoesNotContain("\"requestIdFromMdc\"");
+    }
+}

--- a/logging/thirdparty/src/test/java/io/quarkus/ts/logging/jboss/JsonProviderSyslogIT.java
+++ b/logging/thirdparty/src/test/java/io/quarkus/ts/logging/jboss/JsonProviderSyslogIT.java
@@ -1,0 +1,58 @@
+package io.quarkus.ts.logging.jboss;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@Tag("QUARKUS-7866")
+@QuarkusScenario
+public class JsonProviderSyslogIT {
+    @Container(image = "linuxserver/syslog-ng", port = 8514, expectedLog = ".*syslog-ng starting up")
+    static RestService syslog = new RestService()
+            .withProperty("LOG_TO_STDOUT", "true")
+            .withProperty("_ignored", "resource_with_destination::/config/|syslog-ng.conf");
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.log.syslog.enabled", "true")
+            .withProperty("quarkus.log.syslog.json.enabled", "true")
+            .withProperty("quarkus.log.syslog.endpoint", () -> syslog.getURI().toString())
+            .withProperty("quarkus.log.syslog.protocol", "tcp")
+            .withProperty("quarkus.log.syslog.json.excluded-keys", "excludedField")
+            .withProperty("json-provider-test.enabled", "true");
+
+    @AfterEach
+    void restartServices() {
+        syslog.stop();
+        syslog.start();
+        app.stop();
+        app.start();
+    }
+
+    @Test
+    void shouldWriteFieldsToSyslog() {
+        app.given().get("/json-provider/info");
+
+        syslog.logs().assertContains("\"message\":\"JSON Provider Info\"");
+        syslog.logs().assertContains("\"customField\":\"customValue\"");
+        syslog.logs().assertContains("\"loggerNameFromRecord\":\"json-provider-category\"");
+        syslog.logs().assertContains("\"requestIdFromMdc\":\"request-123\"");
+        syslog.logs().assertContains("\"nestedObject\":{\"nestedField1\":\"nestedValue1\",\"nestedField2\":\"nestedValue2\"}");
+        syslog.logs().assertDoesNotContain("\"excludedField\"");
+        syslog.logs().assertDoesNotContain("\"isErrorRecord\"");
+    }
+
+    @Test
+    void shouldWriteErrorFieldsToSyslog() {
+        app.given().get("/json-provider/error");
+
+        syslog.logs().assertContains("\"message\":\"JSON Provider Error\"");
+        syslog.logs().assertContains("\"isErrorRecord\":\"true\"");
+        syslog.logs().assertDoesNotContain("\"requestIdFromMdc\"");
+    }
+}


### PR DESCRIPTION
### Summary
TP: https://github.com/quarkus-qe/quarkus-test-plans/pull/312
JIRA: https://redhat.atlassian.net/browse/QUARKUS-7866

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)