### PR TITLE
[3.33] Backport of QUARKUS-7957 (IllegalStateException: GlobalOpenTelemetry.set has already been called)

### DIFF
--- a/monitoring/opentelemetry/src/main/java/io/quarkus/ts/opentelemetry/TracerInitResource.java
+++ b/monitoring/opentelemetry/src/main/java/io/quarkus/ts/opentelemetry/TracerInitResource.java
@@ -1,0 +1,20 @@
+package io.quarkus.ts.opentelemetry;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.quarkus.arc.Arc;
+
+@Path("/tracer-init")
+public class TracerInitResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        Arc.container().instance(OpenTelemetry.class).get();
+        return "Hello from tracer-init";
+    }
+}

--- a/monitoring/opentelemetry/src/main/java/io/quarkus/ts/opentelemetry/beans/TracerInitBean.java
+++ b/monitoring/opentelemetry/src/main/java/io/quarkus/ts/opentelemetry/beans/TracerInitBean.java
@@ -1,0 +1,19 @@
+package io.quarkus.ts.opentelemetry.beans;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import io.opentelemetry.api.trace.Tracer;
+import io.quarkus.runtime.StartupEvent;
+
+@ApplicationScoped
+public class TracerInitBean {
+
+    @Inject
+    Tracer tracer;
+
+    void startup(@Observes StartupEvent event) {
+        tracer.spanBuilder("test").startSpan().end();
+    }
+}

--- a/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryTracerInitIT.java
+++ b/monitoring/opentelemetry/src/test/java/io/quarkus/ts/opentelemetry/OpenTelemetryTracerInitIT.java
@@ -1,0 +1,43 @@
+package io.quarkus.ts.opentelemetry;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.JaegerService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.JaegerContainer;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.opentelemetry.beans.TracerInitBean;
+
+@Tag("QUARKUS-7957")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@QuarkusScenario
+public class OpenTelemetryTracerInitIT {
+
+    @JaegerContainer(expectedLog = "\"Health Check state change\",\"status\":\"ready\"")
+    static final JaegerService jaeger = new JaegerService();
+
+    @QuarkusApplication(classes = { TracerInitResource.class, TracerInitBean.class })
+    static final RestService app = new RestService()
+            .withProperty("quarkus.otel.exporter.otlp.traces.endpoint", jaeger::getCollectorUrl)
+            .withProperty("quarkus.otel.sdk.disabled", "true")
+            .setAutoStart(false);
+
+    @Order(1)
+    @Test
+    public void testTracerInit() {
+        assertDoesNotThrow(app::start, "The app should start without any errors");
+    }
+
+    @Order(2)
+    @Test
+    public void testAppLogsTracerInit() {
+        app.logs().assertDoesNotContain("GlobalOpenTelemetry.set has already been called");
+    }
+}


### PR DESCRIPTION
### Summary

Backport of :
- https://github.com/quarkus-qe/quarkus-test-suite/pull/3114

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)