### PR TITLE
[3.40] Throttle memory leak test polling to avoid port exhaustion

### DIFF
--- a/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/RestClientReactiveMemoryLeakIT.java
+++ b/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/RestClientReactiveMemoryLeakIT.java
@@ -41,13 +41,19 @@ public class RestClientReactiveMemoryLeakIT {
         assertEquals(200, response.statusCode());
         long count = Long.parseLong(response.getBody().asString());
         assertNotEquals(0, count);
+        long lastLogged = count;
         try {
-            while (count < (200_000)) { // as of 3.36.1, the job fails around 100 000, but let's have some margin for error
+            // as of 3.27.4 and 3.36.1, the job fails around 100 000, let's have some margin for error
+            while (count < 200_000) {
+                // the app increments the counter on its own, polling faster only exhausts ephemeral ports faster
+                Thread.sleep(100);
+
                 response = client.given().get("/client/events");
                 assertEquals(200, response.statusCode());
                 count = Long.parseLong(response.getBody().asString());
-                if (count % 1000 == 0) {
+                if (count - lastLogged >= 10_000) {
                     Log.info("Current count is " + count);
+                    lastLogged = count;
                 }
             }
         } catch (Exception ex) {


### PR DESCRIPTION
The test watches a counter that `EventsClientResource` increments on its own, polling it in a tight loop (more than 1000 requests per second), which may exhaust the ephemeral port range (very easy on Windows). If so, the run fails with `BindException: Address already in use: connect`.

Wiht this commit, the test polls every 100 ms instead, which makes the request volume 2 orders of magnitude smaller without any effect on the ability to reproduce the OOM (verified the test still fails on 3.27.4 and passes on 3.27.5). Also, progress is reported by counter delta rather than on exact multiples of 1000, which was frequently stepped over.

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please select the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [ ] This change requires execution with OCP on Aarch64 (use `run arm tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)