### PR TITLE
[3.27] Create dedicated build-platform.sh for 3.27 stream

### DIFF
--- a/.github/build_platform.sh
+++ b/.github/build_platform.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -xeuo pipefail
+
+#QUARKUS_BUILD=999-SNAPSHOT
+#LANGCHAIN4J_BUILD=999-SNAPSHOT
+#MCP_BUILD=999-SNAPSHOT
+#PLATFORM_BUILD=999-core-main-SNAPSHOT
+
+# This output also allows us to fail early if any variable is unset
+echo "Building platform ${PLATFORM_BUILD} using Quarkus Core ${QUARKUS_BUILD}, Langchain4j ${LANGCHAIN4J_BUILD} and MCP server ${MCP_BUILD}"
+
+./mvnw versions:set -DnewVersion=${PLATFORM_BUILD}
+./mvnw versions:set-property -Dproperty=quarkus.version -DnewVersion=${QUARKUS_BUILD} -DgenerateBackupPoms=false
+./mvnw versions:set-property -Dproperty=quarkus-langchain4j.version -DnewVersion=${LANGCHAIN4J_BUILD} -DgenerateBackupPoms=false
+./mvnw versions:set-property -Dproperty=quarkus-mcp-server.version -DnewVersion=${MCP_BUILD} -DgenerateBackupPoms=false
+
+if [ ! $(which xsltproc) ]; then
+  echo "xsltproc is not installed!"
+  exit 1
+fi
+
+# mark everything as disabled
+xsltproc -o pom.xml minimise_platform.xsl pom.xml
+./mvnw -Dsync
+#same script but with standard bash
+#grep -A1 '<member>' pom.xml | grep name | grep -iv -e 'langchain4j' -e 'mcpserver' | xargs -I '{}' sed -i '\|{}|a <enabled>false<\/enabled>' pom.xml
+./mvnw clean -V install -DskipTests -DskipITs -Prelease -Dgpg.skip=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,9 @@ jobs:
           EOF
 
           cp $GITHUB_WORKSPACE/.github/minimise_platform.xsl .
-          wget -O build_platform.sh "https://github.com/quarkus-qe/quarkus-test-suite/raw/refs/heads/main/.github/build_platform.sh"
-          chmod u+x build_platform.sh
+          chmod u+x $GITHUB_WORKSPACE/.github/build_platform.sh
 
-          PLATFORM_BUILD=${{ env.PLATFORM_BUILD }} MCP_BUILD=${{ env.MCP_BUILD }} LANGCHAIN4J_BUILD=${{ env.LANGCHAIN4J_BUILD }} QUARKUS_BUILD=${{ env.QUARKUS_BUILD }} ./build_platform.sh
+          PLATFORM_BUILD=${{ env.PLATFORM_BUILD }} MCP_BUILD=${{ env.MCP_BUILD }} LANGCHAIN4J_BUILD=${{ env.LANGCHAIN4J_BUILD }} QUARKUS_BUILD=${{ env.QUARKUS_BUILD }} $GITHUB_WORKSPACE/.github/build_platform.sh
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository


### PR DESCRIPTION
### Summary

The https://github.com/quarkus-qe/quarkus-test-suite/pull/3116 add platform member and this member is not part of 3.27 so we won't be building it. This creating  `build_platform.sh` script for the 3.27 branch. It's the same as main before https://github.com/quarkus-qe/quarkus-test-suite/pull/3116


Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)