### PR TITLE
Disable BasicMCPIT.roots pending MCP roots API clarification (#3130)

### DIFF
--- a/ai/mcp/src/test/java/io/quarkus/ts/mcp/BasicMCPIT.java
+++ b/ai/mcp/src/test/java/io/quarkus/ts/mcp/BasicMCPIT.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -114,6 +115,7 @@ public abstract class BasicMCPIT {
     }
 
     @Test
+    @Disabled("https://github.com/quarkus-qe/quarkus-test-suite/issues/3130")
     public void roots() {
         Response before = client().given().get("/mcp/roots");
         Assertions.assertEquals(200, before.statusCode());


### PR DESCRIPTION
## Summary

Disables `ai/mcp` `BasicMCPIT.roots()` because it is broken by an MCP protocol behavior change (MCP protocol `2026-07-28` and later), which the Daily Build now pulls in via the platform BOM.

Two independent changes break the test:

1. **Before any root is configured**, the langchain4j MCP client no longer advertises the `roots` capability, so the server-side `rootchecker` tool returns `"Roots not supported"` instead of `"No roots found"` (fails at line 120).
2. **`McpClient.setRoots()` is no longer supported** — it now throws:
   ```
   java.lang.UnsupportedOperationException: setRoots is not supported with MCP protocol 2026-07-28 or later
       at dev.langchain4j.mcp.client.DefaultMcpClient.setRoots(DefaultMcpClient.java:946)
   ```
   so `POST /mcp/roots` returns HTTP 500 and the test fails at line 125 with `expected: <204> but was: <500>`.

Because the client API the test relied on to configure roots is gone, the test cannot simply have its string expectations adjusted — the correct new expectation (and how roots should be configured under the new protocol) is unknown. This PR disables the test pending clarification in #3130 to unblock the Daily Build, following the repo's `@Disabled("<issue-url>")` convention.

## Context

This started as a simple expectation adjustment, but CI revealed the `setRoots` API removal, so the interim fix was changed to disabling the test.

- Failing Daily Build: https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/32362778910
- Failing PR CI (expectation-only attempt): https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/32399353924
- Related issue: #3130
