### PR TITLE
Switch quarkus-quickstarts tests from development branch to 3.x

### DIFF
--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/AoTQuickstartIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/AoTQuickstartIT.java
@@ -23,7 +23,7 @@ public class AoTQuickstartIT {
     public static final String QUICKSTART_DIRECTORY = "getting-started-reactive";
     public static final String AOT_PROPERTIES = "-Dquarkus.package.jar.appcds.enabled=true -Dquarkus.package.jar.appcds.use-aot=true";
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = QUICKSTART_DIRECTORY, branch = "development", mavenArgs = AOT_PROPERTIES
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = QUICKSTART_DIRECTORY, branch = "3.x", mavenArgs = AOT_PROPERTIES
             + " -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
     static final RestService app = new RestService()
             .withProperty("-Xlog", "aot")

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/QuickstartIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/QuickstartIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
 @QuarkusScenario
 public class QuickstartIT {
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}", branch = "development")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}", branch = "3.x")
     static final RestService app = new RestService();
 
     @Test


### PR DESCRIPTION
## Summary

Switch `QuickstartIT` and `AoTQuickstartIT` from `branch = "development"` to `branch = "3.x"` for the `quarkus-quickstarts` repository.

The `development` branch now targets Java 21, causing `QuickstartIT` to fail on JDK 17 runners with `error: invalid target release: 21`. The `3.x` branch matches the Quarkus version used in the test suite.

Evidence: [Daily Build Aug 5 — Linux JVM 17 root-modules](https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/31015554052/job/92350238947)

## Test plan

- [ ] `QuickstartIT` passes on JDK 17
- [ ] `AoTQuickstartIT` still works on JDK 25