### PR TITLE
Update DumpLogSegment for Kafka as it was moved in Kafka 4.3.0

### DIFF
--- a/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/OpenShiftKafkaSnappyIT.java
+++ b/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/OpenShiftKafkaSnappyIT.java
@@ -23,7 +23,7 @@ import io.vertx.mutiny.core.buffer.Buffer;
 public class OpenShiftKafkaSnappyIT {
 
     private static final int TIMEOUT_SEC = 5;
-    private static final String FILTER_COMMAND_LOG_CONTAINER = "/bin/bash -c \"./bin/kafka-run-class.sh kafka.tools.DumpLogSegments --deep-iteration --print-data-log --files /tmp/kraft-combined-logs/test-0/00000000000000000000.log | head\"";
+    private static final String FILTER_COMMAND_LOG_CONTAINER = "/bin/bash -c \"./bin/kafka-run-class.sh org.apache.kafka.tools.DumpLogSegments --deep-iteration --print-data-log --files /tmp/kraft-combined-logs/test-0/00000000000000000000.log | head\"";
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI)
     static final KafkaService kafka = new KafkaService().withProperty("auto.create.topics.enable", "false");

--- a/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/SnappyCompressionIT.java
+++ b/messaging/kafka-producer/src/test/java/io/quarkus/ts/messaging/kafka/producer/SnappyCompressionIT.java
@@ -40,7 +40,7 @@ public class SnappyCompressionIT {
 
     private static final String BIG_JSON = "/big_json.json";
 
-    private static final String COMMAND_LOG_CONTAINER = "./bin/kafka-run-class.sh kafka.tools.DumpLogSegments --deep-iteration --print-data-log --files /tmp/default-log-dir/test-0/00000000000000000000.log | head";
+    private static final String COMMAND_LOG_CONTAINER = "./bin/kafka-run-class.sh org.apache.kafka.tools.DumpLogSegments --deep-iteration --print-data-log --files /tmp/default-log-dir/test-0/00000000000000000000.log | head";
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI)
     static final KafkaService kafka = new KafkaService().withProperty("auto.create.topics.enable", "false");


### PR DESCRIPTION
### Summary

The tests failing as they fail to dump info so there is no log to check. This happen in Kafka 4.3.0 see https://issues.apache.org/jira/browse/KAFKA-14579

Thu Kafka was updated to 4.3.0 as part of https://github.com/quarkus-qe/quarkus-test-framework/pull/1948

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)