### PR TITLE
Switch main branch from Quarkus 3.x to 3.39 as 3.x was deleted

### DIFF
--- a/.github/actions/prepare-quarkus-cli-win/action.yml
+++ b/.github/actions/prepare-quarkus-cli-win/action.yml
@@ -1,5 +1,5 @@
-name: 'Create Quarkus CLI 3.999-SNAPSHOT'
-description: 'Creates Quarkus CLI based on the current Quarkus main (3.999-SNAPSHOT version)'
+name: 'Create Quarkus CLI 3.39.999-SNAPSHOT'
+description: 'Creates Quarkus CLI based on the current Quarkus main (3.39.999-SNAPSHOT version)'
 runs:
   using: "composite"
   steps:
@@ -8,7 +8,7 @@ runs:
       run: |
         $quarkusCliFileContent = @"
         @ECHO OFF
-        java -jar %HOMEDRIVE%%HOMEPATH%\.m2\repository\io\quarkus\quarkus-cli\3.999-SNAPSHOT\quarkus-cli-3.999-SNAPSHOT-runner.jar %*
+        java -jar %HOMEDRIVE%%HOMEPATH%\.m2\repository\io\quarkus\quarkus-cli\3.39.999-SNAPSHOT\quarkus-cli-3.39.999-SNAPSHOT-runner.jar %*
         "@
         New-Item -Path "$(pwd)\quarkus-dev-cli.bat" -ItemType File
         Set-Content -Path "$(pwd)\quarkus-dev-cli.bat" -Value $quarkusCliFileContent

--- a/.github/actions/prepare-quarkus-cli/action.yml
+++ b/.github/actions/prepare-quarkus-cli/action.yml
@@ -1,5 +1,5 @@
-name: 'Create Quarkus CLI 3.999-SNAPSHOT'
-description: 'Creates Quarkus CLI based on the current Quarkus main (3.999-SNAPSHOT version)'
+name: 'Create Quarkus CLI 3.39.999-SNAPSHOT'
+description: 'Creates Quarkus CLI based on the current Quarkus main (3.39.999-SNAPSHOT version)'
 runs:
   using: "composite"
   steps:
@@ -8,7 +8,7 @@ runs:
       run: |
         cat <<EOF > ./quarkus-dev-cli
         #!/bin/bash
-        java -jar ~/.m2/repository/io/quarkus/quarkus-cli/3.999-SNAPSHOT/quarkus-cli-3.999-SNAPSHOT-runner.jar "\$@"
+        java -jar ~/.m2/repository/io/quarkus/quarkus-cli/3.39.999-SNAPSHOT/quarkus-cli-3.39.999-SNAPSHOT-runner.jar "\$@"
         EOF
         chmod +x ./quarkus-dev-cli
         ./quarkus-dev-cli version

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 23 * * *'
 env:
-  QUARKUS_BUILD: 3.999-SNAPSHOT
+  QUARKUS_BUILD: 3.39.999-SNAPSHOT
 jobs:
   build-quarkus:
     name: Build Quarkus
@@ -33,7 +33,7 @@ jobs:
           echo "MVN_SETTINGS=$GITHUB_WORKSPACE/.github/mvn-settings.xml" >> $GITHUB_ENV
       - name: Build Quarkus ${{ env.QUARKUS_BUILD }}
         run: |
-          git clone -b 3.x https://github.com/quarkusio/quarkus.git && cd quarkus
+          git clone -b 3.39 https://github.com/quarkusio/quarkus.git && cd quarkus
           ./mvnw -B --no-transfer-progress -s ${{ env.MVN_SETTINGS }} clean install -Dquickly -Dno-test-modules -Prelocations -Dmaven.repo.local=${{ env.LOCAL_REPO }}
       - name: Build Quarkus Langchain4j 999-SNAPSHOT
         run: |
@@ -52,7 +52,7 @@ jobs:
         run: |
           git clone https://github.com/quarkiverse/quarkus-http-problem.git && cd quarkus-http-problem
           ./mvnw -B --no-transfer-progress -s ${{ env.MVN_SETTINGS }} clean install -DskipTests -Dquarkus.version=${QUARKUS_BUILD} -Dmaven.repo.local=${{ env.LOCAL_REPO }}
-      - name: Build Quarkus Platform main with Quarkus core ${{ env.QUARKUS_BUILD }} (version 999-core-3.x-SNAPSHOT)
+      - name: Build Quarkus Platform main with Quarkus core ${{ env.QUARKUS_BUILD }} (version 999-core-3.39-SNAPSHOT)
         run: |
           git clone https://github.com/quarkusio/quarkus-platform.git && cd quarkus-platform
 
@@ -65,7 +65,7 @@ jobs:
           EOF
           cp $GITHUB_WORKSPACE/.github/minimise_platform.xsl .
           chmod u+x $GITHUB_WORKSPACE/.github/build_platform.sh
-          PLATFORM_BUILD=999-core-3.x-SNAPSHOT MCP_BUILD=999-SNAPSHOT LANGCHAIN4J_BUILD=999-SNAPSHOT HTTP_PROBLEM_BUILD=999-SNAPSHOT QUARKUS_BUILD=${QUARKUS_BUILD} $GITHUB_WORKSPACE/.github/build_platform.sh
+          PLATFORM_BUILD=999-core-3.39-SNAPSHOT MCP_BUILD=999-SNAPSHOT LANGCHAIN4J_BUILD=999-SNAPSHOT HTTP_PROBLEM_BUILD=999-SNAPSHOT QUARKUS_BUILD=${QUARKUS_BUILD} $GITHUB_WORKSPACE/.github/build_platform.sh
       - name: Cache Build Outputs
         uses: actions/cache/save@v6
         with:

--- a/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/utils/AnalyticsUtils.java
+++ b/build-time-analytics/src/test/java/io/quarkus/ts/buildtimeanalytics/utils/AnalyticsUtils.java
@@ -7,8 +7,8 @@ import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 public class AnalyticsUtils {
     private static final String QUARKUS_SNAPSHOT_SUFFIX = "-SNAPSHOT";
-    // occasionally, in daily runs we got extensions with versions like 3.999-20260723.132749-19
-    private static final String QUARKUS_EXTENSION_SNAPSHOT_VERSION_REGEX = "3\\.999-.*";
+    // occasionally, in daily runs we got extensions with versions like 3.39.999-20260723.132749-19
+    private static final String QUARKUS_EXTENSION_SNAPSHOT_VERSION_REGEX = "3\\.39\\.999-.*";
     // RHBQ artifacts may differ in the number suffix from a platform version.
     // E.g.: 3.8.0.redhat-00002 vs. 3.8.5.redhat-00003
     private static final String RHBQ_VERSION_REGEX_FORMAT = "%s\\.redhat-\\d{5}";

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/AoTQuickstartIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/AoTQuickstartIT.java
@@ -23,7 +23,7 @@ public class AoTQuickstartIT {
     public static final String QUICKSTART_DIRECTORY = "getting-started-reactive";
     public static final String AOT_PROPERTIES = "-Dquarkus.package.jar.appcds.enabled=true -Dquarkus.package.jar.appcds.use-aot=true";
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = QUICKSTART_DIRECTORY, branch = "3.x", mavenArgs = AOT_PROPERTIES
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = QUICKSTART_DIRECTORY, branch = "3.39", mavenArgs = AOT_PROPERTIES
             + " -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
     static final RestService app = new RestService()
             .withProperty("-Xlog", "aot")

--- a/external-applications/src/test/java/io/quarkus/ts/external/applications/QuickstartIT.java
+++ b/external-applications/src/test/java/io/quarkus/ts/external/applications/QuickstartIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
 @QuarkusScenario
 public class QuickstartIT {
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}", branch = "3.x")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}", branch = "3.39")
     static final RestService app = new RestService();
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <failsafe-plugin.version>3.5.6</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>999-core-3.x-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>999-core-3.39-SNAPSHOT</quarkus.platform.version>
         <quarkus.ide.version>3.30.0</quarkus.ide.version>
         <quarkus.qe.framework.version>999-SNAPSHOT</quarkus.qe.framework.version>
         <quarkus-qpid-jms.version>2.12.0</quarkus-qpid-jms.version>
@@ -443,7 +443,7 @@
             <id>core-only</id>
             <properties>
                 <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-                <quarkus.platform.version>3.999-SNAPSHOT</quarkus.platform.version>
+                <quarkus.platform.version>3.39.999-SNAPSHOT</quarkus.platform.version>
                 <repository.update.policy>never</repository.update.policy>
             </properties>
         </profile>

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java
@@ -156,11 +156,11 @@ public class QuarkusCliCreateJvmApplicationIT {
 
     private static void useQuarkusSnapshotFromSonatypeIfNeeded(QuarkusCliRestService app, String quarkusVersion) {
         // must match only the 'main' branch snapshot, not 999-SNAPSHOT in other branches as they are not published
-        boolean is999Snapshot = "3.999-SNAPSHOT".equals(quarkusVersion);
+        boolean is999Snapshot = "3.39.999-SNAPSHOT".equals(quarkusVersion);
         var localRepository = System.getProperty("localRepository");
         if (is999Snapshot && localRepository != null) {
             if (!doesQuarkusSnapshotExistInLocalRepo(localRepository)) { // not adding external repository when not needed
-                Log.info("Configuring Sonatype Maven Snapshots repository to make Quarkus 3.999-SNAPSHOT available");
+                Log.info("Configuring Sonatype Maven Snapshots repository to make Quarkus 3.39.999-SNAPSHOT available");
                 configureGradleSnapshotRepository(app, "build.gradle"); // Maven repository
                 configureGradleSnapshotRepository(app, "settings.gradle"); // plugin Maven repository
             }
@@ -174,8 +174,8 @@ public class QuarkusCliCreateJvmApplicationIT {
                 .resolve("io")
                 .resolve("quarkus")
                 .resolve("io.quarkus.gradle.plugin")
-                .resolve("3.999-SNAPSHOT")
-                .resolve("io.quarkus.gradle.plugin-3.999-SNAPSHOT.jar"));
+                .resolve("3.39.999-SNAPSHOT")
+                .resolve("io.quarkus.gradle.plugin-3.39.999-SNAPSHOT.jar"));
     }
 
     private void runGradleDaemon(QuarkusCliRestService app) {
@@ -260,7 +260,7 @@ public class QuarkusCliCreateJvmApplicationIT {
         // otherwise when the quarkus version is defined (3.27.0) or if it's snapshot of some quarkus stream (3.27.999-SNAPSHOT)
         // it will set the correct stream to use
         String version = Version.getVersion(); // We are interested in core version only
-        String quarkusStream = version.equals("3.999-SNAPSHOT") ? null
+        String quarkusStream = version.equals("3.39.999-SNAPSHOT") ? null
                 : version.replaceAll("^(\\d+\\.\\d+).*", "$1");
         // This can't use `--platform-bom` as it contain quarkiverse extension
         QuarkusCliRestService app = cliClient.createApplication("app",

--- a/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
+++ b/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliExtensionsIT.java
@@ -93,7 +93,7 @@ public class QuarkusCliExtensionsIT {
         assertListDefaultOptionOutput();
     }
 
-    @DisabledOnQuarkusSnapshot(reason = "3.999-SNAPSHOT is not pushed into the platform site")
+    @DisabledOnQuarkusSnapshot(reason = "3.39.999-SNAPSHOT is not pushed into the platform site")
     @Test
     public void shouldListExtensionsUsingStream() {
         var req = ListExtensionRequest.withSetStream();


### PR DESCRIPTION
### Summary

Same as https://github.com/quarkus-qe/quarkus-test-framework/pull/1964. It will need new FW snapshot before this. The failure is expected as we need it to build and cache it first. After the merge I'll run the daily to compare it with older one

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [x] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)