### PR TITLE
QUARKUS-7867 - Add test coverage for OIDC SPIFFE client authentication

### DIFF
--- a/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/spiffe/SpiffeTestResource.java
+++ b/security/keycloak-oidc-client-extended/src/main/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/spiffe/SpiffeTestResource.java
@@ -1,0 +1,73 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient.spiffe;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Base64;
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.runtime.StartupEvent;
+
+@Path("/spiffe-test")
+@ApplicationScoped
+public class SpiffeTestResource {
+
+    // This resource ships in the application that every IT in this module starts, but only the SPIFFE tests set
+    // this property, so it is genuinely absent elsewhere. It stays Optional because there is no valid non-empty
+    // default (an empty-string default is treated as "unset" by SmallRye and would fail startup for a plain String).
+    @ConfigProperty(name = "spiffe.test.token-path")
+    Optional<String> tokenPath;
+
+    @ConfigProperty(name = "spiffe.test.jwks", defaultValue = "{\"keys\":[]}")
+    String jwks;
+
+    void onStartup(@Observes StartupEvent event) {
+        if (tokenPath.isPresent() && !tokenPath.get().isEmpty()) {
+            try {
+                long exp = System.currentTimeMillis() / 1000 - 1;
+                String header = Base64.getUrlEncoder().withoutPadding()
+                        .encodeToString("{\"alg\":\"none\"}".getBytes(StandardCharsets.UTF_8));
+                String payload = Base64.getUrlEncoder().withoutPadding()
+                        .encodeToString("{\"sub\":\"spiffe://example.org/workload\",\"exp\":%d}".formatted(exp)
+                                .getBytes(StandardCharsets.UTF_8));
+                Files.writeString(java.nio.file.Path.of(tokenPath.get()), header + "." + payload + ".dummy");
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to create initial SPIFFE token file", e);
+            }
+        }
+    }
+
+    @POST
+    @Path("/token")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Response updateToken(String content) {
+        if (tokenPath.isEmpty()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity("SPIFFE not configured").build();
+        }
+        try {
+            Files.writeString(java.nio.file.Path.of(tokenPath.get()), content);
+            return Response.ok().build();
+        } catch (IOException e) {
+            return Response.serverError().entity(e.getMessage()).build();
+        }
+    }
+
+    @GET
+    @Path("/bundle")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String getBundle() {
+        return jwks;
+    }
+}

--- a/security/keycloak-oidc-client-extended/src/main/resources/application.properties
+++ b/security/keycloak-oidc-client-extended/src/main/resources/application.properties
@@ -7,7 +7,7 @@ quarkus.oidc.client-id=test-application-client
 quarkus.oidc.credentials.secret=test-application-client-secret
 
 quarkus.http.auth.basic=false
-quarkus.http.auth.permission.unsecured.paths=/generate-token/*,/q/*,/token-refresh-public/*,/token-echo/*,/method-public/*,/method-secured/*
+quarkus.http.auth.permission.unsecured.paths=/generate-token/*,/q/*,/token-refresh-public/*,/token-echo/*,/method-public/*,/method-secured/*,/spiffe-test/*
 quarkus.http.auth.permission.unsecured.policy=permit
 
 quarkus.http.auth.permission.authenticated.paths=/*

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractSpiffeClientAuthIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/AbstractSpiffeClientAuthIT.java
@@ -1,0 +1,283 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient;
+
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.restassured.RestAssured.given;
+
+import java.io.File;
+import java.math.BigInteger;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyFactory;
+import java.security.Signature;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.LookupService;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.annotations.DisabledOnFips;
+import io.quarkus.test.services.QuarkusApplication;
+import io.smallrye.jwt.build.Jwt;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisabledOnFips(reason = "Test uses pre-generated certificate and private key.")
+@Tag("QUARKUS-7867")
+abstract public class AbstractSpiffeClientAuthIT {
+
+    static final String SPIFFE_CLIENT_ID = "spiffe-application-client";
+    static final String CLIENT_ID_SECRET = "test-application-client";
+    static final String CLIENT_SECRET = "test-application-client-secret";
+    static final String USER_USERNAME = "test-user";
+    static final String USER_PASSWORD = "test-user";
+    static final String PRIVATE_KEY_FILE = "key.pem";
+    static final String SPIFFE_ID = "spiffe://example.org/workload";
+    static final String SPIFFE_TRUST_DOMAIN = "spiffe://example.org";
+    static final String SPIFFE_IDP_ALIAS = "spiffe-idp";
+    static final String SPIFFE_TOKEN_PATH = System.getProperty("java.io.tmpdir") + File.separator + "spiffe-test-token";
+    static final int SHORT_TOKEN_EXPIRY_SEC = 3;
+
+    static RSAPrivateCrtKey privateKey;
+
+    @BeforeAll
+    public static void loadPrivateKey() throws Exception {
+        privateKey = readPKCS8PrivateKey(
+                new File(AbstractSpiffeClientAuthIT.class.getClassLoader().getResource(PRIVATE_KEY_FILE).getFile())
+                        .toPath());
+    }
+
+    @LookupService
+    static KeycloakService keycloak;
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperties(() -> keycloak.getTlsProperties())
+            .withProperty("quarkus.oidc.client-id", SPIFFE_CLIENT_ID)
+            .withProperty("quarkus.oidc.credentials.secret", "")
+            .withProperty("quarkus.oidc.token.require-jwt-introspection-only", "true")
+            .withProperty("quarkus.oidc.credentials.jwt.source", "spiffe-jwt")
+            .withProperty("quarkus.oidc.credentials.jwt.token-path", SPIFFE_TOKEN_PATH)
+            .withProperty("quarkus.oidc-client.client-id", SPIFFE_CLIENT_ID)
+            .withProperty("quarkus.oidc-client.credentials.secret", "")
+            .withProperty("quarkus.oidc-client.credentials.jwt.source", "spiffe-jwt")
+            .withProperty("quarkus.oidc-client.credentials.jwt.token-path", SPIFFE_TOKEN_PATH)
+            .withProperty("quarkus.oidc-client.early-tokens-acquisition", "false")
+            .withProperty("spiffe.test.token-path", SPIFFE_TOKEN_PATH)
+            .withProperty("spiffe.test.jwks", AbstractSpiffeClientAuthIT::computeJwks);
+
+    @Test
+    @Order(1)
+    public void invalidSubClaimTest() throws Exception {
+        String token = createJwtWithSub("not-a-spiffe-id", Duration.ofMinutes(5));
+        updateTokenFile(token);
+
+        given().auth().oauth2(createUserToken())
+                .get("/secured/getClaimsFromToken")
+                .then().statusCode(HttpStatus.SC_UNAUTHORIZED);
+
+        app.logs().assertContains(
+                "SPIFFE JWT-SVID token 'sub' claim is missing or does not start with 'spiffe://'");
+    }
+
+    @Test
+    @Order(2)
+    public void missingExpirationTest() throws Exception {
+        String token = createJwtWithoutExp();
+        updateTokenFile(token);
+
+        given().auth().oauth2(createUserToken())
+                .get("/secured/getClaimsFromToken")
+                .then().statusCode(HttpStatus.SC_UNAUTHORIZED);
+
+        app.logs().assertContains("SPIFFE JWT-SVID token or its expiry claim is invalid");
+    }
+
+    @Test
+    @Order(3)
+    public void missingAudienceTest() throws Exception {
+        String token = Jwt.subject(SPIFFE_ID)
+                .expiresIn(Duration.ofSeconds(SHORT_TOKEN_EXPIRY_SEC))
+                .sign(privateKey);
+        updateTokenFile(token);
+
+        given().auth().oauth2(createUserToken())
+                .get("/secured/getClaimsFromToken")
+                .then().statusCode(HttpStatus.SC_UNAUTHORIZED);
+
+        // wait for the short-lived token to expire so the OIDC client discards it before the next test
+        Thread.sleep((SHORT_TOKEN_EXPIRY_SEC + 1) * 1000L);
+    }
+
+    @Test
+    @Order(4)
+    public void tokenRefreshTest() throws Exception {
+        String expiredToken = Jwt.subject(SPIFFE_ID)
+                .audience(keycloak.getRealmUrl())
+                .expiresAt(System.currentTimeMillis() / 1000 - 60)
+                .sign(privateKey);
+        updateTokenFile(expiredToken);
+
+        given().auth().oauth2(createUserToken())
+                .get("/secured/getClaimsFromToken")
+                .then().statusCode(HttpStatus.SC_UNAUTHORIZED);
+
+        String validToken = createSpiffeJwt(Duration.ofMinutes(5));
+        updateTokenFile(validToken);
+
+        given().auth().oauth2(createUserToken())
+                .get("/secured/getClaimsFromToken")
+                .then().statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    @Order(5)
+    public void clientCredentialsGrantTest() throws Exception {
+        updateTokenFile(createSpiffeJwt(Duration.ofMinutes(5)));
+
+        given()
+                .get("/generate-token/client-credentials")
+                .then().statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    @Order(6)
+    public void codeFlowAuthTest() throws Exception {
+        given().auth().oauth2(createUserToken())
+                .get("/secured/getClaimsFromToken")
+                .then().statusCode(HttpStatus.SC_OK);
+    }
+
+    protected static void createSpiffeIdentityProvider(String bundleEndpointUrl) {
+        // getRealmUrl() strips the standard port (80/443), so it cannot be used to reach the admin API: rest-assured
+        // would fall back to the globally-configured application port. The Keycloak service URI keeps the real port,
+        // so the absolute admin URLs below carry an explicit port and are routed correctly.
+        var keycloakUri = keycloak.getURI(keycloak.getRealmUrl().startsWith("https") ? Protocol.HTTPS : Protocol.HTTP);
+        String keycloakBaseUrl = keycloakUri.getScheme() + "://" + keycloakUri.getHost() + ":" + keycloakUri.getPort();
+        String adminTokenEndpoint = keycloakBaseUrl + "/realms/master/protocol/openid-connect/token";
+        String idpEndpoint = keycloakBaseUrl + "/admin/realms/" + DEFAULT_REALM + "/identity-provider/instances";
+
+        String adminToken = given()
+                .relaxedHTTPSValidation()
+                .param("grant_type", "password")
+                .param("client_id", "admin-cli")
+                .param("username", "admin")
+                .param("password", "admin")
+                .post(adminTokenEndpoint)
+                .jsonPath().getString("access_token");
+
+        String idpBody = """
+                {
+                  "alias": "%s",
+                  "providerId": "spiffe",
+                  "enabled": true,
+                  "config": {
+                    "trustDomain": "%s",
+                    "bundleEndpoint": "%s"
+                  }
+                }
+                """.formatted(SPIFFE_IDP_ALIAS, SPIFFE_TRUST_DOMAIN, bundleEndpointUrl);
+
+        given()
+                .relaxedHTTPSValidation()
+                .header("Authorization", "Bearer " + adminToken)
+                .header("Content-Type", "application/json")
+                .body(idpBody)
+                .post(idpEndpoint)
+                .then().statusCode(HttpStatus.SC_CREATED);
+    }
+
+    private void updateTokenFile(String content) {
+        given().header("Content-Type", "text/plain")
+                .body(content)
+                .post("/spiffe-test/token")
+                .then().statusCode(HttpStatus.SC_OK);
+    }
+
+    private String createSpiffeJwt(Duration expiresIn) throws Exception {
+        return Jwt.subject(SPIFFE_ID)
+                .audience(keycloak.getRealmUrl())
+                .expiresIn(expiresIn)
+                .sign(privateKey);
+    }
+
+    private String createJwtWithSub(String sub, Duration expiresIn) throws Exception {
+        return Jwt.subject(sub)
+                .audience(keycloak.getRealmUrl())
+                .expiresIn(expiresIn)
+                .sign(privateKey);
+    }
+
+    private String createJwtWithoutExp() throws Exception {
+        long iat = System.currentTimeMillis() / 1000;
+        String headerStr = "{\"alg\":\"RS256\",\"typ\":\"JWT\"}";
+        String payloadStr = "{\"sub\":\"%s\",\"aud\":\"%s\",\"iat\":%d}".formatted(SPIFFE_ID, keycloak.getRealmUrl(), iat);
+
+        String header = Base64.encodeBase64URLSafeString(headerStr.getBytes(StandardCharsets.UTF_8));
+        String payload = Base64.encodeBase64URLSafeString(payloadStr.getBytes(StandardCharsets.UTF_8));
+        String signingInput = header + "." + payload;
+
+        Signature sig = Signature.getInstance("SHA256withRSA");
+        sig.initSign(privateKey);
+        sig.update(signingInput.getBytes(StandardCharsets.UTF_8));
+        String signature = Base64.encodeBase64URLSafeString(sig.sign());
+
+        return signingInput + "." + signature;
+    }
+
+    private String createUserToken() {
+        return keycloak.createAuthzClient(CLIENT_ID_SECRET, CLIENT_SECRET)
+                .obtainAccessToken(USER_USERNAME, USER_PASSWORD).getToken();
+    }
+
+    static RSAPrivateCrtKey readPKCS8PrivateKey(Path file) throws Exception {
+        String key = Files.readString(file, Charset.defaultCharset());
+
+        String privateKeyPEM = key
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replaceAll(System.lineSeparator(), "")
+                .replace("-----END PRIVATE KEY-----", "");
+
+        byte[] encoded = Base64.decodeBase64(privateKeyPEM);
+
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encoded);
+        return (RSAPrivateCrtKey) keyFactory.generatePrivate(keySpec);
+    }
+
+    static String computeJwks() {
+        try {
+            RSAPrivateCrtKey key = readPKCS8PrivateKey(
+                    new File(AbstractSpiffeClientAuthIT.class.getClassLoader()
+                            .getResource(PRIVATE_KEY_FILE).getFile()).toPath());
+            String n = Base64.encodeBase64URLSafeString(stripLeadingZero(key.getModulus()));
+            String e = Base64.encodeBase64URLSafeString(stripLeadingZero(key.getPublicExponent()));
+            return "{\"keys\":[{\"kty\":\"RSA\",\"use\":\"sig\",\"n\":\"%s\",\"e\":\"%s\"}]}".formatted(n, e);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to compute JWKS", e);
+        }
+    }
+
+    // Strips the leading 0x00 sign byte that BigInteger.toByteArray() adds for positive values with MSB set
+    static byte[] stripLeadingZero(BigInteger value) {
+        byte[] bytes = value.toByteArray();
+        if (bytes[0] == 0) {
+            byte[] tmp = new byte[bytes.length - 1];
+            System.arraycopy(bytes, 1, tmp, 0, tmp.length);
+            return tmp;
+        }
+        return bytes;
+    }
+}

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftSpiffeClientAuthIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/OpenShiftSpiffeClientAuthIT.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient;
+
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
+import org.junit.jupiter.api.BeforeAll;
+
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.KeycloakContainer;
+
+@OpenShiftScenario
+public class OpenShiftSpiffeClientAuthIT extends AbstractSpiffeClientAuthIT {
+
+    @KeycloakContainer(runKeycloakInProdMode = true, image = "${rhbk.image}", command = { "start", "--import-realm",
+            "--hostname-strict=false", "--features=client-auth-federated,spiffe" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+
+    @BeforeAll
+    public static void setup() {
+        var uri = app.getURI(Protocol.HTTP);
+        String bundleUrl = "http://" + uri.getHost() + ":" + uri.getPort() + "/spiffe-test/bundle";
+        createSpiffeIdentityProvider(bundleUrl);
+    }
+}

--- a/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/SpiffeClientAuthIT.java
+++ b/security/keycloak-oidc-client-extended/src/test/java/io/quarkus/ts/security/keycloak/oidcclient/extended/restclient/SpiffeClientAuthIT.java
@@ -1,0 +1,57 @@
+package io.quarkus.ts.security.keycloak.oidcclient.extended.restclient;
+
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_BASE_PATH;
+import static io.quarkus.test.bootstrap.KeycloakService.DEFAULT_REALM_FILE;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.BeforeAll;
+
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KeycloakContainer;
+
+@QuarkusScenario
+public class SpiffeClientAuthIT extends AbstractSpiffeClientAuthIT {
+
+    private static final Logger LOG = Logger.getLogger(SpiffeClientAuthIT.class);
+
+    @KeycloakContainer(runKeycloakInProdMode = true, command = { "start", "--import-realm",
+            "--hostname-strict=false", "--features=client-auth-federated,spiffe" })
+    static KeycloakService keycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM, DEFAULT_REALM_BASE_PATH);
+
+    @BeforeAll
+    public static void setup() {
+        int appPort = app.getURI(Protocol.HTTP).getPort();
+        String bundleUrl = "http://" + getContainerHostIp() + ":" + appPort + "/spiffe-test/bundle";
+        createSpiffeIdentityProvider(bundleUrl);
+    }
+
+    static String getContainerHostIp() {
+        for (String bridge : new String[] { "docker0", "podman0" }) {
+            try {
+                NetworkInterface iface = NetworkInterface.getByName(bridge);
+                if (iface != null) {
+                    var addresses = iface.getInetAddresses();
+                    while (addresses.hasMoreElements()) {
+                        InetAddress addr = addresses.nextElement();
+                        if (addr instanceof Inet4Address) {
+                            return addr.getHostAddress();
+                        }
+                    }
+                }
+            } catch (SocketException e) {
+                // This bridge is not queryable on this host; log it and try the next candidate before
+                // falling back to host.docker.internal.
+                LOG.debugf(e, "Could not inspect network interface '%s' while resolving the container host IP", bridge);
+            }
+        }
+        return "host.docker.internal";
+    }
+}

--- a/security/keycloak-oidc-client-extended/src/test/resources/test-realm-realm.json
+++ b/security/keycloak-oidc-client-extended/src/test/resources/test-realm-realm.json
@@ -80,6 +80,19 @@
             "access.token.claim": "true",
             "introspection.token.claim": "true"
           }
+        },
+        {
+          "name": "spiffe-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "spiffe-application-client",
+            "id.token.claim": "false",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
         }
       ],
       "redirectUris": [
@@ -139,6 +152,65 @@
           "consentRequired": false,
           "config": {
             "included.client.audience": "token-application-client",
+            "id.token.claim": "false",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ],
+      "redirectUris": [
+        "*"
+      ]
+    },
+    {
+      "clientId": "spiffe-application-client",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "clientAuthenticatorType": "federated-jwt",
+      "attributes": {
+        "jwt.credential.issuer": "spiffe-idp",
+        "jwt.credential.sub": "spiffe://example.org/workload"
+      },
+      "protocolMappers": [
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "spiffe-application-client",
             "id.token.claim": "false",
             "lightweight.claim": "false",
             "access.token.claim": "true",


### PR DESCRIPTION
JIRA: https://redhat.atlassian.net/browse/QUARKUS-7867
Upstream PR: quarkusio/quarkus#53773
Test plan: quarkus-qe/quarkus-test-plans#319

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow the best practices