### PR TITLE
Install Maven settings in test jobs to avoid Maven Central rate-limiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,8 @@ jobs:
           wait-before-restore: false
       - uses: ./.github/actions/prepare-quarkus-cli
       - uses: ./.github/actions/use-docker-mirror
+      - name: Install Maven settings
+        run: cp .github/mvn-settings.xml ~/.m2/settings.xml
       - name: Build with Maven
         run: |
           mvn -fae -V -B -nsu --no-transfer-progress clean verify -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" ${{ matrix.module-mvn-args }} -am
@@ -216,6 +218,8 @@ jobs:
           wait-before-restore: false
       - uses: ./.github/actions/prepare-quarkus-cli
       - uses: ./.github/actions/use-docker-mirror
+      - name: Install Maven settings
+        run: cp .github/mvn-settings.xml ~/.m2/settings.xml
       - name: Build with Maven
         run: |
           mvn -fae -V -B -nsu --no-transfer-progress \
@@ -270,6 +274,9 @@ jobs:
         with:
           wait-before-restore: false
       - uses: ./.github/actions/prepare-quarkus-cli-win
+      - name: Install Maven settings
+        shell: bash
+        run: cp .github/mvn-settings.xml ~/.m2/settings.xml
       - name: Build in JVM mode
         shell: bash
         run: |

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -93,6 +93,8 @@ jobs:
       - uses: ./.github/actions/cache-quarkus
       - uses: ./.github/actions/prepare-quarkus-cli
       - uses: ./.github/actions/use-docker-mirror
+      - name: Install Maven settings
+        run: cp .github/mvn-settings.xml ~/.m2/settings.xml
       - name: Test in JVM mode
         run: |
           mvn -fae -V -B -nsu --no-transfer-progress clean verify -P ${{ matrix.profiles }} -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
@@ -129,6 +131,8 @@ jobs:
       - uses: ./.github/actions/cache-quarkus
       - uses: ./.github/actions/prepare-quarkus-cli
       - uses: ./.github/actions/use-docker-mirror
+      - name: Install Maven settings
+        run: cp .github/mvn-settings.xml ~/.m2/settings.xml
       - name: Test in Native mode
         run: |
           mvn -fae -V -B -nsu --no-transfer-progress -P ${{ matrix.profiles }} clean verify -Dnative \
@@ -161,6 +165,9 @@ jobs:
           check-latest: true
       - uses: ./.github/actions/cache-quarkus
       - uses: ./.github/actions/prepare-quarkus-cli-win
+      - name: Install Maven settings
+        shell: bash
+        run: cp .github/mvn-settings.xml ~/.m2/settings.xml
       - name: Build in JVM mode
         shell: bash
         run: |
@@ -245,6 +252,8 @@ jobs:
           registry: registry.redhat.io
           username: ${{ secrets.RED_HAT_REGISTRY_USERNAME }}
           password: ${{ secrets.RED_HAT_REGISTRY_PASSWORD }}
+      - name: Install Maven settings
+        run: cp .github/mvn-settings.xml ~/.m2/settings.xml
       - name: Test in JVM mode
         run: |
           mvn -fae -V -B -nsu --no-transfer-progress clean verify -Daarch64 -P ${{ matrix.profiles }} -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
@@ -287,6 +296,8 @@ jobs:
           registry: registry.redhat.io
           username: ${{ secrets.RED_HAT_REGISTRY_USERNAME }}
           password: ${{ secrets.RED_HAT_REGISTRY_PASSWORD }}
+      - name: Install Maven settings
+        run: cp .github/mvn-settings.xml ~/.m2/settings.xml
       - name: Test in Native mode
         run: |
           mvn -fae -V -B -nsu --no-transfer-progress -P ${{ matrix.profiles }} clean verify -Daarch64 -Dnative \

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -210,11 +210,14 @@ jobs:
         # For details see https://github.com/actions/virtual-environments/issues/785
         uses: al-cheb/configure-pagefile-action@v1.5
       - uses: ./.github/actions/cache-quarkus
+      - name: Install Maven settings
+        shell: bash
+        run: cp .github/mvn-settings.xml ~/.m2/settings.xml
       - name: Build in Native mode
         shell: bash
         run: |
           # Running only http/http-minimum as after some time, it gives disk full in Windows when running on Native.
-          mvn -B -nsu --no-transfer-progress -fae -s .github/mvn-settings.xml clean verify -Dall-modules -Dnative -Dquarkus.native.container-build=false -pl http/http-minimum
+          mvn -B -nsu --no-transfer-progress -fae clean verify -Dall-modules -Dnative -Dquarkus.native.container-build=false -pl http/http-minimum
       - uses: ./.github/actions/zip-and-archive
         name: Zip and archive artifacts
         if: failure()


### PR DESCRIPTION
## Summary

Copy `.github/mvn-settings.xml` to `~/.m2/settings.xml` in each test job (Linux JVM, Linux Native, Windows JVM, AArch64 JVM, AArch64 Native) so that all Maven invocations — including `mvnw` spawned by the test framework inside generated apps — use the Google Maven Central mirror.

Currently, the settings file is only passed via `-s` to the main `mvn` command, but tests like `CliProdModeJvmIT` create Quarkus apps and run `mvnw build` on them. These spawned processes don't inherit the `-s` flag and hit `repo.maven.apache.org` directly, resulting in `429 Too Many Requests` errors.

Evidence:
- [Daily Build Aug 3 — AArch64 JVM 25 root-modules](https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/30961557841/job/92171950243): `CliProdModeJvmIT.extensionSetA` and `extensionSetB` failed with `Could not transfer artifact ... status code: 429, reason phrase: Too Many Requests`
- [Daily Build Aug 2 — Windows JVM 25](https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/30773081486/job/91567206565): AMQP, QPID, OpenTelemetry modules failed with `Connect to central.sonatype.com:443 failed: Connect timed out`

## Test plan

- [ ] `CliProdModeJvmIT` passes without 429 errors
- [ ] Daily build passes on all platforms