### PR TITLE
[3.27] Disable QuarkusCliCreateExtensionIT on 3.27 

### DIFF
--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateExtensionIT.java
@@ -2,6 +2,8 @@ package io.quarkus.ts.quarkus.cli;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliDefaultService;
 import io.quarkus.test.bootstrap.QuarkusVersionAwareCliClient;
@@ -9,6 +11,7 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.TestQuarkusCli;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 
+@Disabled("quarkusio/quarkus#53531 not backported to 3.27 - annotationProcessorPathsUseDepMgmt missing in deployment template")
 @QuarkusScenario
 @DisabledOnNative(reason = "Only for JVM verification")
 public class QuarkusCliCreateExtensionIT {


### PR DESCRIPTION
### Summary

Disable QuarkusCliCreateExtensionIT on 3.27 
 Since only security fixes are backported to 3.27, the test is disabled on this branch.


Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)