### PR TITLE
Fix Windows-only flaky tests with Awaitility polling

### DIFF
--- a/cache/caffeine/src/test/java/io/quarkus/ts/cache/caffeine/cache/caffeine/UniFailureCacheIT.java
+++ b/cache/caffeine/src/test/java/io/quarkus/ts/cache/caffeine/cache/caffeine/UniFailureCacheIT.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -188,13 +189,16 @@ public class UniFailureCacheIT {
                 .then()
                 .statusCode(200);
 
-        // cache should now contain "A" and "C". The key "B" has been evicted.
-        given()
-                .when().get(RESOURCE_REACTIVE_FAILURE_API_PATH + "/cache-keys/" + cacheName)
-                .then()
-                .statusCode(200)
-                .body("$", hasSize(2))
-                .body("$", containsInAnyOrder("A", "C"));
+        // Caffeine eviction is asynchronous, so wait for it to complete
+        Awaitility.await()
+                .atMost(5, TimeUnit.SECONDS)
+                .pollInterval(200, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> given()
+                        .when().get(RESOURCE_REACTIVE_FAILURE_API_PATH + "/cache-keys/" + cacheName)
+                        .then()
+                        .statusCode(200)
+                        .body("$", hasSize(2))
+                        .body("$", containsInAnyOrder("A", "C")));
     }
 
     @Test

--- a/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/AccessLoggingIT.java
+++ b/logging/jboss/src/test/java/io/quarkus/ts/logging/jboss/AccessLoggingIT.java
@@ -9,9 +9,11 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -55,8 +57,12 @@ public class AccessLoggingIT {
         sendRequests(3);
 
         assertTrue(Files.exists(accessLogPath()), "There should be an access log file.");
-        // check that one request actually match one line in a log file
-        assertEquals(3, Files.lines(accessLogPath()).count(), "There should be 3 lines in access log.");
+        // Access log flushing can be delayed on Windows, so wait for all entries
+        Awaitility.await()
+                .atMost(5, TimeUnit.SECONDS)
+                .pollInterval(200, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> assertEquals(3, Files.lines(accessLogPath()).count(),
+                        "There should be 3 lines in access log."));
 
         assertEquals(1, getLogFileNames().size(), "There should be just one log file");
     }


### PR DESCRIPTION
## Summary

Fixes https://redhat.atlassian.net/browse/QQE-2819

- **`AccessLoggingIT.accessTest`**: Access log flushing is delayed on Windows — the third entry may not be written when the assertion runs immediately after sending requests. Replace direct `assertEquals` with `Awaitility.await()` polling.
- **`UniFailureCacheIT.testSizeBasedEviction`**: Caffeine cache eviction is asynchronous and may not complete immediately on slower/Windows runners. Replace direct assertion with `Awaitility.await()` polling until eviction completes.

Both tests pass consistently on Linux but fail intermittently on Windows due to timing differences in filesystem flushing and background thread scheduling.

## Test plan

- [x] `AccessLoggingIT.accessTest` passes on Windows JVM
- [x] `UniFailureCacheIT.testSizeBasedEviction` passes on Windows JVM
- [x] Both tests still pass on Linux JVM