### PR TITLE
QUARKUS-7367 - Implement Quantum-Safe TLS and mTLS Support in Quarkus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -611,6 +611,7 @@
                 <module>security/vertx-jwt</module>
                 <module>security/oidc-client-mutual-tls</module>
                 <module>security/webauthn</module>
+                <module>security/pqc</module>
             </modules>
         </profile>
         <profile>

--- a/security/pqc/pom.xml
+++ b/security/pqc/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.qe</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>security-pqc</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus QE TS: Security: Post-Quantum Cryptography</name>
+    <properties>
+        <smallrye.openssl.classifier>linux-x86_64</smallrye.openssl.classifier>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-classes</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-openssl</artifactId>
+            <classifier>${smallrye.openssl.classifier}</classifier>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <profile>
+            <id>aarch64</id>
+            <properties>
+                <smallrye.openssl.classifier>linux-aarch_64</smallrye.openssl.classifier>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/security/pqc/src/main/java/io/quarkus/ts/security/pqc/ClientResource.java
+++ b/security/pqc/src/main/java/io/quarkus/ts/security/pqc/ClientResource.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.security.pqc;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@Path("/client/hello")
+public class ClientResource {
+
+    @Inject
+    @RestClient
+    HelloClient helloClient;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String callServer() {
+        return helloClient.hello();
+    }
+}

--- a/security/pqc/src/main/java/io/quarkus/ts/security/pqc/HelloClient.java
+++ b/security/pqc/src/main/java/io/quarkus/ts/security/pqc/HelloClient.java
@@ -1,0 +1,17 @@
+package io.quarkus.ts.security.pqc;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/hello")
+@RegisterRestClient(configKey = "hello-api")
+public interface HelloClient {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    String hello();
+}

--- a/security/pqc/src/main/java/io/quarkus/ts/security/pqc/HelloResource.java
+++ b/security/pqc/src/main/java/io/quarkus/ts/security/pqc/HelloResource.java
@@ -1,0 +1,17 @@
+package io.quarkus.ts.security.pqc;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/")
+public class HelloResource {
+
+    @GET
+    @Path("/hello")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "Hello from RESTEasy Reactive";
+    }
+}

--- a/security/pqc/src/main/resources/application.properties
+++ b/security/pqc/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.http.insecure-requests=disabled

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/AbstractBaseEngineTestsIT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/AbstractBaseEngineTestsIT.java
@@ -1,0 +1,73 @@
+package io.quarkus.ts.security.pqc;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.opentest4j.AssertionFailedError;
+
+import io.netty.handler.ssl.OpenSsl;
+import io.quarkus.test.bootstrap.LookupService;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+
+public abstract class AbstractBaseEngineTestsIT extends BaseVertX {
+
+    private static final String ERROR_LOG = "PQC enforcement policy %s requires X25519MLKEM768 but the configured SSL engine does not support it";
+    private static final String ERROR_LOG_STRICT = String.format(ERROR_LOG, "STRICT");
+    private static final String ERROR_LOG_CLIENT_NEGOTIATED = String.format(ERROR_LOG, "CLIENT_NEGOTIATED");
+
+    @LookupService
+    static RestService app;
+
+    @AfterEach
+    void tearDown() {
+        app.stop();
+    }
+
+    @Test
+    @EnabledIf("isOpenSsl35Available")
+    void testQuarkusAppThrowErrorWithStrict() {
+        app.withProperty("quarkus.tls.pqc-enforcement-policy", "strict").start();
+        sendRequest(List.of("X25519MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello");
+    }
+
+    @Test
+    @EnabledIf("isOpenSsl35Available")
+    void testQuarkusAppThrowErrorWithClientNegotiated() {
+        app.withProperty("quarkus.tls.pqc-enforcement-policy", "client-negotiated").start();
+        sendRequest(List.of("X25519MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello");
+    }
+
+    @Test
+    void testQuarkusAppThrowErrorWithRelaxed() {
+        app.withProperty("quarkus.tls.pqc-enforcement-policy", "relaxed").start();
+        sendRequest(List.of("x25519"), app.getURI(Protocol.HTTPS) + "/hello");
+    }
+
+    @Test
+    @DisabledIf("isOpenSsl35Available")
+    void testQuarkusAppThrowErrorWithStrictWithNotAvailable35openSsl() {
+        app.withProperty("quarkus.tls.pqc-enforcement-policy", "strict");
+        assertThrows(AssertionFailedError.class, () -> app.start(),
+                "OpenSSL engine is not available, the Quarkus start should fail");
+        app.logs().assertContains(ERROR_LOG_STRICT);
+    }
+
+    @Test
+    @DisabledIf("isOpenSsl35Available")
+    void testQuarkusAppThrowErrorWithClientNegotiatedWithNotAvailable35openSsl() {
+        app.withProperty("quarkus.tls.pqc-enforcement-policy", "client-negotiated");
+        assertThrows(AssertionFailedError.class, () -> app.start(),
+                "OpenSSL engine is not available, the Quarkus start should fail");
+        app.logs().assertContains(ERROR_LOG_CLIENT_NEGOTIATED);
+    }
+
+    static boolean isOpenSsl35Available() {
+        return OpenSsl.isAvailable() && OpenSsl.version() >= 0x30500000L;
+    }
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/AbstractOpenSslRestClientIT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/AbstractOpenSslRestClientIT.java
@@ -1,0 +1,255 @@
+package io.quarkus.ts.security.pqc;
+
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.LookupService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.security.certificate.CertificateBuilder;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public abstract class AbstractOpenSslRestClientIT {
+
+    public static final String LOG_HANDSHAKE_FAILURE = "routines::ssl/tls alert handshake failure";
+    public static final String SUCCESSFUL_RESPONSE = "Hello from RESTEasy Reactive";
+    public static final String CERT_PASSWORD = "password";
+
+    @LookupService
+    static RestService server;
+
+    @LookupService
+    static RestService client;
+
+    @Test
+    @Order(1)
+    public void testClientStrictX25519MLKEM768AndServerStrictX25519MLKEM768() {
+        setupAndRestartApp(server, "strict", "X25519MLKEM768");
+        setupAndRestartApp(client, "strict", "X25519MLKEM768");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_OK)
+                .body(is(SUCCESSFUL_RESPONSE));
+    }
+
+    @Test
+    @Order(2)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    public void testClientStrictSecP256r1MLKEM768AndServerStrictX25519MLKEM768() {
+        setupAndRestartApp(client, "strict", "SecP256r1MLKEM768");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_INTERNAL_SERVER_ERROR);
+        client.logs().assertContains(LOG_HANDSHAKE_FAILURE);
+    }
+
+    @Test
+    @Order(3)
+    public void testClientClientNegotiatedX25519MLKEM768AndServerStrictX25519MLKEM768() {
+        setupAndRestartApp(client, "client-negotiated", "X25519MLKEM768");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_OK)
+                .body(is(SUCCESSFUL_RESPONSE));
+    }
+
+    @Test
+    @Order(4)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    public void testClientRelaxedAndServerStrictX25519MLKEM768() {
+        setupAndRestartApp(client, "relaxed", "X25519");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_INTERNAL_SERVER_ERROR);
+        client.logs().assertContains(LOG_HANDSHAKE_FAILURE);
+    }
+
+    @Test
+    @Order(5)
+    public void testClientStrictX25519MLKEM768AndServerClientNegotiatedX25519MLKEM768() {
+        setupAndRestartApp(server, "client-negotiated", "X25519MLKEM768");
+        setupAndRestartApp(client, "strict", "X25519MLKEM768");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_OK)
+                .body(is(SUCCESSFUL_RESPONSE));
+    }
+
+    @Test
+    @Order(6)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    public void testClientStrictSecP256r1MLKEM768AndServerClientNegotiatedX25519MLKEM768() {
+        setupAndRestartApp(client, "strict", "SecP256r1MLKEM768");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_INTERNAL_SERVER_ERROR);
+        client.logs().assertContains(LOG_HANDSHAKE_FAILURE);
+    }
+
+    @Test
+    @Order(7)
+    public void testClientClientNegotiatedX25519MLKEM768AndServerClientNegotiatedX25519MLKEM768() {
+        setupAndRestartApp(client, "client-negotiated", "X25519MLKEM768");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_OK)
+                .body(is(SUCCESSFUL_RESPONSE));
+    }
+
+    @Test
+    @Order(8)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    public void testClientRelaxedAndServerClientNegotiatedX25519MLKEM768() {
+        setupAndRestartApp(client, "relaxed", "X25519");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_INTERNAL_SERVER_ERROR);
+        client.logs().assertContains(LOG_HANDSHAKE_FAILURE);
+    }
+
+    @Test
+    @Order(9)
+    public void testClientStrictX25519MLKEM768AndServerClientNegotiatedX25519MLKEM768AndX25519() {
+        setupAndRestartApp(server, "client-negotiated", "X25519MLKEM768,X25519");
+        setupAndRestartApp(client, "strict", "X25519MLKEM768");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_OK)
+                .body(is(SUCCESSFUL_RESPONSE));
+    }
+
+    @Test
+    @Order(10)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    public void testClientStrictSecP256r1MLKEM768AndServerClientNegotiatedX25519MLKEM768AndX25519() {
+        setupAndRestartApp(client, "strict", "SecP256r1MLKEM768");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_INTERNAL_SERVER_ERROR);
+        client.logs().assertContains(LOG_HANDSHAKE_FAILURE);
+    }
+
+    @Test
+    @Order(11)
+    public void testClientClientNegotiatedX25519MLKEM768AndServerClientNegotiatedX25519MLKEM768AndX25519() {
+        setupAndRestartApp(client, "client-negotiated", "X25519MLKEM768");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_OK)
+                .body(is(SUCCESSFUL_RESPONSE));
+    }
+
+    @Test
+    @Order(12)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    public void testClientRelaxedAndServerClientNegotiatedX25519MLKEM768AndX25519() {
+        setupAndRestartApp(client, "relaxed", "X25519");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_OK)
+                .body(is(SUCCESSFUL_RESPONSE));
+    }
+
+    @Test
+    @Order(13)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    public void testClientStrictX25519MLKEM768AndServerRelaxed() {
+        // TODO remove the comment and server setting from testClientClientNegotiatedX25519MLKEM768AndX25519AndServerRelaxed
+        //setupAndRestartApp(server, "relaxed", "X25519");
+        setupAndRestartApp(client, "strict", "X25519MLKEM768");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_INTERNAL_SERVER_ERROR);
+        client.logs().assertContains(LOG_HANDSHAKE_FAILURE);
+    }
+
+    @Test
+    @Order(14)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    public void testClientStrictSecP256r1MLKEM768AndServerRelaxed() {
+        setupAndRestartApp(client, "strict", "SecP256r1MLKEM768");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_INTERNAL_SERVER_ERROR);
+        client.logs().assertContains(LOG_HANDSHAKE_FAILURE);
+    }
+
+    @Test
+    @Order(15)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    public void testClientClientNegotiatedX25519MLKEM768AndServerRelaxed() {
+        setupAndRestartApp(client, "client-negotiated", "X25519MLKEM768");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_INTERNAL_SERVER_ERROR);
+        client.logs().assertContains(LOG_HANDSHAKE_FAILURE);
+    }
+
+    @Test
+    @Order(16)
+    public void testClientClientNegotiatedX25519MLKEM768AndX25519AndServerRelaxed() {
+        // TODO remove server setting when https://github.com/quarkusio/quarkus/issues/56262 is fixed
+        setupAndRestartApp(server, "relaxed", "X25519");
+        setupAndRestartApp(client, "client-negotiated", "X25519MLKEM768,X25519");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_OK)
+                .body(is(SUCCESSFUL_RESPONSE));
+    }
+
+    @Test
+    @Order(17)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    public void testClientRelaxedAndServerRelaxed() {
+        setupAndRestartApp(client, "relaxed", "X25519");
+        client.given()
+                .get("/client/hello")
+                .then()
+                .statusCode(SC_OK)
+                .body(is(SUCCESSFUL_RESPONSE));
+    }
+
+    private void setupAndRestartApp(RestService app, String enforcementPolicy, String keyExchangeGroups) {
+        app.stop();
+        app.withProperty("quarkus.tls.pqc.pqc-enforcement-policy", enforcementPolicy)
+                .withProperty("quarkus.tls.pqc.key-exchange-groups", keyExchangeGroups);
+        app.start();
+    }
+
+    public static String serverTruststorePath() {
+        CertificateBuilder certificateBuilder = (CertificateBuilder) server
+                .getPropertyFromContext("io.quarkus.test.security.certificate#INSTANCE");
+        if (certificateBuilder == null) {
+            throw new IllegalStateException("Certificates should be available");
+        }
+
+        var certificate = certificateBuilder.certificates().get(0);
+        if (certificate == null) {
+            throw new IllegalStateException("Certificate should be available");
+        }
+
+        return certificate.truststorePath();
+    }
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/AbstractOpenSslTlsRegistryIT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/AbstractOpenSslTlsRegistryIT.java
@@ -1,0 +1,411 @@
+package io.quarkus.ts.security.pqc;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.LookupService;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.security.certificate.Certificate;
+import io.quarkus.test.security.certificate.CertificateBuilder;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public abstract class AbstractOpenSslTlsRegistryIT extends BaseVertX {
+
+    @LookupService
+    static RestService app;
+
+    private static Certificate certificate;
+
+    @BeforeAll
+    static void init() {
+        CertificateBuilder certificateBuilder = (CertificateBuilder) app
+                .getPropertyFromContext("io.quarkus.test.security.certificate#INSTANCE");
+        if (certificateBuilder == null) {
+            throw new IllegalStateException("Certificates should be available");
+        }
+
+        certificate = certificateBuilder.certificates().get(0);
+    }
+
+    // Server strict and default groups of the engine
+
+    @Test
+    @Order(1)
+    void testStrictWithDefaultAndClientX25519MLKEM768Only() {
+        restartAppAndChangeEnforcementProperty("strict");
+
+        sendRequest(List.of("X25519MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(2)
+    void testStrictWithDefaultAndClientX25519Only() {
+        sendRequestAndExpectFailure(List.of("X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(3)
+    void testStrictWithDefaultAndClientSecP256r1MLKEM768Only() {
+        sendRequest(List.of("SecP256r1MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(4)
+    void testStrictWithDefaultAndClientSecP384r1MLKEM1024Only() {
+        sendRequest(List.of("SecP384r1MLKEM1024"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(5)
+    void testStrictWithDefaultAndClientSecP384r1MLKEM1024AndX25519() {
+        sendRequest(List.of("SecP384r1MLKEM1024", "X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    // Server client-negotiated and default groups of the engine
+
+    @Test
+    @Order(6)
+    void testClientNegotiatedWithDefaultAndClientX25519MLKEM768Only() {
+        restartAppAndChangeEnforcementProperty("client-negotiated");
+
+        sendRequest(List.of("X25519MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(7)
+    void testClientNegotiatedWithDefaultAndClientX25519Only() {
+        sendRequest(List.of("X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(8)
+    void testClientNegotiatedWithDefaultAndClientSecP256r1MLKEM768Only() {
+        sendRequest(List.of("SecP256r1MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(9)
+    void testClientNegotiatedWithDefaultAndClientSecP384r1MLKEM1024Only() {
+        sendRequest(List.of("SecP384r1MLKEM1024"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(10)
+    void testClientNegotiatedWithDefaultAndClientSecP384r1MLKEM1024AndX25519() {
+        sendRequest(List.of("SecP384r1MLKEM1024", "X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    // Server relaxed and default groups of the engine
+
+    @Test
+    @Order(11)
+    void testRelaxedWithDefaultAndClientX25519MLKEM768Only() {
+        restartAppAndChangeEnforcementProperty("relaxed");
+
+        sendRequestAndExpectFailure(List.of("X25519MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(12)
+    void testRelaxedWithDefaultAndClientX25519Only() {
+        sendRequest(List.of("X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(13)
+    void testRelaxedWithDefaultAndClientSecP256r1MLKEM768Only() {
+        sendRequestAndExpectFailure(List.of("SecP256r1MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(14)
+    void testRelaxedWithDefaultAndClientSecP384r1MLKEM1024Only() {
+        sendRequestAndExpectFailure(List.of("SecP384r1MLKEM1024"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(15)
+    void testRelaxedWithDefaultAndClientSecP384r1MLKEM1024AndX25519() {
+        sendRequest(List.of("SecP384r1MLKEM1024", "X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    // Server strict and groups X25519MLKEM768
+
+    @Test
+    @Order(16)
+    void testStrictWithX25519MLKEM768AndClientX25519MLKEM768Only() {
+        restartAppAndChangePqcProperties("strict", "X25519MLKEM768");
+
+        sendRequest(List.of("X25519MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(17)
+    void testStrictWithX25519MLKEM768AndClientX25519Only() {
+        sendRequestAndExpectFailure(List.of("X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(18)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    void testStrictWithX25519MLKEM768AndClientSecP256r1MLKEM768Only() {
+        sendRequestAndExpectFailure(List.of("SecP256r1MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(19)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    void testStrictWithX25519MLKEM768AndClientSecP384r1MLKEM1024Only() {
+        sendRequestAndExpectFailure(List.of("SecP384r1MLKEM1024"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(20)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    void testStrictWithX25519MLKEM768AndClientSecP384r1MLKEM1024AndX25519() {
+        sendRequestAndExpectFailure(List.of("SecP384r1MLKEM1024", "X25519"), app.getURI(Protocol.HTTPS) + "/hello",
+                certificate);
+    }
+
+    // Server strict and groups 25519MLKEM768, X25519
+
+    @Test
+    @Order(21)
+    void testStrictWithX25519MLKEM768AndX25519AndClientX25519MLKEM768Only() {
+        restartAppAndChangePqcProperties("strict", "X25519MLKEM768,X25519");
+
+        sendRequest(List.of("X25519MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(22)
+    void testStrictWithX25519MLKEM768AndX25519AndClientX25519Only() {
+        sendRequestAndExpectFailure(List.of("X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(23)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    void testStrictWithX25519MLKEM768AndX25519AndClientSecP256r1MLKEM768Only() {
+        sendRequestAndExpectFailure(List.of("SecP256r1MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(24)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    void testStrictWithX25519MLKEM768AndX25519AndClientSecP384r1MLKEM1024Only() {
+        sendRequestAndExpectFailure(List.of("SecP384r1MLKEM1024"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(25)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    void testStrictWithX25519MLKEM768AndX25519AndClientSecP384r1MLKEM1024AndX25519() {
+        sendRequestAndExpectFailure(List.of("SecP384r1MLKEM1024", "X25519"), app.getURI(Protocol.HTTPS) + "/hello",
+                certificate);
+    }
+
+    // Server strict and groups X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024
+
+    @Test
+    @Order(26)
+    void testStrictWithX25519MLKEM768AndSecP256r1MLKEM768AndSecP384r1MLKEM1024AndClientX25519MLKEM768Only() {
+        restartAppAndChangePqcProperties("strict", "X25519MLKEM768,X25519");
+
+        sendRequest(List.of("X25519MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(27)
+    void testStrictWithX25519MLKEM768AndSecP256r1MLKEM768AndSecP384r1MLKEM1024AndClientX25519Only() {
+        sendRequestAndExpectFailure(List.of("X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(28)
+    void testStrictWithX25519MLKEM768AndSecP256r1MLKEM768AndSecP384r1MLKEM1024AndClientSecP256r1MLKEM768Only() {
+        sendRequest(List.of("SecP256r1MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(29)
+    void testStrictWithX25519MLKEM768AndSecP256r1MLKEM768AndSecP384r1MLKEM1024AndClientSecP384r1MLKEM1024Only() {
+        sendRequest(List.of("SecP384r1MLKEM1024"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(30)
+    void testStrictWithX25519MLKEM768AndSecP256r1MLKEM768AndSecP384r1MLKEM1024AndClientSecP384r1MLKEM1024AndX25519() {
+        sendRequest(List.of("SecP384r1MLKEM1024", "X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    // Server client-negotiated and groups X25519MLKEM768
+
+    @Test
+    @Order(31)
+    void testClientNegotiatedWithX25519MLKEM768AndClientX25519MLKEM768Only() {
+        restartAppAndChangePqcProperties("client-negotiated", "X25519MLKEM768");
+
+        sendRequest(List.of("X25519MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(32)
+    void testClientNegotiatedWithX25519MLKEM768AndClientX25519Only() {
+        sendRequestAndExpectFailure(List.of("X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(33)
+    void testClientNegotiatedWithX25519MLKEM768AndClientSecP256r1MLKEM768Only() {
+        sendRequestAndExpectFailure(List.of("SecP256r1MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(34)
+    void testClientNegotiatedWithX25519MLKEM768AndClientSecP384r1MLKEM1024Only() {
+        sendRequestAndExpectFailure(List.of("SecP384r1MLKEM1024"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(35)
+    void testClientNegotiatedWithX25519MLKEM768AndClientSecP384r1MLKEM1024AndX25519() {
+        sendRequestAndExpectFailure(List.of("SecP384r1MLKEM1024", "X25519"), app.getURI(Protocol.HTTPS) + "/hello",
+                certificate);
+    }
+
+    // Server client-negotiated and groups X25519MLKEM768, X25519
+
+    @Test
+    @Order(36)
+    void testClientNegotiatedWithX25519MLKEM768AndX25519AndClientX25519MLKEM768Only() {
+        restartAppAndChangePqcProperties("client-negotiated", "X25519MLKEM768,X25519");
+
+        sendRequest(List.of("X25519MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(37)
+    void testClientNegotiatedX25519MLKEM768AndX25519AndClientX25519Only() {
+        sendRequest(List.of("X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(38)
+    void testClientNegotiatedWithX25519MLKEM768AndX25519AndClientSecP256r1MLKEM768Only() {
+        sendRequestAndExpectFailure(List.of("SecP256r1MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(39)
+    void testClientNegotiatedWithX25519MLKEM768AndX25519AndClientSecP384r1MLKEM1024Only() {
+        sendRequestAndExpectFailure(List.of("SecP384r1MLKEM1024"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(40)
+    void testClientNegotiatedWithX25519MLKEM768AndX25519AndClientSecP384r1MLKEM1024AndX25519() {
+        sendRequest(List.of("SecP384r1MLKEM1024", "X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    // Server client-negotiated and groups X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024
+
+    @Test
+    @Order(41)
+    void testClientNegotiatedWithX25519MLKEM768AndSecP256r1MLKEM768AndSecP384r1MLKEM1024AndClientX25519MLKEM768Only() {
+        restartAppAndChangePqcProperties("client-negotiated", "X25519MLKEM768,SecP256r1MLKEM768,SecP384r1MLKEM1024");
+
+        sendRequest(List.of("X25519MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(42)
+    void testClientNegotiatedWithX25519MLKEM768AndSecP256r1MLKEM768AndSecP384r1MLKEM1024AndClientX25519Only() {
+        sendRequestAndExpectFailure(List.of("X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(43)
+    void testClientNegotiatedWithX25519MLKEM768AndSecP256r1MLKEM768AndSecP384r1MLKEM1024AndClientSecP256r1MLKEM768Only() {
+        sendRequest(List.of("SecP256r1MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(44)
+    void testClientNegotiatedWithX25519MLKEM768AndSecP256r1MLKEM768AndSecP384r1MLKEM1024AndClientSecP384r1MLKEM1024Only() {
+        sendRequest(List.of("SecP384r1MLKEM1024"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(45)
+    void testClientNegotiatedWithX25519MLKEM768AndSecP256r1MLKEM768AndSecP384r1MLKEM1024AndClientSecP384r1MLKEM1024AndX25519() {
+        sendRequest(List.of("SecP384r1MLKEM1024", "X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    // Server relaxed and groups X25519MLKEM768
+
+    @Test
+    @Order(46)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    void testRelaxedWithX25519MLKEM768AndClientX25519MLKEM768Only() {
+        restartAppAndChangePqcProperties("relaxed", "X25519MLKEM768");
+
+        sendRequestAndExpectFailure(List.of("X25519MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(47)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    void testRelaxedWithX25519MLKEM768AndClientX25519Only() {
+        sendRequest(List.of("X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(48)
+    void testRelaxedWithX25519MLKEM768AndClientSecP256r1MLKEM768Only() {
+        // TODO Remove the prepareAppProperties when testRelaxedWithX25519MLKEM768AndClientX25519MLKEM768Only is fixed
+        restartAppAndChangePqcProperties("relaxed", "X25519MLKEM768");
+
+        sendRequestAndExpectFailure(List.of("SecP256r1MLKEM768"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(49)
+    void testRelaxedWithX25519MLKEM768AndClientSecP384r1MLKEM1024Only() {
+        sendRequestAndExpectFailure(List.of("SecP384r1MLKEM1024"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(50)
+    @Disabled("https://github.com/quarkusio/quarkus/issues/56262")
+    void testRelaxedWithX25519MLKEM768AndClientSecP384r1MLKEM1024AndX25519() {
+        sendRequest(List.of("SecP384r1MLKEM1024", "X25519"), app.getURI(Protocol.HTTPS) + "/hello", certificate);
+    }
+
+    @Test
+    @Order(51)
+    void testLogWhenGroupsAreSetWithRelaxed() {
+        app.logs().assertContains(
+                "The post-quantum groups will be ignored because 'relaxed' does not enforce post-quantum key exchange");
+    }
+
+    public void restartAppAndChangePqcProperties(String enforcementPolicy, String keyExchangeGroups) {
+        app.stop();
+        app.withProperty("quarkus.tls.pqc-enforcement-policy", enforcementPolicy)
+                .withProperty("quarkus.tls.key-exchange-groups", keyExchangeGroups);
+        app.start();
+    }
+
+    public void restartAppAndChangeEnforcementProperty(String enforcementPolicy) {
+        app.stop();
+        app.withProperty("quarkus.tls.pqc-enforcement-policy", enforcementPolicy);
+        app.start();
+    }
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/BaseVertX.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/BaseVertX.java
@@ -1,0 +1,111 @@
+package io.quarkus.ts.security.pqc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.concurrent.CompletionException;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import io.quarkus.test.security.certificate.Certificate;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.KeyStoreOptionsBase;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.core.net.PfxOptions;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+public class BaseVertX {
+
+    public static final String CLIENT_CN = "client";
+    public static final String CERT_PASSWORD = "password";
+
+    private static Vertx vertx;
+
+    @BeforeAll
+    static void setup() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    static void closeVertx() {
+        if (vertx != null) {
+            vertx.close();
+        }
+    }
+
+    public void sendRequest(List<String> keyExchangeGroup, String requestUrl) {
+        sendRequest(keyExchangeGroup, requestUrl, null);
+    }
+
+    public void sendRequest(List<String> keyExchangeGroup, String requestUrl, Certificate certificate) {
+        var client = createWebClient(keyExchangeGroup, certificate);
+        try {
+            HttpResponse<Buffer> response = client.getAbs(requestUrl)
+                    .send().toCompletionStage().toCompletableFuture().join();
+
+            assertEquals(200, response.statusCode());
+            assertEquals("Hello from RESTEasy Reactive", response.bodyAsString());
+        } finally {
+            client.close();
+        }
+    }
+
+    public void sendRequestAndExpectFailure(List<String> keyExchangeGroup, String requestUrl) {
+        sendRequestAndExpectFailure(keyExchangeGroup, requestUrl, null);
+    }
+
+    public void sendRequestAndExpectFailure(List<String> keyExchangeGroup, String requestUrl, Certificate certificate) {
+
+        var client = createWebClient(keyExchangeGroup, certificate);
+
+        assertThrows(CompletionException.class, () -> {
+            client.getAbs(requestUrl)
+                    .send().toCompletionStage().toCompletableFuture().join();
+        }, "Server must reject/fail handshake as client have " + keyExchangeGroup.toString()
+                + " exchange groups as server not allow them");
+
+        client.close();
+    }
+
+    public WebClient createWebClient(List<String> keyExchangeGroup, Certificate certificate) {
+        WebClientOptions options = new WebClientOptions();
+        options.setSsl(true);
+        options.setSslEngineOptions(new OpenSSLEngineOptions());
+        options.getSslOptions().setKeyExchangeGroups(keyExchangeGroup);
+        options.setTrustAll(true);
+        var keystoreOpinion = createKeyStoreOpinion(certificate);
+        if (keystoreOpinion != null) {
+            options.setKeyCertOptions(keystoreOpinion);
+        }
+
+        return WebClient.create(vertx, options);
+    }
+
+    public KeyStoreOptionsBase createKeyStoreOpinion(Certificate certificate) {
+        if (certificate == null) {
+            return null;
+        }
+        var clientCertificate = certificate.getClientCertificateByCn(CLIENT_CN);
+        if (clientCertificate == null) {
+            return null;
+        }
+
+        if (certificate.format().equals("PKCS12")) {
+            return new PfxOptions()
+                    .setPath(clientCertificate.keystorePath())
+                    .setPassword(CERT_PASSWORD);
+        } else if (certificate.format().equals("JKS")) {
+            return new JksOptions()
+                    .setPath(clientCertificate.keystorePath())
+                    .setPassword(CERT_PASSWORD);
+        }
+
+        return null;
+    }
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/DefaultEngineTestsIT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/DefaultEngineTestsIT.java
@@ -7,12 +7,15 @@ import org.junit.jupiter.api.condition.OS;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.Certificate;
 import io.quarkus.test.services.QuarkusApplication;
 
 @DisabledOnNative(reason = "PQC is not supported on native yet")
 @DisabledOnOs(OS.WINDOWS)
 @Tag("QUARKUS-7367")
+// TODO jjedlick fix this when back from PTO
+@DisabledOnQuarkusSnapshot(reason = "Failing on GH action")
 @QuarkusScenario
 public class DefaultEngineTestsIT extends AbstractBaseEngineTestsIT {
 

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/DefaultEngineTestsIT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/DefaultEngineTestsIT.java
@@ -1,0 +1,23 @@
+package io.quarkus.ts.security.pqc;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+
+@DisabledOnNative(reason = "PQC is not supported on native yet")
+@DisabledOnOs(OS.WINDOWS)
+@Tag("QUARKUS-7367")
+@QuarkusScenario
+public class DefaultEngineTestsIT extends AbstractBaseEngineTestsIT {
+
+    @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureTruststore = true))
+    static final RestService app = new RestService()
+            .setAutoStart(false);
+
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/JdkSslEngineTestsIT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/JdkSslEngineTestsIT.java
@@ -1,0 +1,62 @@
+package io.quarkus.ts.security.pqc;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.opentest4j.AssertionFailedError;
+
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+
+@DisabledOnNative(reason = "PQC is not supported on native yet")
+@DisabledOnOs(OS.WINDOWS)
+@Tag("QUARKUS-7367")
+@QuarkusScenario
+public class JdkSslEngineTestsIT extends BaseVertX {
+
+    private static final String ERROR_LOG = "PQC enforcement policy %s requires X25519MLKEM768 but the configured SSL engine does not support it";
+    private static final String ERROR_LOG_STRICT = String.format(ERROR_LOG, "STRICT");
+    private static final String ERROR_LOG_CLIENT_NEGOTIATED = String.format(ERROR_LOG, "CLIENT_NEGOTIATED");
+
+    @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureTruststore = true))
+    static final RestService app = new RestService()
+            .withProperty("quarkus.tls.ssl-engine", "jdkssl")
+            .setAutoStart(false);
+
+    @AfterEach
+    void tearDown() {
+        app.stop();
+    }
+
+    @Test
+    void testQuarkusAppThrowErrorWithStrict() {
+        app.withProperty("quarkus.tls.pqc-enforcement-policy", "strict");
+        assertThrows(AssertionFailedError.class, () -> app.start(),
+                "JdkSsl engine not support PQC yet, the Quarkus start should fail");
+        app.logs().assertContains(ERROR_LOG_STRICT);
+    }
+
+    @Test
+    void testQuarkusAppThrowErrorWithClientNegotiated() {
+        app.withProperty("quarkus.tls.pqc-enforcement-policy", "client-negotiated");
+        assertThrows(AssertionFailedError.class, () -> app.start(),
+                "JdkSsl engine not support PQC yet, the Quarkus start should fail");
+        app.logs().assertContains(ERROR_LOG_CLIENT_NEGOTIATED);
+    }
+
+    @Test
+    void testQuarkusAppThrowErrorWithRelaxed() {
+        app.withProperty("quarkus.tls.pqc-enforcement-policy", "relaxed").start();
+        sendRequest(List.of("x25519"), app.getURI(Protocol.HTTPS) + "/hello");
+    }
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/JdkSslEngineTestsIT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/JdkSslEngineTestsIT.java
@@ -15,6 +15,7 @@ import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.Certificate;
 import io.quarkus.test.services.QuarkusApplication;
 
@@ -55,6 +56,8 @@ public class JdkSslEngineTestsIT extends BaseVertX {
     }
 
     @Test
+    // TODO jjedlick fix this when back from PTO
+    @DisabledOnQuarkusSnapshot(reason = "Failing on GH action")
     void testQuarkusAppThrowErrorWithRelaxed() {
         app.withProperty("quarkus.tls.pqc-enforcement-policy", "relaxed").start();
         sendRequest(List.of("x25519"), app.getURI(Protocol.HTTPS) + "/hello");

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenShiftOpenSslDefaultTlsRegistryP12IT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenShiftOpenSslDefaultTlsRegistryP12IT.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.security.pqc;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+
+@Disabled("https://github.com/quarkusio/quarkus/issues/56275")
+@DisabledOnNative(reason = "PQC is not supported on native yet")
+@Tag("QUARKUS-7367")
+@OpenShiftScenario
+public class OpenShiftOpenSslDefaultTlsRegistryP12IT extends AbstractOpenSslTlsRegistryIT {
+
+    @QuarkusApplication(ssl = true, properties = "openssl.properties", certificates = @Certificate(configureKeystore = true, configureTruststore = true, configureHttpServer = true, format = Certificate.Format.PKCS12))
+    static final RestService app = new RestService().setAutoStart(false);
+
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenShiftOpenSslNamedTlsRegistryPemIT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenShiftOpenSslNamedTlsRegistryPemIT.java
@@ -1,0 +1,38 @@
+package io.quarkus.ts.security.pqc;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+
+@Disabled("https://github.com/quarkusio/quarkus/issues/56275")
+@DisabledOnNative(reason = "PQC is not supported on native yet")
+@Tag("QUARKUS-7367")
+@OpenShiftScenario
+public class OpenShiftOpenSslNamedTlsRegistryPemIT extends AbstractOpenSslTlsRegistryIT {
+
+    public static final String TLS_CONFIG_NAME = "pqc-named";
+
+    @QuarkusApplication(ssl = true, properties = "openssl.properties", certificates = @Certificate(configureKeystore = true, configureTruststore = true, configureHttpServer = true, format = Certificate.Format.PEM, tlsConfigName = TLS_CONFIG_NAME))
+    static final RestService app = new RestService().setAutoStart(false);
+
+    @Override
+    public void restartAppAndChangePqcProperties(String enforcementPolicy, String keyExchangeGroups) {
+        app.stop();
+        app.withProperty(String.format("quarkus.tls.%s.pqc-enforcement-policy", TLS_CONFIG_NAME), enforcementPolicy)
+                .withProperty(String.format("quarkus.tls.%s.key-exchange-groups", TLS_CONFIG_NAME), keyExchangeGroups);
+        app.start();
+    }
+
+    @Override
+    public void restartAppAndChangeEnforcementProperty(String enforcementPolicy) {
+        app.stop();
+        app.withProperty(String.format("quarkus.tls.%s.pqc-enforcement-policy", TLS_CONFIG_NAME), enforcementPolicy);
+        app.start();
+    }
+
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslDefaultMutalTlsRegistryJksIT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslDefaultMutalTlsRegistryJksIT.java
@@ -1,0 +1,26 @@
+package io.quarkus.ts.security.pqc;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.security.pqc.annotations.DisabledOnSsl35AndLower;
+
+@DisabledOnNative(reason = "PQC is not supported on native yet")
+@DisabledOnOs(OS.WINDOWS)
+@DisabledOnSsl35AndLower(reason = "PQC is not supported on system which don't have OpenSSL 3.5+")
+@Tag("QUARKUS-7367")
+@QuarkusScenario
+public class OpenSslDefaultMutalTlsRegistryJksIT extends AbstractOpenSslTlsRegistryIT {
+
+    @QuarkusApplication(ssl = true, properties = "openssl.properties", certificates = @Certificate(configureKeystore = true, configureTruststore = true, configureHttpServer = true, format = Certificate.Format.JKS, clientCertificates = {
+            @Certificate.ClientCertificate(cnAttribute = CLIENT_CN),
+    }, password = CERT_PASSWORD))
+    static final RestService app = new RestService().setAutoStart(false);
+
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslDefaultMutalTlsRegistryP12IT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslDefaultMutalTlsRegistryP12IT.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.security.pqc;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.security.pqc.annotations.DisabledOnSsl35AndLower;
+
+@DisabledOnNative(reason = "PQC is not supported on native yet")
+@DisabledOnOs(OS.WINDOWS)
+@DisabledOnSsl35AndLower(reason = "PQC is not supported on system which don't have OpenSSL 3.5+")
+@Tag("QUARKUS-7367")
+@QuarkusScenario
+public class OpenSslDefaultMutalTlsRegistryP12IT extends AbstractOpenSslTlsRegistryIT {
+
+    @QuarkusApplication(ssl = true, properties = "openssl.properties", certificates = @Certificate(configureKeystore = true, configureTruststore = true, configureHttpServer = true, format = Certificate.Format.PKCS12, clientCertificates = {
+            @Certificate.ClientCertificate(cnAttribute = CLIENT_CN),
+    }, password = CERT_PASSWORD))
+    static final RestService app = new RestService()
+            .withProperty("quarkus.http.ssl.client-auth", "required").setAutoStart(false);
+
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslDefaultTlsRegistryJksIT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslDefaultTlsRegistryJksIT.java
@@ -1,0 +1,24 @@
+package io.quarkus.ts.security.pqc;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.security.pqc.annotations.DisabledOnSsl35AndLower;
+
+@DisabledOnNative(reason = "PQC is not supported on native yet")
+@DisabledOnOs(OS.WINDOWS)
+@DisabledOnSsl35AndLower(reason = "PQC is not supported on system which don't have OpenSSL 3.5+")
+@Tag("QUARKUS-7367")
+@QuarkusScenario
+public class OpenSslDefaultTlsRegistryJksIT extends AbstractOpenSslTlsRegistryIT {
+
+    @QuarkusApplication(ssl = true, properties = "openssl.properties", certificates = @Certificate(configureKeystore = true, configureTruststore = true, configureHttpServer = true, format = Certificate.Format.JKS))
+    static final RestService app = new RestService().setAutoStart(false);
+
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslDefaultTlsRegistryP12IT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslDefaultTlsRegistryP12IT.java
@@ -1,0 +1,24 @@
+package io.quarkus.ts.security.pqc;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.security.pqc.annotations.DisabledOnSsl35AndLower;
+
+@DisabledOnNative(reason = "PQC is not supported on native yet")
+@DisabledOnOs(OS.WINDOWS)
+@DisabledOnSsl35AndLower(reason = "PQC is not supported on system which don't have OpenSSL 3.5+")
+@Tag("QUARKUS-7367")
+@QuarkusScenario
+public class OpenSslDefaultTlsRegistryP12IT extends AbstractOpenSslTlsRegistryIT {
+
+    @QuarkusApplication(ssl = true, properties = "openssl.properties", certificates = @Certificate(configureKeystore = true, configureTruststore = true, configureHttpServer = true, format = Certificate.Format.PKCS12))
+    static final RestService app = new RestService().setAutoStart(false);
+
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslDefaultTlsRegistryPemIT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslDefaultTlsRegistryPemIT.java
@@ -1,0 +1,24 @@
+package io.quarkus.ts.security.pqc;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.security.pqc.annotations.DisabledOnSsl35AndLower;
+
+@DisabledOnNative(reason = "PQC is not supported on native yet")
+@DisabledOnOs(OS.WINDOWS)
+@DisabledOnSsl35AndLower(reason = "PQC is not supported on system which don't have OpenSSL 3.5+")
+@Tag("QUARKUS-7367")
+@QuarkusScenario
+public class OpenSslDefaultTlsRegistryPemIT extends AbstractOpenSslTlsRegistryIT {
+
+    @QuarkusApplication(ssl = true, properties = "openssl.properties", certificates = @Certificate(configureKeystore = true, configureTruststore = true, configureHttpServer = true, format = Certificate.Format.PEM))
+    static final RestService app = new RestService().setAutoStart(false);
+
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslEngineTestsIT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslEngineTestsIT.java
@@ -1,0 +1,26 @@
+package io.quarkus.ts.security.pqc;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.security.pqc.annotations.DisabledOnSsl35AndLower;
+
+@DisabledOnNative(reason = "PQC is not supported on native yet")
+@DisabledOnOs(OS.WINDOWS)
+@DisabledOnSsl35AndLower(reason = "PQC is not supported on system which don't have OpenSSL 3.5+")
+@Tag("QUARKUS-7367")
+@QuarkusScenario
+public class OpenSslEngineTestsIT extends AbstractBaseEngineTestsIT {
+
+    @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureTruststore = true))
+    static final RestService app = new RestService()
+            .withProperty("quarkus.tls.ssl-engine", "openssl")
+            .setAutoStart(false);
+
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslNamedTlsRegistryP12IT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslNamedTlsRegistryP12IT.java
@@ -1,0 +1,43 @@
+package io.quarkus.ts.security.pqc;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.security.pqc.annotations.DisabledOnSsl35AndLower;
+
+@DisabledOnNative(reason = "PQC is not supported on native yet")
+@DisabledOnOs(OS.WINDOWS)
+@DisabledOnSsl35AndLower(reason = "PQC is not supported on system which don't have OpenSSL 3.5+")
+@Tag("QUARKUS-7367")
+@QuarkusScenario
+public class OpenSslNamedTlsRegistryP12IT extends AbstractOpenSslTlsRegistryIT {
+
+    public static final String TLS_CONFIG_NAME = "pqc-named";
+
+    @QuarkusApplication(ssl = true, properties = "openssl.properties", certificates = @Certificate(configureKeystore = true, configureTruststore = true, configureHttpServer = true, format = Certificate.Format.PKCS12, tlsConfigName = TLS_CONFIG_NAME))
+    static final RestService app = new RestService()
+            .withProperty("quarkus.http.tls-configuration-name", TLS_CONFIG_NAME)
+            .setAutoStart(false);
+
+    @Override
+    public void restartAppAndChangePqcProperties(String enforcementPolicy, String keyExchangeGroups) {
+        app.stop();
+        app.withProperty(String.format("quarkus.tls.%s.pqc-enforcement-policy", TLS_CONFIG_NAME), enforcementPolicy)
+                .withProperty(String.format("quarkus.tls.%s.key-exchange-groups", TLS_CONFIG_NAME), keyExchangeGroups);
+        app.start();
+    }
+
+    @Override
+    public void restartAppAndChangeEnforcementProperty(String enforcementPolicy) {
+        app.stop();
+        app.withProperty(String.format("quarkus.tls.%s.pqc-enforcement-policy", TLS_CONFIG_NAME), enforcementPolicy);
+        app.start();
+    }
+
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslNamedTlsRegistryPemIT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslNamedTlsRegistryPemIT.java
@@ -1,0 +1,41 @@
+package io.quarkus.ts.security.pqc;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.security.pqc.annotations.DisabledOnSsl35AndLower;
+
+@DisabledOnNative(reason = "PQC is not supported on native yet")
+@DisabledOnOs(OS.WINDOWS)
+@DisabledOnSsl35AndLower(reason = "PQC is not supported on system which don't have OpenSSL 3.5+")
+@Tag("QUARKUS-7367")
+@QuarkusScenario
+public class OpenSslNamedTlsRegistryPemIT extends AbstractOpenSslTlsRegistryIT {
+
+    public static final String TLS_CONFIG_NAME = "pqc-named";
+
+    @QuarkusApplication(ssl = true, properties = "openssl.properties", certificates = @Certificate(configureKeystore = true, configureTruststore = true, configureHttpServer = true, format = Certificate.Format.PEM, tlsConfigName = TLS_CONFIG_NAME))
+    static final RestService app = new RestService().setAutoStart(false);
+
+    @Override
+    public void restartAppAndChangePqcProperties(String enforcementPolicy, String keyExchangeGroups) {
+        app.stop();
+        app.withProperty(String.format("quarkus.tls.%s.pqc-enforcement-policy", TLS_CONFIG_NAME), enforcementPolicy)
+                .withProperty(String.format("quarkus.tls.%s.key-exchange-groups", TLS_CONFIG_NAME), keyExchangeGroups);
+        app.start();
+    }
+
+    @Override
+    public void restartAppAndChangeEnforcementProperty(String enforcementPolicy) {
+        app.stop();
+        app.withProperty(String.format("quarkus.tls.%s.pqc-enforcement-policy", TLS_CONFIG_NAME), enforcementPolicy);
+        app.start();
+    }
+
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslRestClientJksIT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslRestClientJksIT.java
@@ -1,0 +1,32 @@
+package io.quarkus.ts.security.pqc;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.security.pqc.annotations.DisabledOnSsl35AndLower;
+
+@DisabledOnNative(reason = "PQC is not supported on native yet")
+@DisabledOnOs(OS.WINDOWS)
+@DisabledOnSsl35AndLower(reason = "PQC is not supported on system which don't have OpenSSL 3.5+")
+@Tag("QUARKUS-7367")
+@QuarkusScenario
+public class OpenSslRestClientJksIT extends AbstractOpenSslRestClientIT {
+
+    @QuarkusApplication(ssl = true, properties = "openssl.properties", certificates = @Certificate(configureKeystore = true, configureTruststore = true, format = Certificate.Format.JKS))
+    static final RestService server = new RestService()
+            .setAutoStart(false);
+
+    @QuarkusApplication(ssl = true, properties = "rest-client.properties")
+    static final RestService client = new RestService()
+            .withProperty("quarkus.rest-client.hello-api.url", () -> server.getURI(Protocol.HTTPS).toString())
+            .withProperty("quarkus.tls.pqc.trust-store.jks.path", AbstractOpenSslRestClientIT::serverTruststorePath)
+            .withProperty("quarkus.tls.pqc.trust-store.jks.password", CERT_PASSWORD)
+            .setAutoStart(false);
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslRestClientP12IT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslRestClientP12IT.java
@@ -1,0 +1,32 @@
+package io.quarkus.ts.security.pqc;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.security.pqc.annotations.DisabledOnSsl35AndLower;
+
+@DisabledOnNative(reason = "PQC is not supported on native yet")
+@DisabledOnOs(OS.WINDOWS)
+@DisabledOnSsl35AndLower(reason = "PQC is not supported on system which don't have OpenSSL 3.5+")
+@Tag("QUARKUS-7367")
+@QuarkusScenario
+public class OpenSslRestClientP12IT extends AbstractOpenSslRestClientIT {
+
+    @QuarkusApplication(ssl = true, properties = "openssl.properties", certificates = @Certificate(configureKeystore = true, configureTruststore = true, format = Certificate.Format.PKCS12))
+    static final RestService server = new RestService()
+            .setAutoStart(false);
+
+    @QuarkusApplication(ssl = true, properties = "rest-client.properties")
+    static final RestService client = new RestService()
+            .withProperty("quarkus.rest-client.hello-api.url", () -> server.getURI(Protocol.HTTPS).toString())
+            .withProperty("quarkus.tls.pqc.trust-store.p12.path", AbstractOpenSslRestClientIT::serverTruststorePath)
+            .withProperty("quarkus.tls.pqc.trust-store.p12.password", CERT_PASSWORD)
+            .setAutoStart(false);
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslRestClientPemIT.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/OpenSslRestClientPemIT.java
@@ -1,0 +1,31 @@
+package io.quarkus.ts.security.pqc;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.security.pqc.annotations.DisabledOnSsl35AndLower;
+
+@DisabledOnNative(reason = "PQC is not supported on native yet")
+@DisabledOnOs(OS.WINDOWS)
+@DisabledOnSsl35AndLower(reason = "PQC is not supported on system which don't have OpenSSL 3.5+")
+@Tag("QUARKUS-7367")
+@QuarkusScenario
+public class OpenSslRestClientPemIT extends AbstractOpenSslRestClientIT {
+
+    @QuarkusApplication(ssl = true, properties = "openssl.properties", certificates = @Certificate(configureKeystore = true, configureTruststore = true, format = Certificate.Format.PEM))
+    static final RestService server = new RestService()
+            .setAutoStart(false);
+
+    @QuarkusApplication(ssl = true, properties = "rest-client.properties")
+    static final RestService client = new RestService()
+            .withProperty("quarkus.rest-client.hello-api.url", () -> server.getURI(Protocol.HTTPS).toString())
+            .withProperty("quarkus.tls.pqc.trust-store.pem.certs", AbstractOpenSslRestClientIT::serverTruststorePath)
+            .setAutoStart(false);
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/annotations/DisabledOnSsl35AndLower.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/annotations/DisabledOnSsl35AndLower.java
@@ -1,0 +1,21 @@
+package io.quarkus.ts.security.pqc.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Inherited
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledOnSsl35AndLowerConditions.class)
+public @interface DisabledOnSsl35AndLower {
+
+    /**
+     * Why is the annotated test class or test method disabled.
+     */
+    String reason();
+}

--- a/security/pqc/src/test/java/io/quarkus/ts/security/pqc/annotations/DisabledOnSsl35AndLowerConditions.java
+++ b/security/pqc/src/test/java/io/quarkus/ts/security/pqc/annotations/DisabledOnSsl35AndLowerConditions.java
@@ -1,0 +1,20 @@
+package io.quarkus.ts.security.pqc.annotations;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.netty.handler.ssl.OpenSsl;
+
+public class DisabledOnSsl35AndLowerConditions implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        boolean isOpenSslNewerThen35 = OpenSsl.isAvailable() && OpenSsl.version() >= 0x30500000L;
+        if (isOpenSslNewerThen35) {
+            return ConditionEvaluationResult.enabled("OpenSsl newer then 3.5 is available");
+        } else {
+            return ConditionEvaluationResult.disabled("OpenSsl newer then 3.5 is not available");
+        }
+    }
+}

--- a/security/pqc/src/test/resources/openssl.properties
+++ b/security/pqc/src/test/resources/openssl.properties
@@ -1,0 +1,5 @@
+quarkus.http.insecure-requests=disabled
+
+quarkus.tls.pqc-enforcement-policy=strict
+quarkus.tls.ssl-engine=openssl
+

--- a/security/pqc/src/test/resources/rest-client.properties
+++ b/security/pqc/src/test/resources/rest-client.properties
@@ -1,0 +1,2 @@
+quarkus.tls.pqc.ssl-engine=openssl
+quarkus.rest-client.hello-api.tls-configuration-name=pqc


### PR DESCRIPTION
### Summary

Adding test development for https://redhat.atlassian.net/browse/QUARKUS-7367

TP: https://github.com/quarkus-qe/quarkus-test-plans/pull/323

Note: OpenShit runs are not needed atm as the base image causing problems due to missing `apr` library. Linked issue have more details.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)