### PR TITLE
[3.33] Use MS SQL images which can start on our hardware

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
                                 <mysql.upstream.image>${mysql.upstream.image}</mysql.upstream.image>
                                 <mysql.84.image>${mysql.84.image}</mysql.84.image>
                                 <mariadb.11.image>docker.io/library/mariadb:11.8-ubi9</mariadb.11.image>
-                                <mssql.image>mcr.microsoft.com/mssql/rhel/server:2022-latest</mssql.image>
+                                <mssql.image>mcr.microsoft.com/mssql/rhel/server:2022-CU26-rhel-8.7</mssql.image>
                                 <!-- Oracle image - we aim to use same version as Dev Services for Oracle so that we only download one image -->
                                 <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
                                 <db2.image>icr.io/db2_community/db2:12.1.0.0</db2.image>

--- a/sql-db/narayana-transactions/src/test/resources/container-license-acceptance.txt
+++ b/sql-db/narayana-transactions/src/test/resources/container-license-acceptance.txt
@@ -2,4 +2,5 @@ mcr.microsoft.com/mssql/server:2017-CU12
 mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-latest
+mcr.microsoft.com/mssql/rhel/server:2022-CU26-rhel-8.7
 mcr.microsoft.com/mssql/rhel/server:2022-latest

--- a/sql-db/reactive-vanilla/src/main/resources/container-license-acceptance.txt
+++ b/sql-db/reactive-vanilla/src/main/resources/container-license-acceptance.txt
@@ -1,5 +1,5 @@
 mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-latest
-mcr.microsoft.com/mssql/rhel/server:2022-latest
+mcr.microsoft.com/mssql/rhel/server:2022-CU26-rhel-8.7
 mcr.microsoft.com/mssql/server:2022-latest

--- a/sql-db/sql-app-compatibility/src/test/resources/container-license-acceptance.txt
+++ b/sql-db/sql-app-compatibility/src/test/resources/container-license-acceptance.txt
@@ -2,4 +2,4 @@ mcr.microsoft.com/mssql/server:2017-CU12
 mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-latest
-mcr.microsoft.com/mssql/rhel/server:2022-latest
+mcr.microsoft.com/mssql/rhel/server:2022-CU26-rhel-8.7

--- a/sql-db/sql-app/src/test/resources/container-license-acceptance.txt
+++ b/sql-db/sql-app/src/test/resources/container-license-acceptance.txt
@@ -2,6 +2,6 @@ mcr.microsoft.com/mssql/server:2017-CU12
 mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04
 mcr.microsoft.com/mssql/server:2019-latest
-mcr.microsoft.com/mssql/rhel/server:2022-latest
+mcr.microsoft.com/mssql/rhel/server:2022-CU26-rhel-8.7
 mcr.microsoft.com/mssql/server:2022-latest
 mcr.microsoft.com/azure-sql-edge:latest


### PR DESCRIPTION
### Summary
Latest RHEL-9 based images fail with `Status 500: {"message":"openat etc/ssl/certs/mssql.crt: path escapes from parent"}` error
The full list can be found here: https://mcr.microsoft.com/artifact/mar/mssql/rhel/server/tags

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)