### PR TITLE
Cover usage of @Cancelable on ContainerResponseFilters

### DIFF
--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/CancelIT.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/CancelIT.java
@@ -1,0 +1,63 @@
+package io.quarkus.ts.http.minimum.reactive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.HttpStatus;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.http.minimum.reactive.cancelling.SlowEndpoint;
+import io.restassured.response.Response;
+
+@QuarkusScenario
+public class CancelIT {
+    private static final int REQUEST_COUNT = 20;
+
+    @QuarkusApplication(classes = SlowEndpoint.class)
+    static RestService app = new RestService()
+            .withProperty("quarkus.rest.output-buffer-size", "1024");
+
+    @Test
+    @Tag("QUARKUS-8419")
+    public void httpServer() throws URISyntaxException, InterruptedException {
+        Response response = app.given().get("/api/slow");
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+        assertEquals("Heeelloooo", response.body().asString());
+
+        URI uri = new URI(app.getURI(Protocol.HTTP).withPath("/api/slow").toString());
+        HttpClient client = HttpClient.newHttpClient();
+        ArrayList<CompletableFuture<HttpResponse<String>>> futures = new ArrayList<>(REQUEST_COUNT);
+        HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
+        for (int i = 0; i < REQUEST_COUNT; i++) {
+            CompletableFuture<HttpResponse<String>> future = client.sendAsync(request,
+                    HttpResponse.BodyHandlers.ofString());
+            futures.add(future);
+        }
+
+        Thread.sleep(1000);
+
+        for (CompletableFuture<HttpResponse<String>> future : futures) {
+            future.cancel(true);
+        }
+
+        Awaitility.await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> {
+            Response count = app.given().get("/api/slow/count");
+            assertEquals(HttpStatus.SC_OK, count.statusCode());
+            assertEquals(String.valueOf(REQUEST_COUNT + 1), count.body().asString());
+        });
+    }
+}

--- a/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/cancelling/SlowEndpoint.java
+++ b/http/http-minimum-reactive/src/test/java/io/quarkus/ts/http/minimum/reactive/cancelling/SlowEndpoint.java
@@ -1,0 +1,47 @@
+package io.quarkus.ts.http.minimum.reactive.cancelling;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.server.Cancellable;
+
+@Path("slow/")
+public class SlowEndpoint {
+    private final static AtomicInteger counter = new AtomicInteger(0);
+
+    @GET
+    public String getSlowResponse() {
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return "Heeelloooo";
+    }
+
+    @GET
+    @Path("count")
+    public int getCount() {
+        return counter.get();
+    }
+
+    @Provider
+    @Cancellable(value = false)
+    public static class CountFilter implements ContainerResponseFilter {
+        public CountFilter() {
+        }
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+            if (requestContext.getUriInfo().getPath().endsWith("slow")) {
+                counter.incrementAndGet();
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary
Cover usage of @Cancelable on ContainerResponseFilters. Verifies, that https://github.com/quarkusio/quarkus/pull/54903 works as advertised

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)