### PR TITLE
Add coverage for QUARKUS-7821 Support @Transactional for Hibernate Reactive - #51063

### DIFF
--- a/hibernate/hibernate-reactive/pom.xml
+++ b/hibernate/hibernate-reactive/pom.xml
@@ -41,6 +41,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-transactions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
         <dependency>

--- a/hibernate/hibernate-reactive/src/main/java/io/quarkus/ts/hibernate/reactive/http/TransactionalEndpoint.java
+++ b/hibernate/hibernate-reactive/src/main/java/io/quarkus/ts/hibernate/reactive/http/TransactionalEndpoint.java
@@ -1,0 +1,185 @@
+package io.quarkus.ts.hibernate.reactive.http;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.transaction.Transactional.TxType;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import io.quarkus.ts.hibernate.reactive.database.Book;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@Path("/transactional")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class TransactionalEndpoint {
+
+    private static final ConcurrentHashMap<String, CompletableFuture<Void>> BARRIERS = new ConcurrentHashMap<>();
+
+    @Inject
+    Mutiny.Session session;
+
+    @Inject
+    Mutiny.StatelessSession statelessSession;
+
+    @POST
+    @Path("/book/{authorId}/{title}")
+    @Transactional
+    public Uni<Response> createBook(Integer authorId, String title) {
+        Book book = new Book();
+        book.setAuthor(authorId);
+        book.setTitle(title);
+        return session.persist(book)
+                .replaceWith(() -> Response.status(Response.Status.CREATED).build());
+    }
+
+    @POST
+    @Path("/book/fail/{authorId}/{title}")
+    @Transactional
+    public Uni<Response> createBookAndFail(Integer authorId, String title) {
+        Book book = new Book();
+        book.setAuthor(authorId);
+        book.setTitle(title);
+        return session.persist(book)
+                .chain(() -> Uni.createFrom().failure(new RuntimeException("Forced failure for rollback test")));
+    }
+
+    @GET
+    @Path("/thread")
+    @Transactional
+    public Uni<String> getThreadInfo() {
+        return Uni.createFrom().item(Thread.currentThread().getName());
+    }
+
+    @GET
+    @Path("/thread/blocking")
+    @Transactional
+    @Blocking
+    public Uni<String> getThreadInfoBlocking() {
+        return Uni.createFrom().item(Thread.currentThread().getName());
+    }
+
+    @GET
+    @Path("/txtype/requires-new")
+    @Transactional(TxType.REQUIRES_NEW)
+    public Uni<String> requiresNew() {
+        return Uni.createFrom().item("ok");
+    }
+
+    @GET
+    @Path("/txtype/mandatory")
+    @Transactional(TxType.MANDATORY)
+    public Uni<String> mandatory() {
+        return Uni.createFrom().item("ok");
+    }
+
+    @POST
+    @Path("/stateless/{authorId}/{title}")
+    @Transactional
+    public Uni<Response> createBookStateless(Integer authorId, String title) {
+        Book book = new Book();
+        book.setAuthor(authorId);
+        book.setTitle(title);
+        return statelessSession.insert(book)
+                .replaceWith(() -> Response.status(Response.Status.CREATED).build());
+    }
+
+    @GET
+    @Path("/stateless/{title}")
+    @Transactional
+    public Uni<Response> getBookStateless(String title) {
+        return findBookStatelessByTitle(title)
+                .onItem().ifNotNull().transform(book -> Response.ok(book).build())
+                .onItem().ifNull().continueWith(Response.status(Response.Status.NOT_FOUND).build());
+    }
+
+    @PUT
+    @Path("/stateless/{title}/{newTitle}")
+    @Transactional
+    public Uni<Response> updateBookStateless(String title, String newTitle) {
+        return findBookStatelessByTitle(title)
+                .map(book -> {
+                    book.setTitle(newTitle);
+                    return book;
+                })
+                .onItem().call(book -> statelessSession.update(book))
+                .replaceWith(() -> Response.noContent().build());
+    }
+
+    @DELETE
+    @Path("/stateless/{title}")
+    @Transactional
+    public Uni<Response> deleteBookStateless(String title) {
+        return findBookStatelessByTitle(title)
+                .call(book -> statelessSession.delete(book))
+                .replaceWith(() -> Response.noContent().build());
+    }
+
+    private Uni<Book> findBookStatelessByTitle(String title) {
+        return statelessSession.createQuery("from Book where title = :title", Book.class)
+                .setParameter("title", title)
+                .getSingleResultOrNull();
+    }
+
+    @POST
+    @Path("/book/isolated/{authorId}/{title}")
+    @Transactional
+    public Uni<Response> createBookWithBarrier(Integer authorId, String title,
+            @QueryParam("rollback") @DefaultValue("false") boolean rollback,
+            @QueryParam("barrier") String barrier) {
+        Book book = new Book();
+        book.setAuthor(authorId);
+        book.setTitle(title);
+        return session.persist(book)
+                .call(session::flush)
+                .chain(() -> waitForBarrier(barrier))
+                .chain(() -> rollback
+                        ? Uni.createFrom().failure(new RuntimeException("Forced failure for rollback test"))
+                        : Uni.createFrom().voidItem())
+                .replaceWith(() -> Response.status(Response.Status.CREATED).build());
+    }
+
+    private Uni<Void> waitForBarrier(String barrierName) {
+        return Uni.createFrom().deferred(() -> {
+            Context ctx = Vertx.currentContext();
+            CompletableFuture<Void> future = BARRIERS.compute(barrierName, (key, existing) -> {
+                if (existing == null) {
+                    return new CompletableFuture<>();
+                } else {
+                    existing.complete(null);
+                    return existing;
+                }
+            });
+            return Uni.createFrom().completionStage(future)
+                    .emitOn(command -> ctx.runOnContext(v -> command.run()))
+                    .ifNoItem().after(Duration.ofSeconds(10))
+                    .failWith(new RuntimeException("Barrier timeout"));
+        });
+    }
+
+    @GET
+    @Path("/multi")
+    @Transactional
+    public Multi<Book> getMulti() {
+        return Multi.createFrom().item(new Book());
+    }
+}

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/AbstractDatabaseHibernateReactiveIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/AbstractDatabaseHibernateReactiveIT.java
@@ -7,6 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.MethodOrderer;
@@ -315,6 +319,165 @@ public abstract class AbstractDatabaseHibernateReactiveIT {
                 .delete("/library/unmanaged/new");
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.statusCode());
         assertThat(response.body().asString(), containsString("IllegalArgumentException"));
+    }
+
+    @Tag("QUARKUS-7821")
+    @Test
+    public void transactionalCommitsOnSuccess() {
+        getApp().given()
+                .contentType(ContentType.JSON)
+                .post("/transactional/book/4/TransactionalBook")
+                .then().statusCode(HttpStatus.SC_CREATED);
+
+        getApp().given()
+                .when().get("/library/books/author/Kahneman")
+                .then().statusCode(HttpStatus.SC_OK)
+                .body("$", hasItem("TransactionalBook"));
+    }
+
+    @Tag("QUARKUS-7821")
+    @Test
+    public void transactionalRollsBackOnFailure() {
+        getApp().given()
+                .contentType(ContentType.JSON)
+                .post("/transactional/book/fail/4/RollbackBook")
+                .then().statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+
+        String books = getApp().given()
+                .when().get("/library/books/author/Kahneman")
+                .then().statusCode(HttpStatus.SC_OK)
+                .extract().body().asString();
+        assertFalse(books.contains("RollbackBook"));
+    }
+
+    @Tag("QUARKUS-7821")
+    @Test
+    public void transactionalUniRunsOnEventLoop() {
+        String threadName = getApp().given()
+                .when().get("/transactional/thread")
+                .then().statusCode(HttpStatus.SC_OK)
+                .extract().body().asString();
+        assertThat(threadName, containsString("vert.x-eventloop"));
+    }
+
+    @Tag("QUARKUS-7821")
+    @Test
+    public void transactionalBlockingRunsOnWorkerThread() {
+        String threadName = getApp().given()
+                .when().get("/transactional/thread/blocking")
+                .then().statusCode(HttpStatus.SC_OK)
+                .extract().body().asString();
+        assertThat(threadName, containsString("executor-thread"));
+    }
+
+    @Tag("QUARKUS-7821")
+    @Test
+    public void transactionalRequiresNewThrowsUnsupportedOperationException() {
+        getApp().given()
+                .when().get("/transactional/txtype/requires-new")
+                .then().statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+                .body(containsString("@Transactional on Reactive methods supports only Transactional.TxType.REQUIRED"));
+    }
+
+    @Tag("QUARKUS-7821")
+    @Test
+    public void transactionalMandatoryThrowsUnsupportedOperationException() {
+        getApp().given()
+                .when().get("/transactional/txtype/mandatory")
+                .then().statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+                .body(containsString("@Transactional on Reactive methods supports only Transactional.TxType.REQUIRED"));
+    }
+
+    @Tag("QUARKUS-7821")
+    @Test
+    public void transactionalStatelessSessionPersists() {
+        getApp().given()
+                .contentType(ContentType.JSON)
+                .post("/transactional/stateless/4/StatelessBook")
+                .then().statusCode(HttpStatus.SC_CREATED);
+
+        getApp().given()
+                .when().get("/library/books/author/Kahneman")
+                .then().statusCode(HttpStatus.SC_OK)
+                .body("$", hasItem("StatelessBook"));
+    }
+
+    @Tag("QUARKUS-7821")
+    @Test
+    public void transactionalMultiReturnTypeFails() {
+        getApp().given()
+                .when().get("/transactional/multi")
+                .then().statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+                .body(containsString("io.smallrye.mutiny.Multi"));
+    }
+
+    @Tag("QUARKUS-7821")
+    @Test
+    public void transactionalStatelessSessionCrud() {
+        getApp().given()
+                .contentType(ContentType.JSON)
+                .post("/transactional/stateless/4/StatelessCrudBook")
+                .then().statusCode(HttpStatus.SC_CREATED);
+
+        getApp().given()
+                .when().get("/transactional/stateless/StatelessCrudBook")
+                .then().statusCode(HttpStatus.SC_OK)
+                .body("title", Matchers.is("StatelessCrudBook"));
+
+        getApp().given()
+                .when().put("/transactional/stateless/StatelessCrudBook/StatelessCrudUpdated")
+                .then().statusCode(HttpStatus.SC_NO_CONTENT);
+
+        getApp().given()
+                .when().get("/transactional/stateless/StatelessCrudUpdated")
+                .then().statusCode(HttpStatus.SC_OK)
+                .body("title", Matchers.is("StatelessCrudUpdated"));
+
+        getApp().given()
+                .when().delete("/transactional/stateless/StatelessCrudUpdated")
+                .then().statusCode(HttpStatus.SC_NO_CONTENT);
+
+        getApp().given()
+                .when().get("/transactional/stateless/StatelessCrudUpdated")
+                .then().statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Tag("QUARKUS-7821")
+    @Test
+    public void transactionalConcurrentRequestsKeepIsolation() throws Exception {
+        int iterations = 5;
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            for (int i = 0; i < iterations; i++) {
+                int iteration = i;
+                String barrier = "isolation-" + iteration;
+                Future<Integer> commitRequest = executor.submit(() -> getApp().given()
+                        .contentType(ContentType.JSON)
+                        .queryParam("barrier", barrier)
+                        .queryParam("rollback", false)
+                        .post("/transactional/book/isolated/4/ConcurrentCommit" + iteration)
+                        .then().extract().statusCode());
+                Future<Integer> rollbackRequest = executor.submit(() -> getApp().given()
+                        .contentType(ContentType.JSON)
+                        .queryParam("barrier", barrier)
+                        .queryParam("rollback", true)
+                        .post("/transactional/book/isolated/4/ConcurrentRollback" + iteration)
+                        .then().extract().statusCode());
+                assertEquals(HttpStatus.SC_CREATED, commitRequest.get());
+                assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, rollbackRequest.get());
+            }
+        } finally {
+            executor.shutdown();
+        }
+
+        String books = getApp().given()
+                .when().get("/library/books/author/Kahneman")
+                .then().statusCode(HttpStatus.SC_OK)
+                .extract().body().asString();
+        for (int i = 0; i < iterations; i++) {
+            assertTrue(books.contains("ConcurrentCommit" + i), "Book from committed transaction is missing: " + i);
+        }
+        assertFalse(books.contains("ConcurrentRollback"), "Books from rolled back transactions were persisted");
     }
 
     protected abstract RestService getApp();

--- a/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MultiDatabaseHibernateReactiveIT.java
+++ b/hibernate/hibernate-reactive/src/test/java/io/quarkus/ts/hibernate/reactive/MultiDatabaseHibernateReactiveIT.java
@@ -14,25 +14,6 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.ts.hibernate.reactive.database.Author;
-import io.quarkus.ts.hibernate.reactive.database.AuthorIdGenerator;
-import io.quarkus.ts.hibernate.reactive.database.AuthorRepository;
-import io.quarkus.ts.hibernate.reactive.database.Book;
-import io.quarkus.ts.hibernate.reactive.database.BookCollectionLegacyValid;
-import io.quarkus.ts.hibernate.reactive.database.BookCollectionTypeUseValid;
-import io.quarkus.ts.hibernate.reactive.database.ClientDevice;
-import io.quarkus.ts.hibernate.reactive.database.ISBNConverter;
-import io.quarkus.ts.hibernate.reactive.database.LibraryAuthor;
-import io.quarkus.ts.hibernate.reactive.database.LibraryBook;
-import io.quarkus.ts.hibernate.reactive.database.PersonEntity;
-import io.quarkus.ts.hibernate.reactive.database.XmlValidatedCustomer;
-import io.quarkus.ts.hibernate.reactive.http.ApplicationExceptionMapper;
-import io.quarkus.ts.hibernate.reactive.http.BookDescription;
-import io.quarkus.ts.hibernate.reactive.http.GroundedEndpoint;
-import io.quarkus.ts.hibernate.reactive.http.OtherResource;
-import io.quarkus.ts.hibernate.reactive.http.PanacheEndpoint;
-import io.quarkus.ts.hibernate.reactive.http.SomeApi;
-import io.quarkus.ts.hibernate.reactive.http.ValidationResource;
 import io.quarkus.ts.hibernate.reactive.multidbSources.CarResource;
 import io.quarkus.ts.hibernate.reactive.multidbSources.FruitResource;
 import io.quarkus.ts.hibernate.reactive.multidbSources.secondDatabase.Fruit;
@@ -69,14 +50,8 @@ public class MultiDatabaseHibernateReactiveIT extends AbstractDatabaseHibernateR
             .withDatabase(SQL_DATABASE);
 
     @QuarkusApplication(properties = "multidb.properties", classes = { Fruit.class, FruitResource.class, Car.class,
-            CarResource.class,
-            // also include default classes
-            Author.class, AuthorIdGenerator.class, AuthorRepository.class, Book.class, ISBNConverter.class, PersonEntity.class,
-            ApplicationExceptionMapper.class, BookDescription.class, GroundedEndpoint.class, OtherResource.class,
-            PanacheEndpoint.class, SomeApi.class, ValidationResource.class, XmlValidatedCustomer.class,
-            ClientDevice.class, BookCollectionLegacyValid.class, BookCollectionTypeUseValid.class, LibraryAuthor.class,
-            LibraryBook.class
-    })
+            CarResource.class
+    }, includeAllClassesFromMain = true)
     static RestService app = new RestService()
             .withProperty("main.url", postgresql1::getReactiveUrl)
             .withProperty("fruits.url", postgresql2::getReactiveUrl)


### PR DESCRIPTION
### Summary

Adding test development for https://github.com/quarkusio/quarkus/pull/51063

TP: https://github.com/quarkus-qe/quarkus-test-plans/pull/325

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Backport
- [x] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)