### PR TITLE
Make PortConflictIT tolerant of the Windows bind-conflict failure path

### DIFF
--- a/http/vertx/src/test/java/io/quarkus/ts/vertx/PortConflictIT.java
+++ b/http/vertx/src/test/java/io/quarkus/ts/vertx/PortConflictIT.java
@@ -26,7 +26,13 @@ public class PortConflictIT {
         assertThrows(AssertionError.class, () -> app.start(),
                 "Should fail because Both http and https servers started on port 50000");
         String logs = app.getLogs().toString();
-        assertTrue(logs.contains("Both http and https servers started on port 50000"));
+        // The app must fail to start due to the http/https port conflict, but the exact failure differs per OS:
+        // - On Linux both servers bind to the shared port and Quarkus detects the clash (the "Both http and https..." message)
+        // - On Windows the second bind loses the race and fails with a bind error ("Port ... seems to be in use ...")
+        assertTrue(
+                logs.contains("Both http and https servers started on port " + COMMON_PORT_HTTP_HTTPS)
+                        || logs.contains("Port " + COMMON_PORT_HTTP_HTTPS + " seems to be in use"),
+                "App should fail to start due to the http/https port conflict on port " + COMMON_PORT_HTTP_HTTPS);
     }
 
 }


### PR DESCRIPTION
## Problem

`PortConflictIT.verifyAppBehaviourUsingSamePorts` fails intermittently on the Windows JVM daily-build jobs (e.g. [run 33346188948](https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/33346188948), `Windows JVM (25)` — `Windows JVM (21)` passed in the same run):

```
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
	at io.quarkus.ts.vertx.PortConflictIT.verifyAppBehaviourUsingSamePorts(PortConflictIT.java:29)
```

## Root cause

The test binds `quarkus.http.port` and `quarkus.http.ssl-port` to the same port (50000) and asserts the app fails to start. The app **does** fail to start in all cases (`assertThrows` passes), but the *log message* differs per OS:

- **Linux:** both servers bind to the shared port (Vert.x server sharing) and Quarkus detects the clash in `VertxHttpRecorder.validateHttpPorts()`, logging `Both http and https servers started on port 50000`.
- **Windows:** the second `listen()` loses the race and completes with a `BindException`, taking the failure branch (`QuarkusBindException` → `Port 50000 seems to be in use ...`). `validateHttpPorts()` never runs, so the expected message is never emitted.

Which path wins is timing-dependent, which is why the same run can pass on one JDK and fail on another. Only the log-message assertion was OS-dependent.

## Fix

Accept either failure message. The `assertThrows` still guarantees the app failed to start; this only relaxes the specific-string check.

## Testing

The change is a test-assertion widening. I could not run the IT locally — it requires the `999-core-3.39-SNAPSHOT` platform, and the Windows-specific bind behavior does not reproduce on Linux/macOS regardless. CI (particularly the Windows JVM jobs) will validate the Windows path.